### PR TITLE
feat: set default open dir as QStandardPaths::DocumentsLocation

### DIFF
--- a/src/window.cpp
+++ b/src/window.cpp
@@ -504,7 +504,7 @@ void Window::openFile()
     dialog.setAcceptMode(QFileDialog::AcceptOpen);
 
     // read history directory.
-    const QString historyDirStr = m_settings->settings->option("advance.editor.file_dialog_dir")->value().toString();
+    QString historyDirStr = m_settings->settings->option("advance.editor.file_dialog_dir")->value().toString();
     if (historyDirStr.isEmpty()) {
         historyDirStr = QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation);
     }

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -504,9 +504,15 @@ void Window::openFile()
     dialog.setAcceptMode(QFileDialog::AcceptOpen);
 
     // read history directory.
-    const QString historyDir = m_settings->settings->option("advance.editor.file_dialog_dir")->value().toString();
-    if (!historyDir.isEmpty()) {
+    const QString historyDirStr = m_settings->settings->option("advance.editor.file_dialog_dir")->value().toString();
+    if (historyDirStr.isEmpty()) {
+        historyDirStr = QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation);
+    }
+    QDir historyDir(historyDirStr);
+    if (historyDir.exists()) {
         dialog.setDirectory(historyDir);
+    } else {
+        qDebug() << "historyDir or default path not existed:" << historyDir;
     }
 
     const int mode = dialog.exec();


### PR DESCRIPTION
使用编辑器打开文件时，文件管理器默认打开是文档目录
手动选择目录后，记录上次选择的目录

额外：当记住的上次选择的位置不存在或文档目录本身不存在时，会 fallback 到家目录。