### PR TITLE
fix: do not overwrite the cursorFlashTime of QGuiApplication

### DIFF
--- a/src/dtextedit.cpp
+++ b/src/dtextedit.cpp
@@ -2286,8 +2286,8 @@ bool DTextEdit::atWordSeparator(int position)
 
 void DTextEdit::showCursorBlink()
 {
-    // the default value on X11 is 1000 milliseconds.
-    QApplication::setCursorFlashTime(1000);
+    // -1 表示恢复Qt的默认值
+    QApplication::setCursorFlashTime(-1);
 }
 
 void DTextEdit::hideCursorBlink()


### PR DESCRIPTION
Fix Qt's cursor flash time setting does not take effect
https://github.com/linuxdeepin/qt5dxcb-plugin/pull/23

修复光标闪动速度的设置不生效