### PR TITLE
fix: crash if DDE file select dialog is not available to use

### DIFF
--- a/src/editwrapper.cpp
+++ b/src/editwrapper.cpp
@@ -238,6 +238,18 @@ void EditWrapper::setTextCodec(QTextCodec *codec, bool reload)
     // TODO: enforce bom for some encodings
 }
 
+void EditWrapper::setTextCodec(QByteArray encodeName, bool reload)
+{
+    QTextCodec* codec = QTextCodec::codecForName(encodeName);
+
+    if (!codec) {
+        qWarning() << "Codec for" << encodeName << "not found! Fallback to UTF-8";
+        codec = QTextCodec::codecForName("UTF-8");
+    }
+
+    setTextCodec(codec);
+}
+
 void EditWrapper::hideToast()
 {
     if (m_toast->isVisible()) {
@@ -335,7 +347,7 @@ void EditWrapper::handleFileLoadFinished(const QByteArray &encode, const QString
     }
 
     m_isLoadFinished = true;
-    m_textCodec = QTextCodec::codecForName(encode);
+    setTextCodec(encode);
 
     // set text.
     m_textEdit->setPlainText(content);

--- a/src/editwrapper.h
+++ b/src/editwrapper.h
@@ -57,7 +57,7 @@ public:
 
     EndOfLineMode endOfLineMode();
     void setEndOfLineMode(EndOfLineMode eol);
-    void setTextCodec(QTextCodec *codec, bool reload = false);
+    void setTextCodec(QByteArray encodeName, bool reload = false);
 
     BottomBar *bottomBar() { return m_bottomBar; }
     QString filePath() { return m_textEdit->filepath; }
@@ -76,6 +76,7 @@ private:
     void handleCursorModeChanged(DTextEdit::CursorMode mode);
     void handleHightlightChanged(const QString &name);
     void handleFileLoadFinished(const QByteArray &encode, const QString &content);
+    void setTextCodec(QTextCodec *codec, bool reload = false);
 
 protected:
     void resizeEvent(QResizeEvent *);

--- a/src/widgets/bottombar.cpp
+++ b/src/widgets/bottombar.cpp
@@ -111,7 +111,7 @@ void BottomBar::setPalette(const QPalette &palette)
 
 void BottomBar::handleEncodeChanged(const QString &name)
 {
-    m_wrapper->setTextCodec(QTextCodec::codecForName(name.toUtf8()), true);
+    m_wrapper->setTextCodec(name.toUtf8(), true);
 }
 
 void BottomBar::paintEvent(QPaintEvent *)

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -636,7 +636,7 @@ bool Window::saveAsFile()
 
         m_tabbar->updateTab(m_tabbar->currentIndex(), newFilePath, newFileInfo.fileName());
 
-        wrapper->setTextCodec(QTextCodec::codecForName(encode));
+        wrapper->setTextCodec(encode);
         wrapper->updatePath(newFilePath);
         wrapper->setEndOfLineMode(eol);
         wrapper->saveFile();


### PR DESCRIPTION
Reproduce steps:

 - Try use deepin-editor save file under a non-DDE enviroment (tested under Mate)
 - a native (**not** dde-file-manager) file dialog opened up, enter any file name.
 - deepin-editor crashes.