### PR TITLE
fix: width -> horizontalAdvance

### DIFF
--- a/src/dtextedit.cpp
+++ b/src/dtextedit.cpp
@@ -427,9 +427,7 @@ int TextEdit::lineNumberAreaWidth()
         ++digits;
     }
 
-    int space = 13 +  fontMetrics().width(QLatin1Char('9')) * (digits) + 40;
-
-    return space;
+    return 13 + fontMetrics().horizontalAdvance(QLatin1Char('9')) * digits + 40;
 }
 
 int TextEdit::getCurrentLine()


### PR DESCRIPTION
```
warning: 'width' is deprecated: Use QFontMetrics::horizontalAdvance
qfontmetrics.h:109:5: note: 'width' has been explicitly marked deprecated here
qglobal.h:294:33: note: expanded from macro 'QT_DEPRECATED_X'
qcompilerdetection.h:675:55: note: expanded from macro 'Q_DECL_DEPRECATED_X'
```