### PR TITLE
feat: Initial packit setup

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,0 +1,17 @@
+# See the documentation for more information:
+# https://packit.dev/docs/configuration/
+
+specfile_path: rpm/deepin-editor.spec
+
+# add or remove files that should be synced
+synced_files:
+    - rpm/deepin-editor.spec
+    - .packit.yaml
+
+upstream_package_name: deepin-editor
+# downstream (Fedora) RPM package name
+downstream_package_name: deepin-editor
+
+actions:
+  fix-spec-file: |
+    bash -c "sed -i -r \"s/Version:(\s*)\S*/Version:\1${PACKIT_PROJECT_VERSION}/\" rpm/deepin-editor.spec"

--- a/rpm/deepin-editor.spec
+++ b/rpm/deepin-editor.spec
@@ -1,0 +1,56 @@
+Name:           deepin-editor
+Version:        5.9.0.7
+Release:        1%{?dist}
+Summary:        Simple editor for Linux Deepin
+License:        GPLv3
+URL:            https://github.com/linuxdeepin/deepin-editor
+Source0:        %{url}/archive/%{version}/%{name}-%{version}.tar.gz
+
+BuildRequires:  gcc-c++
+BuildRequires:  freeimage-devel
+BuildRequires:  cmake(KF5Codecs)
+BuildRequires:  cmake(KF5SyntaxHighlighting)
+BuildRequires:  cmake(DFrameworkdbus)
+BuildRequires:  pkgconfig(dtkwidget) >= 2.0.6
+BuildRequires:  pkgconfig(libexif)
+BuildRequires:  pkgconfig(xcb-aux)
+BuildRequires:  pkgconfig(xtst)
+BuildRequires:  pkgconfig(polkit-qt5-1)
+BuildRequires:  pkgconfig(Qt5)
+BuildRequires:  pkgconfig(Qt5DBus)
+BuildRequires:  pkgconfig(Qt5Gui)
+BuildRequires:  pkgconfig(Qt5Svg)
+BuildRequires:  pkgconfig(Qt5X11Extras)
+BuildRequires:  desktop-file-utils
+BuildRequires:  qt5-linguist
+BuildRequires:  qt5-qtbase-private-devel
+%{?_qt5:Requires: %{_qt5}%{?_isa} = %{_qt5_version}}
+Requires:       deepin-notifications
+Requires:       deepin-qt5integration
+
+%description
+%{summary}.
+
+%prep
+%autosetup -p1
+
+%build
+%cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo
+%cmake_build
+
+%install
+%cmake_install
+
+%check
+desktop-file-validate %{buildroot}%{_datadir}/applications/%{name}.desktop
+
+%files
+%doc README.md
+%license LICENSE
+%{_bindir}/dedit
+%{_bindir}/%{name}
+%{_datadir}/%{name}/
+%{_datadir}/applications/%{name}.desktop
+%{_datadir}/icons/hicolor/scalable/apps/%{name}.svg
+
+%changelog


### PR DESCRIPTION
This commit contains the specfile for building the official package for Fedora
with a Packit setup.

Ultimately, a unified specfile is targeted for Fedora and any other rpm-based
distributions, e.g. openEuler.

And Packit(https://packit.dev/) is a tool for maintaining specfile within
upstream source. It requires a simple config file(.packit.yaml).

Log:
Signed-off-by: Robin Lee <cheeselee@fedoraproject.org>