### PR TITLE
fix: crash when saving a modified file

### DIFF
--- a/src/editor/dtextedit.cpp
+++ b/src/editor/dtextedit.cpp
@@ -2717,7 +2717,7 @@ void TextEdit::redo_()
     m_pUndoStack->redo();
     if(m_pUndoStack->index() == m_lastSaveIndex){
         this->m_wrapper->window()->updateModifyStatus(m_sFilePath, false);
-        this->m_wrapper->setTemFile(false);
+        //this->m_wrapper->setTemFile(false);
         this->document()->setModified(false);
     }
 
@@ -2727,7 +2727,7 @@ void TextEdit::undo_()
     m_pUndoStack->undo();
     if(m_pUndoStack->index() == m_lastSaveIndex){
         this->m_wrapper->window()->updateModifyStatus(m_sFilePath, false);
-        this->m_wrapper->setTemFile(false);
+        //this->m_wrapper->setTemFile(false);
         this->document()->setModified(false);
     }
 }


### PR DESCRIPTION
step:
1. modify a file
2. close deepin-editor
3. reopen deepin-editor
4. press `Ctrl + Z` to undo modify
5. press `Ctrl + S` to save file
6. the deepin-editor is crash now