### PR TITLE
fix: broken KF5 include path

### DIFF
--- a/src/editor/dtextedit.cpp
+++ b/src/editor/dtextedit.cpp
@@ -34,9 +34,9 @@
 #include "indenttextcommond.h"
 #include "undolist.h"
 
-#include <KF5/KSyntaxHighlighting/definition.h>
-#include <KF5/KSyntaxHighlighting/syntaxhighlighter.h>
-#include <KF5/KSyntaxHighlighting/theme.h>
+#include <KSyntaxHighlighting/definition.h>
+#include <KSyntaxHighlighting/syntaxhighlighter.h>
+#include <KSyntaxHighlighting/theme.h>
 
 #include <QAbstractTextDocumentLayout>
 #include <QTextDocumentFragment>

--- a/src/editor/showflodcodewidget.h
+++ b/src/editor/showflodcodewidget.h
@@ -23,10 +23,10 @@
 #include <DFrame>
 #include <DPlainTextEdit>
 #include <DApplicationHelper>
-#include <KF5/KSyntaxHighlighting/repository.h>
-#include <KF5/KSyntaxHighlighting/definition.h>
-#include <KF5/KSyntaxHighlighting/syntaxhighlighter.h>
-#include <KF5/KSyntaxHighlighting/theme.h>
+#include <KSyntaxHighlighting/repository.h>
+#include <KSyntaxHighlighting/definition.h>
+#include <KSyntaxHighlighting/syntaxhighlighter.h>
+#include <KSyntaxHighlighting/theme.h>
 
 DWIDGET_USE_NAMESPACE
 


### PR DESCRIPTION
The `KF5/` part is redundant and breaks building on Arch with latest KF5. Removing it also makes it more consistent with the rest of the project.

Log: fix broken KF5 include path