### PR TITLE
fix: 修复133M的文本文件，点击打印没有反应文本编辑器卡死

### DIFF
--- a/src/editor/editwrapper.h
+++ b/src/editor/editwrapper.h
@@ -129,6 +129,10 @@ public:
     QDateTime getLastModifiedTime() const;
     void setLastModifiedTime(const QString &time);
 
+    // 取得当前编辑器使用的高亮处理(用于打印高亮)
+    inline CSyntaxHighlighter *getSyntaxHighlighter() const
+    { return m_pSyntaxHighlighter; }
+
 signals:
     void sigClearDoubleCharaterEncode();
 

--- a/tests/src/widgets/ut_window.cpp
+++ b/tests/src/widgets/ut_window.cpp
@@ -2005,6 +2005,56 @@ TEST(UT_Window_doprint, UT_Window_doprint)
     p = nullptr;
 }
 
+TEST(UT_Window_doprint, UT_Window_doPrintWithLargeDoc)
+{
+    Window* w = new Window();
+    DPrinter* p = new DPrinter;
+    w->m_pPreview = new DPrintPreviewDialog;
+    Window::PrintInfo info;
+    info.doc = new QTextDocument;
+    w->m_printDocList.append(info);
+
+    editwrapper_texteditor = new TextEdit;
+    Stub s1;s1.set(ADDR(EditWrapper,textEditor),EditWrapper_textEditor_stub);
+
+    QVector<int> pages{1,2,3,4,5};
+#if (DTK_VERSION_MAJOR > 5 \
+ || (DTK_VERSION_MAJOR == 5 && DTK_VERSION_MINOR > 4) \
+ || (DTK_VERSION_MAJOR == 5 && DTK_VERSION_MINOR == 4 && DTK_VERSION_PATCH >= 10))
+    w->doPrintWithLargeDoc(p, pages);
+#endif
+
+    EXPECT_NE(w, nullptr);
+    w->deleteLater();
+    editwrapper_texteditor->deleteLater();
+    w->m_printDoc->deleteLater();
+    w->m_pPreview->deleteLater();
+    delete p;
+    p = nullptr;
+}
+
+TEST(UT_Window_doprint, UT_Window_cloneLargeDocument)
+{
+    Window* w = new Window();
+    EditWrapper* wra = new EditWrapper(w);
+    QString text = "123";
+    wra->textEditor()->document()->setPlainText(text);
+
+    // 拷贝数据
+    w->cloneLargeDocument(wra);
+    EXPECT_FALSE(w->m_printDocList.isEmpty());
+    if (!w->m_printDocList.isEmpty()) {
+        EXPECT_NE(w->m_printDocList.first().doc, nullptr);
+    }
+
+    // 清空数据
+    w->clearPrintTextDocument();
+    EXPECT_TRUE(w->m_printDocList.isEmpty());
+
+    wra->deleteLater();
+    w->deleteLater();
+}
+
 
 TEST(UT_Window_slotClearDoubleCharaterEncode, UT_Window_slotClearDoubleCharaterEncode)
 {


### PR DESCRIPTION
Description: 大文本打印时，文本拷贝、布局和高亮耗时长，计算时占用主线程，导致文本编辑器卡死。修改文本拷贝、布局和高亮的计算方式，将计算步骤拆分为单独的子步骤，使用QApplication::processEvents处理其它事件。界面不再卡死，对超过100MB的文本文件有效支持。对需要高亮的代码文件需要进一步优化高亮处理效率。

Log: 修复133M的文本文件，点击打印没有反应文本编辑器卡死
Bug: https://pms.uniontech.com/bug-view-143359.html
Influence: 文档打印