### PR TITLE
fix: 修复撤销时改变光标的位置后继续撤销,光标未移回要撤销的位置

### DIFF
--- a/src/editor/deletebackcommond.cpp
+++ b/src/editor/deletebackcommond.cpp
@@ -29,6 +29,9 @@ void DeleteBackCommond::redo()
     m_cursor.setPosition(m_delPos);
     m_cursor.setPosition(m_delPos+m_delText.size(), QTextCursor::KeepAnchor);
     m_cursor.deleteChar();
+
+    // 撤销恢复时光标移回要撤销的位置
+    m_edit->setTextCursor(m_cursor);
 }
 
 DeleteBackAltCommond::DeleteBackAltCommond(QList<QTextEdit::ExtraSelection> &selections,QPlainTextEdit* edit):

--- a/src/editor/deletetextundocommand.h
+++ b/src/editor/deletetextundocommand.h
@@ -31,13 +31,13 @@
 class DeleteTextUndoCommand : public QUndoCommand
 {
 public:
-    explicit DeleteTextUndoCommand(QTextCursor textcursor, QUndoCommand *parent = nullptr);
-    explicit DeleteTextUndoCommand(QList<QTextEdit::ExtraSelection> &selections, QUndoCommand *parent = nullptr);
+    explicit DeleteTextUndoCommand(QTextCursor textcursor, QPlainTextEdit* edit, QUndoCommand *parent = nullptr);
+    explicit DeleteTextUndoCommand(QList<QTextEdit::ExtraSelection> &selections, QPlainTextEdit* edit, QUndoCommand *parent = nullptr);
     virtual void undo();
     virtual void redo();
 
-
 private:
+    QPlainTextEdit* m_edit;
     QTextCursor m_textCursor;
     QString m_sInsertText;
     QList<QString> m_selectTextList;

--- a/src/editor/inserttextundocommand.h
+++ b/src/editor/inserttextundocommand.h
@@ -25,16 +25,18 @@
 #include <QUndoCommand>
 #include <QTextCursor>
 #include <QTextEdit>
+#include <QPlainTextEdit>
 
 class InsertTextUndoCommand : public QUndoCommand
 {
 public:
-    explicit InsertTextUndoCommand(QTextCursor textcursor, QString text, QUndoCommand *parent = nullptr);
-    explicit InsertTextUndoCommand(QList<QTextEdit::ExtraSelection> &selections, QString text, QUndoCommand *parent = nullptr);
+    explicit InsertTextUndoCommand(QTextCursor textcursor, QString text, QPlainTextEdit *edit, QUndoCommand *parent = nullptr);
+    explicit InsertTextUndoCommand(QList<QTextEdit::ExtraSelection> &selections, QString text, QPlainTextEdit *edit, QUndoCommand *parent = nullptr);
     virtual void undo();
     virtual void redo();
 
 private:
+    QPlainTextEdit *m_pEdit = nullptr;
     QTextCursor m_textCursor;
     int m_beginPostion {0};
     int m_endPostion   {0};

--- a/tests/src/editor/ut_deletetextundocommand.cpp
+++ b/tests/src/editor/ut_deletetextundocommand.cpp
@@ -1,5 +1,6 @@
 #include "ut_deletetextundocommand.h"
 #include "src/stub.h"
+#include <QPlainTextEdit>
 
 namespace deletetextstub {
 
@@ -63,7 +64,7 @@ TEST(UT_Deletetextundocommond_DeleteTextUndoCommand, UT_Deletetextundocommond_De
 TEST(UT_Deletetextundocommond_undo, UT_Deletetextundocommond_undo)
 {
     QTextCursor cursor;
-    DeleteTextUndoCommand * commond1 = new DeleteTextUndoCommand(cursor);
+    DeleteTextUndoCommand * commond1 = new DeleteTextUndoCommand(cursor, nullptr);
     commond1->m_sInsertText = "ddd";
 
     QList<QTextEdit::ExtraSelection> extraSelections;
@@ -73,7 +74,7 @@ TEST(UT_Deletetextundocommond_undo, UT_Deletetextundocommond_undo)
     selection.format.setProperty(QTextFormat::FullWidthSelection, true);
     selection.cursor.clearSelection();
     extraSelections.append(selection);
-    DeleteTextUndoCommand * commond2 = new DeleteTextUndoCommand(extraSelections);
+    DeleteTextUndoCommand * commond2 = new DeleteTextUndoCommand(extraSelections, nullptr);
 
     commond1->undo();
     commond2->undo();
@@ -85,6 +86,41 @@ TEST(UT_Deletetextundocommond_undo, UT_Deletetextundocommond_undo)
     delete commond2;commond2=nullptr;
 }
 
+TEST(UT_Deletetextundocommond_undo, undo_withTextCursor_restoreCursor)
+{
+    // 撤销后恢复光标位置
+    QPlainTextEdit *edit = new QPlainTextEdit;
+    edit->setPlainText("123456789");
+
+    QTextCursor cursor = edit->textCursor();
+    cursor.setPosition(3);
+    cursor.movePosition(QTextCursor::NextCharacter, QTextCursor::KeepAnchor, 3);
+    EXPECT_EQ(QString("456"), cursor.selectedText());
+    DeleteTextUndoCommand *command = new DeleteTextUndoCommand(cursor, edit);
+    cursor.deleteChar();
+    command->undo();
+
+    EXPECT_EQ(command->m_textCursor.position(), edit->textCursor().position());
+
+    QList<QTextEdit::ExtraSelection> extraSelections;
+    QTextEdit::ExtraSelection selection;
+    QColor lineColor = QColor(Qt::yellow).lighter(160);
+    selection.format.setBackground(lineColor);
+    selection.format.setProperty(QTextFormat::FullWidthSelection, true);
+    selection.cursor = edit->textCursor();
+    selection.cursor.setPosition(3);
+    selection.cursor.movePosition(QTextCursor::NextCharacter, QTextCursor::KeepAnchor, 3);
+    extraSelections.append(selection);
+    DeleteTextUndoCommand *command2 = new DeleteTextUndoCommand(extraSelections, edit);
+    selection.cursor.deleteChar();
+    command2->undo();
+
+    EXPECT_EQ(command2->m_ColumnEditSelections.last().cursor.position(), edit->textCursor().position());
+
+    delete command;
+    delete command2;
+    delete edit;
+}
 
 TEST(UT_Deletetextundocommond_redo, UT_Deletetextundocommond_redo)
 {
@@ -94,14 +130,14 @@ TEST(UT_Deletetextundocommond_redo, UT_Deletetextundocommond_redo)
                                                           QString("Holle world."));
     QTextCursor cursor1 = pWindow->currentWrapper()->textEditor()->textCursor();
     auto cursor2 = pWindow->currentWrapper()->textEditor()->textCursor();
-    DeleteTextUndoCommand * commond1 = new DeleteTextUndoCommand(cursor1);
-    DeleteTextUndoCommand * commond2 = new DeleteTextUndoCommand(cursor2);
+    DeleteTextUndoCommand * commond1 = new DeleteTextUndoCommand(cursor1, nullptr);
+    DeleteTextUndoCommand * commond2 = new DeleteTextUndoCommand(cursor2, nullptr);
     QTextEdit::ExtraSelection select[2];
     select[0].cursor = cursor1;
     select[1].cursor = cursor2;
 
     QList<QTextEdit::ExtraSelection> selections{select[0],select[1]};
-    DeleteTextUndoCommand * commond3 = new DeleteTextUndoCommand(selections);
+    DeleteTextUndoCommand * commond3 = new DeleteTextUndoCommand(selections, nullptr);
     commond1->redo();
     commond2->redo();
     commond3->redo();
@@ -112,45 +148,42 @@ TEST(UT_Deletetextundocommond_redo, UT_Deletetextundocommond_redo)
     delete commond1;commond1=nullptr;
     delete commond2;commond2=nullptr;
     delete commond3;commond3=nullptr;
-
-
 }
 
-TEST(UT_Deletetextundocommond_DeleteTextUndoCommand2, UT_Deletetextundocommond_DeleteTextUndoCommand2_001)
+TEST(UT_Deletetextundocommond_rddo, redo_withTextCursor_changeCursor)
 {
-//    Window* window = new Window;
-//    EditWrapper* wrapper = new EditWrapper(window);
-//    TextEdit * edit = new TextEdit(window);
-//    edit->m_wrapper = wrapper;
+    // 重做后恢复光标位置
+    QPlainTextEdit *edit = new QPlainTextEdit;
+    edit->setPlainText("123456789");
 
-//    QTextCursor cursor1,cursor2;
+    QTextCursor cursor = edit->textCursor();
+    cursor.setPosition(3);
+    cursor.movePosition(QTextCursor::NextCharacter, QTextCursor::KeepAnchor, 3);
+    EXPECT_EQ(QString("456"), cursor.selectedText());
+    DeleteTextUndoCommand *command = new DeleteTextUndoCommand(cursor, edit);
+    command->redo();
 
-//    DeleteTextUndoCommand2 * commond1 = new DeleteTextUndoCommand2(cursor1,"ddd",edit,false);
+    EXPECT_EQ(command->m_textCursor.position(), edit->textCursor().position());
 
-//    QTextEdit::ExtraSelection select[2];
-//    select[0].cursor = cursor1;
-//    select[1].cursor = cursor2;
+    edit->setPlainText("123456789");
+    QList<QTextEdit::ExtraSelection> extraSelections;
+    QTextEdit::ExtraSelection selection;
+    QColor lineColor = QColor(Qt::yellow).lighter(160);
+    selection.format.setBackground(lineColor);
+    selection.format.setProperty(QTextFormat::FullWidthSelection, true);
+    selection.cursor = edit->textCursor();
+    selection.cursor.setPosition(3);
+    selection.cursor.movePosition(QTextCursor::NextCharacter, QTextCursor::KeepAnchor, 3);
+    extraSelections.append(selection);
+    DeleteTextUndoCommand *command2 = new DeleteTextUndoCommand(extraSelections, edit);
+    command2->redo();
 
-//    QList<QTextEdit::ExtraSelection> selections{select[0],select[1]};
+    EXPECT_EQ(command2->m_ColumnEditSelections.last().cursor.position(), edit->textCursor().position());
 
-//    Stub s1;
-//    s1.set(ADDR(QTextCursor,positionInBlock),retintstub);
-//    s1.set(ADDR(QTextCursor,hasSelection),retfalsestub);
-//    s1.set(ADDR(QString,at),rettruestub);
-
-//    intvalue = 1;
-//    DeleteTextUndoCommand2 * commond3 = new DeleteTextUndoCommand2(selections,"test",edit,false);
-
-//    EXPECT_NE(edit,nullptr);
-//    window->deleteLater();
-//    wrapper->deleteLater();
-//    edit->deleteLater();
-//    delete commond1;
-//    commond1=nullptr;
-//    delete commond3;
-//    commond3=nullptr;
+    delete command;
+    delete command2;
+    delete edit;
 }
-
 
 TEST(UT_Deletetextundocommond_DeleteTextUndoCommand2, UT_Deletetextundocommond_DeleteTextUndoCommand2_002)
 {

--- a/tests/src/editor/ut_inserttextundocommand.cpp
+++ b/tests/src/editor/ut_inserttextundocommand.cpp
@@ -9,7 +9,7 @@ void test_InsertTextUndoCommand::SetUp()
 {
     QTextCursor textcursor;
     QString test;
-    ituc = new InsertTextUndoCommand(textcursor, test);
+    ituc = new InsertTextUndoCommand(textcursor, test, nullptr);
 }
 
 void test_InsertTextUndoCommand::TearDown()
@@ -28,7 +28,7 @@ TEST_F(test_InsertTextUndoCommand, undo)
     extraSelections.append(selection);
 
     QString text = "aaa";
-    InsertTextUndoCommand *command = new InsertTextUndoCommand(extraSelections, text);
+    InsertTextUndoCommand *command = new InsertTextUndoCommand(extraSelections, text, nullptr);
     command->undo();
 
     int iRet = command->m_textCursor.position();
@@ -40,7 +40,7 @@ TEST_F(test_InsertTextUndoCommand, undo2)
 {
     QList<QTextEdit::ExtraSelection> extraSelections;
     QString text = "aaa";
-    InsertTextUndoCommand *command = new InsertTextUndoCommand(extraSelections, text);
+    InsertTextUndoCommand *command = new InsertTextUndoCommand(extraSelections, text, nullptr);
     command->undo();
 
     int iRet = command->m_textCursor.position();
@@ -51,7 +51,7 @@ TEST_F(test_InsertTextUndoCommand, redo)
 {
     QList<QTextEdit::ExtraSelection> extraSelections;
     QString text = "aaa";
-    InsertTextUndoCommand *command = new InsertTextUndoCommand(extraSelections, text);
+    InsertTextUndoCommand *command = new InsertTextUndoCommand(extraSelections, text, nullptr);
     ituc->redo();
 
     int iRet = command->m_textCursor.position();
@@ -68,9 +68,80 @@ TEST_F(test_InsertTextUndoCommand, redo2)
     selection.cursor.clearSelection();
     extraSelections.append(selection);
     QString text = "aaa";
-    InsertTextUndoCommand *command = new InsertTextUndoCommand(extraSelections, text);
+    InsertTextUndoCommand *command = new InsertTextUndoCommand(extraSelections, text, nullptr);
     command->redo();
 
     int iRet = command->m_textCursor.position();
     ASSERT_TRUE(iRet != 0);
+}
+
+TEST_F(test_InsertTextUndoCommand, redo_withTextCursor_restoreCursor)
+{
+    // 重做恢复光标位置
+    QPlainTextEdit *edit = new QPlainTextEdit;
+    edit->setPlainText("123789");
+
+    QTextCursor cursor = edit->textCursor();
+    cursor.setPosition(3);
+    InsertTextUndoCommand *command = new InsertTextUndoCommand(cursor, QString("456"), edit);
+    command->redo();
+
+    EXPECT_EQ(QString("123456789"), edit->toPlainText());
+    EXPECT_EQ(6, edit->textCursor().position());
+
+    edit->setPlainText("123789");
+    QList<QTextEdit::ExtraSelection> extraSelections;
+    QTextEdit::ExtraSelection selection;
+    QColor lineColor = QColor(Qt::yellow).lighter(160);
+    selection.format.setBackground(lineColor);
+    selection.format.setProperty(QTextFormat::FullWidthSelection, true);
+    selection.cursor = edit->textCursor();
+    selection.cursor.setPosition(3);
+    extraSelections.append(selection);
+    InsertTextUndoCommand *command2 = new InsertTextUndoCommand(extraSelections, QString("456"), edit);
+    command2->redo();
+
+    EXPECT_EQ(QString("123456789"), edit->toPlainText());
+    EXPECT_EQ(6, edit->textCursor().position());
+
+    delete command;
+    delete command2;
+    delete edit;
+}
+
+TEST_F(test_InsertTextUndoCommand, undo_withTextCursor_restoreCursor)
+{
+    // 撤销后恢复光标位置
+    QPlainTextEdit *edit = new QPlainTextEdit;
+    edit->setPlainText("123456789");
+
+    QTextCursor cursor = edit->textCursor();
+    cursor.setPosition(6);
+    InsertTextUndoCommand *command = new InsertTextUndoCommand(cursor, QString("456"), edit);
+    command->m_endPostion = 6;
+    command->m_beginPostion = 3;
+    command->undo();
+
+    EXPECT_EQ(QString("123789"), edit->toPlainText());
+    EXPECT_EQ(3, edit->textCursor().position());
+
+    edit->setPlainText("123456789");
+    QList<QTextEdit::ExtraSelection> extraSelections;
+    QTextEdit::ExtraSelection selection;
+    QColor lineColor = QColor(Qt::yellow).lighter(160);
+    selection.format.setBackground(lineColor);
+    selection.format.setProperty(QTextFormat::FullWidthSelection, true);
+    selection.cursor = edit->textCursor();
+    selection.cursor.setPosition(3);
+    selection.cursor.movePosition(QTextCursor::NextCharacter, QTextCursor::KeepAnchor, 3);
+    extraSelections.append(selection);
+    InsertTextUndoCommand *command2 = new InsertTextUndoCommand(extraSelections, QString("456"), edit);
+    command2->undo();
+
+    EXPECT_EQ(QString("123789"), edit->toPlainText());
+    EXPECT_EQ(3, edit->textCursor().position());
+
+    delete command;
+    delete command2;
+    delete edit;
 }


### PR DESCRIPTION
Description: 旧版代码在进行撤销恢复时未将光标位置复位，在撤销项执行撤销恢复时将光标位置同样进行恢复。

Log: 修复撤销时改变光标的位置后继续撤销,光标未移回要撤销的位置
Bug: https://pms.uniontech.com/bug-view-115027.html
Influence: 撤销恢复