### PR TITLE
fix: 修复对需折叠的代码块判断不准确和对代码中括号的匹配不准确问题

### DIFF
--- a/src/editor/dtextedit.h
+++ b/src/editor/dtextedit.h
@@ -628,6 +628,8 @@ private:
     // 计算颜色标记替换信息列表
     void calcMarkReplaceList(QList<TextEdit::MarkReplaceInfo> &replaceList, const QString &oldText,
                              const QString &replaceText, const QString &withText, int offset = 0) const;
+    // 查找行号line起始的折叠区域
+    bool findFoldBlock(int line, QTextBlock &beginBlock, QTextBlock &endBlock, QTextBlock &curBlock);
 
 public:
     int getFirstVisibleBlockId() const;


### PR DESCRIPTION
Description: 旧版代码在计算代码括号匹配区域时未能正确过滤代码文本中的字符串内容，添加过滤字符串内容的代码，将重复的代码重构为单个接口。

Log: 修复对需折叠的代码块判断不准确和对代码中括号的匹配不准确问题
Bug: https://pms.uniontech.com/bug-view-138113.html, https://pms.uniontech.com/bug-view-138997.html
Influence: 代码高亮 代码折叠