### PR TITLE
fix: 修复在文本编辑器设置中使用小键盘中的按键组合编辑快捷键，新设置的快捷键无效

### DIFF
--- a/src/common/utils.cpp
+++ b/src/common/utils.cpp
@@ -411,6 +411,11 @@ QString Utils::getKeyshortcut(QKeyEvent *keyEvent)
         if (modifiers.testFlag(Qt::ShiftModifier)) {
             keys.append("Shift");
         }
+
+        // 添加小键盘处理，若为小键盘按键按下，组合键需添加 Num ，例如 Ctrl+Num+6 / Ctrl+Num+Up
+        if (modifiers.testFlag(Qt::KeypadModifier)) {
+            keys.append("Num");
+        }
     }
 
     if (keyEvent->key() != 0 && keyEvent->key() != Qt::Key_unknown) {


### PR DESCRIPTION
Description: 使用小键盘时，组合键包含"Num"标识，旧版代码未处理导致不能识别小键盘快捷键，添加相应处理。

Log: 修复在文本编辑器设置中使用小键盘中的按键组合编辑快捷键，新设置的快捷键无效
Bug: https://pms.uniontech.com/bug-view-109339.html
Influence: 快捷键