### PR TITLE
fix: 修复文本编辑器使用快捷键粘贴，第一次粘贴不生效

### DIFF
--- a/src/editor/dtextedit.cpp
+++ b/src/editor/dtextedit.cpp
@@ -6779,6 +6779,13 @@ void TextEdit::keyPressEvent(QKeyEvent *e)
             return;
         }
 
+        // 左右移动光标后退出全选状态
+        if (Qt::Key_Left == e->key()
+                || Qt::Key_Right == e->key()) {
+            m_isSelectAll = false;
+            // 继续后续判断
+        }
+
         //插入键盘可现实字符
         if (modifiers == Qt::NoModifier && (e->key() <= Qt::Key_ydiaeresis && e->key() >= Qt::Key_Space) && !e->text().isEmpty()) {
 


### PR DESCRIPTION
Description: 使用全选后，文本编辑器设置的全选标识，在使用左、右按键后，全选标识未被移除，导致黏贴时将全文本替换，显示为黏贴未生效。添加选中状态变更时移除全选标识的代码。

Log: 修复文本编辑器使用快捷键粘贴，第一次粘贴不生效
Bug: https://pms.uniontech.com/bug-view-150301.html
Influence: 黏贴文本