### PR TITLE
fix: 修复书签&代码折叠标志的位置比行号稍高一些

### DIFF
--- a/src/editor/dtextedit.cpp
+++ b/src/editor/dtextedit.cpp
@@ -2347,7 +2347,8 @@ void TextEdit::codeFLodAreaPaintEvent(QPaintEvent *event)
                 int w = this->m_fontSize <= 15 ? 15 : m_fontSize;
                 updateLeftWidgetWidth(w);
                 int h = cursorRect(cur).height();
-                int offset = h <= 20 ? h / 8 : h / 4;
+                // 绘制行纵向居中
+                int offset = qMax(0, (h - w) / 2);
                 //the language currently set by the system is Tibetan.
                 if ("bo_CN" == Utils::getSystemLan())
                     offset = h <= 20 ? 0 : h / 10;
@@ -3971,7 +3972,8 @@ void TextEdit::bookMarkAreaPaintEvent(QPaintEvent *event)
             int w = this->m_fontSize <= 15 ? 15 : m_fontSize;
             updateLeftWidgetWidth(w);
             int h = cursorRect(cur).height();
-            int offset = h <= 20 ? h / 8 : h / 4;
+            // 绘制行纵向居中
+            int offset = qMax(0, (h - w) / 2);
             //the language currently set by the system is Tibetan.
             if ("bo_CN" == Utils::getSystemLan())
                 offset = h <= 20 ? 0 : h / 10;


### PR DESCRIPTION
Description: 旧版代码按比例计算书签和代码折叠标志的位置，行号显示在单行中部，当文本行高变更时，两者计算方式不同，导致出现显示位置的差异。修改书签和代码折叠标志的位置计算方式，改为显示在行中部。

Log: 修复书签&代码折叠标志的位置比行号稍高一些
Bug: https://pms.uniontech.com/bug-view-107837.html
Influence: 书签 代码折叠标志