### PR TITLE
fix: 修复文本编辑器打开单行50MB的文档过程中，快速点击标签页关闭按钮会使文本编辑器崩溃

### DIFF
--- a/src/widgets/window.h
+++ b/src/widgets/window.h
@@ -270,6 +270,8 @@ protected:
     void keyReleaseEvent(QKeyEvent *keyEvent) override;
     void dragEnterEvent(QDragEnterEvent *e) override;
     void dropEvent(QDropEvent *event) override;
+    // 处理延迟处理等定时器事件
+    void timerEvent(QTimerEvent *e) override;
 
 private:
     DBusDaemon::dbus *m_rootSaveDBus {nullptr};
@@ -324,6 +326,9 @@ private:
     EditWrapper *m_printWrapper = nullptr;          // 当前处理的编辑对象(关闭标签页时需要退出打印)
     QVector<PrintInfo> m_printDocList;              // 打印文档列表，用于超大文档打印
     int m_multiDocPageCount = 0;                    // 用于超大文档打印时单独记录多文档的打印页数
+
+    QBasicTimer m_delayCloseTabTimer;               // 延迟关闭标签页定时器，防止异常情况多次触发关闭同一标签页的情况
+    int m_requestCloseTabIndex = 0;                 // 请求关闭的标签页索引
 
     //语音助手服务是否被注册
     bool m_bIsRegistIflytekAiassistant {false};


### PR DESCRIPTION
Description: 原因：单行文本加载时布局等计算阻塞主线程，且标签页关闭信号通过Qt::QueuedConnection方式抛出，按键点击事件被阻塞。在阻塞恢复后，事件队列中同时存在多个对同一标签页的关闭事件，导致多个标签页被关闭，窗口同时关闭。部分情况下，删除所有标签页后，访问到不存在的标签内容，窗口崩溃。
修改方式：修改为延迟处理标签页关闭信号，防止单个时刻频繁的调用关闭操作，同时添加边界判断。

Log: 修复文本编辑器打开单行50MB的文档过程中，快速点击标签页关闭按钮会使文本编辑器崩溃
Bug: https://pms.uniontech.com/bug-view-154591.html
Influence: 标签页关闭