### PR TITLE
fix: 修复在打开大文件的时候，从主菜单打开其他文档时不会及时打开并加载

### DIFF
--- a/src/common/fileloadthread.cpp
+++ b/src/common/fileloadthread.cpp
@@ -39,26 +39,49 @@ void FileLoadThread::run()
     QFile file(m_strFilePath);
 
     if (file.open(QIODevice::ReadOnly)) {
-        // reads all remaining data from the file.
-        QByteArray indata = file.readAll();
-        file.close();
-        QByteArray outData;
+        QByteArray encode;
+        QByteArray indata;
 
-        //编码识别，如果文件数据大于1M，则只裁剪出1M文件数据去做编码探测
-        QByteArray dateUsedForCodeIdentify;
-        if (indata.length() > DATA_SIZE_1024 * DATA_SIZE_1024) {
-            dateUsedForCodeIdentify = indata.mid(0, DATA_SIZE_1024 * DATA_SIZE_1024);
-        } else {
-            dateUsedForCodeIdentify = indata;
+        // 判断文件大小是否超过40MB, 超过40MB的文件过大，需要调整读取策略，优先加载头部文件
+        static const int s_maxDirectReadLen = 40 * DATA_SIZE_1024 * DATA_SIZE_1024;
+        if (file.size() > s_maxDirectReadLen) {
+            // 先读取1MB数据
+            indata = file.read(DATA_SIZE_1024 * DATA_SIZE_1024);
+            encode = DetectCode::GetFileEncodingFormat(m_strFilePath, indata);
+
+            // 发送文件头信息，用于预先加载数据
+            QString textEncode = QString::fromLocal8Bit(encode);
+            if (textEncode.contains("ASCII", Qt::CaseInsensitive) || textEncode.contains("UTF-8", Qt::CaseInsensitive)) {
+                emit sigPreProcess(encode, indata);
+            } else {
+                QByteArray outHeadData;
+                DetectCode::ChangeFileEncodingFormat(indata, outHeadData, textEncode, QString("UTF-8"));
+                emit sigPreProcess(encode, outHeadData);
+            }
         }
-        QByteArray encode = DetectCode::GetFileEncodingFormat(m_strFilePath, dateUsedForCodeIdentify);
-        QString textEncode = QString::fromLocal8Bit(encode);
 
-         if (textEncode.contains("ASCII", Qt::CaseInsensitive) || textEncode.contains("UTF-8", Qt::CaseInsensitive)) {
-           emit sigLoadFinished(encode, indata);
-         } else {
-           DetectCode::ChangeFileEncodingFormat(indata, outData, textEncode, QString("UTF-8"));
-           emit sigLoadFinished(encode, outData);
-         }
+        // reads all remaining data from the file.
+        indata += file.read(file.size());
+        file.close();
+
+        if (encode.isEmpty()) {
+            //编码识别，如果文件数据大于1M，则只裁剪出1M文件数据去做编码探测
+            QByteArray dateUsedForCodeIdentify;
+            if (indata.length() > DATA_SIZE_1024 * DATA_SIZE_1024) {
+                dateUsedForCodeIdentify = indata.mid(0, DATA_SIZE_1024 * DATA_SIZE_1024);
+            } else {
+                dateUsedForCodeIdentify = indata;
+            }
+            encode = DetectCode::GetFileEncodingFormat(m_strFilePath, dateUsedForCodeIdentify);
+        }
+
+        QString textEncode = QString::fromLocal8Bit(encode);
+        if (textEncode.contains("ASCII", Qt::CaseInsensitive) || textEncode.contains("UTF-8", Qt::CaseInsensitive)) {
+            emit sigLoadFinished(encode, indata);
+        } else {
+            QByteArray outData;
+            DetectCode::ChangeFileEncodingFormat(indata, outData, textEncode, QString("UTF-8"));
+            emit sigLoadFinished(encode, outData);
+        }
     }
 }

--- a/src/common/fileloadthread.h
+++ b/src/common/fileloadthread.h
@@ -32,6 +32,8 @@ public:
     void run();
 
 signals:
+    // 预处理信号，优先处理文件头，防止出现加载时间过长的情况
+    void sigPreProcess(const QByteArray &encode, const QByteArray &content);
     void sigLoadFinished(const QByteArray &encode, const QByteArray &content);
 
 private:

--- a/src/editor/editwrapper.h
+++ b/src/editor/editwrapper.h
@@ -129,6 +129,9 @@ public:
     QDateTime getLastModifiedTime() const;
     void setLastModifiedTime(const QString &time);
 
+    void updateModifyStatus(bool isModified);
+    void updateSaveAsFileName(QString strOldFilePath, QString strNewFilePath);
+
     // 取得当前编辑器使用的高亮处理(用于打印高亮)
     inline CSyntaxHighlighter *getSyntaxHighlighter() const
     { return m_pSyntaxHighlighter; }
@@ -145,17 +148,19 @@ private:
     void loadContent(const QByteArray &);
     void handleHightlightChanged(const QString &name);
     int GetCorrectUnicode1(const QByteArray &ba);
+    // 文件加载时重新初始化部分设置
+    void reinitOnFileLoad(const QByteArray &encode);
 
 public slots:
+    // 处理文档预加载数据
+    void handleFilePreProcess(const QByteArray &encode, const QByteArray &content);
     void handleFileLoadFinished(const QByteArray &encode, const QByteArray &content);
     void OnThemeChangeSlot(QString theme);
     void UpdateBottomBarWordCnt(int cnt);
     void OnUpdateHighlighter();
     //set the value of m_bIsTemFile
     void setTemFile(bool value);
-public:
-    void updateModifyStatus(bool isModified);
-    void updateSaveAsFileName(QString strOldFilePath, QString strNewFilePath);
+
 private:
     //第一次打开文件编码
     QString m_sFirstEncode = QString("UTF-8");
@@ -189,6 +194,7 @@ private:
     bool m_bHighlighterAll = false;
 
     bool m_bAsyncReadFileFinished = false;
+    bool m_bHasPreProcess = false;               // 预处理标识
 };
 
 #endif


### PR DESCRIPTION
Description: 旧版代码处理在页面加载前会将所有的文档数据读取，在读取性能较差的设备上，会持续占用IO通道，导致读取时间过长，界面未加载内容。修改为大文件预先加载文件头内容，防止长时间显示白屏。

Log: 修复在打开大文件的时候，从主菜单打开其他文档时不会及时打开并加载
Bug: https://pms.uniontech.com/bug-view-154903.html
Influence: 文件加载