### PR TITLE
fix: 修复添加书签后关闭文档，再次打开文档后，标记的书签消失

### DIFF
--- a/src/editor/editwrapper.cpp
+++ b/src/editor/editwrapper.cpp
@@ -806,17 +806,8 @@ void EditWrapper::handleFileLoadFinished(const QByteArray &encode, const QByteAr
                     QJsonValue localPathValue = object.value("localPath");  // 获取指定 key 对应的 value
                     QJsonValue temFilePathValue = object.value("temFilePath");  // 获取指定 key 对应的 value
 
-                    if (localPathValue.toString() == m_pTextEdit->getFilePath()) {
-                        QJsonValue value = object.value("cursorPosition");  // 获取指定 key 对应的 value
-
-                        if (value.isString()) {
-                            QTextCursor cursor = m_pTextEdit->textCursor();
-                            cursor.setPosition(value.toString().toInt());
-                            m_pTextEdit->setTextCursor(cursor);
-                            OnUpdateHighlighter();
-                            break;
-                        }
-                    } else if (temFilePathValue.toString() == m_pTextEdit->getFilePath()) {
+                    if (localPathValue.toString() == m_pTextEdit->getFilePath()
+                            || temFilePathValue.toString() == m_pTextEdit->getFilePath()) {
                         QJsonValue value = object.value("cursorPosition");  // 获取指定 key 对应的 value
 
                         if (value.isString()) {
@@ -831,6 +822,7 @@ void EditWrapper::handleFileLoadFinished(const QByteArray &encode, const QByteAr
             }
         }
     }
+
     //备份显示修改状态
     if (m_bIsTemFile) {
         updateModifyStatus(true);

--- a/src/resources/settings.json
+++ b/src/resources/settings.json
@@ -2059,6 +2059,12 @@
                             "hide": true,
                             "reset": true,
                             "default": "/usr/share/deepin-editor/themes/deepin.theme"
+                        },
+                        {
+                            "key": "bookmark",
+                            "hide": true,
+                            "reset": false,
+                            "default": ""
                         }
                     ]
                 }

--- a/src/startmanager.h
+++ b/src/startmanager.h
@@ -82,6 +82,11 @@ public:
      */
     QList<int> analyzeBookmakeInfo(QString bookmarkInfo);
 
+    // 主动更新记录书签信息
+    void recordBookmark(const QString &localPath, const QList<int> &bookmark);
+    // 查找文件对应的书签记录
+    QList<int> findBookmark(const QString &localPath);
+
 public slots:
     Q_SCRIPTABLE void openFilesInTab(QStringList files);
     Q_SCRIPTABLE void openFilesInWindow(QStringList files);
@@ -111,6 +116,12 @@ protected:
 
 private:
     void initBlockShutdown();
+    // 初始化书签信息
+    void initBookmark();
+    // 保存书签信息
+    void saveBookmark();
+
+private:
     static StartManager *m_instance;
     QList<Window *> m_windows;
 
@@ -121,12 +132,13 @@ private:
     QDBusPendingReply<QDBusUnixFileDescriptor> m_inhibitReply;
     QScopedPointer<Dock> m_pDock;
     QScopedPointer<Entry> m_pEntry;
-    QStringList m_qlistTemFile;///<备份信息列表
+    QStringList m_qlistTemFile;                 ///< 备份信息列表
+    QHash<QString, QList<int>> m_bookmarkTable; ///< 书签标记信息表
     QTimer *m_pTimer;
-    QBasicTimer m_DelayTimer; ///< 延迟备份定时器
-    QString m_blankFileDir;///<新建文件目录
-    QString m_backupDir;///<用户备份文件目录
-    QString m_autoBackupDir;///<自动备份文件目录
+    QBasicTimer m_DelayTimer;   ///< 延迟备份定时器
+    QString m_blankFileDir;     ///< 新建文件目录
+    QString m_backupDir;        ///< 用户备份文件目录
+    QString m_autoBackupDir;    ///< 自动备份文件目录
     Window *pFocusWindow;
 
     bool    m_bIsTagDragging = false;   ///< 当前Tab页处于拖拽状态时，部分处理被延后

--- a/src/widgets/window.cpp
+++ b/src/widgets/window.cpp
@@ -612,6 +612,10 @@ void Window::addTab(const QString &filepath, bool activeTab)
                 }
 
                 wrapper->openFile(filepath, filepath);
+
+                // 查找文件是否存在书签
+                auto bookmarkInfo = StartManager::instance()->findBookmark(filepath);
+                wrapper->textEditor()->setBookMarkList(bookmarkInfo);
             }
             // Activate window.
             activateWindow();
@@ -713,6 +717,13 @@ bool Window::closeTab(const QString &filePath)
 
     if (wrapper->getFileLoading()) {
         isModified = false;
+    }
+
+    // 关闭标签页前，记录全局的书签信息
+    QList<int> bookmarkInfo = wrapper->textEditor()->getBookmarkInfo();
+    if (!bookmarkInfo.isEmpty()) {
+        QString localPath = wrapper->textEditor()->getTruePath();
+        StartManager::instance()->recordBookmark(localPath, bookmarkInfo);
     }
 
     if (isDraftFile) {
@@ -2333,6 +2344,10 @@ void Window::addTemFileTab(QString qstrPath, QString qstrName, QString qstrTrueP
     EditWrapper *wrapper = createEditor();
     m_tabbar->addTab(qstrPath, qstrName, qstrTruePath);
     wrapper->openFile(qstrPath, qstrTruePath, bIsTemFile);
+
+    // 查找文件是否存在书签，临时文件同样可标记书签
+    auto bookmarkInfo = StartManager::instance()->findBookmark(qstrTruePath);
+    wrapper->textEditor()->setBookMarkList(bookmarkInfo);
 
     //set m_tModifiedDateTime in wrapper again.
     if (bIsTemFile && !lastModifiedTime.isEmpty()) {


### PR DESCRIPTION
Description: 旧版代码只记录关闭窗口后缓存的书签信息，关闭标签页后，文件的书签不会被记录。补充书签功能，书签信息根据文件路径进行记录，文件标签页关闭后仍保留，直到文件被删除或移动。

Log: 修复添加书签后关闭文档，再次打开文档后，标记的书签消失
Bug: https://pms.uniontech.com/bug-view-155115.html
Influence: 书签