### PR TITLE
fix: 修复更换“跳到行”控件后，在“跳到行”框中输入和显示数字有异常

### DIFF
--- a/src/controls/jumplinebar.cpp
+++ b/src/controls/jumplinebar.cpp
@@ -54,8 +54,9 @@ void JumpLineBar::activeInput(QString file, int row, int column, int lineCount, 
     m_columnBeforeJump = column;
     m_jumpFileScrollOffset = scrollOffset;
     m_lineCount = lineCount;
-    m_pSpinBoxInput->setRange(1, lineCount);
-    m_pSpinBoxInput->clear();
+    // 调整为 0~lineCount ，0已被处理不允许首位输入，不影响仅单行的情况
+    // 设置 range 后会自动调整输入范围，不使用 clear() 防止在读取文件时已输入的行号被清空
+    m_pSpinBoxInput->setRange(0, lineCount);
     setFixedSize(nJumpLineBarWidth + QString::number(lineCount).size() * fontMetrics().width('9'), nJumpLineBarHeight);
 
     // Clear line number.


### PR DESCRIPTION
Description: 问题1: 更新文本内容时将输入框内容清空了；
修改1: 移除清空代码，保留输入换行超过允许范围时清空内容。
问题2: 输入范围默认从1开始，当仅单行文本时，最小值和最大值相同，校验代码出现问题；
修改2: 修改输入范围从0开始，0已被处理不允许首位输入，不影响仅单行的情况。

Log: 修复更换“跳到行”控件后，在“跳到行”框中输入和显示数字有异常
Bug: https://pms.uniontech.com/bug-view-112003.html
Influencei: “跳到行”功能