### PR TITLE
fix: 修复多窗口下关闭应用，“保存”草稿文件时引起当前窗口的直接关闭 ； “取消”时焦点未顺移至下个标签页，但会继续弹出保存提示框

### DIFF
--- a/src/editor/editwrapper.cpp
+++ b/src/editor/editwrapper.cpp
@@ -321,7 +321,8 @@ bool EditWrapper::reloadFileEncode(QByteArray encode)
         if (res == 1) {
             //草稿文件
             if (Utils::isDraftFile(m_pTextEdit->getFilePath())) {
-                if (saveDraftFile()) {
+                QString newFilePath;
+                if (saveDraftFile(newFilePath)) {
                     return readFile(encode);
                 } else {
                     return false;
@@ -376,7 +377,8 @@ void EditWrapper::reloadModifyFile()
         if (res == 2) {
             //临时文件保存另存为 需要删除源草稿文件文件
             if (Utils::isDraftFile(m_pTextEdit->getFilePath())) {
-                if (!saveDraftFile()) {
+                QString newFilePath;
+                if (!saveDraftFile(newFilePath)) {
                     return;
                 }
             } else {
@@ -606,7 +608,13 @@ bool EditWrapper::isTemFile()
     return m_bIsTemFile;
 }
 
-bool EditWrapper::saveDraftFile()
+/**
+ * @brief 保存草稿文件，若保存成功，新文件路径通过 \a newFilePath 返回，
+ *      且对应标签页已更新为新的文件信息。
+ * @param newFilePath 保存的新文件路径
+ * @return 是否保存成功
+ */
+bool EditWrapper::saveDraftFile(QString &newFilePath)
 {
     DFileDialog dialog(this, tr("Save"));
     dialog.setAcceptMode(QFileDialog::AcceptSave);
@@ -627,7 +635,7 @@ bool EditWrapper::saveDraftFile()
     hideWarningNotices();
 
     if (mode == 1) {
-        const QString newFilePath = dialog.selectedFiles().value(0);
+        newFilePath = dialog.selectedFiles().value(0);
         if (newFilePath.isEmpty())
             return false;
 
@@ -906,8 +914,8 @@ void EditWrapper::OnUpdateHighlighter()
             // 判断是否此文本块为折叠区域起始的文本块，判断'{''}'处理
             QTextBlock prevBlock = endBlock;
             while (prevBlock.isValid()
-                   && !foundBrace
-                   && maxFindBlockNumber < prevBlock.blockNumber()) {
+                    && !foundBrace
+                    && maxFindBlockNumber < prevBlock.blockNumber()) {
                 // 逆序查询文本块数据，查找起始文本块
                 QString text = prevBlock.text();
                 for (int i = text.size() - 1; i >= 0; i--) {

--- a/src/editor/editwrapper.h
+++ b/src/editor/editwrapper.h
@@ -64,7 +64,7 @@ public:
     //重新加载文件编码
     bool saveAsFile(const QString &newFilePath, QByteArray encodeName);
     //保存草稿文件
-    bool saveDraftFile();
+    bool saveDraftFile(QString &newFilePath);
     //另存为第一次打开文件编码文件
     bool saveAsFile();
     //重新加载文件编码 1.文件修改 2.文件未修改处理逻辑一样 切换编码重新加载和另存为 梁卫东

--- a/tests/src/editor/ut_editwrapper.cpp
+++ b/tests/src/editor/ut_editwrapper.cpp
@@ -497,7 +497,9 @@ TEST(UT_Editwrapper_saveDraftFile, UT_Editwrapper_saveDraftFile_001)
     fptr fileDialogExec = (fptr)(&QDialog::exec);
     Stub stub;
     stub.set(fileDialogExec, saveDraftFile001_exec_stub);
-    pWindow->currentWrapper()->saveDraftFile();
+    QString newFilePath;
+    pWindow->currentWrapper()->saveDraftFile(newFilePath);
+    EXPECT_EQ(pWindow->m_tabbar->currentPath(), newFilePath);
 
     pWindow->deleteLater();
 }
@@ -516,7 +518,9 @@ TEST(UT_Editwrapper_saveDraftFile, UT_Editwrapper_saveDraftFile_002)
     fptr fileDialogExec = (fptr)(&QDialog::exec);
     Stub stub;
     stub.set(fileDialogExec, saveDraftFile002_exec_stub);
-    pWindow->currentWrapper()->saveDraftFile();
+    QString newFilePath;
+    pWindow->currentWrapper()->saveDraftFile(newFilePath);
+    EXPECT_TRUE((newFilePath.isEmpty()));
 
     pWindow->deleteLater();
 }
@@ -578,6 +582,8 @@ QByteArray FileLoadThreadRun(const QString &strFilePath, QByteArray *encode)
            return outData;
          }
     }
+
+    return QByteArray();
 }
 
 void handleFileLoadFinished_001_setPrintEnabled_stub()
@@ -1035,7 +1041,8 @@ TEST(UT_Editwrapper_reloadModifyFile, UT_Editwrapper_reloadModifyFile_003)
     Stub stub;
     stub.set(qDialogExec, reloadModifyFile_003_exec_stub);
     pWindow->currentWrapper()->reloadModifyFile();
-    ASSERT_FALSE(pWindow->currentWrapper()->saveDraftFile());
+    QString newFilePath;
+    ASSERT_FALSE(pWindow->currentWrapper()->saveDraftFile(newFilePath));
 
     pWindow->deleteLater();
 }


### PR DESCRIPTION
Description: 问题1：保存草稿文件时未正确获取需要删除的标签页文件路径；
修改1：获取保存草稿文件后的文件路径，正确删除标签页。
问题2：遍历删除标签页时未考虑存在部分标签页取消的情况；
修改2：新的处理流程取消后会停止在当前标签页。

Log: 修复多窗口下关闭应用，“保存”草稿文件时引起当前窗口的直接关闭 ； “取消”时焦点未顺移至下个标签页，但会继续弹出保存提示框
Bug: https://pms.uniontech.com/bug-view-129877.html
Influence: 标签页关闭 保存草稿文件