### PR TITLE
fix: 修复编辑大小在30-40W字（实际大小在1-2M间）的中文文本文档，保存后再打开，大概率显示乱码

### DIFF
--- a/src/encodes/detectcode.cpp
+++ b/src/encodes/detectcode.cpp
@@ -9,8 +9,7 @@
 #include <QDateTime>
 #include <stdio.h>
 
-
-QMap<QString,QByteArray> DetectCode::sm_LangsMap;
+QMap<QString, QByteArray> DetectCode::sm_LangsMap;
 
 DetectCode::DetectCode()
 {
@@ -29,9 +28,55 @@ QByteArray DetectCode::GetFileEncodingFormat(QString filepath, QByteArray conten
     QString str(content);
     bool bFlag = str.contains(QRegExp("[\\x4e00-\\x9fa5]+")); //匹配的是中文
     if (bFlag) {
+        // 判断校验内容是否为大文本数据(>=1MB)，大文本数据存在中间字符被截断的可能
+        static const int s_dLargeContentSize = 1024 * 1024;
+        bool isLargeContent = bool(content.size() >= s_dLargeContentSize);
+
         QByteArray newContent = content;
+        if (isLargeContent) {
+            // 大文本数据存在从文档中间截断的可能，导致unicode中文字符被截断，解析为乱码，处理部分情况
+            ushort lastCheck = *reinterpret_cast<ushort *>(newContent.data() + newContent.size() - 2);
+            if (lastCheck < 0x4E00 || lastCheck > 0x9fa5) {
+                // 移除尾部字符
+                newContent.chop(1);
+            }
+        }
+
         newContent += "为增加探测率保留的中文";    //手动添加中文字符，避免字符长度太短而导致判断编码错误
         DetectCode::ChartDet_DetectingTextCoding(newContent, charDetectedResult, chardetconfidence);
+
+        // 最低的检测准确度判断，低于90%需要调整策略
+        static const float s_dMinConfidence = 0.9f;
+        if (chardetconfidence < s_dMinConfidence
+                && isLargeContent) {
+            int findSplitPos = newContent.size() / 2;
+            // 查找中文字符位置，期望以完整中文字符位置进行分割
+            while (findSplitPos < newContent.size() - 1) {
+                ushort zhChar = *reinterpret_cast<ushort *>(newContent.data() + findSplitPos);
+                if (0x4E00 <= zhChar && zhChar <= 0x9fa5) {
+                    // 回退到完整分割索引位置
+                    findSplitPos--;
+                    break;
+                }
+                ++findSplitPos;
+            }
+
+            if (findSplitPos != newContent.size() - 1) {
+                QString detectRet1, detectRet2;
+                float confidence1 = 0.0f, confidence2 = 0.0f;
+                DetectCode::ChartDet_DetectingTextCoding(newContent.left(findSplitPos), detectRet1, confidence1);
+                DetectCode::ChartDet_DetectingTextCoding(newContent.right(newContent.size() - findSplitPos), detectRet2, confidence2);
+
+                // 判断是否存在更高准确度的文件格式
+                if (confidence1 > confidence2
+                        && confidence1 > chardetconfidence) {
+                    charDetectedResult = detectRet1;
+                } else if (confidence2 > confidence1
+                           && confidence2 > chardetconfidence) {
+                    charDetectedResult = detectRet2;
+                }
+            }
+        }
     } else {
         DetectCode::ChartDet_DetectingTextCoding(content, charDetectedResult, chardetconfidence);
     }
@@ -39,14 +84,14 @@ QByteArray DetectCode::GetFileEncodingFormat(QString filepath, QByteArray conten
 
     /* uchardet识别编码 */
     if (ucharDetectdRet.contains("unknown") || ucharDetectdRet.contains("???") || ucharDetectdRet.isEmpty()) {
-       ucharDetectdRet = DetectCode::UchardetCode(filepath);
+        ucharDetectdRet = DetectCode::UchardetCode(filepath);
     }
 
     /* icu识别编码 */
     icuDetectTextEncoding(filepath, icuDetectRetList);
     detectRet = selectCoding(ucharDetectdRet, icuDetectRetList);
 
-    if(detectRet.contains("ASCII") || detectRet.isEmpty()) {
+    if (detectRet.contains("ASCII") || detectRet.isEmpty()) {
         detectRet = "UTF-8";
     }
 
@@ -55,12 +100,12 @@ QByteArray DetectCode::GetFileEncodingFormat(QString filepath, QByteArray conten
 
 QByteArray DetectCode::UchardetCode(QString filepath)
 {
-    FILE* fp;
+    FILE *fp;
     QByteArray charset;
 
     size_t buffer_size = 0x10000;
-    char* buff = new char[buffer_size];
-    memset(buff,0,buffer_size);
+    char *buff = new char[buffer_size];
+    memset(buff, 0, buffer_size);
 
     /* 通过样本字符分析文本编码 */
     uchardet_t handle = uchardet_new();
@@ -68,9 +113,8 @@ QByteArray DetectCode::UchardetCode(QString filepath)
     /* 打开被检测文本文件，并读取一定数量的样本字符 */
     fp = fopen(filepath.toLocal8Bit().data(), "rb");
 
-    if(fp){
-        while (!feof(fp))
-        {
+    if (fp) {
+        while (!feof(fp)) {
             size_t len = fread(buff, 1, buffer_size, fp);
             int retval = uchardet_handle_data(handle, buff, len);
             if (retval != 0) {
@@ -89,9 +133,9 @@ QByteArray DetectCode::UchardetCode(QString filepath)
     delete [] buff;
     buff = nullptr;
 
-    if(charset == "MAC-CENTRALEUROPE") charset = "MACCENTRALEUROPE";
-    if(charset == "MAC-CYRILLIC") charset = "MACCYRILLIC";
-    if(charset.contains("WINDOWS-")) charset = charset.replace("WINDOWS-","CP");
+    if (charset == "MAC-CENTRALEUROPE") charset = "MACCENTRALEUROPE";
+    if (charset == "MAC-CYRILLIC") charset = "MACCYRILLIC";
+    if (charset.contains("WINDOWS-")) charset = charset.replace("WINDOWS-", "CP");
     return charset;
 }
 
@@ -110,11 +154,11 @@ void DetectCode::icuDetectTextEncoding(const QString &filePath, QByteArrayList &
     char *buffer = new char[iBuffSize];
     memset(buffer, 0, iBuffSize);
 
-    int readed=0;
+    int readed = 0;
     while (!feof(file)) {
         int32_t len = fread(buffer, 1, iBuffSize, file);
-        readed+=len;
-        if(readed>1*1024*1024){
+        readed += len;
+        if (readed > 1 * 1024 * 1024) {
             break;
         }
         if (!detectTextEncoding(buffer, len, &detected, listDetectRet)) {
@@ -156,7 +200,7 @@ bool DetectCode::detectTextEncoding(const char *data, size_t len, char **detecte
     }
 
     if (matchCount >= 3) {
-        for(int i=0;i<3;i++){
+        for (int i = 0; i < 3; i++) {
             auto str = ucsdet_getName(csm[i], &status);
             if (status != U_ZERO_ERROR) {
                 return false;
@@ -217,70 +261,69 @@ QByteArray DetectCode::EncaDetectCode(QString filepath)
      */
 
     sm_LangsMap.clear();
-    const char* langArray[]={"zh","be","bg","cs","et","hr","hu","lt","lv","pl","ru","sk","sl","uk"};
-    #if 0 /* EncaAnalyserState */
+    const char *langArray[] = {"zh", "be", "bg", "cs", "et", "hr", "hu", "lt", "lv", "pl", "ru", "sk", "sl", "uk"};
+#if 0 /* EncaAnalyserState */
     size_t size;
-    const char** lang = enca_get_languages(&size);
+    const char **lang = enca_get_languages(&size);
     QStringList langs;
-    for (size_t i=0;i <size;i++) {
-       langs<<lang[i];
+    for (size_t i = 0; i < size; i++) {
+        langs << lang[i];
     }
-    #endif
+#endif
 
-   QByteArray charset;
+    QByteArray charset;
 
-   for (size_t i= 0; i < sizeof (langArray)/sizeof (const char *); i++) {
+    for (size_t i = 0; i < sizeof(langArray) / sizeof(const char *); i++) {
 
-       EncaAnalyser analyser = nullptr;
-       analyser = enca_analyser_alloc(langArray[i]);
-       enca_set_threshold(analyser, 1.38);
-       enca_set_multibyte(analyser, 1);
-       enca_set_ambiguity(analyser, 1);
-       enca_set_garbage_test(analyser, 1);
+        EncaAnalyser analyser = nullptr;
+        analyser = enca_analyser_alloc(langArray[i]);
+        enca_set_threshold(analyser, 1.38);
+        enca_set_multibyte(analyser, 1);
+        enca_set_ambiguity(analyser, 1);
+        enca_set_garbage_test(analyser, 1);
 
-       size_t buffer_size = 0x10000;
+        size_t buffer_size = 0x10000;
 
-       unsigned char* buff = new unsigned char[buffer_size];
-       memset(buff,0,buffer_size);
+        unsigned char *buff = new unsigned char[buffer_size];
+        memset(buff, 0, buffer_size);
 
-       /* 打开被检测文本文件，并读取一定数量的样本字符 */
-       FILE *fp; /* the processed file */
-       fp = fopen(filepath.toLocal8Bit().data(), "rb");
+        /* 打开被检测文本文件，并读取一定数量的样本字符 */
+        FILE *fp; /* the processed file */
+        fp = fopen(filepath.toLocal8Bit().data(), "rb");
 
-       if(fp){
-           while (!feof(fp))
-           {
+        if (fp) {
+            while (!feof(fp)) {
                 size_t len = fread(buff, 1, buffer_size, fp);
-                EncaEncoding encoding = enca_analyse(analyser,buff,len);
-                charset = enca_charset_name(encoding.charset,EncaNameStyle::ENCA_NAME_STYLE_MIME);
-                qDebug()<<QStringLiteral("ENCA文本的编码方式是:")<<charset;
+                EncaEncoding encoding = enca_analyse(analyser, buff, len);
+                charset = enca_charset_name(encoding.charset, EncaNameStyle::ENCA_NAME_STYLE_MIME);
+                qDebug() << QStringLiteral("ENCA文本的编码方式是:") << charset;
                 //识别文本编码识别
-                if(encoding.charset == -1) continue;
+                if (encoding.charset == -1) continue;
                 break;
-           }
+            }
 
-           enca_analyser_free(analyser);
-           analyser = nullptr;
+            enca_analyser_free(analyser);
+            analyser = nullptr;
 
-           delete [] buff;
-           buff = nullptr;
+            delete [] buff;
+            buff = nullptr;
 
-           fclose(fp);
-       }else {
-            qDebug()<<QStringLiteral("ENCA打开失败:")<<filepath;
-       }
+            fclose(fp);
+        } else {
+            qDebug() << QStringLiteral("ENCA打开失败:") << filepath;
+        }
 
-       if(charset == "US-ASCII") charset = "ASCII";
-       if(charset == "GB2312" || charset == "GBK") charset = "GB18030";
-       if(charset == "ISO-10646-UCS-2") charset = "UTF-16BE";
-       sm_LangsMap[langArray[i]] = charset;
+        if (charset == "US-ASCII") charset = "ASCII";
+        if (charset == "GB2312" || charset == "GBK") charset = "GB18030";
+        if (charset == "ISO-10646-UCS-2") charset = "UTF-16BE";
+        sm_LangsMap[langArray[i]] = charset;
 
-       if(!charset.isEmpty()){
-           break;
-       }
-   }
+        if (!charset.isEmpty()) {
+            break;
+        }
+    }
 
-   return charset;
+    return charset;
 }
 #endif
 
@@ -351,7 +394,7 @@ int DetectCode::ChartDet_DetectingTextCoding(const char *str, QString &encoding,
     return CHARDET_SUCCESS ;
 }
 
-bool DetectCode::ChangeFileEncodingFormat(QByteArray &inputStr, QByteArray &outStr,QString fromCode, QString toCode)
+bool DetectCode::ChangeFileEncodingFormat(QByteArray &inputStr, QByteArray &outStr, QString fromCode, QString toCode)
 {
     if (fromCode == toCode) {
         outStr = inputStr;
@@ -363,11 +406,11 @@ bool DetectCode::ChangeFileEncodingFormat(QByteArray &inputStr, QByteArray &outS
     // iconvctl(handle, ICONV_SET_DISCARD_ILSEQ, &val);
 
     if (handle != reinterpret_cast<iconv_t>(-1)) {
-        char* inbuf = inputStr.data();
-        size_t inbytesleft = static_cast<size_t>(inputStr.size())+1;
-        size_t outbytesleft = 4*inbytesleft;
-        char* outbuf = new char[outbytesleft];
-        char* tmp = outbuf;
+        char *inbuf = inputStr.data();
+        size_t inbytesleft = static_cast<size_t>(inputStr.size()) + 1;
+        size_t outbytesleft = 4 * inbytesleft;
+        char *outbuf = new char[outbytesleft];
+        char *tmp = outbuf;
 
         memset(outbuf, 0, outbytesleft);
         iconv(handle, &inbuf, &inbytesleft, &outbuf, &outbytesleft);


### PR DESCRIPTION
Description: 在处理大文件时，会截取前1MB的内容进行文本编码格式解析，当文本截取过程时将中文字符的Unicode码截断导致乱码时，会使得编码解析错误。 修改编码格式解析流程，添加判断存在截断字符的代码，对识别率低于90%的文本进行拆分后二次解析，规避字符截断导致的编码格式解析错误。

Log: 修复编辑大小在30-40W字（实际大小在1-2M间）的中文文本文档，保存后再打开，大概率显示乱码
Bug: https://pms.uniontech.com/bug-view-159471.html
Influence: 文本编码解析