### PR TITLE
fix: 修复文本中含括号时，对文件多次进行删除操作后，不能准确撤回

### DIFF
--- a/src/editor/deletetextundocommand.cpp
+++ b/src/editor/deletetextundocommand.cpp
@@ -11,6 +11,7 @@ DeleteTextUndoCommand::DeleteTextUndoCommand(QTextCursor textcursor, QPlainTextE
     : QUndoCommand(parent)
     , m_edit(edit)
     , m_textCursor(textcursor)
+    , m_beginPos(m_textCursor.position())
 {
     if(m_textCursor.hasSelection()){
         m_sInsertText = m_textCursor.selectedText();
@@ -30,6 +31,7 @@ DeleteTextUndoCommand::DeleteTextUndoCommand(QList<QTextEdit::ExtraSelection> &s
     : QUndoCommand(parent)
     , m_edit(edit)
     , m_ColumnEditSelections(selections)
+    , m_beginPos(m_textCursor.position())
 {
     int cnt = m_ColumnEditSelections.size();
     for (int i = 0; i < cnt; i++) {
@@ -53,6 +55,8 @@ DeleteTextUndoCommand::DeleteTextUndoCommand(QList<QTextEdit::ExtraSelection> &s
 void DeleteTextUndoCommand::undo()
 {
     if(m_ColumnEditSelections.isEmpty()){
+        // 插入前将光标恢复到删除前位置
+        m_textCursor.setPosition(m_beginPos);
         m_textCursor.insertText(m_sInsertText);
         m_textCursor.movePosition(QTextCursor::Left,QTextCursor::KeepAnchor,m_sInsertText.length());
 

--- a/src/editor/deletetextundocommand.h
+++ b/src/editor/deletetextundocommand.h
@@ -25,6 +25,7 @@ private:
     QString m_sInsertText;
     QList<QString> m_selectTextList;
     QList<QTextEdit::ExtraSelection> m_ColumnEditSelections;
+    int m_beginPos;     // 记录光标删除前位置
 };
 
 //重写ctrl + k 和Ctrl +shift +K 逻辑的删除和撤销功能 ut002764


### PR DESCRIPTION
Description: 文件逆序删除后撤销，光标位置变更但仍直接插入数据，导致恢复的数据位置变更，未准确撤回数据。修改为在删除前记录当前光标位置，执行恢复时在删除位置插入恢复数据，以准确恢复数据。

Log: 修复文本中含括号时，对文件多次进行删除操作后，不能准确撤回
Bug: https://pms.uniontech.com/bug-view-140501.html
Influence: 撤销重做