### PR TITLE
fix: 修复查找过程中，代码着色会消失，需滚动鼠标才能恢复

### DIFF
--- a/src/widgets/window.cpp
+++ b/src/widgets/window.cpp
@@ -2577,6 +2577,9 @@ void Window::handleFindKeyword(const QString &keyword, bool state)
     wrapper->textEditor()->renderAllSelections();
     wrapper->textEditor()->restoreMarkStatus();
     wrapper->textEditor()->updateLeftAreaWidget();
+
+    // 变更查询字符串位置后(可能滚屏)，刷新当前界面的代码高亮效果
+    wrapper->OnUpdateHighlighter();
 }
 
 void Window::slotFindbarClose()
@@ -2680,6 +2683,8 @@ void Window::handleUpdateSearchKeyword(QWidget *widget, const QString &file, con
     }
     EditWrapper *wrapper = currentWrapper();
     wrapper->textEditor()->updateLeftAreaWidget();
+    // 在设置查询字符串并跳转后，及时刷新代码高亮效果
+    wrapper->OnUpdateHighlighter();
 }
 
 void Window::loadTheme(const QString &path)


### PR DESCRIPTION
Description: 查找过程使用“下一个”按钮触发跳转，但未触发滚屏信号，没有立即刷新页面的代码高亮效果。在查询过程跳转后刷新页面的代码高亮效果。

Log: 修复查找过程中，代码着色会消失，需滚动鼠标才能恢复
Bug: https://pms.uniontech.com/bug-view-144323.html
Influence: 代码高亮