### PR TITLE
fix: 修复右键菜单复制文本编辑器中多行源到source.list时，更新源报错

### DIFF
--- a/tests/src/editor/ut_textedit.cpp
+++ b/tests/src/editor/ut_textedit.cpp
@@ -9401,3 +9401,61 @@ TEST(UT_Textedit_replaceWithMark, UT_Textedit_replaceWithOutterMark)
     edit->deleteLater();
     wra->deleteLater();
 }
+
+TEST(UT_Textedit_selectText, SelectText_SingleBlock_Pass)
+{
+    TextEdit* edit = new TextEdit;
+    EditWrapper* wra = new EditWrapper;
+    edit->m_wrapper = wra;
+
+    edit->setPlainText("123456789\n");
+    // 选中 "456"
+    QTextCursor cursor = edit->textCursor();
+    cursor.setPosition(3);
+    cursor.movePosition(QTextCursor::NextCharacter, QTextCursor::KeepAnchor, 3);
+    edit->setTextCursor(cursor);
+
+    EXPECT_EQ(cursor.selectedText(), edit->selectedText());
+    EXPECT_EQ(QString("456"), edit->selectedText());
+
+    edit->deleteLater();
+    wra->deleteLater();
+}
+
+TEST(UT_Textedit_selectText, SelectText_MultiBlock_Pass)
+{
+    TextEdit* edit = new TextEdit;
+    EditWrapper* wra = new EditWrapper;
+    edit->m_wrapper = wra;
+
+    edit->setPlainText("123456789\n"
+                       "abcdefghi\n"
+                       "123456789\n");
+    // 选中 "789\nabc"
+    QString str1 = QString("789\nabc");
+    QTextCursor cursor = edit->textCursor();
+    cursor.setPosition(6);
+    cursor.movePosition(QTextCursor::NextCharacter, QTextCursor::KeepAnchor, str1.length());
+    edit->setTextCursor(cursor);
+    EXPECT_EQ(cursor.selectedText().replace("\u2029", "\n"), edit->selectedText());
+    EXPECT_EQ(str1, edit->selectedText());
+
+    // 选中 "789\nabcdefghi\n123"
+    QString str2 = QString("789\nabcdefghi\n123");
+    cursor.setPosition(6);
+    cursor.movePosition(QTextCursor::NextCharacter, QTextCursor::KeepAnchor, str2.length());
+    edit->setTextCursor(cursor);
+    EXPECT_EQ(cursor.selectedText().replace("\u2029", "\n"), edit->selectedText());
+    EXPECT_EQ(str2, edit->selectedText());
+
+    // 选中 "789\nabcdefghi\n123456789\n"
+    QString str3 = QString("789\nabcdefghi\n123456789\n");
+    cursor.setPosition(6);
+    cursor.movePosition(QTextCursor::NextCharacter, QTextCursor::KeepAnchor, str3.length());
+    edit->setTextCursor(cursor);
+    EXPECT_EQ(cursor.selectedText().replace("\u2029", "\n"), edit->selectedText());
+    EXPECT_EQ(str3, edit->selectedText());
+
+    edit->deleteLater();
+    wra->deleteLater();
+}


### PR DESCRIPTION
Description: 旧版代码在拷贝多行文本时，使用QTextCursor::EndoOfLine移动光标，使得每行文本均插入换行符，文本被分割，使得更新源失败。修改光标移动策略，按原有行结构拷贝。

Log: 修复右键菜单复制文本编辑器中多行源到source.list时，更新源报错
Bug: https://pms.uniontech.com/bug-view-162605.html
Influence: 拷贝多行文本