### PR TITLE
fix: 修复通过鼠标中键进行粘贴的文本，无法撤销的问题

### DIFF
--- a/src/editor/dtextedit.h
+++ b/src/editor/dtextedit.h
@@ -613,6 +613,10 @@ private:
     // 查找行号line起始的折叠区域
     bool findFoldBlock(int line, QTextBlock &beginBlock, QTextBlock &endBlock, QTextBlock &curBlock);
 
+private slots:
+    // 文档内容变更时触发
+    void onTextContentChanged(int from, int charsRemoved, int charsAdded);
+
 public:
     int getFirstVisibleBlockId() const;
     void setLeftAreaUpdateState(UpdateOperationType statevalue);
@@ -859,5 +863,7 @@ private:
     bool m_Permission2 = false;
     //左边栏更新标记
     UpdateOperationType m_LeftAreaUpdateState;
+
+    bool m_MidButtonPatse = false;      // 鼠标中键黏贴处理
 };
 #endif

--- a/src/editor/inserttextundocommand.h
+++ b/src/editor/inserttextundocommand.h
@@ -29,4 +29,23 @@ private:
     QString m_selectText = QString();
 };
 
+/**
+ * @brief 鼠标中键插入字符时使用的文本插入撤销项, 需要注意中键插入不会覆盖被选中的文本。
+ */
+class MidButtonInsertTextUndoCommand : public QUndoCommand
+{
+public:
+    explicit MidButtonInsertTextUndoCommand(QTextCursor textcursor, QString text, QPlainTextEdit *edit, QUndoCommand *parent = nullptr);
+
+    virtual void undo();
+    virtual void redo();
+
+private:
+    QPlainTextEdit  *m_pEdit = nullptr;     // 关联的文本编辑控件
+    QTextCursor     m_textCursor;           // 插入前的光标
+    QString         m_sInsertText;          // 插入文本
+    int             m_beginPostion = 0;     // 维护插入位置的标记
+    int             m_endPostion = 0;
+};
+
 #endif // INSERTTEXTUNDOCOMMAND_H

--- a/tests/src/editor/ut_inserttextundocommand.cpp
+++ b/tests/src/editor/ut_inserttextundocommand.cpp
@@ -149,3 +149,43 @@ TEST_F(test_InsertTextUndoCommand, undo_withTextCursor_restoreCursor)
     delete command2;
     delete edit;
 }
+
+TEST(test_MidButtonInsertTextUndoCommand, redo_withTextCursor_restoreCursor)
+{
+    // 重做恢复光标位置
+    QPlainTextEdit *edit = new QPlainTextEdit;
+    edit->setPlainText("123789");
+
+    QTextCursor cursor = edit->textCursor();
+    cursor.setPosition(3);
+    MidButtonInsertTextUndoCommand *command = new MidButtonInsertTextUndoCommand(cursor, QString("456"), edit);
+    EXPECT_EQ(command->m_beginPostion, 3);
+    EXPECT_EQ(command->m_endPostion, 6);
+    command->redo();
+
+    EXPECT_EQ(QString("123456789"), edit->toPlainText());
+    EXPECT_EQ(6, edit->textCursor().position());
+
+    delete command;
+    delete edit;
+}
+
+TEST(test_MidButtonInsertTextUndoCommand, undo_withTextCursor_restoreCursor)
+{
+    // 撤销后恢复光标位置
+    QPlainTextEdit *edit = new QPlainTextEdit;
+    edit->setPlainText("123456789");
+
+    QTextCursor cursor = edit->textCursor();
+    cursor.setPosition(6);
+    MidButtonInsertTextUndoCommand *command = new MidButtonInsertTextUndoCommand(cursor, QString("456"), edit);
+    command->m_endPostion = 6;
+    command->m_beginPostion = 3;
+    command->undo();
+
+    EXPECT_EQ(QString("123789"), edit->toPlainText());
+    EXPECT_EQ(3, edit->textCursor().position());
+
+    delete command;
+    delete edit;
+}

--- a/tests/src/editor/ut_textedit.cpp
+++ b/tests/src/editor/ut_textedit.cpp
@@ -9459,3 +9459,32 @@ TEST(UT_Textedit_selectText, SelectText_MultiBlock_Pass)
     edit->deleteLater();
     wra->deleteLater();
 }
+
+TEST(UT_Textedit_MidButtonInsertText, onTextContentChanged_MidButtonInsertText_Pass)
+{
+    TextEdit* edit = new TextEdit;
+    EditWrapper* wra = new EditWrapper;
+    edit->m_wrapper = wra;
+
+    QString sourceText("123456789");
+    edit->setPlainText(sourceText);
+    edit->m_MidButtonPatse = true;
+
+    QString insertText("test");
+    QTextCursor cursor = edit->textCursor();
+    cursor.setPosition(4);
+    // 插入触发 onTextContentChanged()
+    cursor.insertText(insertText);
+
+    EXPECT_TRUE(edit->m_pUndoStack->canUndo());
+    edit->m_pUndoStack->undo();
+    EXPECT_EQ(edit->toPlainText(), sourceText);
+
+    cursor = edit->textCursor();
+    EXPECT_EQ(cursor.position(), 4);
+
+    EXPECT_FALSE(edit->m_MidButtonPatse);
+
+    edit->deleteLater();
+    wra->deleteLater();
+}


### PR DESCRIPTION
Description: 文本编辑器维护独立的撤销栈结构，鼠标中键黏贴事件没有被压入撤销栈中。添加鼠标中键黏贴撤销项，接收鼠标中键释放事件，判断文本内容变更是否为鼠标中键黏贴，若为则添加文本插入撤销项。

Log: 修复通过鼠标中键进行粘贴的文本，无法撤销的问题
Bug: https://pms.uniontech.com/bug-view-162695.html
Influence: 鼠标中键黏贴