### PR TITLE
fix: 修复打开文件默认显示编码格式为WINDOWS-1252，文件显示异常，编码格式改为UTF-16BE显示正常

### DIFF
--- a/src/encodes/detectcode.cpp
+++ b/src/encodes/detectcode.cpp
@@ -72,8 +72,11 @@ QByteArray DetectCode::GetFileEncodingFormat(QString filepath, QByteArray conten
     }
     ucharDetectdRet = charDetectedResult.toLatin1();
 
-    /* uchardet识别编码 */
-    if (ucharDetectdRet.contains("unknown") || ucharDetectdRet.contains("???") || ucharDetectdRet.isEmpty()) {
+    // uchardet识别编码 若识别率过低, 考虑是否非单字节编码格式。
+    if (ucharDetectdRet.contains("unknown")
+            || ucharDetectdRet.contains("???")
+            || ucharDetectdRet.isEmpty()
+            || chardetconfidence < s_dMinConfidence) {
         ucharDetectdRet = DetectCode::UchardetCode(filepath);
     }
 
@@ -226,6 +229,11 @@ QByteArray DetectCode::selectCoding(QByteArray ucharDetectdRet, QByteArrayList i
             if (icuDetectRetList.contains("GB18030")) {
                 return QByteArray("GB18030");
             } else {
+                // 筛选部分带后缀的编码格式，例如 UTF-16 BE 和 UTF-16
+                if (icuDetectRetList[0].contains(ucharDetectdRet)) {
+                    return icuDetectRetList[0];
+                }
+
                 return ucharDetectdRet;
             }
         }


### PR DESCRIPTION
Description: 旧版代码在进行文本编码识别时，未对识别准确度进行判断，多字节编码（utf-16、utf-32）可能被识别为单字节编码（utf-8、windows-1252）。添加编码识别准确度判断，在单字节编码识别准确度低时，考虑是否为多字节编码格式。

Log: 修复打开文件默认显示编码格式为WINDOWS-1252，文件显示异常，编码格式改为UTF-16BE显示正常
Bug: https://pms.uniontech.com/bug-view-117927.html
Influence: 编码格式识别