### PR TITLE
fix: 修复系统语言选择波兰语时，“跳到行”功能显示不全

### DIFF
--- a/src/controls/jumplinebar.cpp
+++ b/src/controls/jumplinebar.cpp
@@ -1,25 +1,35 @@
 // SPDX-FileCopyrightText: 2011-2022 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
-#include "dthememanager.h"
+
 #include "jumplinebar.h"
 
+#include <DThemeManager>
+
 #include <QDebug>
+
+// 各项组件的默认大小
+const int nJumpLineBarWidth = 212;
+const int nJumpLineBarHeight = 60;
+const int s_nJumpLineBarSpinBoxWidth = 124;
+const int s_nJumpLineBarSPinBoxHeight = 36;
+// 水平方向与边界间距
+const int s_nJumpLineBarHorizenMargin = 10;
 
 JumpLineBar::JumpLineBar(DFloatingWidget *parent)
     : DFloatingWidget(parent)
 {
-    // Init.
-    setFixedSize(nJumpLineBarWidth, nJumpLineBarHeight);
-
     // Init layout and widgets.
     m_layout = new QHBoxLayout();
     m_layout->setContentsMargins(10, 6, 10, 6);
-    m_layout->setSpacing(0);
+    m_layout->setSpacing(5);
 
     m_label = new QLabel();
     m_label->setText(tr("Go to Line: "));
+    // 按文本长度计算显示宽度，不同语言下翻译文本长度不一，需完整显示
+    m_label->setFixedWidth(fontMetrics().width(m_label->text()));
     m_pSpinBoxInput = new DSpinBox;
+    m_pSpinBoxInput->setFixedSize(s_nJumpLineBarSpinBoxWidth, s_nJumpLineBarSPinBoxHeight);
     m_pSpinBoxInput->lineEdit()->clear();
     m_pSpinBoxInput->setButtonSymbols(QAbstractSpinBox::NoButtons);
     m_pSpinBoxInput->installEventFilter(this);
@@ -27,6 +37,10 @@ JumpLineBar::JumpLineBar(DFloatingWidget *parent)
     m_layout->addWidget(m_label);
     m_layout->addWidget(m_pSpinBoxInput);
     this->setLayout(m_layout);
+
+    // 初始化浮动条宽度，根据文本长度计算
+    setFixedHeight(nJumpLineBarHeight);
+    setFixedWidth(m_layout->sizeHint().width() + s_nJumpLineBarHorizenMargin);
 
     connect(this, &JumpLineBar::pressEsc, this, &JumpLineBar::jumpCancel, Qt::QueuedConnection);
     connect(m_pSpinBoxInput->lineEdit(), &QLineEdit::returnPressed, this, &JumpLineBar::jumpConfirm, Qt::QueuedConnection);
@@ -57,7 +71,13 @@ void JumpLineBar::activeInput(QString file, int row, int column, int lineCount, 
     // 调整为 0~lineCount ，0已被处理不允许首位输入，不影响仅单行的情况
     // 设置 range 后会自动调整输入范围，不使用 clear() 防止在读取文件时已输入的行号被清空
     m_pSpinBoxInput->setRange(0, lineCount);
-    setFixedSize(nJumpLineBarWidth + QString::number(lineCount).size() * fontMetrics().width('9'), nJumpLineBarHeight);
+    int lineWidth = QString::number(lineCount).size() * fontMetrics().width('9');
+    if (m_pSpinBoxInput->minimumWidth() < lineWidth) {
+        m_pSpinBoxInput->setFixedWidth(lineWidth);
+    } else {
+        m_pSpinBoxInput->setFixedWidth(s_nJumpLineBarSpinBoxWidth);
+    }
+    setFixedWidth(m_layout->sizeHint().width() + s_nJumpLineBarHorizenMargin);
 
     // Clear line number.
     if (m_pSpinBoxInput->lineEdit()->text().toInt() > lineCount)

--- a/src/controls/jumplinebar.h
+++ b/src/controls/jumplinebar.h
@@ -17,9 +17,6 @@
 
 DWIDGET_USE_NAMESPACE
 
-const int nJumpLineBarWidth = 212;
-const int nJumpLineBarHeight = 60;
-
 class JumpLineBar : public DFloatingWidget
 {
     Q_OBJECT


### PR DESCRIPTION
Description: 旧版代码设置固定的控件大小，未根据显示文本调整控件宽度。修改为根据翻译文本显示宽度调整“跳到行”控件的显示宽度。

Log: 修复系统语言选择波兰语时，“跳到行”功能显示不全
Bug: https://pms.uniontech.com/bug-view-163143.html
Influence: “跳到行”功能