### PR TITLE
fix: 修复文本编辑器新建标签页，修改编码格式并输入内容，保存时仍为utf-8格式

### DIFF
--- a/src/widgets/bottombar.cpp
+++ b/src/widgets/bottombar.cpp
@@ -65,9 +65,15 @@ BottomBar::BottomBar(QWidget *parent)
 
     //切换编码
     connect(m_pEncodeMenu, &DDropdownMenu::currentActionChanged, this,[this](QAction* pAct){
-        if(!m_pWrapper->getFileLoading() && m_pWrapper->reloadFileEncode(pAct->text().toLocal8Bit())) {
-            m_pEncodeMenu->setCurrentTextOnly(pAct->text());
+        // 保持界面统一，先更新底栏展示结果
+        QString previousText = m_pEncodeMenu->getCurrentText();
+        m_pEncodeMenu->setCurrentTextOnly(pAct->text());
+
+        // 处于文件加载状态或转换失败则恢复默认编码格式
+        if (m_pWrapper->getFileLoading() || !m_pWrapper->reloadFileEncode(pAct->text().toLocal8Bit())) {
+            m_pEncodeMenu->setCurrentTextOnly(previousText);
         }
+
         //先屏蔽，双字节空字符先按照显示字符编码号处理
         //m_pWrapper->clearDoubleCharaterEncode();
     });

--- a/src/widgets/ddropdownmenu.cpp
+++ b/src/widgets/ddropdownmenu.cpp
@@ -207,6 +207,11 @@ DToolButton *DDropdownMenu::getButton()
     return m_pToolButton;
 }
 
+QString DDropdownMenu::getCurrentText() const
+{
+    return m_text;
+}
+
 DDropdownMenu *DDropdownMenu::createEncodeMenu()
 {
     DDropdownMenu *m_pEncodeMenu = new DDropdownMenu();

--- a/src/widgets/ddropdownmenu.h
+++ b/src/widgets/ddropdownmenu.h
@@ -37,6 +37,7 @@ public:
     void setChildrenFocus(bool ok);
     void setRequestMenu(bool request);
     DToolButton* getButton();
+    QString getCurrentText() const;
 
 public slots:
     void setCurrentAction(QAction*);


### PR DESCRIPTION
Description: 在更新编码后使用默认的保存文件路径，没有及时更新待保存的编码格式标志。修改为在保存前更新待保存的文件编码格式，添加相关改动的UT用例。

Log: 修复文本编辑器新建标签页，修改编码格式并输入内容，保存时仍为utf-8格式
Bug: https://pms.uniontech.com/bug-view-169265.html
Influence: 文件保存