### PR TITLE
fix: 修复文本编辑器选择语法高亮不能及时生效

### DIFF
--- a/src/editor/editwrapper.h
+++ b/src/editor/editwrapper.h
@@ -69,16 +69,14 @@ public:
     bool saveAsFile();
     //重新加载文件编码 1.文件修改 2.文件未修改处理逻辑一样 切换编码重新加载和另存为 梁卫东
     bool reloadFileEncode(QByteArray encode);
+    // 重新加载文件高亮类型
+    void reloadFileHighlight(QString definitionName);
     //重写加载修改文件
     void reloadModifyFile();
     //获取文件编码
     QString getTextEncode();
 
-    /**
-     * @brief saveTemFile 保存备份文件
-     * @param qstrDir　备份文件路径
-     * @return true or false
-     */
+    // 保存备份文件
     bool saveTemFile(QString qstrDir);
     //更新路径
     void updatePath(const QString &file, QString qstrTruePath = QString());

--- a/src/widgets/bottombar.cpp
+++ b/src/widgets/bottombar.cpp
@@ -81,6 +81,9 @@ BottomBar::BottomBar(QWidget *parent)
     //切换文件类型
     connect(m_pHighlightMenu, &DDropdownMenu::currentActionChanged, this,[this](QAction* pAct) {
         m_pHighlightMenu->setCurrentTextOnly(pAct->text());
+
+        // 更新使用格式高亮类型
+        m_pWrapper->reloadFileHighlight(pAct->text());
     });
 
     //编码按钮/文本类型按钮失去焦点后，设置光标回到文本框里

--- a/src/widgets/ddropdownmenu.cpp
+++ b/src/widgets/ddropdownmenu.cpp
@@ -324,6 +324,13 @@ DDropdownMenu *DDropdownMenu::createHighLightMenu()
         m_pActionGroup->addAction(action);
     }
 
+    // 转发选中“None“无高亮选项的信号
+    connect(noHlAction, &QAction::triggered, m_pHighLightMenu, [noHlAction, m_pHighLightMenu] (bool checked) {
+        if (checked) {
+            emit m_pHighLightMenu->currentActionChanged(noHlAction);
+        }
+    });
+
     connect(m_pActionGroup, &QActionGroup::triggered, m_pHighLightMenu, [m_pHighLightMenu] (QAction *action) {
         const auto defName = action->text();
         const auto def = m_pHighLightMenu->m_Repository.definitionForName(defName);
@@ -333,7 +340,7 @@ DDropdownMenu *DDropdownMenu::createHighLightMenu()
         else {
             m_pHighLightMenu->setText(tr("None"));
         }
-
+        
     });
 
     m_pHighLightMenu->setText(tr("None"));

--- a/tests/src/editor/ut_editwrapper.cpp
+++ b/tests/src/editor/ut_editwrapper.cpp
@@ -1310,3 +1310,25 @@ TEST(UT_Editwrapper_loadContent, UT_Editwrapper_loadContent_002)
     window->deleteLater();
 }
 
+TEST(UT_Editwrapper_reloadFileHighlight, reloadFileHighlight_ChangeDefinition_Success)
+{
+    Window* window = new Window();
+    EditWrapper* wra = new EditWrapper(window);
+    wra->m_pTextEdit->setPlainText("#include <iostream>;\n"
+                                   "int main(int argc, char *argv[]) { }");
+    const QString definitionName("C++");
+    wra->reloadFileHighlight(definitionName);
+    EXPECT_FALSE(wra->m_bHighlighterAll);
+    EXPECT_TRUE(wra->m_Definition.isValid());
+    EXPECT_EQ(wra->m_Definition.name(), definitionName);
+    EXPECT_NE(wra->m_pSyntaxHighlighter, nullptr);
+
+    wra->reloadFileHighlight(QString("None"));
+    EXPECT_FALSE(wra->m_bHighlighterAll);
+    EXPECT_FALSE(wra->m_Definition.isValid());
+    EXPECT_EQ(wra->m_pSyntaxHighlighter, nullptr);
+
+    wra->deleteLater();
+    window->deleteLater();
+}
+


### PR DESCRIPTION
Description: 原因是缺失切换语法高亮格式后触发高亮变更的处理。添加语法高亮切换信号处理，切换后重新更新当前界面展示的语法高亮效果。

Log: 修复文本编辑器选择语法高亮不能及时生效
Bug: https://pms.uniontech.com/bug-view-163627.html
Influence: 语法高亮