### PR TITLE
fix: 修复切换基础设置中的打印机设置时，原页面不展示页码，切换一下页面后才可展示

### DIFF
--- a/src/widgets/window.cpp
+++ b/src/widgets/window.cpp
@@ -42,7 +42,6 @@
 
 #define PRINT_FLAG 2
 #define PRINT_ACTION 8
-#define PRINT_FORMAT_MARGIN 10
 #define FLOATTIP_MARGIN 95
 
 /**
@@ -1950,7 +1949,6 @@ void Window::doPrint(DPrinter *printer, const QVector<int> &pageRange)
 
     int dpiy = p.device()->logicalDpiY();
     int margin = (int)((2 / 2.54) * dpiy); // 2 cm margins
-    margin = PRINT_FORMAT_MARGIN;
 
     auto fmt = m_printDoc->rootFrame()->frameFormat();
     fmt.setMargin(margin);
@@ -2047,7 +2045,6 @@ void Window::doPrintWithLargeDoc(DPrinter *printer, const QVector<int> &pageRang
 
     int dpiy = p.device()->logicalDpiY();
     int margin = static_cast<int>((2 / 2.54) * dpiy); // 2 cm margins
-    margin = PRINT_FORMAT_MARGIN;
 
     QRectF pageRect(printer->pageRect());
     QRectF body = QRectF(0, 0, pageRect.width(), pageRect.height());


### PR DESCRIPTION
Description: 原因是初始打印时设置了错误的边距，修改bug时引入。移除设置错误边距的代码。

Log: 修复切换基础设置中的打印机设置时，原页面不展示页码，切换一下页面后才可展示
Bug: https://pms.uniontech.com/bug-view-163917.html
Influence: 文档打印