### PR TITLE
fix: 修复文件名称中含有&符打开应用无显示

### DIFF
--- a/src/controls/tabbar.h
+++ b/src/controls/tabbar.h
@@ -48,6 +48,9 @@ public:
     QString fileAt(int index) const;
     QString textAt(int index) const;
 
+    // 设置索引为index的标签页显示文本为text
+    void setTabText(int index, const QString &text);
+
     void setTabPalette(const QString &activeColor, const QString &inactiveColor);
     void setBackground(const QString &startColor, const QString &endColor);
     void setDNDColor(const QString &startColor, const QString &endColor);


### PR DESCRIPTION
Description: 原因是‘&’字符在Qt中被标记为助记符，标记为快捷键的一部分，部分控件不显示'&'，同绘制部分的Qt::TextShowMnemonic标识有关，Qt帮助文档建议为将‘&’替换为“&&”显示。修改方案为涉及标签页显示的文本将‘&’替换为“&&”以正常显示‘&’字符。

Log: 修复文件名称中含有&符打开应用无显示
Bug: https://pms.uniontech.com/bug-view-171007.html
Influence: 标签页