### PR TITLE
fix: 修复单行文本切换语法高亮不能生效问题

### DIFF
--- a/src/editor/editwrapper.cpp
+++ b/src/editor/editwrapper.cpp
@@ -392,8 +392,11 @@ void EditWrapper::reloadFileHighlight(QString definitionName)
         // 移除当前页面旧的高亮内容
         QTextCursor cursor(beginBlock);
         cursor.beginEditBlock();
-        for (QTextBlock var = beginBlock; var != endBlock; var = var.next()) {
+        for (QTextBlock var = beginBlock; var.isValid(); var = var.next()) {
             var.layout()->clearFormats();
+            if (var == endBlock) {
+                break;
+            }
         }
         cursor.endEditBlock();
         // 复位标识位

--- a/tests/src/editor/ut_editwrapper.cpp
+++ b/tests/src/editor/ut_editwrapper.cpp
@@ -1332,3 +1332,25 @@ TEST(UT_Editwrapper_reloadFileHighlight, reloadFileHighlight_ChangeDefinition_Su
     window->deleteLater();
 }
 
+TEST(UT_Editwrapper_reloadFileHighlight, reloadFileHighlight_SingleLineText_Success)
+{
+    Window* window = new Window();
+    EditWrapper* wra = new EditWrapper(window);
+    wra->m_pTextEdit->setPlainText("import time");
+    auto firstBlock = wra->m_pTextEdit->document()->firstBlock();
+    auto formats = firstBlock.layout()->formats();
+    EXPECT_TRUE(formats.isEmpty());
+
+    const QString definitionName("Python");
+    wra->reloadFileHighlight(definitionName);
+    EXPECT_TRUE(wra->m_Definition.isValid());
+    EXPECT_EQ(wra->m_Definition.name(), definitionName);
+    EXPECT_NE(wra->m_pSyntaxHighlighter, nullptr);
+
+    firstBlock = wra->m_pTextEdit->document()->firstBlock();
+    formats = firstBlock.layout()->formats();
+    EXPECT_FALSE(formats.isEmpty());
+
+    wra->deleteLater();
+    window->deleteLater();
+}


### PR DESCRIPTION
Description: 原因时清理旧的语法高亮信息时，循环处理中遗漏了对尾行的判断，导致单行文本未正常切换高亮。修改循环处理逻辑，正确清理单行文本的格式信息。

Log: 修复单行文本切换语法高亮不能生效问题
Bug: https://pms.uniontech.com/bug-view-163627.html
Influence: 语法高亮