### PR TITLE
fix: 修复修改引入导致1030环境编译报错问题

### DIFF
--- a/src/widgets/window.cpp
+++ b/src/widgets/window.cpp
@@ -1616,6 +1616,9 @@ void Window::popupPrintDialog()
         return;
     }
 
+    const QString &filePath = currentWrapper()->textEditor()->getFilePath();
+    const QString &fileDir = QFileInfo(filePath).dir().absolutePath();
+
     //适配打印接口2.0，dtk版本大于或等于5.4.10才放开最新的2.0打印预览接口
 #if (DTK_VERSION_MAJOR > 5 \
     || (DTK_VERSION_MAJOR == 5 && DTK_VERSION_MINOR > 4) \
@@ -1669,8 +1672,6 @@ void Window::popupPrintDialog()
 
     // 设置 QPrinter 的文档名称，保留绝对路径和文件后缀(在cups的page_log中保留完整的job-name)
     // 注意和文件的输出文件路径进行区分
-    const QString &filePath = currentWrapper()->textEditor()->getFilePath();
-    const QString &fileDir = QFileInfo(filePath).dir().absolutePath();
     if (fileDir == m_blankFileDir) {
         m_pPreview->setDocName(filePath);
     } else {


### PR DESCRIPTION
Description: 原因是打印处理在DTK5.4.10版本前后使用宏切换不同分支，修改bug过程中调整了部分代码位置，导致在1030环境编译时遇到变量未定义问题。恢复代码位置，使同时兼容两个分支编译。

Log: 修复修改引入导致1030环境编译报错问题
Influence: 1030环境打印处理编译