### PR TITLE
fix: 修复选中文字结合Ctrl复制文本后，进行撤销操作恢复结果不正确的问题。

### DIFF
--- a/src/editor/dtextedit.h
+++ b/src/editor/dtextedit.h
@@ -560,7 +560,7 @@ public slots:
 
     void redo_();
     void undo_();
-    void moveText(int from, int to, const QString &text);
+    void moveText(int from, int to, const QString& text, bool copy = false);
     QTextCursor findCursor(const QString &substr, const QString &text, int from, bool backward = false, int cursorPos = 0);
     QString selectedText();
 protected:


### PR DESCRIPTION
Description: 文本编辑器使用了自定的撤销栈，未对按住Ctrl拖拽复制文本撤销时，拷贝了多余的文本，导致撤销异常。 修改按住Ctrl状态下的处理逻辑，拷贝状态下不在原文本位置插入用于撤销栈管理的文本。

Log: 修复选中文字结合Ctrl复制文本后，进行撤销操作恢复结果不正确的问题。
Bug: https://pms.uniontech.com/bug-view-172865.html
Influence: 撤销栈
Change-Id: I870679a762487bd3365c9104fe845efe4196ae3e