### PR TITLE
fix: 修复多选包含已打开文件的情况下，批量打开功能异常

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -61,6 +61,7 @@ int main(int argc, char *argv[])
         UrlInfo info(path);
         urls << info.url.toLocalFile();
     }
+    qInfo() << Q_FUNC_INFO << "Open file urls" << urls;
 
     bool hasWindowFlag = parser.isSet(newWindowOption);
 

--- a/src/startmanager.cpp
+++ b/src/startmanager.cpp
@@ -467,7 +467,8 @@ void StartManager::openFilesInTab(QStringList files)
         for (const QString &file : files) {
 
             if (!checkPath(file)) {
-                return;
+                // 存在已打开文件时，进行下一文件判断
+                continue;
             }
 
             FileTabInfo info = getFileTabInfo(file);


### PR DESCRIPTION
Description: 批量打开文件时，判断已打开文件后直接跳出，流程错误。修改判断流程，识别已打开文件后继续判断文件。

Log: 修复多选包含已打开文件的情况下，批量打开功能异常
Bug: https://pms.uniontech.com/bug-view-182217.html
Influence: 批量打开文件