### PR TITLE
fix: 修复读取超大文件时软件闪退的问题

### DIFF
--- a/src/common/fileloadthread.cpp
+++ b/src/common/fileloadthread.cpp
@@ -45,9 +45,18 @@ void FileLoadThread::run()
             }
         }
 
-        // reads all remaining data from the file.
-        indata += file.read(file.size());
-        file.close();
+        // 读取申请开辟内存空间时，捕获可能出现的 std::bad_alloc() 异常，防止闪退。
+        try {
+            // reads all remaining data from the file.
+            indata += file.read(file.size());
+            file.close();
+        } catch (const std::exception &e) {
+            qWarning() << Q_FUNC_INFO << "Read file data error, " << QString(e.what());
+
+            file.close();
+            emit sigLoadFinished(encode, indata, true);
+            return;
+        }
 
         if (encode.isEmpty()) {
             //编码识别，如果文件数据大于1M，则只裁剪出1M文件数据去做编码探测
@@ -62,11 +71,11 @@ void FileLoadThread::run()
 
         QString textEncode = QString::fromLocal8Bit(encode);
         if (textEncode.contains("ASCII", Qt::CaseInsensitive) || textEncode.contains("UTF-8", Qt::CaseInsensitive)) {
-            emit sigLoadFinished(encode, indata);
+            emit sigLoadFinished(encode, indata, false);
         } else {
             QByteArray outData;
             DetectCode::ChangeFileEncodingFormat(indata, outData, textEncode, QString("UTF-8"));
-            emit sigLoadFinished(encode, outData);
+            emit sigLoadFinished(encode, outData, false);
         }
     }
 }

--- a/src/common/fileloadthread.h
+++ b/src/common/fileloadthread.h
@@ -19,7 +19,7 @@ public:
 signals:
     // 预处理信号，优先处理文件头，防止出现加载时间过长的情况
     void sigPreProcess(const QByteArray &encode, const QByteArray &content);
-    void sigLoadFinished(const QByteArray &encode, const QByteArray &content);
+    void sigLoadFinished(const QByteArray &encode, const QByteArray &content, bool error = false);
 
 private:
     QString m_strFilePath;

--- a/src/controls/warningnotices.cpp
+++ b/src/controls/warningnotices.cpp
@@ -53,6 +53,12 @@ void WarningNotices::setSaveAsBtn()
     setWidget(m_saveAsBtn);
 }
 
+void WarningNotices::clearBtn()
+{
+    m_saveAsBtn->setVisible(false);
+    m_reloadBtn->setVisible(false);
+}
+
 void WarningNotices::slotreloadBtnClicked()
 {
     this->hide();

--- a/src/controls/warningnotices.h
+++ b/src/controls/warningnotices.h
@@ -22,6 +22,7 @@ public:
 
     void setReloadBtn();
     void setSaveAsBtn();
+    void clearBtn();
 
 signals:
     void reloadBtnClicked();

--- a/src/editor/dtextedit.cpp
+++ b/src/editor/dtextedit.cpp
@@ -3602,7 +3602,7 @@ QString TextEdit::getWordAtMouse()
     }
 }
 
-void TextEdit::toggleReadOnlyMode()
+void TextEdit::toggleReadOnlyMode(bool notNotify)
 {
     if (m_readOnlyMode) {
         if (m_cursorMode == Overwrite) {
@@ -3614,14 +3614,20 @@ void TextEdit::toggleReadOnlyMode()
         m_readOnlyMode = false;
         setCursorWidth(1);
         updateHighlightLineSelection();
-        popupNotify(tr("Read-Only mode is off"));
+
+        if (!notNotify) {
+            popupNotify(tr("Read-Only mode is off"));
+        }
     } else {
         m_readOnlyMode = true;
         setReadOnly(true);
         setCursorWidth(0); //隐藏光标
         document()->clearUndoRedoStacks();
         updateHighlightLineSelection();
-        popupNotify(tr("Read-Only mode is on"));
+
+        if (!notNotify) {
+            popupNotify(tr("Read-Only mode is on"));
+        }
         emit cursorModeChanged(Readonly);
     }
 }

--- a/src/editor/dtextedit.h
+++ b/src/editor/dtextedit.h
@@ -263,7 +263,7 @@ public:
     void completionWord(QString word);
     QString getWordAtMouse();
     QString getWordAtCursor();
-    void toggleReadOnlyMode();
+    void toggleReadOnlyMode(bool notNotify = false);
     void toggleComment(bool bValue);
     int getNextWordPosition(QTextCursor &cursor, QTextCursor::MoveMode moveMode);
     int getPrevWordPosition(QTextCursor cursor, QTextCursor::MoveMode moveMode);

--- a/src/editor/editwrapper.cpp
+++ b/src/editor/editwrapper.cpp
@@ -850,45 +850,48 @@ void EditWrapper::handleFilePreProcess(const QByteArray &encode, const QByteArra
  * @param encode    文件编码
  * @param content   完整文件内容
  */
-void EditWrapper::handleFileLoadFinished(const QByteArray &encode, const QByteArray &content)
+void EditWrapper::handleFileLoadFinished(const QByteArray &encode, const QByteArray &content, bool error)
 {
     // 判断是否预加载，若已预加载，则无需重新初始化
     if (!m_bHasPreProcess) {
         reinitOnFileLoad(encode);
     }
 
-    bool flag = m_pTextEdit->getReadOnlyPermission();
-    if (flag == true) {
-        // note: 特殊处理，由于需要TextEdit处于可编辑状态追加文件数据，临时设置非只读状态
-        m_pTextEdit->setReadOnly(false);
+    if (!error) {
+        bool flag = m_pTextEdit->getReadOnlyPermission();
+        if (flag == true) {
+            // note: 特殊处理，由于需要TextEdit处于可编辑状态追加文件数据，临时设置非只读状态
+            m_pTextEdit->setReadOnly(false);
+        }
+
+        m_bFileLoading = true;
+
+        //备份显示修改状态
+        if (m_bIsTemFile) {
+            updateModifyStatus(true);
+        }
+
+        // 判断处理前后对象状态
+        QPointer<QObject> checkPtr(this);
+        // 加载数据
+        loadContent(content);
+        if (checkPtr.isNull()) {
+            return;
+        }
+
+        m_bFileLoading = false;
+        if (flag == true) {
+            m_pTextEdit->setReadOnly(true);
+        }
+
+        if (m_bQuit) {
+            return;
+        }
+    } else {
+        // 清除之前读取的数据
+        m_pTextEdit->clear();
     }
 
-    m_bFileLoading = true;
-
-    //备份显示修改状态
-    if (m_bIsTemFile) {
-        updateModifyStatus(true);
-    }
-
-    // 判断处理前后对象状态
-    QPointer<QObject> checkPtr(this);
-    // 加载数据
-    loadContent(content);
-    if (checkPtr.isNull()) {
-        return;
-    }
-
-    //先屏蔽，双字节空字符先按照显示字符编码号处理
-    //clearDoubleCharaterEncode();
-    //PerformanceMonitor::openFileFinish(filePath(), QFileInfo(filePath()).size());
-
-    m_bFileLoading = false;
-    if (flag == true) {
-        m_pTextEdit->setReadOnly(true);
-    }
-    if (m_bQuit) {
-        return;
-    }
     m_pTextEdit->setTextFinished();
 
     QStringList temFileList = Settings::instance()->settings->option("advance.editor.browsing_history_temfile")->value().toStringList();
@@ -936,6 +939,19 @@ void EditWrapper::handleFileLoadFinished(const QByteArray &encode, const QByteAr
     }
 
     m_pBottomBar->setEncodeName(m_sCurEncode);
+
+    // 提示读取错误信息
+    if (error) {
+        // 设置文本为只读模式，且不显示通知
+        if (!m_pTextEdit->getReadOnlyMode()) {
+            m_pTextEdit->toggleReadOnlyMode(true);
+        }
+
+        m_pWaringNotices->setMessage(tr("The file cannot be read, which may be too large or has been damaged!"));
+        m_pWaringNotices->clearBtn();
+        m_pWaringNotices->show();
+        DMessageManager::instance()->sendMessage(m_pTextEdit, m_pWaringNotices);
+    }
 }
 
 

--- a/src/editor/editwrapper.h
+++ b/src/editor/editwrapper.h
@@ -137,7 +137,7 @@ private:
 public slots:
     // 处理文档预加载数据
     void handleFilePreProcess(const QByteArray &encode, const QByteArray &content);
-    void handleFileLoadFinished(const QByteArray &encode, const QByteArray &content);
+    void handleFileLoadFinished(const QByteArray &encode, const QByteArray &content, bool error);
     void OnThemeChangeSlot(QString theme);
     void UpdateBottomBarWordCnt(int cnt);
     void OnUpdateHighlighter();

--- a/tests/src/editor/ut_editwrapper.cpp
+++ b/tests/src/editor/ut_editwrapper.cpp
@@ -688,7 +688,7 @@ TEST(UT_Editwrapper_handleFileLoadFinished, UT_Editwrapper_handleFileLoadFinishe
     setPrintEnabled_stub.set(ADDR(Window, setPrintEnabled), handleFileLoadFinished_001_setPrintEnabled_stub);
     Stub setTextFinished_stub;
     setTextFinished_stub.set(ADDR(TextEdit, setTextFinished), handleFileLoadFinished_001_setTextFinished_stub);
-    pWindow->currentWrapper()->handleFileLoadFinished(encode, retFileContent);
+    pWindow->currentWrapper()->handleFileLoadFinished(encode, retFileContent, false);
     ASSERT_TRUE(pWindow->currentWrapper()->m_pBottomBar->m_pEncodeMenu != nullptr);
 
     pWindow->deleteLater();
@@ -734,7 +734,7 @@ TEST(UT_Editwrapper_handleFileLoadFinished, UT_Editwrapper_handleFileLoadFinishe
     stringList.push_back(c2);
 
 
-    pWindow->currentWrapper()->handleFileLoadFinished(encode, retFileContent);
+    pWindow->currentWrapper()->handleFileLoadFinished(encode, retFileContent, false);
     ASSERT_TRUE(pWindow->currentWrapper()->m_pBottomBar->m_pEncodeMenu != nullptr);
 
     pWindow->deleteLater();
@@ -781,7 +781,7 @@ TEST(UT_Editwrapper_handleFileLoadFinished, UT_Editwrapper_handleFileLoadFinishe
     stringList.push_back(c2);
 
 
-    pWindow->currentWrapper()->handleFileLoadFinished(encode, retFileContent);
+    pWindow->currentWrapper()->handleFileLoadFinished(encode, retFileContent, false);
     ASSERT_TRUE(pWindow->currentWrapper()->m_pBottomBar->m_pEncodeMenu != nullptr);
 
     pWindow->deleteLater();
@@ -789,6 +789,22 @@ TEST(UT_Editwrapper_handleFileLoadFinished, UT_Editwrapper_handleFileLoadFinishe
     d = nullptr;
 }
 
+TEST(UT_Editwrapper_handleFileLoadFinished, UT_Editwrapper_handleFileLoadFinished_004_error)
+{
+    Window *pWindow = new Window();
+    pWindow->addBlankTab(QString());
+    const QString filePath = QCoreApplication::applicationDirPath() + QString("/Makefile");
+    QByteArray encode = QByteArray();
+    const QByteArray retFileContent = FileLoadThreadRun(filePath, &encode);
+    Stub setPrintEnabled_stub;
+    setPrintEnabled_stub.set(ADDR(Window, setPrintEnabled), handleFileLoadFinished_001_setPrintEnabled_stub);
+    Stub setTextFinished_stub;
+    setTextFinished_stub.set(ADDR(TextEdit, setTextFinished), handleFileLoadFinished_001_setTextFinished_stub);
+    pWindow->currentWrapper()->handleFileLoadFinished(encode, retFileContent, true);
+    EXPECT_TRUE(pWindow->currentWrapper()->textEditor()->getReadOnlyPermission());
+
+    pWindow->deleteLater();
+}
 
 ////重新加载文件编码 1.文件修改 2.文件未修改处理逻辑一样 切换编码重新加载和另存为 梁卫东
 //bool reloadFileEncode(QByteArray encode);

--- a/translations/deepin-editor.ts
+++ b/translations/deepin-editor.ts
@@ -2,17 +2,17 @@
 <context>
     <name>BottomBar</name>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="39"/>
+        <location filename="../src/widgets/bottombar.cpp" line="24"/>
         <source>Row</source>
         <translation>Row</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="40"/>
+        <location filename="../src/widgets/bottombar.cpp" line="25"/>
         <source>Column</source>
         <translation>Column</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="41"/>
+        <location filename="../src/widgets/bottombar.cpp" line="26"/>
         <source>Characters %1</source>
         <translation>Characters %1</translation>
     </message>
@@ -20,9 +20,9 @@
 <context>
     <name>DDropdownMenu</name>
     <message>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="300"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="344"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="349"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="290"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="341"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="346"/>
         <source>None</source>
         <translation>None</translation>
     </message>
@@ -30,80 +30,85 @@
 <context>
     <name>EditWrapper</name>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="201"/>
-        <location filename="../src/editor/editwrapper.cpp" line="264"/>
-        <location filename="../src/editor/editwrapper.cpp" line="321"/>
-        <location filename="../src/editor/editwrapper.cpp" line="536"/>
+        <location filename="../src/editor/editwrapper.cpp" line="246"/>
+        <location filename="../src/editor/editwrapper.cpp" line="314"/>
+        <location filename="../src/editor/editwrapper.cpp" line="439"/>
+        <location filename="../src/editor/editwrapper.cpp" line="702"/>
         <source>Save</source>
         <translation>Save</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="316"/>
+        <location filename="../src/editor/editwrapper.cpp" line="434"/>
         <source>Do you want to save this file?</source>
         <translation>Do you want to save this file?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="262"/>
-        <location filename="../src/editor/editwrapper.cpp" line="319"/>
+        <location filename="../src/editor/editwrapper.cpp" line="312"/>
+        <location filename="../src/editor/editwrapper.cpp" line="437"/>
         <source>Cancel</source>
         <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="259"/>
+        <location filename="../src/editor/editwrapper.cpp" line="309"/>
         <source>Encoding changed. Do you want to save the file now?</source>
         <translation>Encoding changed. Do you want to save the file now?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="320"/>
+        <location filename="../src/editor/editwrapper.cpp" line="438"/>
         <source>Discard</source>
         <translation>Discard</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="445"/>
+        <location filename="../src/editor/editwrapper.cpp" line="564"/>
         <source>You do not have permission to save %1</source>
         <translation>You do not have permission to save %1</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="607"/>
+        <location filename="../src/editor/editwrapper.cpp" line="774"/>
         <source>File removed on the disk. Save it now?</source>
         <translation>File removed on the disk. Save it now?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="612"/>
+        <location filename="../src/editor/editwrapper.cpp" line="779"/>
         <source>File has changed on disk. Reload?</source>
         <translation>File has changed on disk. Reload?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="634"/>
-        <location filename="../src/widgets/bottombar.cpp" line="60"/>
+        <location filename="../src/editor/editwrapper.cpp" line="801"/>
+        <location filename="../src/widgets/bottombar.cpp" line="45"/>
         <source>INSERT</source>
         <translation>INSERT</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="637"/>
+        <location filename="../src/editor/editwrapper.cpp" line="804"/>
         <source>OVERWRITE</source>
         <translation>OVERWRITE</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="640"/>
+        <location filename="../src/editor/editwrapper.cpp" line="807"/>
         <source>R/O</source>
         <translation>R/O</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="945"/>
+        <source>The file cannot be read, which may be too large or has been damaged!</source>
+        <translation>The file cannot be read, which may be too large or has been damaged!</translation>
     </message>
 </context>
 <context>
     <name>FindBar</name>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="40"/>
+        <location filename="../src/controls/findbar.cpp" line="22"/>
         <source>Find</source>
         <translation>Find</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="44"/>
+        <location filename="../src/controls/findbar.cpp" line="26"/>
         <source>Previous</source>
         <translation>Previous</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="46"/>
+        <location filename="../src/controls/findbar.cpp" line="28"/>
         <source>Next</source>
         <translation>Next</translation>
     </message>
@@ -111,7 +116,7 @@
 <context>
     <name>JumpLineBar</name>
     <message>
-        <location filename="../src/controls/jumplinebar.cpp" line="40"/>
+        <location filename="../src/controls/jumplinebar.cpp" line="28"/>
         <source>Go to Line: </source>
         <translation>Go to Line: </translation>
     </message>
@@ -119,12 +124,12 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/editorapplication.cpp" line="27"/>
+        <location filename="../src/editorapplication.cpp" line="11"/>
         <source>Text Editor is a powerful tool for viewing and editing text files.</source>
         <translation>Text Editor is a powerful tool for viewing and editing text files.</translation>
     </message>
     <message>
-        <location filename="../src/editorapplication.cpp" line="38"/>
+        <location filename="../src/editorapplication.cpp" line="22"/>
         <source>Text Editor</source>
         <translation>Text Editor</translation>
     </message>
@@ -132,572 +137,572 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/editorapplication.cpp" line="35"/>
+        <location filename="../src/editorapplication.cpp" line="19"/>
         <source>Text Editor</source>
         <translation>Text Editor</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="203"/>
-        <location filename="../src/editor/editwrapper.cpp" line="538"/>
-        <location filename="../src/widgets/window.cpp" line="956"/>
-        <location filename="../src/widgets/window.cpp" line="973"/>
-        <location filename="../src/widgets/window.cpp" line="1064"/>
-        <location filename="../src/widgets/window.cpp" line="1079"/>
+        <location filename="../src/editor/editwrapper.cpp" line="248"/>
+        <location filename="../src/editor/editwrapper.cpp" line="704"/>
+        <location filename="../src/widgets/window.cpp" line="1089"/>
+        <location filename="../src/widgets/window.cpp" line="1111"/>
+        <location filename="../src/widgets/window.cpp" line="1203"/>
+        <location filename="../src/widgets/window.cpp" line="1218"/>
         <source>Encoding</source>
         <translation>Encoding</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="24"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="9"/>
         <source>Basic</source>
         <translation>Basic</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="25"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="10"/>
         <source>Font Style</source>
         <translation>Font Style</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="26"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="11"/>
         <source>Font</source>
         <translation>Font</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="27"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="12"/>
         <source>Font Size</source>
         <translation>Font Size</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="28"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="13"/>
         <source>Shortcuts</source>
         <translation>Shortcuts</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="29"/>
-        <location filename="../src/controls/settingsdialog.cpp" line="30"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="14"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="15"/>
         <source>Keymap</source>
         <translation>Keymap</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="31"/>
-        <location filename="../src/controls/settingsdialog.cpp" line="107"/>
-        <location filename="../src/widgets/window.cpp" line="1482"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="16"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="92"/>
+        <location filename="../src/widgets/window.cpp" line="1811"/>
         <source>Window</source>
         <translation>Window</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="32"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="17"/>
         <source>New tab</source>
         <translation>New tab</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="33"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="18"/>
         <source>New window</source>
         <translation>New window</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="34"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="19"/>
         <source>Save</source>
         <translation>Save</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="35"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="20"/>
         <source>Save as</source>
         <translation>Save as</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="36"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="21"/>
         <source>Next tab</source>
         <translation>Next tab</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="37"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="22"/>
         <source>Previous tab</source>
         <translation>Previous tab</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="38"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="23"/>
         <source>Close tab</source>
         <translation>Close tab</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="39"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="24"/>
         <source>Close other tabs</source>
         <translation>Close other tabs</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="40"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="25"/>
         <source>Restore tab</source>
         <translation>Restore tab</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="41"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="26"/>
         <source>Open file</source>
         <translation>Open file</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="42"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="27"/>
         <source>Increment font size</source>
         <translation>Increment font size</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="43"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="28"/>
         <source>Decrement font size</source>
         <translation>Decrement font size</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="44"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="29"/>
         <source>Reset font size</source>
         <translation>Reset font size</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="45"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="30"/>
         <source>Help</source>
         <translation>Help</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="46"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="31"/>
         <source>Toggle fullscreen</source>
         <translation>Toggle fullscreen</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="47"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="32"/>
         <source>Find</source>
         <translation>Find</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="48"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="33"/>
         <source>Replace</source>
         <translation>Replace</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="49"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="34"/>
         <source>Go to line</source>
         <translation>Go to line</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="50"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="35"/>
         <source>Save cursor position</source>
         <translation>Save cursor position</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="51"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="36"/>
         <source>Reset cursor position</source>
         <translation>Reset cursor position</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="52"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="37"/>
         <source>Exit</source>
         <translation>Exit</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="53"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="38"/>
         <source>Display shortcuts</source>
         <translation>Display shortcuts</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="54"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="39"/>
         <source>Print</source>
         <translation>Print</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="55"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="40"/>
         <source>Editor</source>
         <translation>Editor</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="56"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="41"/>
         <source>Increase indent</source>
         <translation>Increase indent</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="57"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="42"/>
         <source>Decrease indent</source>
         <translation>Decrease indent</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="58"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="43"/>
         <source>Forward character</source>
         <translation>Forward character</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="59"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="44"/>
         <source>Backward character</source>
         <translation>Backward character</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="60"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="45"/>
         <source>Forward word</source>
         <translation>Forward word</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="61"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="46"/>
         <source>Backward word</source>
         <translation>Backward word</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="62"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="47"/>
         <source>Next line</source>
         <translation>Next line</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="63"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="48"/>
         <source>Previous line</source>
         <translation>Previous line</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="64"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="49"/>
         <source>New line</source>
         <translation>New line</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="65"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="50"/>
         <source>New line above</source>
         <translation>New line above</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="66"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="51"/>
         <source>New line below</source>
         <translation>New line below</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="67"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="52"/>
         <source>Duplicate line</source>
         <translation>Duplicate line</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="68"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="53"/>
         <source>Delete to end of line</source>
         <translation>Delete to end of line</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="69"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="54"/>
         <source>Delete current line</source>
         <translation>Delete current line</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="70"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="55"/>
         <source>Swap line up</source>
         <translation>Swap line up</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="71"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="56"/>
         <source>Swap line down</source>
         <translation>Swap line down</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="72"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="57"/>
         <source>Scroll up one line</source>
         <translation>Scroll up one line</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="73"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="58"/>
         <source>Scroll down one line</source>
         <translation>Scroll down one line</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="74"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="59"/>
         <source>Page up</source>
         <translation>Page up</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="75"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="60"/>
         <source>Page down</source>
         <translation>Page down</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="76"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="61"/>
         <source>Move to end of line</source>
         <translation>Move to end of line</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="77"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="62"/>
         <source>Move to start of line</source>
         <translation>Move to start of line</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="78"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="63"/>
         <source>Move to end of text</source>
         <translation>Move to end of text</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="79"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="64"/>
         <source>Move to start of text</source>
         <translation>Move to start of text</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="80"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="65"/>
         <source>Move to line indentation</source>
         <translation>Move to line indentation</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="81"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="66"/>
         <source>Upper case</source>
         <translation>Upper case</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="82"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="67"/>
         <source>Lower case</source>
         <translation>Lower case</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="83"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="68"/>
         <source>Capitalize</source>
         <translation>Capitalize</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="84"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="69"/>
         <source>Delete backward word</source>
         <translation>Delete backward word</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="85"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="70"/>
         <source>Delete forward word</source>
         <translation>Delete forward word</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="86"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="71"/>
         <source>Forward over a pair</source>
         <translation>Forward over a pair</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="87"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="72"/>
         <source>Backward over a pair</source>
         <translation>Backward over a pair</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="88"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="73"/>
         <source>Select all</source>
         <translation>Select all</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="89"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="74"/>
         <source>Copy</source>
         <translation>Copy</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="90"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="75"/>
         <source>Cut</source>
         <translation>Cut</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="91"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="76"/>
         <source>Paste</source>
         <translation>Paste</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="92"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="77"/>
         <source>Transpose character</source>
         <translation>Transpose character</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="93"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="78"/>
         <source>Mark</source>
         <translation>Mark</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="94"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="79"/>
         <source>Unmark</source>
         <translation>Unmark</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="95"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="80"/>
         <source>Copy line</source>
         <translation>Copy line</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="96"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="81"/>
         <source>Cut line</source>
         <translation>Cut line</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="97"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="82"/>
         <source>Merge lines</source>
         <translation>Merge lines</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="98"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="83"/>
         <source>Read-Only mode</source>
         <translation>Read-Only mode</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="99"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="84"/>
         <source>Add comment</source>
         <translation>Add comment</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="100"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="85"/>
         <source>Remove comment</source>
         <translation>Remove comment</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="101"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="86"/>
         <source>Undo</source>
         <translation>Undo</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="102"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="87"/>
         <source>Redo</source>
         <translation>Redo</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="103"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="88"/>
         <source>Add/Remove bookmark</source>
         <translation>Add/Remove bookmark</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="104"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="89"/>
         <source>Move to previous bookmark</source>
         <translation>Move to previous bookmark</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="105"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="90"/>
         <source>Move to next bookmark</source>
         <translation>Move to next bookmark</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="106"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="91"/>
         <source>Advanced</source>
         <translation>Advanced</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="108"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="93"/>
         <source>Window size</source>
         <translation>Window size</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="109"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="94"/>
         <source>Tab width</source>
         <translation>Tab width</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="111"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="96"/>
         <source>Word wrap</source>
         <translation>Word wrap</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="112"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="97"/>
         <source>Code folding flag</source>
         <translation>Code folding flag</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="113"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="98"/>
         <source>Show line numbers</source>
         <translation>Show line numbers</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="114"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="99"/>
         <source>Show bookmarks icon</source>
         <translation>Show bookmarks icon</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="115"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="100"/>
         <source>Show whitespaces and tabs</source>
         <translation>Show whitespaces and tabs</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="116"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="101"/>
         <source>Highlight current line</source>
         <translation>Highlight current line</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="117"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="102"/>
         <source>Color mark</source>
         <translation>Color mark</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="120"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="105"/>
         <source>Unicode</source>
         <translation>Unicode</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="121"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="106"/>
         <source>WesternEuropean</source>
         <translation>WesternEuropean</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="122"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="107"/>
         <source>CentralEuropean</source>
         <translation>CentralEuropean</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="123"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="108"/>
         <source>Baltic</source>
         <translation>Baltic</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="124"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="109"/>
         <source>Cyrillic</source>
         <translation>Cyrillic</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="125"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="110"/>
         <source>Arabic</source>
         <translation>Arabic</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="130"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="115"/>
         <source>Celtic</source>
         <translation>Celtic</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="131"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="116"/>
         <source>SouthEasternEuropean</source>
         <translation>SouthEasternEuropean</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="126"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="111"/>
         <source>Greek</source>
         <translation>Greek</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="127"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="112"/>
         <source>Hebrew</source>
         <translation>Hebrew</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="132"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="117"/>
         <source>ChineseSimplified</source>
         <translation>ChineseSimplified</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="133"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="118"/>
         <source>ChineseTraditional</source>
         <translation>ChineseTraditional</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="134"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="119"/>
         <source>Japanese</source>
         <translation>Japanese</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="135"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="120"/>
         <source>Korean</source>
         <translation>Korean</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="129"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="114"/>
         <source>Thai</source>
         <translation>Thai</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="128"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="113"/>
         <source>Turkish</source>
         <translation>Turkish</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="136"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="121"/>
         <source>Vietnamese</source>
         <translation>Vietnamese</translation>
     </message>
     <message>
-        <location filename="../src/startmanager.cpp" line="762"/>
+        <location filename="../src/startmanager.cpp" line="832"/>
         <source>File not saved</source>
         <translation>File not saved</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="974"/>
-        <location filename="../src/widgets/window.cpp" line="1065"/>
-        <location filename="../src/widgets/window.cpp" line="1080"/>
+        <location filename="../src/widgets/window.cpp" line="1112"/>
+        <location filename="../src/widgets/window.cpp" line="1204"/>
+        <location filename="../src/widgets/window.cpp" line="1219"/>
         <source>Line Endings</source>
         <translation>Line Endings</translation>
     </message>
@@ -705,32 +710,32 @@
 <context>
     <name>ReplaceBar</name>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="39"/>
+        <location filename="../src/controls/replacebar.cpp" line="21"/>
         <source>Find</source>
         <translation>Find</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="43"/>
+        <location filename="../src/controls/replacebar.cpp" line="25"/>
         <source>Replace With</source>
         <translation>Replace With</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="47"/>
+        <location filename="../src/controls/replacebar.cpp" line="29"/>
         <source>Replace</source>
         <translation>Replace</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="50"/>
+        <location filename="../src/controls/replacebar.cpp" line="32"/>
         <source>Skip</source>
         <translation>Skip</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="53"/>
+        <location filename="../src/controls/replacebar.cpp" line="35"/>
         <source>Replace Rest</source>
         <translation>Replace Rest</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="56"/>
+        <location filename="../src/controls/replacebar.cpp" line="38"/>
         <source>Replace All</source>
         <translation>Replace All</translation>
     </message>
@@ -747,58 +752,58 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../src/common/settings.cpp" line="91"/>
+        <location filename="../src/common/settings.cpp" line="115"/>
         <source>Standard</source>
         <translation>Standard</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="91"/>
+        <location filename="../src/common/settings.cpp" line="115"/>
         <source>Customize</source>
         <translation>Customize</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="104"/>
+        <location filename="../src/common/settings.cpp" line="128"/>
         <source>Normal</source>
         <translation>Normal</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="104"/>
+        <location filename="../src/common/settings.cpp" line="128"/>
         <source>Maximum</source>
         <translation>Maximum</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="104"/>
+        <location filename="../src/common/settings.cpp" line="128"/>
         <source>Fullscreen</source>
         <translation>Fullscreen</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="292"/>
+        <location filename="../src/common/settings.cpp" line="316"/>
         <source>This shortcut conflicts with system shortcut %1</source>
         <translation>This shortcut conflicts with system shortcut %1</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="294"/>
+        <location filename="../src/common/settings.cpp" line="318"/>
         <source>This shortcut conflicts with %1, click on Replace to make this shortcut effective immediately</source>
         <translation>This shortcut conflicts with %1, click on Replace to make this shortcut effective immediately</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="410"/>
-        <location filename="../src/common/settings.cpp" line="418"/>
+        <location filename="../src/common/settings.cpp" line="464"/>
+        <location filename="../src/common/settings.cpp" line="472"/>
         <source>The shortcut %1 is invalid, please set another one.</source>
         <translation>The shortcut %1 is invalid, please set another one.</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="445"/>
+        <location filename="../src/common/settings.cpp" line="507"/>
         <source>Cancel</source>
         <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="446"/>
+        <location filename="../src/common/settings.cpp" line="508"/>
         <source>Replace</source>
         <translation>Replace</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="448"/>
+        <location filename="../src/common/settings.cpp" line="510"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
@@ -806,7 +811,7 @@
 <context>
     <name>StartManager</name>
     <message>
-        <location filename="../src/startmanager.cpp" line="340"/>
+        <location filename="../src/startmanager.cpp" line="350"/>
         <source>Untitled %1</source>
         <translation>Untitled %1</translation>
     </message>
@@ -814,32 +819,32 @@
 <context>
     <name>Tabbar</name>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="515"/>
+        <location filename="../src/controls/tabbar.cpp" line="540"/>
         <source>Close tab</source>
         <translation>Close tab</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="516"/>
+        <location filename="../src/controls/tabbar.cpp" line="541"/>
         <source>Close other tabs</source>
         <translation>Close other tabs</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="517"/>
+        <location filename="../src/controls/tabbar.cpp" line="542"/>
         <source>More options</source>
         <translation>More options</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="518"/>
+        <location filename="../src/controls/tabbar.cpp" line="543"/>
         <source>Close tabs to the left</source>
         <translation>Close tabs to the left</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="519"/>
+        <location filename="../src/controls/tabbar.cpp" line="544"/>
         <source>Close tabs to the right</source>
         <translation>Close tabs to the right</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="520"/>
+        <location filename="../src/controls/tabbar.cpp" line="545"/>
         <source>Close unmodified tabs</source>
         <translation>Close unmodified tabs</translation>
     </message>
@@ -847,261 +852,259 @@
 <context>
     <name>TextEdit</name>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="235"/>
+        <location filename="../src/editor/dtextedit.cpp" line="259"/>
         <source>Undo</source>
         <translation>Undo</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="236"/>
+        <location filename="../src/editor/dtextedit.cpp" line="260"/>
         <source>Redo</source>
         <translation>Redo</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="237"/>
+        <location filename="../src/editor/dtextedit.cpp" line="261"/>
         <source>Cut</source>
         <translation>Cut</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="238"/>
+        <location filename="../src/editor/dtextedit.cpp" line="262"/>
         <source>Copy</source>
         <translation>Copy</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="239"/>
+        <location filename="../src/editor/dtextedit.cpp" line="263"/>
         <source>Paste</source>
         <translation>Paste</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="240"/>
+        <location filename="../src/editor/dtextedit.cpp" line="264"/>
         <source>Delete</source>
         <translation>Delete</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="241"/>
+        <location filename="../src/editor/dtextedit.cpp" line="265"/>
         <source>Select All</source>
         <translation>Select All</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="242"/>
-        <location filename="../src/widgets/window.cpp" line="361"/>
+        <location filename="../src/editor/dtextedit.cpp" line="266"/>
+        <location filename="../src/widgets/window.cpp" line="450"/>
         <source>Find</source>
         <translation>Find</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="243"/>
-        <location filename="../src/widgets/window.cpp" line="362"/>
+        <location filename="../src/editor/dtextedit.cpp" line="267"/>
+        <location filename="../src/widgets/window.cpp" line="451"/>
         <source>Replace</source>
         <translation>Replace</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="244"/>
+        <location filename="../src/editor/dtextedit.cpp" line="268"/>
         <source>Go to Line</source>
         <translation>Go to Line</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="245"/>
+        <location filename="../src/editor/dtextedit.cpp" line="269"/>
         <source>Turn on Read-Only mode</source>
         <translation>Turn on Read-Only mode</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="246"/>
+        <location filename="../src/editor/dtextedit.cpp" line="270"/>
         <source>Turn off Read-Only mode</source>
         <translation>Turn off Read-Only mode</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="247"/>
+        <location filename="../src/editor/dtextedit.cpp" line="271"/>
         <source>Fullscreen</source>
         <translation>Fullscreen</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="248"/>
+        <location filename="../src/editor/dtextedit.cpp" line="272"/>
         <source>Exit fullscreen</source>
         <translation>Exit fullscreen</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="249"/>
+        <location filename="../src/editor/dtextedit.cpp" line="273"/>
         <source>Display in file manager</source>
         <translation>Display in file manager</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="250"/>
-        <location filename="../src/editor/dtextedit.cpp" line="302"/>
+        <location filename="../src/editor/dtextedit.cpp" line="274"/>
+        <location filename="../src/editor/dtextedit.cpp" line="326"/>
         <source>Add Comment</source>
         <translation>Add Comment</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="251"/>
+        <location filename="../src/editor/dtextedit.cpp" line="275"/>
         <source>Text to Speech</source>
         <translation>Text to Speech</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="252"/>
+        <location filename="../src/editor/dtextedit.cpp" line="276"/>
         <source>Stop reading</source>
         <translation>Stop reading</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="253"/>
+        <location filename="../src/editor/dtextedit.cpp" line="277"/>
         <source>Speech to Text</source>
         <translation>Speech to Text</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="254"/>
+        <location filename="../src/editor/dtextedit.cpp" line="278"/>
         <source>Translate</source>
         <translation>Translate</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="255"/>
+        <location filename="../src/editor/dtextedit.cpp" line="279"/>
         <source>Column Mode</source>
         <translation>Column Mode</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="256"/>
+        <location filename="../src/editor/dtextedit.cpp" line="280"/>
         <source>Add bookmark</source>
         <translation>Add bookmark</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="257"/>
+        <location filename="../src/editor/dtextedit.cpp" line="281"/>
         <source>Remove Bookmark</source>
         <translation>Remove Bookmark</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="258"/>
+        <location filename="../src/editor/dtextedit.cpp" line="282"/>
         <source>Previous bookmark</source>
         <translation>Previous bookmark</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="259"/>
+        <location filename="../src/editor/dtextedit.cpp" line="283"/>
         <source>Next bookmark</source>
         <translation>Next bookmark</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="260"/>
+        <location filename="../src/editor/dtextedit.cpp" line="284"/>
         <source>Remove All Bookmarks</source>
         <translation>Remove All Bookmarks</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="261"/>
+        <location filename="../src/editor/dtextedit.cpp" line="285"/>
         <source>Fold All</source>
         <translation>Fold All</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="262"/>
+        <location filename="../src/editor/dtextedit.cpp" line="286"/>
         <source>Fold Current Level</source>
         <translation>Fold Current Level</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="263"/>
+        <location filename="../src/editor/dtextedit.cpp" line="287"/>
         <source>Unfold All</source>
         <translation>Unfold All</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="264"/>
+        <location filename="../src/editor/dtextedit.cpp" line="288"/>
         <source>Unfold Current Level</source>
         <translation>Unfold Current Level</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="269"/>
+        <location filename="../src/editor/dtextedit.cpp" line="293"/>
         <source>Color Mark</source>
         <translation>Color Mark</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="273"/>
+        <location filename="../src/editor/dtextedit.cpp" line="297"/>
         <source>Clear All Marks</source>
         <translation>Clear All Marks</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="274"/>
+        <location filename="../src/editor/dtextedit.cpp" line="298"/>
         <source>Clear Last Mark</source>
         <translation>Clear Last Mark</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="283"/>
+        <location filename="../src/editor/dtextedit.cpp" line="307"/>
         <source>Mark</source>
         <translation>Mark</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="295"/>
+        <location filename="../src/editor/dtextedit.cpp" line="319"/>
         <source>Mark All</source>
         <translation>Mark All</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="303"/>
+        <location filename="../src/editor/dtextedit.cpp" line="327"/>
         <source>Remove Comment</source>
         <translation>Remove Comment</translation>
     </message>
     <message>
-        <source>Failed to paste text: it is too large</source>
-        <translation type="vanished">Failed to paste text: it is too large</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="2581"/>
+        <location filename="../src/editor/dtextedit.cpp" line="2672"/>
         <source>Copy failed: not enough memory</source>
         <translation>Copy failed: not enough memory</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="2665"/>
+        <location filename="../src/editor/dtextedit.cpp" line="2756"/>
         <source>Press ALT and click lines to edit in column mode</source>
         <translation>Press ALT and click lines to edit in column mode</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="346"/>
+        <location filename="../src/editor/dtextedit.cpp" line="370"/>
         <source>Change Case</source>
         <translation>Change Case</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="347"/>
+        <location filename="../src/editor/dtextedit.cpp" line="371"/>
         <source>Upper Case</source>
         <translation>Upper Case</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="348"/>
+        <location filename="../src/editor/dtextedit.cpp" line="372"/>
         <source>Lower Case</source>
         <translation>Lower Case</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="349"/>
+        <location filename="../src/editor/dtextedit.cpp" line="373"/>
         <source>Capitalize</source>
         <translation>Capitalize</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="64"/>
+        <location filename="../src/widgets/bottombar.cpp" line="49"/>
         <source>None</source>
         <translation>None</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1184"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1222"/>
         <source>Selected line(s) copied</source>
         <translation>Selected line(s) copied</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1190"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1228"/>
         <source>Current line copied</source>
         <translation>Current line copied</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1210"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1248"/>
         <source>Selected line(s) clipped</source>
         <translation>Selected line(s) clipped</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1222"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1259"/>
         <source>Current line clipped</source>
         <translation>Current line clipped</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="2591"/>
+        <location filename="../src/editor/dtextedit.cpp" line="2682"/>
         <source>Paste failed: not enough memory</source>
         <translation>Paste failed: not enough memory</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3439"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3617"/>
         <source>Read-Only mode is off</source>
         <translation>Read-Only mode is off</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3446"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3465"/>
-        <location filename="../src/editor/dtextedit.cpp" line="6150"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3624"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3643"/>
+        <location filename="../src/editor/dtextedit.cpp" line="6656"/>
+        <location filename="../src/editor/dtextedit.cpp" line="6664"/>
+        <location filename="../src/editor/dtextedit.cpp" line="6675"/>
         <source>Read-Only mode is on</source>
         <translation>Read-Only mode is on</translation>
     </message>
@@ -1109,7 +1112,7 @@
 <context>
     <name>WarningNotices</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="36"/>
+        <location filename="../src/controls/warningnotices.cpp" line="19"/>
         <source>Reload</source>
         <translation>Reload</translation>
     </message>
@@ -1117,129 +1120,130 @@
 <context>
     <name>Window</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="38"/>
-        <location filename="../src/widgets/window.cpp" line="357"/>
+        <location filename="../src/controls/warningnotices.cpp" line="21"/>
+        <location filename="../src/widgets/window.cpp" line="446"/>
         <source>Save as</source>
         <translation>Save as</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="353"/>
+        <location filename="../src/widgets/window.cpp" line="442"/>
         <source>New window</source>
         <translation>New window</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="354"/>
+        <location filename="../src/widgets/window.cpp" line="443"/>
         <source>New tab</source>
         <translation>New tab</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="355"/>
+        <location filename="../src/widgets/window.cpp" line="444"/>
         <source>Open file</source>
         <translation>Open file</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="356"/>
-        <location filename="../src/widgets/window.cpp" line="2217"/>
+        <location filename="../src/widgets/window.cpp" line="445"/>
+        <location filename="../src/widgets/window.cpp" line="2796"/>
         <source>Save</source>
         <translation>Save</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="358"/>
+        <location filename="../src/widgets/window.cpp" line="447"/>
         <source>Print</source>
         <translation>Print</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="359"/>
+        <location filename="../src/widgets/window.cpp" line="448"/>
         <source>Switch theme</source>
         <translation>Switch theme</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="360"/>
-        <location filename="../src/widgets/window.cpp" line="1542"/>
+        <location filename="../src/widgets/window.cpp" line="449"/>
+        <location filename="../src/widgets/window.cpp" line="1871"/>
         <source>Settings</source>
         <translation>Settings</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="471"/>
-        <location filename="../src/widgets/window.cpp" line="2468"/>
+        <location filename="../src/widgets/window.cpp" line="563"/>
+        <location filename="../src/widgets/window.cpp" line="3047"/>
         <source>Read-Only</source>
         <translation>Read-Only</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="487"/>
+        <location filename="../src/widgets/window.cpp" line="579"/>
         <source>You do not have permission to open %1</source>
         <translation>You do not have permission to open %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="522"/>
+        <location filename="../src/widgets/window.cpp" line="619"/>
+        <location filename="../src/widgets/window.cpp" line="2359"/>
         <source>Invalid file: %1</source>
         <translation>Invalid file: %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="602"/>
-        <location filename="../src/widgets/window.cpp" line="644"/>
+        <location filename="../src/widgets/window.cpp" line="733"/>
+        <location filename="../src/widgets/window.cpp" line="779"/>
         <source>Do you want to save this file?</source>
         <translation>Do you want to save this file?</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="894"/>
+        <location filename="../src/widgets/window.cpp" line="1027"/>
         <source>You do not have permission to save %1</source>
         <translation>You do not have permission to save %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="918"/>
+        <location filename="../src/widgets/window.cpp" line="1051"/>
         <source>Saved successfully</source>
         <translation>Saved successfully</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="954"/>
-        <location filename="../src/widgets/window.cpp" line="1021"/>
-        <location filename="../src/widgets/window.cpp" line="1062"/>
+        <location filename="../src/widgets/window.cpp" line="1087"/>
+        <location filename="../src/widgets/window.cpp" line="1160"/>
+        <location filename="../src/widgets/window.cpp" line="1201"/>
         <source>Save File</source>
         <translation>Save File</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1023"/>
+        <location filename="../src/widgets/window.cpp" line="1162"/>
         <source>Encoding</source>
         <translation>Encoding</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1211"/>
+        <location filename="../src/widgets/window.cpp" line="1350"/>
         <source>Read-Only mode is on</source>
         <translation>Read-Only mode is on</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1441"/>
+        <location filename="../src/widgets/window.cpp" line="1770"/>
         <source>Current location remembered</source>
         <translation>Current location remembered</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1492"/>
+        <location filename="../src/widgets/window.cpp" line="1821"/>
         <source>Ctrl+&apos;=&apos;</source>
         <translation>Ctrl+&apos;=&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1495"/>
+        <location filename="../src/widgets/window.cpp" line="1824"/>
         <source>Ctrl+&apos;-&apos;</source>
         <translation>Ctrl+&apos;-&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1524"/>
+        <location filename="../src/widgets/window.cpp" line="1853"/>
         <source>Editor</source>
         <translation>Editor</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1890"/>
+        <location filename="../src/widgets/window.cpp" line="2451"/>
         <source>Untitled %1</source>
         <translation>Untitled %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2215"/>
+        <location filename="../src/widgets/window.cpp" line="2794"/>
         <source>Cancel</source>
         <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2216"/>
+        <location filename="../src/widgets/window.cpp" line="2795"/>
         <source>Discard</source>
         <translation>Discard</translation>
     </message>

--- a/translations/deepin-editor_az.ts
+++ b/translations/deepin-editor_az.ts
@@ -2,17 +2,17 @@
 <context>
     <name>BottomBar</name>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="39"/>
+        <location filename="../src/widgets/bottombar.cpp" line="24"/>
         <source>Row</source>
         <translation>Sətir</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="40"/>
+        <location filename="../src/widgets/bottombar.cpp" line="25"/>
         <source>Column</source>
         <translation>Sütun</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="41"/>
+        <location filename="../src/widgets/bottombar.cpp" line="26"/>
         <source>Characters %1</source>
         <translation>%1 simvol</translation>
     </message>
@@ -20,9 +20,9 @@
 <context>
     <name>DDropdownMenu</name>
     <message>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="300"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="344"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="349"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="290"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="341"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="346"/>
         <source>None</source>
         <translation>Heç biri</translation>
     </message>
@@ -30,80 +30,85 @@
 <context>
     <name>EditWrapper</name>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="201"/>
-        <location filename="../src/editor/editwrapper.cpp" line="264"/>
-        <location filename="../src/editor/editwrapper.cpp" line="321"/>
-        <location filename="../src/editor/editwrapper.cpp" line="536"/>
+        <location filename="../src/editor/editwrapper.cpp" line="246"/>
+        <location filename="../src/editor/editwrapper.cpp" line="314"/>
+        <location filename="../src/editor/editwrapper.cpp" line="439"/>
+        <location filename="../src/editor/editwrapper.cpp" line="702"/>
         <source>Save</source>
         <translation>Saxlamaq</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="316"/>
+        <location filename="../src/editor/editwrapper.cpp" line="434"/>
         <source>Do you want to save this file?</source>
         <translation>Bu faylı saxlamaq istəyirsiniz?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="262"/>
-        <location filename="../src/editor/editwrapper.cpp" line="319"/>
+        <location filename="../src/editor/editwrapper.cpp" line="312"/>
+        <location filename="../src/editor/editwrapper.cpp" line="437"/>
         <source>Cancel</source>
         <translation>İmtina</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="259"/>
+        <location filename="../src/editor/editwrapper.cpp" line="309"/>
         <source>Encoding changed. Do you want to save the file now?</source>
         <translation>Kodlaşma dəyişdirildi. Faylı indi saxlamaq istəyirsiniz?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="320"/>
+        <location filename="../src/editor/editwrapper.cpp" line="438"/>
         <source>Discard</source>
         <translation>Rədd etmək</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="445"/>
+        <location filename="../src/editor/editwrapper.cpp" line="564"/>
         <source>You do not have permission to save %1</source>
         <translation>%1 saxlamaq üçün imtiyazınız yoxdur</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="607"/>
+        <location filename="../src/editor/editwrapper.cpp" line="774"/>
         <source>File removed on the disk. Save it now?</source>
         <translation>Diskdəki fayl silindi. O, indi saxlanılsın?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="612"/>
+        <location filename="../src/editor/editwrapper.cpp" line="779"/>
         <source>File has changed on disk. Reload?</source>
         <translation>Diskdəki fayl dəyişdirildi. Yenidən yüklənsin?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="634"/>
-        <location filename="../src/widgets/bottombar.cpp" line="60"/>
+        <location filename="../src/editor/editwrapper.cpp" line="801"/>
+        <location filename="../src/widgets/bottombar.cpp" line="45"/>
         <source>INSERT</source>
         <translation>DAXİL_ETMƏK</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="637"/>
+        <location filename="../src/editor/editwrapper.cpp" line="804"/>
         <source>OVERWRITE</source>
         <translation>ÜZƏRİNƏ_YAZMAQ</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="640"/>
+        <location filename="../src/editor/editwrapper.cpp" line="807"/>
         <source>R/O</source>
         <translation>Y/O</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="945"/>
+        <source>The file cannot be read, which may be too large or has been damaged!</source>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
     <name>FindBar</name>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="40"/>
+        <location filename="../src/controls/findbar.cpp" line="22"/>
         <source>Find</source>
         <translation>Tapmaq</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="44"/>
+        <location filename="../src/controls/findbar.cpp" line="26"/>
         <source>Previous</source>
         <translation>Əvvəlki</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="46"/>
+        <location filename="../src/controls/findbar.cpp" line="28"/>
         <source>Next</source>
         <translation>Sonrakı</translation>
     </message>
@@ -111,7 +116,7 @@
 <context>
     <name>JumpLineBar</name>
     <message>
-        <location filename="../src/controls/jumplinebar.cpp" line="40"/>
+        <location filename="../src/controls/jumplinebar.cpp" line="28"/>
         <source>Go to Line: </source>
         <translation>Sətirə keçin:</translation>
     </message>
@@ -119,12 +124,12 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/editorapplication.cpp" line="27"/>
+        <location filename="../src/editorapplication.cpp" line="11"/>
         <source>Text Editor is a powerful tool for viewing and editing text files.</source>
         <translation>Mətn Redaktoru, mətn fayllarına baxmaq və onlara düzəliş etmək üçün güclü bir vasitədir.</translation>
     </message>
     <message>
-        <location filename="../src/editorapplication.cpp" line="38"/>
+        <location filename="../src/editorapplication.cpp" line="22"/>
         <source>Text Editor</source>
         <translation>Mətn Redaktoru</translation>
     </message>
@@ -132,572 +137,572 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/editorapplication.cpp" line="35"/>
+        <location filename="../src/editorapplication.cpp" line="19"/>
         <source>Text Editor</source>
         <translation>Mətn Redaktoru</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="203"/>
-        <location filename="../src/editor/editwrapper.cpp" line="538"/>
-        <location filename="../src/widgets/window.cpp" line="956"/>
-        <location filename="../src/widgets/window.cpp" line="973"/>
-        <location filename="../src/widgets/window.cpp" line="1064"/>
-        <location filename="../src/widgets/window.cpp" line="1079"/>
+        <location filename="../src/editor/editwrapper.cpp" line="248"/>
+        <location filename="../src/editor/editwrapper.cpp" line="704"/>
+        <location filename="../src/widgets/window.cpp" line="1089"/>
+        <location filename="../src/widgets/window.cpp" line="1111"/>
+        <location filename="../src/widgets/window.cpp" line="1203"/>
+        <location filename="../src/widgets/window.cpp" line="1218"/>
         <source>Encoding</source>
         <translation>Kodlaşma</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="24"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="9"/>
         <source>Basic</source>
         <translation>Əsas</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="25"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="10"/>
         <source>Font Style</source>
         <translation>Şrift üslubu</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="26"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="11"/>
         <source>Font</source>
         <translation>Şrift</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="27"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="12"/>
         <source>Font Size</source>
         <translation>Şriftin ölçüsü</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="28"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="13"/>
         <source>Shortcuts</source>
         <translation>Qısa yollar</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="29"/>
-        <location filename="../src/controls/settingsdialog.cpp" line="30"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="14"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="15"/>
         <source>Keymap</source>
         <translation>Düymələr xəritəsi</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="31"/>
-        <location filename="../src/controls/settingsdialog.cpp" line="107"/>
-        <location filename="../src/widgets/window.cpp" line="1482"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="16"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="92"/>
+        <location filename="../src/widgets/window.cpp" line="1811"/>
         <source>Window</source>
         <translation>Pəncərə</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="32"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="17"/>
         <source>New tab</source>
         <translation>Yeni vərəq</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="33"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="18"/>
         <source>New window</source>
         <translation>Yeni pəncərə</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="34"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="19"/>
         <source>Save</source>
         <translation>Saxlamaq</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="35"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="20"/>
         <source>Save as</source>
         <translation>Belə saxlayın</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="36"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="21"/>
         <source>Next tab</source>
         <translation>Sonrakı vərəq</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="37"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="22"/>
         <source>Previous tab</source>
         <translation>Əvvəlki vərəq</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="38"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="23"/>
         <source>Close tab</source>
         <translation>Vərəqi bağlamaq</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="39"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="24"/>
         <source>Close other tabs</source>
         <translation>Digər vərəqləri bağlamaq</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="40"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="25"/>
         <source>Restore tab</source>
         <translation>Vərəqi bərpa etmək</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="41"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="26"/>
         <source>Open file</source>
         <translation>Faylı açın</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="42"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="27"/>
         <source>Increment font size</source>
         <translation>Şriftin ölçüsünü artırmaq</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="43"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="28"/>
         <source>Decrement font size</source>
         <translation>Şriftin ölçüsünü azaltmaq</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="44"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="29"/>
         <source>Reset font size</source>
         <translation>Şriftin ölçüsünü sıfırlamaq</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="45"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="30"/>
         <source>Help</source>
         <translation>Kömək</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="46"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="31"/>
         <source>Toggle fullscreen</source>
         <translation>Tam ekran açmaq</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="47"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="32"/>
         <source>Find</source>
         <translation>Tapmaq</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="48"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="33"/>
         <source>Replace</source>
         <translation>Əvəzləmək</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="49"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="34"/>
         <source>Go to line</source>
         <translation>Sətirə keçmək</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="50"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="35"/>
         <source>Save cursor position</source>
         <translation>Kursorun yerini saxlamaq</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="51"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="36"/>
         <source>Reset cursor position</source>
         <translation>Kursorun yerini sıfırlamaq</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="52"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="37"/>
         <source>Exit</source>
         <translation>Çıxış</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="53"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="38"/>
         <source>Display shortcuts</source>
         <translation>Qısayolları göstərmək</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="54"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="39"/>
         <source>Print</source>
         <translation>Çap</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="55"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="40"/>
         <source>Editor</source>
         <translation>Redaktor</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="56"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="41"/>
         <source>Increase indent</source>
         <translation>Abzası böyütmək</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="57"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="42"/>
         <source>Decrease indent</source>
         <translation>Abzası daraltmaq</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="58"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="43"/>
         <source>Forward character</source>
         <translation>Bir sonrakı somvol</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="59"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="44"/>
         <source>Backward character</source>
         <translation>Bir əvvəlki simvol</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="60"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="45"/>
         <source>Forward word</source>
         <translation>Başlanğıc söz</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="61"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="46"/>
         <source>Backward word</source>
         <translation>Bir əvvəlki söz</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="62"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="47"/>
         <source>Next line</source>
         <translation>Sonrakı sətir</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="63"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="48"/>
         <source>Previous line</source>
         <translation>Əvvəlki sətir</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="64"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="49"/>
         <source>New line</source>
         <translation>Yeni sətir</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="65"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="50"/>
         <source>New line above</source>
         <translation>Yeni sətir yuxarı</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="66"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="51"/>
         <source>New line below</source>
         <translation>Yeni sətir aşağı</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="67"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="52"/>
         <source>Duplicate line</source>
         <translation>Sətirin təkrarı</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="68"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="53"/>
         <source>Delete to end of line</source>
         <translation>Sətirin sonundək silmək</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="69"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="54"/>
         <source>Delete current line</source>
         <translation>Cari sətiri silmək</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="70"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="55"/>
         <source>Swap line up</source>
         <translation>Sətiri yuxarı dəyişmək</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="71"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="56"/>
         <source>Swap line down</source>
         <translation>Sətiri aşağı dəyişmək</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="72"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="57"/>
         <source>Scroll up one line</source>
         <translation>Bir sətir yuxarı sürüşdürmək</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="73"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="58"/>
         <source>Scroll down one line</source>
         <translation>Bir sətir aşağı sürüşdürmək</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="74"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="59"/>
         <source>Page up</source>
         <translation>Bir səhifə yuxarı</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="75"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="60"/>
         <source>Page down</source>
         <translation>Bir səhifə aşağı</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="76"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="61"/>
         <source>Move to end of line</source>
         <translation>Sətirin sonuna köçürmək</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="77"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="62"/>
         <source>Move to start of line</source>
         <translation>Sətirin başlanğıcına köçürmək</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="78"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="63"/>
         <source>Move to end of text</source>
         <translation>Mətnin sonuna köçürmək</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="79"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="64"/>
         <source>Move to start of text</source>
         <translation>Mətnin əvvəlinə köçürmək </translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="80"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="65"/>
         <source>Move to line indentation</source>
         <translation>Sətirin abzasına keçmək</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="81"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="66"/>
         <source>Upper case</source>
         <translation>Böyük hərf</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="82"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="67"/>
         <source>Lower case</source>
         <translation>Kiçik hərf</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="83"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="68"/>
         <source>Capitalize</source>
         <translation>Baş hərflərlə</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="84"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="69"/>
         <source>Delete backward word</source>
         <translation>Bir əvvəlki sözü silmək</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="85"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="70"/>
         <source>Delete forward word</source>
         <translation>Bir sonrakı sözü silmək</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="86"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="71"/>
         <source>Forward over a pair</source>
         <translation>Sonrakı cüt</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="87"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="72"/>
         <source>Backward over a pair</source>
         <translation>Əvvəlki cüt</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="88"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="73"/>
         <source>Select all</source>
         <translation>Hamısını seçmək</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="89"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="74"/>
         <source>Copy</source>
         <translation>Kopyalamaq</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="90"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="75"/>
         <source>Cut</source>
         <translation>Kəsmək</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="91"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="76"/>
         <source>Paste</source>
         <translation>Yerləşdirmək</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="92"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="77"/>
         <source>Transpose character</source>
         <translation>Simvolun yerini dəyişmək</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="93"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="78"/>
         <source>Mark</source>
         <translation>İşarələmək</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="94"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="79"/>
         <source>Unmark</source>
         <translation>İşarəni qaldırmaq</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="95"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="80"/>
         <source>Copy line</source>
         <translation>Sətiri kopyalamaq</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="96"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="81"/>
         <source>Cut line</source>
         <translation>Sətiri kəsmək</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="97"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="82"/>
         <source>Merge lines</source>
         <translation>Sətirləri birləşdirmək</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="98"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="83"/>
         <source>Read-Only mode</source>
         <translation>Yalnız-oxu rejimi</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="99"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="84"/>
         <source>Add comment</source>
         <translation>Şərh əlavə edin</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="100"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="85"/>
         <source>Remove comment</source>
         <translation>Şərhi silmək</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="101"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="86"/>
         <source>Undo</source>
         <translation>Qaytarmaq</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="102"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="87"/>
         <source>Redo</source>
         <translation>Hazır</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="103"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="88"/>
         <source>Add/Remove bookmark</source>
         <translation>Əlfəcin əlavə edin/silin</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="104"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="89"/>
         <source>Move to previous bookmark</source>
         <translation>Əvvəlki əlfəcinlərə köçürmək</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="105"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="90"/>
         <source>Move to next bookmark</source>
         <translation>Sonrakı əlfəcinə köçürmək</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="106"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="91"/>
         <source>Advanced</source>
         <translation>Əlavə</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="108"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="93"/>
         <source>Window size</source>
         <translation>Pəncərə ölçüsü</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="109"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="94"/>
         <source>Tab width</source>
         <translation>Vərəqin eni</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="111"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="96"/>
         <source>Word wrap</source>
         <translation>Sözü sətirə keçirmək</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="112"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="97"/>
         <source>Code folding flag</source>
         <translation>Kod yığma bayrağı</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="113"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="98"/>
         <source>Show line numbers</source>
         <translation>Sətir nömrəsini göstərmək</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="114"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="99"/>
         <source>Show bookmarks icon</source>
         <translation>Əlfəcinlərin nişanlarını göstərmək</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="115"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="100"/>
         <source>Show whitespaces and tabs</source>
         <translation>Ara boşluqlarını və vərəqləri göstərmək</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="116"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="101"/>
         <source>Highlight current line</source>
         <translation>Cari sətiri vurğulamaq</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="117"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="102"/>
         <source>Color mark</source>
         <translation>Rəng markeri</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="120"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="105"/>
         <source>Unicode</source>
         <translation>Unicode</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="121"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="106"/>
         <source>WesternEuropean</source>
         <translation>Qərbi_Avropa</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="122"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="107"/>
         <source>CentralEuropean</source>
         <translation>Mərkəzi_Avropa</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="123"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="108"/>
         <source>Baltic</source>
         <translation>Baltik</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="124"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="109"/>
         <source>Cyrillic</source>
         <translation>Kiril</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="125"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="110"/>
         <source>Arabic</source>
         <translation>Ərəb</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="130"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="115"/>
         <source>Celtic</source>
         <translation>Kelt</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="131"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="116"/>
         <source>SouthEasternEuropean</source>
         <translation>Cənub-Şərqi_Avropa</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="126"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="111"/>
         <source>Greek</source>
         <translation>Yunan</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="127"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="112"/>
         <source>Hebrew</source>
         <translation>İvrit</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="132"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="117"/>
         <source>ChineseSimplified</source>
         <translation>Çin_Sadələşdirilmiş</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="133"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="118"/>
         <source>ChineseTraditional</source>
         <translation>Çin_Ənənəvi</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="134"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="119"/>
         <source>Japanese</source>
         <translation>Yapon</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="135"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="120"/>
         <source>Korean</source>
         <translation>Koreya</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="129"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="114"/>
         <source>Thai</source>
         <translation>Tay</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="128"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="113"/>
         <source>Turkish</source>
         <translation>Türk</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="136"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="121"/>
         <source>Vietnamese</source>
         <translation>Vyetnam</translation>
     </message>
     <message>
-        <location filename="../src/startmanager.cpp" line="762"/>
+        <location filename="../src/startmanager.cpp" line="832"/>
         <source>File not saved</source>
         <translation>Fayl saxlanılmadı</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="974"/>
-        <location filename="../src/widgets/window.cpp" line="1065"/>
-        <location filename="../src/widgets/window.cpp" line="1080"/>
+        <location filename="../src/widgets/window.cpp" line="1112"/>
+        <location filename="../src/widgets/window.cpp" line="1204"/>
+        <location filename="../src/widgets/window.cpp" line="1219"/>
         <source>Line Endings</source>
         <translation>Sətrin sonu</translation>
     </message>
@@ -705,32 +710,32 @@
 <context>
     <name>ReplaceBar</name>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="39"/>
+        <location filename="../src/controls/replacebar.cpp" line="21"/>
         <source>Find</source>
         <translation>Tapmaq</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="43"/>
+        <location filename="../src/controls/replacebar.cpp" line="25"/>
         <source>Replace With</source>
         <translation>Bununla əvəzləmək</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="47"/>
+        <location filename="../src/controls/replacebar.cpp" line="29"/>
         <source>Replace</source>
         <translation>Əvəzləmək</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="50"/>
+        <location filename="../src/controls/replacebar.cpp" line="32"/>
         <source>Skip</source>
         <translation>Ötürmək</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="53"/>
+        <location filename="../src/controls/replacebar.cpp" line="35"/>
         <source>Replace Rest</source>
         <translation>Başqalarını dəyişin</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="56"/>
+        <location filename="../src/controls/replacebar.cpp" line="38"/>
         <source>Replace All</source>
         <translation>Hamısını əvəzləmək</translation>
     </message>
@@ -747,58 +752,58 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../src/common/settings.cpp" line="91"/>
+        <location filename="../src/common/settings.cpp" line="115"/>
         <source>Standard</source>
         <translation>Standard</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="91"/>
+        <location filename="../src/common/settings.cpp" line="115"/>
         <source>Customize</source>
         <translation>Özəlləşdirmək</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="104"/>
+        <location filename="../src/common/settings.cpp" line="128"/>
         <source>Normal</source>
         <translation>Normal</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="104"/>
+        <location filename="../src/common/settings.cpp" line="128"/>
         <source>Maximum</source>
         <translation>Ən çox</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="104"/>
+        <location filename="../src/common/settings.cpp" line="128"/>
         <source>Fullscreen</source>
         <translation>Tam ekran</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="292"/>
+        <location filename="../src/common/settings.cpp" line="316"/>
         <source>This shortcut conflicts with system shortcut %1</source>
         <translation>Bu qısayol %1 sistem qısayolu ilə ziddiyyətlidir</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="294"/>
+        <location filename="../src/common/settings.cpp" line="318"/>
         <source>This shortcut conflicts with %1, click on Replace to make this shortcut effective immediately</source>
         <translation>Bu qısayol %1 ilə ziddiyyətlidir, bu qısayolu dərhal qüvvəyə mindirmək üçün Əvəzləmək düyməsinə vurun</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="410"/>
-        <location filename="../src/common/settings.cpp" line="418"/>
+        <location filename="../src/common/settings.cpp" line="464"/>
+        <location filename="../src/common/settings.cpp" line="472"/>
         <source>The shortcut %1 is invalid, please set another one.</source>
         <translation>%1 qısayolu işləmir, başqa birini təyin edin.</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="445"/>
+        <location filename="../src/common/settings.cpp" line="507"/>
         <source>Cancel</source>
         <translation>İmtina</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="446"/>
+        <location filename="../src/common/settings.cpp" line="508"/>
         <source>Replace</source>
         <translation>Əvəzləmək</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="448"/>
+        <location filename="../src/common/settings.cpp" line="510"/>
         <source>OK</source>
         <translation>OLDU</translation>
     </message>
@@ -806,7 +811,7 @@
 <context>
     <name>StartManager</name>
     <message>
-        <location filename="../src/startmanager.cpp" line="340"/>
+        <location filename="../src/startmanager.cpp" line="350"/>
         <source>Untitled %1</source>
         <translation>Başlıqsız %1</translation>
     </message>
@@ -814,32 +819,32 @@
 <context>
     <name>Tabbar</name>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="515"/>
+        <location filename="../src/controls/tabbar.cpp" line="540"/>
         <source>Close tab</source>
         <translation>Vərəqi bağlamaq</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="516"/>
+        <location filename="../src/controls/tabbar.cpp" line="541"/>
         <source>Close other tabs</source>
         <translation>Digər vərəqləri baölamaq</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="517"/>
+        <location filename="../src/controls/tabbar.cpp" line="542"/>
         <source>More options</source>
         <translation>Daha çox seçimlər</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="518"/>
+        <location filename="../src/controls/tabbar.cpp" line="543"/>
         <source>Close tabs to the left</source>
         <translation>Soldakı vərəqləri bağlamaq</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="519"/>
+        <location filename="../src/controls/tabbar.cpp" line="544"/>
         <source>Close tabs to the right</source>
         <translation>Saödakı vərəqləri bağlamaq</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="520"/>
+        <location filename="../src/controls/tabbar.cpp" line="545"/>
         <source>Close unmodified tabs</source>
         <translation>Dəyişdirilməmiş vərəqləri bağlamaq</translation>
     </message>
@@ -847,261 +852,259 @@
 <context>
     <name>TextEdit</name>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="235"/>
+        <location filename="../src/editor/dtextedit.cpp" line="259"/>
         <source>Undo</source>
         <translation>Qaytarmaq</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="236"/>
+        <location filename="../src/editor/dtextedit.cpp" line="260"/>
         <source>Redo</source>
         <translation>Hazır</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="237"/>
+        <location filename="../src/editor/dtextedit.cpp" line="261"/>
         <source>Cut</source>
         <translation>Kəsmək</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="238"/>
+        <location filename="../src/editor/dtextedit.cpp" line="262"/>
         <source>Copy</source>
         <translation>Kopyalamaq</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="239"/>
+        <location filename="../src/editor/dtextedit.cpp" line="263"/>
         <source>Paste</source>
         <translation>Yerləşdirmək</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="240"/>
+        <location filename="../src/editor/dtextedit.cpp" line="264"/>
         <source>Delete</source>
         <translation>Silmək</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="241"/>
+        <location filename="../src/editor/dtextedit.cpp" line="265"/>
         <source>Select All</source>
         <translation>Hamısını seçmək</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="242"/>
-        <location filename="../src/widgets/window.cpp" line="361"/>
+        <location filename="../src/editor/dtextedit.cpp" line="266"/>
+        <location filename="../src/widgets/window.cpp" line="450"/>
         <source>Find</source>
         <translation>Tapmaq</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="243"/>
-        <location filename="../src/widgets/window.cpp" line="362"/>
+        <location filename="../src/editor/dtextedit.cpp" line="267"/>
+        <location filename="../src/widgets/window.cpp" line="451"/>
         <source>Replace</source>
         <translation>Əvəzləmək</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="244"/>
+        <location filename="../src/editor/dtextedit.cpp" line="268"/>
         <source>Go to Line</source>
         <translation>Sətirə keçin</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="245"/>
+        <location filename="../src/editor/dtextedit.cpp" line="269"/>
         <source>Turn on Read-Only mode</source>
         <translation>Yalnız-oxu, rejimini açmaq</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="246"/>
+        <location filename="../src/editor/dtextedit.cpp" line="270"/>
         <source>Turn off Read-Only mode</source>
         <translation>Yalnız-oxu, rejimini söndürmək</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="247"/>
+        <location filename="../src/editor/dtextedit.cpp" line="271"/>
         <source>Fullscreen</source>
         <translation>Tam ekran</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="248"/>
+        <location filename="../src/editor/dtextedit.cpp" line="272"/>
         <source>Exit fullscreen</source>
         <translation>Tam ekrandan çıxış</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="249"/>
+        <location filename="../src/editor/dtextedit.cpp" line="273"/>
         <source>Display in file manager</source>
         <translation>Fayl bələdçisində göstərmək</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="250"/>
-        <location filename="../src/editor/dtextedit.cpp" line="302"/>
+        <location filename="../src/editor/dtextedit.cpp" line="274"/>
+        <location filename="../src/editor/dtextedit.cpp" line="326"/>
         <source>Add Comment</source>
         <translation>Şərh əlavə edin</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="251"/>
+        <location filename="../src/editor/dtextedit.cpp" line="275"/>
         <source>Text to Speech</source>
         <translation>Mətndən_Nitqə</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="252"/>
+        <location filename="../src/editor/dtextedit.cpp" line="276"/>
         <source>Stop reading</source>
         <translation>Oxunuşu saxlamaq</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="253"/>
+        <location filename="../src/editor/dtextedit.cpp" line="277"/>
         <source>Speech to Text</source>
         <translation>Nitqdən_Mətnə</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="254"/>
+        <location filename="../src/editor/dtextedit.cpp" line="278"/>
         <source>Translate</source>
         <translation>Tərcümə</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="255"/>
+        <location filename="../src/editor/dtextedit.cpp" line="279"/>
         <source>Column Mode</source>
         <translation>Sütun rejimi</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="256"/>
+        <location filename="../src/editor/dtextedit.cpp" line="280"/>
         <source>Add bookmark</source>
         <translation>Əlfəcin əlavə etmək</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="257"/>
+        <location filename="../src/editor/dtextedit.cpp" line="281"/>
         <source>Remove Bookmark</source>
         <translation>Əlfəcini silmək</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="258"/>
+        <location filename="../src/editor/dtextedit.cpp" line="282"/>
         <source>Previous bookmark</source>
         <translation>Əvvəlki əlfəcin</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="259"/>
+        <location filename="../src/editor/dtextedit.cpp" line="283"/>
         <source>Next bookmark</source>
         <translation>Sonrakı əlfəcin</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="260"/>
+        <location filename="../src/editor/dtextedit.cpp" line="284"/>
         <source>Remove All Bookmarks</source>
         <translation>Bütün əlfəcinləri silmək</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="261"/>
+        <location filename="../src/editor/dtextedit.cpp" line="285"/>
         <source>Fold All</source>
         <translation>Hamısını bükmək</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="262"/>
+        <location filename="../src/editor/dtextedit.cpp" line="286"/>
         <source>Fold Current Level</source>
         <translation>Cari səviyyəni bükmək</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="263"/>
+        <location filename="../src/editor/dtextedit.cpp" line="287"/>
         <source>Unfold All</source>
         <translation>Hamısını açmaq</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="264"/>
+        <location filename="../src/editor/dtextedit.cpp" line="288"/>
         <source>Unfold Current Level</source>
         <translation>Cari səviyyəni açmaq</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="269"/>
+        <location filename="../src/editor/dtextedit.cpp" line="293"/>
         <source>Color Mark</source>
         <translation>Rəng markeri</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="273"/>
+        <location filename="../src/editor/dtextedit.cpp" line="297"/>
         <source>Clear All Marks</source>
         <translation>Bütün işarələri qaldırmaq</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="274"/>
+        <location filename="../src/editor/dtextedit.cpp" line="298"/>
         <source>Clear Last Mark</source>
         <translation>Sonuncu işarəni qaldırmaq</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="283"/>
+        <location filename="../src/editor/dtextedit.cpp" line="307"/>
         <source>Mark</source>
         <translation>İşarələmək</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="295"/>
+        <location filename="../src/editor/dtextedit.cpp" line="319"/>
         <source>Mark All</source>
         <translation>Hamısını işarələmək</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="303"/>
+        <location filename="../src/editor/dtextedit.cpp" line="327"/>
         <source>Remove Comment</source>
         <translation>Şərhi silmək</translation>
     </message>
     <message>
-        <source>Failed to paste text: it is too large</source>
-        <translation type="vanished">Mətn yerləşdririlə bilmədi: o, çox böyükdür</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="2581"/>
+        <location filename="../src/editor/dtextedit.cpp" line="2672"/>
         <source>Copy failed: not enough memory</source>
         <translation>Kopyalanmadı: kifayət qədər yaddaş yoxdur</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="2665"/>
+        <location filename="../src/editor/dtextedit.cpp" line="2756"/>
         <source>Press ALT and click lines to edit in column mode</source>
         <translation>Sütun rejimində düzəliş etmək üçün ALT düyməsini basın və sətirə vurun</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="346"/>
+        <location filename="../src/editor/dtextedit.cpp" line="370"/>
         <source>Change Case</source>
         <translation>Böyük-kiçik hərfi dəyişdirmək</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="347"/>
+        <location filename="../src/editor/dtextedit.cpp" line="371"/>
         <source>Upper Case</source>
         <translation>Böyük hərf</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="348"/>
+        <location filename="../src/editor/dtextedit.cpp" line="372"/>
         <source>Lower Case</source>
         <translation>Kiçik hərf</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="349"/>
+        <location filename="../src/editor/dtextedit.cpp" line="373"/>
         <source>Capitalize</source>
         <translation>Baş hərflərlə</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="64"/>
+        <location filename="../src/widgets/bottombar.cpp" line="49"/>
         <source>None</source>
         <translation>Heç biri</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1184"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1222"/>
         <source>Selected line(s) copied</source>
         <translation>Seçilmiş sətir(lər) kopyalandı</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1190"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1228"/>
         <source>Current line copied</source>
         <translation>Cari sətir kopyalandı</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1210"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1248"/>
         <source>Selected line(s) clipped</source>
         <translation>Seçilmiş sətir(lər) kəsildi</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1222"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1259"/>
         <source>Current line clipped</source>
         <translation>Cari sətir kəsildi</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="2591"/>
+        <location filename="../src/editor/dtextedit.cpp" line="2682"/>
         <source>Paste failed: not enough memory</source>
         <translation>Yerləşdirilmədi: kifayət qədər yaddaş yoxdur</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3439"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3617"/>
         <source>Read-Only mode is off</source>
         <translation>Yalnız-oxu, rejimi söndürülüb</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3446"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3465"/>
-        <location filename="../src/editor/dtextedit.cpp" line="6150"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3624"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3643"/>
+        <location filename="../src/editor/dtextedit.cpp" line="6656"/>
+        <location filename="../src/editor/dtextedit.cpp" line="6664"/>
+        <location filename="../src/editor/dtextedit.cpp" line="6675"/>
         <source>Read-Only mode is on</source>
         <translation>Yalnız-ozu, rejimi aktivdir</translation>
     </message>
@@ -1109,7 +1112,7 @@
 <context>
     <name>WarningNotices</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="36"/>
+        <location filename="../src/controls/warningnotices.cpp" line="19"/>
         <source>Reload</source>
         <translation>Yenidən yükləmək</translation>
     </message>
@@ -1117,129 +1120,130 @@
 <context>
     <name>Window</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="38"/>
-        <location filename="../src/widgets/window.cpp" line="357"/>
+        <location filename="../src/controls/warningnotices.cpp" line="21"/>
+        <location filename="../src/widgets/window.cpp" line="446"/>
         <source>Save as</source>
         <translation>Belə saxlayın</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="353"/>
+        <location filename="../src/widgets/window.cpp" line="442"/>
         <source>New window</source>
         <translation>Yeni pəncərə</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="354"/>
+        <location filename="../src/widgets/window.cpp" line="443"/>
         <source>New tab</source>
         <translation>Yeni vərəq</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="355"/>
+        <location filename="../src/widgets/window.cpp" line="444"/>
         <source>Open file</source>
         <translation>Faylı açın</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="356"/>
-        <location filename="../src/widgets/window.cpp" line="2217"/>
+        <location filename="../src/widgets/window.cpp" line="445"/>
+        <location filename="../src/widgets/window.cpp" line="2796"/>
         <source>Save</source>
         <translation>Saxlamaq</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="358"/>
+        <location filename="../src/widgets/window.cpp" line="447"/>
         <source>Print</source>
         <translation>Çap</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="359"/>
+        <location filename="../src/widgets/window.cpp" line="448"/>
         <source>Switch theme</source>
         <translation>Mövzunu dəyişmək</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="360"/>
-        <location filename="../src/widgets/window.cpp" line="1542"/>
+        <location filename="../src/widgets/window.cpp" line="449"/>
+        <location filename="../src/widgets/window.cpp" line="1871"/>
         <source>Settings</source>
         <translation>Ayarlar</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="471"/>
-        <location filename="../src/widgets/window.cpp" line="2468"/>
+        <location filename="../src/widgets/window.cpp" line="563"/>
+        <location filename="../src/widgets/window.cpp" line="3047"/>
         <source>Read-Only</source>
         <translation>Yalnız-oxumaq</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="487"/>
+        <location filename="../src/widgets/window.cpp" line="579"/>
         <source>You do not have permission to open %1</source>
         <translation>%1 açmaq üçün imtiyazınız yoxdur</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="522"/>
+        <location filename="../src/widgets/window.cpp" line="619"/>
+        <location filename="../src/widgets/window.cpp" line="2359"/>
         <source>Invalid file: %1</source>
         <translation>Səhv fayl: %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="602"/>
-        <location filename="../src/widgets/window.cpp" line="644"/>
+        <location filename="../src/widgets/window.cpp" line="733"/>
+        <location filename="../src/widgets/window.cpp" line="779"/>
         <source>Do you want to save this file?</source>
         <translation>Bu faylı saxlamaq istəyirsiniz?</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="894"/>
+        <location filename="../src/widgets/window.cpp" line="1027"/>
         <source>You do not have permission to save %1</source>
         <translation>%1 saxlamaq üçün imtiyazınız yoxdur</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="918"/>
+        <location filename="../src/widgets/window.cpp" line="1051"/>
         <source>Saved successfully</source>
         <translation>Uğurla saxlanıldı</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="954"/>
-        <location filename="../src/widgets/window.cpp" line="1021"/>
-        <location filename="../src/widgets/window.cpp" line="1062"/>
+        <location filename="../src/widgets/window.cpp" line="1087"/>
+        <location filename="../src/widgets/window.cpp" line="1160"/>
+        <location filename="../src/widgets/window.cpp" line="1201"/>
         <source>Save File</source>
         <translation>Faylı saxlayın</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1023"/>
+        <location filename="../src/widgets/window.cpp" line="1162"/>
         <source>Encoding</source>
         <translation>Kodlaşma</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1211"/>
+        <location filename="../src/widgets/window.cpp" line="1350"/>
         <source>Read-Only mode is on</source>
         <translation>Yalnız-ozu, rejimi aktivdir</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1441"/>
+        <location filename="../src/widgets/window.cpp" line="1770"/>
         <source>Current location remembered</source>
         <translation>Cari yer yadda saxlanıldı</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1492"/>
+        <location filename="../src/widgets/window.cpp" line="1821"/>
         <source>Ctrl+&apos;=&apos;</source>
         <translation>Ctrl+&apos;=&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1495"/>
+        <location filename="../src/widgets/window.cpp" line="1824"/>
         <source>Ctrl+&apos;-&apos;</source>
         <translation>Ctrl+&apos;-&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1524"/>
+        <location filename="../src/widgets/window.cpp" line="1853"/>
         <source>Editor</source>
         <translation>Redaktor</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1890"/>
+        <location filename="../src/widgets/window.cpp" line="2451"/>
         <source>Untitled %1</source>
         <translation>Başlıqsız %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2215"/>
+        <location filename="../src/widgets/window.cpp" line="2794"/>
         <source>Cancel</source>
         <translation>İmtina</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2216"/>
+        <location filename="../src/widgets/window.cpp" line="2795"/>
         <source>Discard</source>
         <translation>Rədd etmək</translation>
     </message>

--- a/translations/deepin-editor_bo.ts
+++ b/translations/deepin-editor_bo.ts
@@ -2,17 +2,17 @@
 <context>
     <name>BottomBar</name>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="39"/>
+        <location filename="../src/widgets/bottombar.cpp" line="24"/>
         <source>Row</source>
         <translation>འཕྲེད་སྟར།</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="40"/>
+        <location filename="../src/widgets/bottombar.cpp" line="25"/>
         <source>Column</source>
         <translation>གཞུང་སྟར།</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="41"/>
+        <location filename="../src/widgets/bottombar.cpp" line="26"/>
         <source>Characters %1</source>
         <translation>ཡིག་འབྲུ། %1</translation>
     </message>
@@ -20,9 +20,9 @@
 <context>
     <name>DDropdownMenu</name>
     <message>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="300"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="344"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="349"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="290"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="341"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="346"/>
         <source>None</source>
         <translation>མེད།</translation>
     </message>
@@ -30,80 +30,85 @@
 <context>
     <name>EditWrapper</name>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="201"/>
-        <location filename="../src/editor/editwrapper.cpp" line="264"/>
-        <location filename="../src/editor/editwrapper.cpp" line="321"/>
-        <location filename="../src/editor/editwrapper.cpp" line="536"/>
+        <location filename="../src/editor/editwrapper.cpp" line="246"/>
+        <location filename="../src/editor/editwrapper.cpp" line="314"/>
+        <location filename="../src/editor/editwrapper.cpp" line="439"/>
+        <location filename="../src/editor/editwrapper.cpp" line="702"/>
         <source>Save</source>
         <translation>ཉར་ཚགས།</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="316"/>
+        <location filename="../src/editor/editwrapper.cpp" line="434"/>
         <source>Do you want to save this file?</source>
         <translation>ཁྱེད་ཀྱིས་ཡིག་ཆ་འདི་ཉར་ཚགས་བྱེད་དམ།</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="262"/>
-        <location filename="../src/editor/editwrapper.cpp" line="319"/>
+        <location filename="../src/editor/editwrapper.cpp" line="312"/>
+        <location filename="../src/editor/editwrapper.cpp" line="437"/>
         <source>Cancel</source>
         <translation>འདོར་བ།</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="259"/>
+        <location filename="../src/editor/editwrapper.cpp" line="309"/>
         <source>Encoding changed. Do you want to save the file now?</source>
         <translation>ཡིག་ཆའི་ཨང་སྒྲིག་བཟོ་བཅོས་བྱས་ཟིན་པས། སྔོན་ལ་ཉར་ཚགས་བྱེད་དམ།</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="320"/>
+        <location filename="../src/editor/editwrapper.cpp" line="438"/>
         <source>Discard</source>
         <translation>མི་ཉར།</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="445"/>
+        <location filename="../src/editor/editwrapper.cpp" line="564"/>
         <source>You do not have permission to save %1</source>
         <translation>ཁྱེད་ལ་%1ཉར་བའི་དབང་ཚད་མེད།</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="607"/>
+        <location filename="../src/editor/editwrapper.cpp" line="774"/>
         <source>File removed on the disk. Save it now?</source>
         <translation>སྡུད་སྡེར་ནང་གི་ཐོག་མའི་ཡིག་ཆ་འབུད་ཟིན་པས། དེ་ཉར་རམ།</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="612"/>
+        <location filename="../src/editor/editwrapper.cpp" line="779"/>
         <source>File has changed on disk. Reload?</source>
         <translation>སྡུད་སྡེར་ནང་གི་ཐོག་མའི་ཡིག་ཆ་བཟོ་བཅོས་བྱས་ཟིན་པས། བསྐྱར་འཇུག་བྱེད་དམ།</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="634"/>
-        <location filename="../src/widgets/bottombar.cpp" line="60"/>
+        <location filename="../src/editor/editwrapper.cpp" line="801"/>
+        <location filename="../src/widgets/bottombar.cpp" line="45"/>
         <source>INSERT</source>
         <translation>ནང་འཇུག</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="637"/>
+        <location filename="../src/editor/editwrapper.cpp" line="804"/>
         <source>OVERWRITE</source>
         <translation>འགེབས་པ།</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="640"/>
+        <location filename="../src/editor/editwrapper.cpp" line="807"/>
         <source>R/O</source>
         <translation>ཀློག་ཙམ།</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="945"/>
+        <source>The file cannot be read, which may be too large or has been damaged!</source>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
     <name>FindBar</name>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="40"/>
+        <location filename="../src/controls/findbar.cpp" line="22"/>
         <source>Find</source>
         <translation>འཚོལ་བ།</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="44"/>
+        <location filename="../src/controls/findbar.cpp" line="26"/>
         <source>Previous</source>
         <translation>གོང་མ།</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="46"/>
+        <location filename="../src/controls/findbar.cpp" line="28"/>
         <source>Next</source>
         <translation>རྗེས་མ།</translation>
     </message>
@@ -111,7 +116,7 @@
 <context>
     <name>JumpLineBar</name>
     <message>
-        <location filename="../src/controls/jumplinebar.cpp" line="40"/>
+        <location filename="../src/controls/jumplinebar.cpp" line="28"/>
         <source>Go to Line: </source>
         <translation>འཕྲེད་སྟར་དུ་མཆོང་བ།</translation>
     </message>
@@ -119,12 +124,12 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/editorapplication.cpp" line="27"/>
+        <location filename="../src/editorapplication.cpp" line="11"/>
         <source>Text Editor is a powerful tool for viewing and editing text files.</source>
         <translation>ཡིག་ཆ་རྩོམ་སྒྲིག་ཆས་ནི་ཡིག་ཆ་ལྟ་བ་དང་རྩོམ་སྒྲིག་བྱེད་པའི་ཡོ་བྱད་ཞིག་རེད།</translation>
     </message>
     <message>
-        <location filename="../src/editorapplication.cpp" line="38"/>
+        <location filename="../src/editorapplication.cpp" line="22"/>
         <source>Text Editor</source>
         <translation>ཡིག་ཆ་རྩོམ་སྒྲིག་ཆས།</translation>
     </message>
@@ -132,572 +137,572 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/editorapplication.cpp" line="35"/>
+        <location filename="../src/editorapplication.cpp" line="19"/>
         <source>Text Editor</source>
         <translation>ཡིག་ཆ་རྩོམ་སྒྲུག་ཆས།</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="203"/>
-        <location filename="../src/editor/editwrapper.cpp" line="538"/>
-        <location filename="../src/widgets/window.cpp" line="956"/>
-        <location filename="../src/widgets/window.cpp" line="973"/>
-        <location filename="../src/widgets/window.cpp" line="1064"/>
-        <location filename="../src/widgets/window.cpp" line="1079"/>
+        <location filename="../src/editor/editwrapper.cpp" line="248"/>
+        <location filename="../src/editor/editwrapper.cpp" line="704"/>
+        <location filename="../src/widgets/window.cpp" line="1089"/>
+        <location filename="../src/widgets/window.cpp" line="1111"/>
+        <location filename="../src/widgets/window.cpp" line="1203"/>
+        <location filename="../src/widgets/window.cpp" line="1218"/>
         <source>Encoding</source>
         <translation>ཨང་སྒྲིག</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="24"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="9"/>
         <source>Basic</source>
         <translation>རྨང་གཞིའི་སྒྲིག་བཀོད།</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="25"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="10"/>
         <source>Font Style</source>
         <translation>ཡིག་གཟུགས་དཔེ་དབྱིབས།</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="26"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="11"/>
         <source>Font</source>
         <translation>ཡིག་གཟུགས།</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="27"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="12"/>
         <source>Font Size</source>
         <translation>ཡིག་ཨང་།</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="28"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="13"/>
         <source>Shortcuts</source>
         <translation>མྱུར་མཐེབ།</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="29"/>
-        <location filename="../src/controls/settingsdialog.cpp" line="30"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="14"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="15"/>
         <source>Keymap</source>
         <translation>མྱུར་མཐེབ་རྟེན་འཕྲོ།</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="31"/>
-        <location filename="../src/controls/settingsdialog.cpp" line="107"/>
-        <location filename="../src/widgets/window.cpp" line="1482"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="16"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="92"/>
+        <location filename="../src/widgets/window.cpp" line="1811"/>
         <source>Window</source>
         <translation>སྒེའུ་ཁུང་།</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="32"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="17"/>
         <source>New tab</source>
         <translation>ཁ་བྱང་ངོས་གསར།</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="33"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="18"/>
         <source>New window</source>
         <translation>སྒེའུ་ཁུང་གསར་པ།</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="34"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="19"/>
         <source>Save</source>
         <translation>ཉར་ཚགས།</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="35"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="20"/>
         <source>Save as</source>
         <translation>གཞན་ཉར།</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="36"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="21"/>
         <source>Next tab</source>
         <translation>ཁ་བྱང་ངོས་རྗེས་མ།</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="37"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="22"/>
         <source>Previous tab</source>
         <translation>ཁ་བྱང་ངོས་གོང་མ།</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="38"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="23"/>
         <source>Close tab</source>
         <translation>ཁ་བྱང་ངོས་ཁ་རྒྱག</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="39"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="24"/>
         <source>Close other tabs</source>
         <translation>ཁ་བྱང་ངོས་གཞན་དག་ཁ་རྒྱག</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="40"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="25"/>
         <source>Restore tab</source>
         <translation>ཁ་བྱང་ངོས་སླར་གསོ།</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="41"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="26"/>
         <source>Open file</source>
         <translation>ཡིག་ཆ་ཁ་ཕྱེ།</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="42"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="27"/>
         <source>Increment font size</source>
         <translation>ཡིག་ཨང་ཆེ་སྒྱུར།</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="43"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="28"/>
         <source>Decrement font size</source>
         <translation>ཡིག་ཨང་ཆུང་སྒྱུར།</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="44"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="29"/>
         <source>Reset font size</source>
         <translation>ཡིག་ཨང་སོར་ལོག</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="45"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="30"/>
         <source>Help</source>
         <translation>རོགས་པ།</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="46"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="31"/>
         <source>Toggle fullscreen</source>
         <translation>བརྙན་ཡོལ་ཡོངས་ལ་བརྗེ་བ།</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="47"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="32"/>
         <source>Find</source>
         <translation>འཚོལ་བ།</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="48"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="33"/>
         <source>Replace</source>
         <translation>བརྗེ་བ།</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="49"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="34"/>
         <source>Go to line</source>
         <translation>འཕྲེད་སྟར་དུ་མཆོང་བ།</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="50"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="35"/>
         <source>Save cursor position</source>
         <translation>འོད་རྟགས་གནས་ཡུལ་ཉར་བ།</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="51"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="36"/>
         <source>Reset cursor position</source>
         <translation>ཉར་བའི་འོད་རྟགས་གནས་ཡུལ་དུ་མཆོང་བ།</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="52"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="37"/>
         <source>Exit</source>
         <translation>ཕྱིར་འབུད།</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="53"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="38"/>
         <source>Display shortcuts</source>
         <translation>མྱུར་མཐེབ་འཆར་བ།</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="54"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="39"/>
         <source>Print</source>
         <translation>པར་འདེབས།</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="55"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="40"/>
         <source>Editor</source>
         <translation>རྩོམ་སྒྲིག</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="56"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="41"/>
         <source>Increase indent</source>
         <translation>སྐུམ་ཚད་ཆེར་གཏོང་།</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="57"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="42"/>
         <source>Decrease indent</source>
         <translation>སྐུམ་ཚད་ཆུང་གཏོང་།</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="58"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="43"/>
         <source>Forward character</source>
         <translation>གཡས་སུ་ཡིག་རྟགས་གཅིག་སྤོ་བ།</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="59"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="44"/>
         <source>Backward character</source>
         <translation>གཡོན་ལ་ཡིག་རྟགས་གཅིག་སྤོ་བ།</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="60"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="45"/>
         <source>Forward word</source>
         <translation>གཡས་སུ་ཚིག་གཅིག་སྤོ་བ།</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="61"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="46"/>
         <source>Backward word</source>
         <translation>གཡོན་དུ་ཚིག་གཅིག་སྤོ་བ།</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="62"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="47"/>
         <source>Next line</source>
         <translation>སྟར་པ་རྗེས་མ།</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="63"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="48"/>
         <source>Previous line</source>
         <translation>སྟར་པ་གོང་མ།</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="64"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="49"/>
         <source>New line</source>
         <translation>སྟར་པ་བརྗེ་བ།</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="65"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="50"/>
         <source>New line above</source>
         <translation>གོང་ལ་སྟར་པ་གཅིག་འཇུག་པ།</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="66"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="51"/>
         <source>New line below</source>
         <translation>འོག་ཏུ་སྟར་པ་གཅིག་འཇུག་པ།</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="67"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="52"/>
         <source>Duplicate line</source>
         <translation>འདྲ་བཤུ་བྱས་རྗེས་མིག་སྔའི་སྟར་པར་སྦྱར་བ།</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="68"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="53"/>
         <source>Delete to end of line</source>
         <translation>སྟར་པའི་མཇུག་བར་སུབ་པ།</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="69"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="54"/>
         <source>Delete current line</source>
         <translation>མིག་སྔའི་སྟར་པ་སུབ་པ།</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="70"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="55"/>
         <source>Swap line up</source>
         <translation>གོང་དུ་སྟར་པ་གཅིག་སྤོ་བ།</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="71"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="56"/>
         <source>Swap line down</source>
         <translation>འོག་ཏུ་སྟར་པ་གཅིག་སྤོ་བ།</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="72"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="57"/>
         <source>Scroll up one line</source>
         <translation>སྟེང་དུ་སྟར་པ་གཅིག་འགྲིལ་བ།</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="73"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="58"/>
         <source>Scroll down one line</source>
         <translation>འོག་ཏུ་སྟར་པ་གཅིག་འགྲིལ་བ།</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="74"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="59"/>
         <source>Page up</source>
         <translation>སྟེང་དུ་ཤོག་ལྷེ་གཅིག་འགྲིལ་བ།</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="75"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="60"/>
         <source>Page down</source>
         <translation>འོག་ཏུ་ཤོག་ལྷེ་གཅིག་འགྲིལ་བ།</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="76"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="61"/>
         <source>Move to end of line</source>
         <translation>སྟར་པའི་མཇུག་ཏུ་སྤོ་བ།</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="77"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="62"/>
         <source>Move to start of line</source>
         <translation>སྟར་པའི་མགོ་ལ་སྤོ་བ།</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="78"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="63"/>
         <source>Move to end of text</source>
         <translation>ཡིག་ཆའི་མཇུག་ཏུ་སྤོ་བ།</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="79"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="64"/>
         <source>Move to start of text</source>
         <translation>ཡིག་ཆའི་མགོ་ལ་སྤོ་བ།</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="80"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="65"/>
         <source>Move to line indentation</source>
         <translation>སྟར་པ་སྐུམ་སར་སྤོ་བ།</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="81"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="66"/>
         <source>Upper case</source>
         <translation>ཆེ་བྲིས་ལ་བརྗེ་བ།</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="82"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="67"/>
         <source>Lower case</source>
         <translation>ཆུང་བྲིས་ལ་བརྗེ་བ།</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="83"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="68"/>
         <source>Capitalize</source>
         <translation>མགོ་ཡིག་ཆེ་བྲིས།</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="84"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="69"/>
         <source>Delete backward word</source>
         <translation>གཡོན་དུ་ཚིག་གཅིག་སུབ་པ།</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="85"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="70"/>
         <source>Delete forward word</source>
         <translation>གཡས་སུ་ཚིག་གཅིག་སུབ་པ།</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="86"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="71"/>
         <source>Forward over a pair</source>
         <translation>གཡས་སུ་སྙོམ་སྒྲིག་བྱེད་པ།</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="87"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="72"/>
         <source>Backward over a pair</source>
         <translation>གཡོན་དུ་སྙོམ་སྒྲིག་བྱེད་པ།</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="88"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="73"/>
         <source>Select all</source>
         <translation>ཡོངས་འདེམས།</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="89"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="74"/>
         <source>Copy</source>
         <translation>པར་སློག</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="90"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="75"/>
         <source>Cut</source>
         <translation>དྲས་གཏུབ།</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="91"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="76"/>
         <source>Paste</source>
         <translation>སྦྱར་བ།</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="92"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="77"/>
         <source>Transpose character</source>
         <translation>ཡིག་རྟགས་བརྗེ་བ།</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="93"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="78"/>
         <source>Mark</source>
         <translation>རྟགས་སྒྲིག་བཀོད།</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="94"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="79"/>
         <source>Unmark</source>
         <translation>རྟགས་འདོར་བ།</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="95"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="80"/>
         <source>Copy line</source>
         <translation>སྟར་པ་འདྲ་བཟོ།</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="96"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="81"/>
         <source>Cut line</source>
         <translation>སྟར་པ་དྲས་པ།</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="97"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="82"/>
         <source>Merge lines</source>
         <translation>སྟར་པ་སྒྲིལ་བ།</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="98"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="83"/>
         <source>Read-Only mode</source>
         <translation>ཀློག་ཙམ་དཔེ་དབྱིབས་ལ་བརྗེ་བ།</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="99"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="84"/>
         <source>Add comment</source>
         <translation>མཆན་སྣོན་པ།</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="100"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="85"/>
         <source>Remove comment</source>
         <translation>མཆན་འདོར་བ།</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="101"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="86"/>
         <source>Undo</source>
         <translation>མི་བྱེད།</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="102"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="87"/>
         <source>Redo</source>
         <translation>བསྐྱར་བྱེད།</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="103"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="88"/>
         <source>Add/Remove bookmark</source>
         <translation>ཤོག་འཛར་སྣོན་པ།/འདོར་བ།</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="104"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="89"/>
         <source>Move to previous bookmark</source>
         <translation>ཤོག་འཛར་གོང་དུ་སྤོ་བ།</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="105"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="90"/>
         <source>Move to next bookmark</source>
         <translation>ཤོག་འཛར་རྗེས་མར་སྤོ་བ།</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="106"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="91"/>
         <source>Advanced</source>
         <translation>མཐོ་རིམ་སྒྲིག་བཀོད།</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="108"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="93"/>
         <source>Window size</source>
         <translation>སྒེའུ་ཁུང་རྣམ་པ།</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="109"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="94"/>
         <source>Tab width</source>
         <translation>Tabཡིག་རྟགས་ཞེང་ཚད།</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="111"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="96"/>
         <source>Word wrap</source>
         <translation>རང་འགུལ་ངང་འཕྲེད་སྟར་བརྗེ་བ།</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="112"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="97"/>
         <source>Code folding flag</source>
         <translation>ཚབ་རྟགས་ལྟེབ་པའི་མཚོན་རྟགས་གསལ་བ།</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="113"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="98"/>
         <source>Show line numbers</source>
         <translation>སྟར་ཨང་གསལ་བ།</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="114"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="99"/>
         <source>Show bookmarks icon</source>
         <translation>ཤོག་འཛར་གྱི་རྟགས་གསལ་བ།</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="115"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="100"/>
         <source>Show whitespaces and tabs</source>
         <translation>སྟོང་ཆའི་ཡིག་རྟགས།/རེའུ་མིག་བཟོ་རྟགས་གསལ་བ།</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="116"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="101"/>
         <source>Highlight current line</source>
         <translation>མིག་སྔའི་མཐོ་ཚད་གསལ་བ།</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="117"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="102"/>
         <source>Color mark</source>
         <translation>ཚོས་གཞིའི་རྟགས། </translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="120"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="105"/>
         <source>Unicode</source>
         <translation>Unicode</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="121"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="106"/>
         <source>WesternEuropean</source>
         <translation>ཡོ་རོབ་ནུབ་མའི་སྐད་ཁོངས།</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="122"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="107"/>
         <source>CentralEuropean</source>
         <translation>ཡོ་རོབ་བར་མའི་སྐད་ཁོངས།</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="123"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="108"/>
         <source>Baltic</source>
         <translation>པོ་ལོའུ་ཏི་ཧའེ་ཡི་སྐད་ཡིག</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="124"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="109"/>
         <source>Cyrillic</source>
         <translation>ཞི་ལེར་གྱི་ཡི་གེ།</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="125"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="110"/>
         <source>Arabic</source>
         <translation>ཨ་རབ་ཀྱི་སྐད།</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="130"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="115"/>
         <source>Celtic</source>
         <translation>ཁའེ་ཐེའི་སྐད།</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="131"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="116"/>
         <source>SouthEasternEuropean</source>
         <translation>ཡོ་རོབ་ཤར་ལྷོའི་སྐད་ཁོངས།</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="126"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="111"/>
         <source>Greek</source>
         <translation>གྷི་རིག་གི་སྐད།</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="127"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="112"/>
         <source>Hebrew</source>
         <translation>ཞི་པོ་ལའེ་ཡི་སྐད།</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="132"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="117"/>
         <source>ChineseSimplified</source>
         <translation>ཟོར་ཡང་རྒྱ་ཡིག</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="133"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="118"/>
         <source>ChineseTraditional</source>
         <translation>ཟོར་ལྕིའི་རྒྱ་ཡིག</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="134"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="119"/>
         <source>Japanese</source>
         <translation>ཉི་ཧོང་སྐད།</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="135"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="120"/>
         <source>Korean</source>
         <translation>ཁོ་རེ་ཡའི་སྐད།</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="129"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="114"/>
         <source>Thai</source>
         <translation>ཐེ་ལན་གྱི་སྐད།</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="128"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="113"/>
         <source>Turkish</source>
         <translation>ཐུར་ཁེའི་སྐད།</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="136"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="121"/>
         <source>Vietnamese</source>
         <translation>ཝེ་ཐེ་ནམ་གྱི་སྐད།</translation>
     </message>
     <message>
-        <location filename="../src/startmanager.cpp" line="762"/>
+        <location filename="../src/startmanager.cpp" line="832"/>
         <source>File not saved</source>
         <translation>ཡིག་ཆ་ཉར་ཚགས་བྱས་མེད།</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="974"/>
-        <location filename="../src/widgets/window.cpp" line="1065"/>
-        <location filename="../src/widgets/window.cpp" line="1080"/>
+        <location filename="../src/widgets/window.cpp" line="1112"/>
+        <location filename="../src/widgets/window.cpp" line="1204"/>
+        <location filename="../src/widgets/window.cpp" line="1219"/>
         <source>Line Endings</source>
         <translation>སྟར་བརྗེ་རྟགས།</translation>
     </message>
@@ -705,32 +710,32 @@
 <context>
     <name>ReplaceBar</name>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="39"/>
+        <location filename="../src/controls/replacebar.cpp" line="21"/>
         <source>Find</source>
         <translation>འཚོལ་བ།</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="43"/>
+        <location filename="../src/controls/replacebar.cpp" line="25"/>
         <source>Replace With</source>
         <translation>ལ་བརྗེ་བ།</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="47"/>
+        <location filename="../src/controls/replacebar.cpp" line="29"/>
         <source>Replace</source>
         <translation>བརྗེ་བ།</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="50"/>
+        <location filename="../src/controls/replacebar.cpp" line="32"/>
         <source>Skip</source>
         <translation>མཆོང་བ།</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="53"/>
+        <location filename="../src/controls/replacebar.cpp" line="35"/>
         <source>Replace Rest</source>
         <translation>ལྷག་མ་བརྗེ་བ། </translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="56"/>
+        <location filename="../src/controls/replacebar.cpp" line="38"/>
         <source>Replace All</source>
         <translation>ཚང་མ་བརྗེ་བ།</translation>
     </message>
@@ -747,58 +752,58 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../src/common/settings.cpp" line="91"/>
+        <location filename="../src/common/settings.cpp" line="115"/>
         <source>Standard</source>
         <translation>ཚད་ལྡན།</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="91"/>
+        <location filename="../src/common/settings.cpp" line="115"/>
         <source>Customize</source>
         <translation>རང་སྒྲུབ།</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="104"/>
+        <location filename="../src/common/settings.cpp" line="128"/>
         <source>Normal</source>
         <translation>རྒྱུན་གཏན་སྒེའུ་ཁུང་།</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="104"/>
+        <location filename="../src/common/settings.cpp" line="128"/>
         <source>Maximum</source>
         <translation>ཆེ་སྒྱུར།</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="104"/>
+        <location filename="../src/common/settings.cpp" line="128"/>
         <source>Fullscreen</source>
         <translation>ཡོལ་གང་།</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="292"/>
+        <location filename="../src/common/settings.cpp" line="316"/>
         <source>This shortcut conflicts with system shortcut %1</source>
         <translation>མྱུར་མཐེབ་འདི་དང་མ་ལག་གི་མྱུར་མཐེབ་%1འགལ་ཟླ་ཡོད།</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="294"/>
+        <location filename="../src/common/settings.cpp" line="318"/>
         <source>This shortcut conflicts with %1, click on Replace to make this shortcut effective immediately</source>
         <translation>མྱུར་མཐེབ་འདི་དང་%1འགལ་ཟླ་ཡོད་པས། བརྗེ་པོ་མནན་ནས་མྱུར་མཐེབ་འདི་ལམ་སེང་སྤྱོད་གོ་ཆོད།</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="410"/>
-        <location filename="../src/common/settings.cpp" line="418"/>
+        <location filename="../src/common/settings.cpp" line="464"/>
+        <location filename="../src/common/settings.cpp" line="472"/>
         <source>The shortcut %1 is invalid, please set another one.</source>
         <translation>%1ནི་ནུས་མེད་མྱུར་མཐེབ་ཡིན་པས། ཡང་བསྐྱར་སྒྲིག་བཀོད་གནང་རྒྱུ།</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="445"/>
+        <location filename="../src/common/settings.cpp" line="507"/>
         <source>Cancel</source>
         <translation>འདོར་བ།</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="446"/>
+        <location filename="../src/common/settings.cpp" line="508"/>
         <source>Replace</source>
         <translation>བརྗེ་བ།</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="448"/>
+        <location filename="../src/common/settings.cpp" line="510"/>
         <source>OK</source>
         <translation>གཏན་འཁེལ།</translation>
     </message>
@@ -806,7 +811,7 @@
 <context>
     <name>StartManager</name>
     <message>
-        <location filename="../src/startmanager.cpp" line="340"/>
+        <location filename="../src/startmanager.cpp" line="350"/>
         <source>Untitled %1</source>
         <translation>མིང་མེད་པའི་ཡིག་ཚགས་%1</translation>
     </message>
@@ -814,32 +819,32 @@
 <context>
     <name>Tabbar</name>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="515"/>
+        <location filename="../src/controls/tabbar.cpp" line="540"/>
         <source>Close tab</source>
         <translation>ཁ་བྱང་ངོས་ཁ་རྒྱག</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="516"/>
+        <location filename="../src/controls/tabbar.cpp" line="541"/>
         <source>Close other tabs</source>
         <translation>ཁ་བྱང་ངོས་གཞན་དག་ཁ་རྒྱག</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="517"/>
+        <location filename="../src/controls/tabbar.cpp" line="542"/>
         <source>More options</source>
         <translation>ཁ་རྒྱག་ཐབས་དེ་ལས་མང་།</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="518"/>
+        <location filename="../src/controls/tabbar.cpp" line="543"/>
         <source>Close tabs to the left</source>
         <translation>གཡོན་ཕྱོགས་ཀྱི་ཁ་བྱང་ངོས་ཚང་མ་ཁ་རྒྱག</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="519"/>
+        <location filename="../src/controls/tabbar.cpp" line="544"/>
         <source>Close tabs to the right</source>
         <translation>གཡས་ཕྱོགས་ཀྱི་ཁ་བྱང་ངོས་ཚང་མ་ཁ་རྒྱག</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="520"/>
+        <location filename="../src/controls/tabbar.cpp" line="545"/>
         <source>Close unmodified tabs</source>
         <translation>བཟོ་བཅོས་བྱས་མེད་པའི་ཁ་བྱང་ངོས་ཚང་མ་ཁ་རྒྱག</translation>
     </message>
@@ -847,261 +852,259 @@
 <context>
     <name>TextEdit</name>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="235"/>
+        <location filename="../src/editor/dtextedit.cpp" line="259"/>
         <source>Undo</source>
         <translation>མི་བྱེད།</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="236"/>
+        <location filename="../src/editor/dtextedit.cpp" line="260"/>
         <source>Redo</source>
         <translation>བསྐྱར་བྱེད།</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="237"/>
+        <location filename="../src/editor/dtextedit.cpp" line="261"/>
         <source>Cut</source>
         <translation>དྲས་གཏུབ།</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="238"/>
+        <location filename="../src/editor/dtextedit.cpp" line="262"/>
         <source>Copy</source>
         <translation>པར་སློག</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="239"/>
+        <location filename="../src/editor/dtextedit.cpp" line="263"/>
         <source>Paste</source>
         <translation>སྦྱར་བ།</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="240"/>
+        <location filename="../src/editor/dtextedit.cpp" line="264"/>
         <source>Delete</source>
         <translation>སུབ་པ། </translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="241"/>
+        <location filename="../src/editor/dtextedit.cpp" line="265"/>
         <source>Select All</source>
         <translation>ཡོངས་འདེམས།</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="242"/>
-        <location filename="../src/widgets/window.cpp" line="361"/>
+        <location filename="../src/editor/dtextedit.cpp" line="266"/>
+        <location filename="../src/widgets/window.cpp" line="450"/>
         <source>Find</source>
         <translation>འཚོལ་བ།</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="243"/>
-        <location filename="../src/widgets/window.cpp" line="362"/>
+        <location filename="../src/editor/dtextedit.cpp" line="267"/>
+        <location filename="../src/widgets/window.cpp" line="451"/>
         <source>Replace</source>
         <translation>བརྗེ་བ།</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="244"/>
+        <location filename="../src/editor/dtextedit.cpp" line="268"/>
         <source>Go to Line</source>
         <translation>འཕྲེད་སྟར་དུ་མཆོང་བ།</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="245"/>
+        <location filename="../src/editor/dtextedit.cpp" line="269"/>
         <source>Turn on Read-Only mode</source>
         <translation>ཀློག་ཙམ་དཔེ་དབྱིབས་ཁ་ཕྱེ།</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="246"/>
+        <location filename="../src/editor/dtextedit.cpp" line="270"/>
         <source>Turn off Read-Only mode</source>
         <translation>ཀློག་ཙམ་དཔེ་དབྱིབས་ཁ་རྒྱག</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="247"/>
+        <location filename="../src/editor/dtextedit.cpp" line="271"/>
         <source>Fullscreen</source>
         <translation>ཡོལ་གང་།</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="248"/>
+        <location filename="../src/editor/dtextedit.cpp" line="272"/>
         <source>Exit fullscreen</source>
         <translation>ཡོལ་གང་ནས་ཕྱིར་འབུད་པ།</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="249"/>
+        <location filename="../src/editor/dtextedit.cpp" line="273"/>
         <source>Display in file manager</source>
         <translation>ཡིག་ཆ་དོ་དམ་ཆས་ཁྲོད་དུ་མངོན་པ།</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="250"/>
-        <location filename="../src/editor/dtextedit.cpp" line="302"/>
+        <location filename="../src/editor/dtextedit.cpp" line="274"/>
+        <location filename="../src/editor/dtextedit.cpp" line="326"/>
         <source>Add Comment</source>
         <translation>མཆན་སྣོན་པ།</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="251"/>
+        <location filename="../src/editor/dtextedit.cpp" line="275"/>
         <source>Text to Speech</source>
         <translation>ཀློག་འདོན་བྱ་རྒྱུ།</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="252"/>
+        <location filename="../src/editor/dtextedit.cpp" line="276"/>
         <source>Stop reading</source>
         <translation>ཀློག་མཚམས་འཇོག་པ།</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="253"/>
+        <location filename="../src/editor/dtextedit.cpp" line="277"/>
         <source>Speech to Text</source>
         <translation>སྐད་སྒྲའི་དཔོད་བྲིས།</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="254"/>
+        <location filename="../src/editor/dtextedit.cpp" line="278"/>
         <source>Translate</source>
         <translation>ཡིག་སྒྱུར།</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="255"/>
+        <location filename="../src/editor/dtextedit.cpp" line="279"/>
         <source>Column Mode</source>
         <translation>གཞུང་སྟར་རྩོམ་སྒྲིག་རྣམ་པ།</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="256"/>
+        <location filename="../src/editor/dtextedit.cpp" line="280"/>
         <source>Add bookmark</source>
         <translation>ཤོག་འཛར་སྣོན་པ།</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="257"/>
+        <location filename="../src/editor/dtextedit.cpp" line="281"/>
         <source>Remove Bookmark</source>
         <translation>ཤོག་འཛར་འདོར་བ།</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="258"/>
+        <location filename="../src/editor/dtextedit.cpp" line="282"/>
         <source>Previous bookmark</source>
         <translation>ཤོག་འཛར་གོང་མ།</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="259"/>
+        <location filename="../src/editor/dtextedit.cpp" line="283"/>
         <source>Next bookmark</source>
         <translation>ཤོག་འཛར་རྗེས་མ།</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="260"/>
+        <location filename="../src/editor/dtextedit.cpp" line="284"/>
         <source>Remove All Bookmarks</source>
         <translation>ཤོག་འཛར་ཚང་མ་འདོར་བ།</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="261"/>
+        <location filename="../src/editor/dtextedit.cpp" line="285"/>
         <source>Fold All</source>
         <translation>བང་རིམ་ཚང་མ་ལྟེབ་པ།</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="262"/>
+        <location filename="../src/editor/dtextedit.cpp" line="286"/>
         <source>Fold Current Level</source>
         <translation>མིག་སྔའི་བང་རིམ་ལྟེབ་པ།</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="263"/>
+        <location filename="../src/editor/dtextedit.cpp" line="287"/>
         <source>Unfold All</source>
         <translation>བང་རིམ་ཚང་མ་བཀྲམ་པ།</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="264"/>
+        <location filename="../src/editor/dtextedit.cpp" line="288"/>
         <source>Unfold Current Level</source>
         <translation>མིག་སྔའི་བང་རིམ་བཀྲམ་པ།</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="269"/>
+        <location filename="../src/editor/dtextedit.cpp" line="293"/>
         <source>Color Mark</source>
         <translation>ཚོས་གཞིའི་རྟགས།</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="273"/>
+        <location filename="../src/editor/dtextedit.cpp" line="297"/>
         <source>Clear All Marks</source>
         <translation>རྟགས་ཚང་མ་གཙང་སེལ།</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="274"/>
+        <location filename="../src/editor/dtextedit.cpp" line="298"/>
         <source>Clear Last Mark</source>
         <translation>གོང་གི་རྟགས་གཙང་སེལ།</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="283"/>
+        <location filename="../src/editor/dtextedit.cpp" line="307"/>
         <source>Mark</source>
         <translation>རྟགས་སྒྲིག་བཀོད།</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="295"/>
+        <location filename="../src/editor/dtextedit.cpp" line="319"/>
         <source>Mark All</source>
         <translation>རྟགས་ཚང་མ།</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="303"/>
+        <location filename="../src/editor/dtextedit.cpp" line="327"/>
         <source>Remove Comment</source>
         <translation>མཆན་འདོར་བ།</translation>
     </message>
     <message>
-        <source>Failed to paste text: it is too large</source>
-        <translation type="vanished">ཡིག་ཆ་ཆེ་དྲགས་པས་སྦྱར་མི་ཐུབ།</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="2581"/>
+        <location filename="../src/editor/dtextedit.cpp" line="2672"/>
         <source>Copy failed: not enough memory</source>
         <translation>གཤོང་ཚད་མ་འདང་བས་པར་སློག་བྱེད་ཐབས་བྲལ།</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="2665"/>
+        <location filename="../src/editor/dtextedit.cpp" line="2756"/>
         <source>Press ALT and click lines to edit in column mode</source>
         <translation>ALT+ཙི་གུའི་འདེམས་པ་སྤྱད་ནས་གཞུང་སྟར་རྩོམ་སྒྲིག་རྣམ་པ་བརྗེ་རྒྱུ།</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="346"/>
+        <location filename="../src/editor/dtextedit.cpp" line="370"/>
         <source>Change Case</source>
         <translation>ཆེ་བྲིས་ཆུང་བྲིས་བརྗེ་བ།</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="347"/>
+        <location filename="../src/editor/dtextedit.cpp" line="371"/>
         <source>Upper Case</source>
         <translation>ཆེ་བྲིས།</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="348"/>
+        <location filename="../src/editor/dtextedit.cpp" line="372"/>
         <source>Lower Case</source>
         <translation>ཆུང་བྲིས།</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="349"/>
+        <location filename="../src/editor/dtextedit.cpp" line="373"/>
         <source>Capitalize</source>
         <translation>མགོ་ཡིག་ཆེ་བྲིས།</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="64"/>
+        <location filename="../src/widgets/bottombar.cpp" line="49"/>
         <source>None</source>
         <translation>མེད།</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1184"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1222"/>
         <source>Selected line(s) copied</source>
         <translation>བདམས་ཟིན་པའི་སྟར་པ(རུ་སྟར)འདི་དྲས་སྦྱར་པང་དུ་པར་སློག་བྱས་ཟིན།</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1190"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1228"/>
         <source>Current line copied</source>
         <translation>མིག་སྔའི་སྟར་པ་འདི་དྲས་སྦྱར་པང་དུ་པར་སློག་བྱས་ཟིན།</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1210"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1248"/>
         <source>Selected line(s) clipped</source>
         <translation>བདམས་ཟིན་པའི་སྟར་པ(རུ་སྟར)འདི་དྲས་སྦྱར་པང་དུ་དྲས་གཏུབ་བྱས་ཟིན།</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1222"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1259"/>
         <source>Current line clipped</source>
         <translation>མིག་སྔའི་སྟར་པ་འདི་དྲས་སྦྱར་པང་དུ་དྲས་གཏུབ་བྱས་ཟིན།</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="2591"/>
+        <location filename="../src/editor/dtextedit.cpp" line="2682"/>
         <source>Paste failed: not enough memory</source>
         <translation>ཤོང་ཚད་མི་འདང་བས་སྦྱར་མ་ཐུབ།</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3439"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3617"/>
         <source>Read-Only mode is off</source>
         <translation>ཀློག་ཙམ་དཔེ་དབྱིབས་ཁ་བརྒྱབ་ཟིན།</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3446"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3465"/>
-        <location filename="../src/editor/dtextedit.cpp" line="6150"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3624"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3643"/>
+        <location filename="../src/editor/dtextedit.cpp" line="6656"/>
+        <location filename="../src/editor/dtextedit.cpp" line="6664"/>
+        <location filename="../src/editor/dtextedit.cpp" line="6675"/>
         <source>Read-Only mode is on</source>
         <translation>ཀློག་ཙམ་དཔེ་དབྱིབས་ཁ་ཕྱེ་ཟིན།</translation>
     </message>
@@ -1109,7 +1112,7 @@
 <context>
     <name>WarningNotices</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="36"/>
+        <location filename="../src/controls/warningnotices.cpp" line="19"/>
         <source>Reload</source>
         <translation>བསྐྱར་འཇུག</translation>
     </message>
@@ -1117,129 +1120,130 @@
 <context>
     <name>Window</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="38"/>
-        <location filename="../src/widgets/window.cpp" line="357"/>
+        <location filename="../src/controls/warningnotices.cpp" line="21"/>
+        <location filename="../src/widgets/window.cpp" line="446"/>
         <source>Save as</source>
         <translation>གཞན་ཉར།</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="353"/>
+        <location filename="../src/widgets/window.cpp" line="442"/>
         <source>New window</source>
         <translation>སྒེའུ་ཁུང་གསར་པ།</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="354"/>
+        <location filename="../src/widgets/window.cpp" line="443"/>
         <source>New tab</source>
         <translation>ཁ་བྱང་ངོས་གསར།</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="355"/>
+        <location filename="../src/widgets/window.cpp" line="444"/>
         <source>Open file</source>
         <translation>ཡིག་ཆ་ཁ་ཕྱེ།</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="356"/>
-        <location filename="../src/widgets/window.cpp" line="2217"/>
+        <location filename="../src/widgets/window.cpp" line="445"/>
+        <location filename="../src/widgets/window.cpp" line="2796"/>
         <source>Save</source>
         <translation>ཉར་ཚགས།</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="358"/>
+        <location filename="../src/widgets/window.cpp" line="447"/>
         <source>Print</source>
         <translation>པར་འདེབས།</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="359"/>
+        <location filename="../src/widgets/window.cpp" line="448"/>
         <source>Switch theme</source>
         <translation>བརྗོད་བྱ་གཙོ་བོ་བརྗེ་བ།</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="360"/>
-        <location filename="../src/widgets/window.cpp" line="1542"/>
+        <location filename="../src/widgets/window.cpp" line="449"/>
+        <location filename="../src/widgets/window.cpp" line="1871"/>
         <source>Settings</source>
         <translation>སྒྲིག་བཀོད།</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="471"/>
-        <location filename="../src/widgets/window.cpp" line="2468"/>
+        <location filename="../src/widgets/window.cpp" line="563"/>
+        <location filename="../src/widgets/window.cpp" line="3047"/>
         <source>Read-Only</source>
         <translation>ཀློག་ཙམ།</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="487"/>
+        <location filename="../src/widgets/window.cpp" line="579"/>
         <source>You do not have permission to open %1</source>
         <translation>ཁྱེད་ལ་%1ཁ་ཕྱེ་བའི་དབང་ཚད་མེད།</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="522"/>
+        <location filename="../src/widgets/window.cpp" line="619"/>
+        <location filename="../src/widgets/window.cpp" line="2359"/>
         <source>Invalid file: %1</source>
         <translation>ཕན་མེད་ཡིག་ཆ། %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="602"/>
-        <location filename="../src/widgets/window.cpp" line="644"/>
+        <location filename="../src/widgets/window.cpp" line="733"/>
+        <location filename="../src/widgets/window.cpp" line="779"/>
         <source>Do you want to save this file?</source>
         <translation>ཁྱེད་ཀྱིས་ཡིག་ཆ་འདི་ཉར་ཚགས་བྱེད་དམ།</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="894"/>
+        <location filename="../src/widgets/window.cpp" line="1027"/>
         <source>You do not have permission to save %1</source>
         <translation>ཁྱེད་ལ་%1ཉར་བའི་དབང་ཚད་མེད།</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="918"/>
+        <location filename="../src/widgets/window.cpp" line="1051"/>
         <source>Saved successfully</source>
         <translation>ཡིག་ཆ་ཉར་ཟིན།</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="954"/>
-        <location filename="../src/widgets/window.cpp" line="1021"/>
-        <location filename="../src/widgets/window.cpp" line="1062"/>
+        <location filename="../src/widgets/window.cpp" line="1087"/>
+        <location filename="../src/widgets/window.cpp" line="1160"/>
+        <location filename="../src/widgets/window.cpp" line="1201"/>
         <source>Save File</source>
         <translation>ཉར་བ།</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1023"/>
+        <location filename="../src/widgets/window.cpp" line="1162"/>
         <source>Encoding</source>
         <translation>ཨང་སྒྲིག</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1211"/>
+        <location filename="../src/widgets/window.cpp" line="1350"/>
         <source>Read-Only mode is on</source>
         <translation>ཀློག་ཙམ་དཔེ་དབྱིབས་ཁ་ཕྱེ་ཟིན།</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1441"/>
+        <location filename="../src/widgets/window.cpp" line="1770"/>
         <source>Current location remembered</source>
         <translation>མིག་སྔའི་གནས་ས་ངེས་ཟིན།</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1492"/>
+        <location filename="../src/widgets/window.cpp" line="1821"/>
         <source>Ctrl+&apos;=&apos;</source>
         <translation>Ctrl+&apos;=&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1495"/>
+        <location filename="../src/widgets/window.cpp" line="1824"/>
         <source>Ctrl+&apos;-&apos;</source>
         <translation>Ctrl+&apos;-&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1524"/>
+        <location filename="../src/widgets/window.cpp" line="1853"/>
         <source>Editor</source>
         <translation>རྩོམ་སྒྲིག</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1890"/>
+        <location filename="../src/widgets/window.cpp" line="2451"/>
         <source>Untitled %1</source>
         <translation>མིང་མེད་པའི་ཡིག་ཚགས་%1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2215"/>
+        <location filename="../src/widgets/window.cpp" line="2794"/>
         <source>Cancel</source>
         <translation>འདོར་བ།</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2216"/>
+        <location filename="../src/widgets/window.cpp" line="2795"/>
         <source>Discard</source>
         <translation>མི་ཉར།</translation>
     </message>

--- a/translations/deepin-editor_ca.ts
+++ b/translations/deepin-editor_ca.ts
@@ -2,17 +2,17 @@
 <context>
     <name>BottomBar</name>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="39"/>
+        <location filename="../src/widgets/bottombar.cpp" line="24"/>
         <source>Row</source>
         <translation>Fila</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="40"/>
+        <location filename="../src/widgets/bottombar.cpp" line="25"/>
         <source>Column</source>
         <translation>Columna</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="41"/>
+        <location filename="../src/widgets/bottombar.cpp" line="26"/>
         <source>Characters %1</source>
         <translation>Caràcters %1</translation>
     </message>
@@ -20,9 +20,9 @@
 <context>
     <name>DDropdownMenu</name>
     <message>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="300"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="344"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="349"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="290"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="341"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="346"/>
         <source>None</source>
         <translation>Cap</translation>
     </message>
@@ -30,80 +30,85 @@
 <context>
     <name>EditWrapper</name>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="201"/>
-        <location filename="../src/editor/editwrapper.cpp" line="264"/>
-        <location filename="../src/editor/editwrapper.cpp" line="321"/>
-        <location filename="../src/editor/editwrapper.cpp" line="536"/>
+        <location filename="../src/editor/editwrapper.cpp" line="246"/>
+        <location filename="../src/editor/editwrapper.cpp" line="314"/>
+        <location filename="../src/editor/editwrapper.cpp" line="439"/>
+        <location filename="../src/editor/editwrapper.cpp" line="702"/>
         <source>Save</source>
         <translation>Desa</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="316"/>
+        <location filename="../src/editor/editwrapper.cpp" line="434"/>
         <source>Do you want to save this file?</source>
         <translation>Voleu desar aquest fitxer?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="262"/>
-        <location filename="../src/editor/editwrapper.cpp" line="319"/>
+        <location filename="../src/editor/editwrapper.cpp" line="312"/>
+        <location filename="../src/editor/editwrapper.cpp" line="437"/>
         <source>Cancel</source>
         <translation>Cancel·la</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="259"/>
+        <location filename="../src/editor/editwrapper.cpp" line="309"/>
         <source>Encoding changed. Do you want to save the file now?</source>
         <translation>Ha canviat la codificació. Voleu desar el fitxer ara?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="320"/>
+        <location filename="../src/editor/editwrapper.cpp" line="438"/>
         <source>Discard</source>
         <translation>Descarta</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="445"/>
+        <location filename="../src/editor/editwrapper.cpp" line="564"/>
         <source>You do not have permission to save %1</source>
         <translation>No teniu permís per desar %1</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="607"/>
+        <location filename="../src/editor/editwrapper.cpp" line="774"/>
         <source>File removed on the disk. Save it now?</source>
         <translation>El fitxer s&apos;ha eliminat del disc. El voleu desar ara?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="612"/>
+        <location filename="../src/editor/editwrapper.cpp" line="779"/>
         <source>File has changed on disk. Reload?</source>
         <translation>El fitxer ha canviat al disc. El torno a carregar?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="634"/>
-        <location filename="../src/widgets/bottombar.cpp" line="60"/>
+        <location filename="../src/editor/editwrapper.cpp" line="801"/>
+        <location filename="../src/widgets/bottombar.cpp" line="45"/>
         <source>INSERT</source>
         <translation>INSEREIX</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="637"/>
+        <location filename="../src/editor/editwrapper.cpp" line="804"/>
         <source>OVERWRITE</source>
         <translation>SOBREESCRIU</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="640"/>
+        <location filename="../src/editor/editwrapper.cpp" line="807"/>
         <source>R/O</source>
         <translation>N/L</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="945"/>
+        <source>The file cannot be read, which may be too large or has been damaged!</source>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
     <name>FindBar</name>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="40"/>
+        <location filename="../src/controls/findbar.cpp" line="22"/>
         <source>Find</source>
         <translation>Troba</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="44"/>
+        <location filename="../src/controls/findbar.cpp" line="26"/>
         <source>Previous</source>
         <translation>Anterior</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="46"/>
+        <location filename="../src/controls/findbar.cpp" line="28"/>
         <source>Next</source>
         <translation>Següent</translation>
     </message>
@@ -111,7 +116,7 @@
 <context>
     <name>JumpLineBar</name>
     <message>
-        <location filename="../src/controls/jumplinebar.cpp" line="40"/>
+        <location filename="../src/controls/jumplinebar.cpp" line="28"/>
         <source>Go to Line: </source>
         <translation>Ves a la línia:</translation>
     </message>
@@ -119,12 +124,12 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/editorapplication.cpp" line="27"/>
+        <location filename="../src/editorapplication.cpp" line="11"/>
         <source>Text Editor is a powerful tool for viewing and editing text files.</source>
         <translation>L&apos;Editor de text és és una eina potent per visualitzar i editar fitxers de text.</translation>
     </message>
     <message>
-        <location filename="../src/editorapplication.cpp" line="38"/>
+        <location filename="../src/editorapplication.cpp" line="22"/>
         <source>Text Editor</source>
         <translation>Editor de text</translation>
     </message>
@@ -132,572 +137,572 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/editorapplication.cpp" line="35"/>
+        <location filename="../src/editorapplication.cpp" line="19"/>
         <source>Text Editor</source>
         <translation>Editor de text</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="203"/>
-        <location filename="../src/editor/editwrapper.cpp" line="538"/>
-        <location filename="../src/widgets/window.cpp" line="956"/>
-        <location filename="../src/widgets/window.cpp" line="973"/>
-        <location filename="../src/widgets/window.cpp" line="1064"/>
-        <location filename="../src/widgets/window.cpp" line="1079"/>
+        <location filename="../src/editor/editwrapper.cpp" line="248"/>
+        <location filename="../src/editor/editwrapper.cpp" line="704"/>
+        <location filename="../src/widgets/window.cpp" line="1089"/>
+        <location filename="../src/widgets/window.cpp" line="1111"/>
+        <location filename="../src/widgets/window.cpp" line="1203"/>
+        <location filename="../src/widgets/window.cpp" line="1218"/>
         <source>Encoding</source>
         <translation>Codificació</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="24"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="9"/>
         <source>Basic</source>
         <translation>Bàsic</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="25"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="10"/>
         <source>Font Style</source>
         <translation>Estil de la lletra</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="26"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="11"/>
         <source>Font</source>
         <translation>Lletra</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="27"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="12"/>
         <source>Font Size</source>
         <translation>Mida de la lletra</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="28"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="13"/>
         <source>Shortcuts</source>
         <translation>Dreceres</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="29"/>
-        <location filename="../src/controls/settingsdialog.cpp" line="30"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="14"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="15"/>
         <source>Keymap</source>
         <translation>Mapa de tecles</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="31"/>
-        <location filename="../src/controls/settingsdialog.cpp" line="107"/>
-        <location filename="../src/widgets/window.cpp" line="1482"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="16"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="92"/>
+        <location filename="../src/widgets/window.cpp" line="1811"/>
         <source>Window</source>
         <translation>Finestra</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="32"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="17"/>
         <source>New tab</source>
         <translation>Pestanya nova</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="33"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="18"/>
         <source>New window</source>
         <translation>Finestra nova</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="34"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="19"/>
         <source>Save</source>
         <translation>Desa</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="35"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="20"/>
         <source>Save as</source>
         <translation>Desa com a</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="36"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="21"/>
         <source>Next tab</source>
         <translation>Pestanya següent</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="37"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="22"/>
         <source>Previous tab</source>
         <translation>Pestanya anterior</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="38"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="23"/>
         <source>Close tab</source>
         <translation>Tanca la pestanya</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="39"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="24"/>
         <source>Close other tabs</source>
         <translation>Tanca les altres pestanyes</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="40"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="25"/>
         <source>Restore tab</source>
         <translation>Restaura la pestanya</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="41"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="26"/>
         <source>Open file</source>
         <translation>Obre un fitxer</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="42"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="27"/>
         <source>Increment font size</source>
         <translation>Augmenta la mida de la lletra</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="43"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="28"/>
         <source>Decrement font size</source>
         <translation>Redueix la mida de la lletra</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="44"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="29"/>
         <source>Reset font size</source>
         <translation>Restableix la mida de la lletra</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="45"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="30"/>
         <source>Help</source>
         <translation>Ajuda</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="46"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="31"/>
         <source>Toggle fullscreen</source>
         <translation>Commuta la pantalla completa</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="47"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="32"/>
         <source>Find</source>
         <translation>Troba</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="48"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="33"/>
         <source>Replace</source>
         <translation>Reemplaça</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="49"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="34"/>
         <source>Go to line</source>
         <translation>Ves a la línia</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="50"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="35"/>
         <source>Save cursor position</source>
         <translation>Desa la posició del cursor</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="51"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="36"/>
         <source>Reset cursor position</source>
         <translation>Restableix la posició del cursor</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="52"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="37"/>
         <source>Exit</source>
         <translation>Surt</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="53"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="38"/>
         <source>Display shortcuts</source>
         <translation>Mostra les dreceres</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="54"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="39"/>
         <source>Print</source>
         <translation>Imprimeix</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="55"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="40"/>
         <source>Editor</source>
         <translation>Editor</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="56"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="41"/>
         <source>Increase indent</source>
         <translation>Augmenta el sagnat</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="57"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="42"/>
         <source>Decrease indent</source>
         <translation>Redueix el sagant</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="58"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="43"/>
         <source>Forward character</source>
         <translation>Caràcter següent</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="59"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="44"/>
         <source>Backward character</source>
         <translation>Caràcter anterior</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="60"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="45"/>
         <source>Forward word</source>
         <translation>Paraula següent</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="61"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="46"/>
         <source>Backward word</source>
         <translation>Paraula anterior</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="62"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="47"/>
         <source>Next line</source>
         <translation>Línia següent</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="63"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="48"/>
         <source>Previous line</source>
         <translation>Línia anterior</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="64"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="49"/>
         <source>New line</source>
         <translation>Línia nova</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="65"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="50"/>
         <source>New line above</source>
         <translation>Línia nova superior</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="66"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="51"/>
         <source>New line below</source>
         <translation>Línia nova inferior</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="67"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="52"/>
         <source>Duplicate line</source>
         <translation>Duplica la línia</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="68"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="53"/>
         <source>Delete to end of line</source>
         <translation>Suprimeix fins al final de la línia</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="69"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="54"/>
         <source>Delete current line</source>
         <translation>Suprimeix la línia actual</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="70"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="55"/>
         <source>Swap line up</source>
         <translation>Intercanvia amb la línia superior</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="71"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="56"/>
         <source>Swap line down</source>
         <translation>Intercanvia amb la línia inferior</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="72"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="57"/>
         <source>Scroll up one line</source>
         <translation>Ves una línia amunt</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="73"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="58"/>
         <source>Scroll down one line</source>
         <translation>Ves una línia avall</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="74"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="59"/>
         <source>Page up</source>
         <translation>Pàgina amunt</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="75"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="60"/>
         <source>Page down</source>
         <translation>Pàgina avall</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="76"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="61"/>
         <source>Move to end of line</source>
         <translation>Mou al final de la línia</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="77"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="62"/>
         <source>Move to start of line</source>
         <translation>Mou a l&apos;inici de la línia</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="78"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="63"/>
         <source>Move to end of text</source>
         <translation>Mou al final del text</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="79"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="64"/>
         <source>Move to start of text</source>
         <translation>Mou a l&apos;inici del text</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="80"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="65"/>
         <source>Move to line indentation</source>
         <translation>Mou al sagnat de la línia</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="81"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="66"/>
         <source>Upper case</source>
         <translation>Majúscules</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="82"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="67"/>
         <source>Lower case</source>
         <translation>Minúscules</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="83"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="68"/>
         <source>Capitalize</source>
         <translation>Posa en majúscules</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="84"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="69"/>
         <source>Delete backward word</source>
         <translation>Suprimeix la paraula anterior</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="85"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="70"/>
         <source>Delete forward word</source>
         <translation>Suprimeix la paraula següent</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="86"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="71"/>
         <source>Forward over a pair</source>
         <translation>Endavant dues</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="87"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="72"/>
         <source>Backward over a pair</source>
         <translation>Endarrere dues</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="88"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="73"/>
         <source>Select all</source>
         <translation>Selecciona-ho tot</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="89"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="74"/>
         <source>Copy</source>
         <translation>Copia</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="90"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="75"/>
         <source>Cut</source>
         <translation>Retalla</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="91"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="76"/>
         <source>Paste</source>
         <translation>Enganyxa</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="92"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="77"/>
         <source>Transpose character</source>
         <translation>Transposa el caràcter</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="93"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="78"/>
         <source>Mark</source>
         <translation>Marca</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="94"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="79"/>
         <source>Unmark</source>
         <translation>Desmarca</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="95"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="80"/>
         <source>Copy line</source>
         <translation>Copia la línia</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="96"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="81"/>
         <source>Cut line</source>
         <translation>Retalla la línia</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="97"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="82"/>
         <source>Merge lines</source>
         <translation>Fusiona les línies</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="98"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="83"/>
         <source>Read-Only mode</source>
         <translation>Mode només de lectura</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="99"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="84"/>
         <source>Add comment</source>
         <translation>Afegeix-hi un comentari</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="100"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="85"/>
         <source>Remove comment</source>
         <translation>Elimina el comentari</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="101"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="86"/>
         <source>Undo</source>
         <translation>Desfés</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="102"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="87"/>
         <source>Redo</source>
         <translation>Refés</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="103"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="88"/>
         <source>Add/Remove bookmark</source>
         <translation>Afegeix / elimina un marcador</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="104"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="89"/>
         <source>Move to previous bookmark</source>
         <translation>Ves al marcador anterior</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="105"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="90"/>
         <source>Move to next bookmark</source>
         <translation>Ves al marcador següent</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="106"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="91"/>
         <source>Advanced</source>
         <translation>Avançat</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="108"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="93"/>
         <source>Window size</source>
         <translation>Mida de la finestra</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="109"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="94"/>
         <source>Tab width</source>
         <translation>Amplada de la pestanya</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="111"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="96"/>
         <source>Word wrap</source>
         <translation>Ajust de paraules</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="112"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="97"/>
         <source>Code folding flag</source>
         <translation>Bandera de plec de codi</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="113"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="98"/>
         <source>Show line numbers</source>
         <translation>Mostra els números de línia</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="114"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="99"/>
         <source>Show bookmarks icon</source>
         <translation>Mostra la icona dels marcadors</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="115"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="100"/>
         <source>Show whitespaces and tabs</source>
         <translation>Mostra els espais en blanc i les tabulacions</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="116"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="101"/>
         <source>Highlight current line</source>
         <translation>Ressalta la línia actual</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="117"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="102"/>
         <source>Color mark</source>
         <translation>Marca de color</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="120"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="105"/>
         <source>Unicode</source>
         <translation>Unicode</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="121"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="106"/>
         <source>WesternEuropean</source>
         <translation>Europeu occidental</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="122"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="107"/>
         <source>CentralEuropean</source>
         <translation>Centreeuropeu</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="123"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="108"/>
         <source>Baltic</source>
         <translation>Bàltic</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="124"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="109"/>
         <source>Cyrillic</source>
         <translation>Cirílic</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="125"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="110"/>
         <source>Arabic</source>
         <translation>Àrab</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="130"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="115"/>
         <source>Celtic</source>
         <translation>Celta</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="131"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="116"/>
         <source>SouthEasternEuropean</source>
         <translation>Sud-est europeu</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="126"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="111"/>
         <source>Greek</source>
         <translation>Grec</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="127"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="112"/>
         <source>Hebrew</source>
         <translation>Hebreu</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="132"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="117"/>
         <source>ChineseSimplified</source>
         <translation>Xinès simplificat</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="133"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="118"/>
         <source>ChineseTraditional</source>
         <translation>Xinès tradicional</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="134"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="119"/>
         <source>Japanese</source>
         <translation>Japonès</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="135"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="120"/>
         <source>Korean</source>
         <translation>Coreà</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="129"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="114"/>
         <source>Thai</source>
         <translation>Tailandès</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="128"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="113"/>
         <source>Turkish</source>
         <translation>Turc</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="136"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="121"/>
         <source>Vietnamese</source>
         <translation>Vietnamita</translation>
     </message>
     <message>
-        <location filename="../src/startmanager.cpp" line="762"/>
+        <location filename="../src/startmanager.cpp" line="832"/>
         <source>File not saved</source>
         <translation>Fitxer no desat</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="974"/>
-        <location filename="../src/widgets/window.cpp" line="1065"/>
-        <location filename="../src/widgets/window.cpp" line="1080"/>
+        <location filename="../src/widgets/window.cpp" line="1112"/>
+        <location filename="../src/widgets/window.cpp" line="1204"/>
+        <location filename="../src/widgets/window.cpp" line="1219"/>
         <source>Line Endings</source>
         <translation>Finals de línia</translation>
     </message>
@@ -705,32 +710,32 @@
 <context>
     <name>ReplaceBar</name>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="39"/>
+        <location filename="../src/controls/replacebar.cpp" line="21"/>
         <source>Find</source>
         <translation>Troba</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="43"/>
+        <location filename="../src/controls/replacebar.cpp" line="25"/>
         <source>Replace With</source>
         <translation>Reemplaça amb</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="47"/>
+        <location filename="../src/controls/replacebar.cpp" line="29"/>
         <source>Replace</source>
         <translation>Reemplaça</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="50"/>
+        <location filename="../src/controls/replacebar.cpp" line="32"/>
         <source>Skip</source>
         <translation>Omet</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="53"/>
+        <location filename="../src/controls/replacebar.cpp" line="35"/>
         <source>Replace Rest</source>
         <translation>Reemplaça&apos;n la resta</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="56"/>
+        <location filename="../src/controls/replacebar.cpp" line="38"/>
         <source>Replace All</source>
         <translation>Reemplaça-ho tot</translation>
     </message>
@@ -747,58 +752,58 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../src/common/settings.cpp" line="91"/>
+        <location filename="../src/common/settings.cpp" line="115"/>
         <source>Standard</source>
         <translation>Estàndard</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="91"/>
+        <location filename="../src/common/settings.cpp" line="115"/>
         <source>Customize</source>
         <translation>Personalitza</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="104"/>
+        <location filename="../src/common/settings.cpp" line="128"/>
         <source>Normal</source>
         <translation>Normal</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="104"/>
+        <location filename="../src/common/settings.cpp" line="128"/>
         <source>Maximum</source>
         <translation>Màxim</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="104"/>
+        <location filename="../src/common/settings.cpp" line="128"/>
         <source>Fullscreen</source>
         <translation>Pantalla completa</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="292"/>
+        <location filename="../src/common/settings.cpp" line="316"/>
         <source>This shortcut conflicts with system shortcut %1</source>
         <translation>Aquesta drecera entra en conflicte amb la drecera del sistema %1</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="294"/>
+        <location filename="../src/common/settings.cpp" line="318"/>
         <source>This shortcut conflicts with %1, click on Replace to make this shortcut effective immediately</source>
         <translation>Aquesta tecla de drecera té conflicte amb %1. Cliqueu a Reemplaça perquè aquesta drecera tingui efecte immediatament.</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="410"/>
-        <location filename="../src/common/settings.cpp" line="418"/>
+        <location filename="../src/common/settings.cpp" line="464"/>
+        <location filename="../src/common/settings.cpp" line="472"/>
         <source>The shortcut %1 is invalid, please set another one.</source>
         <translation>La drecera %1 no és vàlida. Establiu-ne una altra.</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="445"/>
+        <location filename="../src/common/settings.cpp" line="507"/>
         <source>Cancel</source>
         <translation>Cancel·la</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="446"/>
+        <location filename="../src/common/settings.cpp" line="508"/>
         <source>Replace</source>
         <translation>Reemplaça</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="448"/>
+        <location filename="../src/common/settings.cpp" line="510"/>
         <source>OK</source>
         <translation>D&apos;acord</translation>
     </message>
@@ -806,7 +811,7 @@
 <context>
     <name>StartManager</name>
     <message>
-        <location filename="../src/startmanager.cpp" line="340"/>
+        <location filename="../src/startmanager.cpp" line="350"/>
         <source>Untitled %1</source>
         <translation>Sense títol: %1</translation>
     </message>
@@ -814,32 +819,32 @@
 <context>
     <name>Tabbar</name>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="515"/>
+        <location filename="../src/controls/tabbar.cpp" line="540"/>
         <source>Close tab</source>
         <translation>Tanca la pestanya</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="516"/>
+        <location filename="../src/controls/tabbar.cpp" line="541"/>
         <source>Close other tabs</source>
         <translation>Tanca les altres pestanyes</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="517"/>
+        <location filename="../src/controls/tabbar.cpp" line="542"/>
         <source>More options</source>
         <translation>Més opcions</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="518"/>
+        <location filename="../src/controls/tabbar.cpp" line="543"/>
         <source>Close tabs to the left</source>
         <translation>Tanca les pestanyes de l&apos;esquerra</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="519"/>
+        <location filename="../src/controls/tabbar.cpp" line="544"/>
         <source>Close tabs to the right</source>
         <translation>Tanca les pestanyes de la dreta</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="520"/>
+        <location filename="../src/controls/tabbar.cpp" line="545"/>
         <source>Close unmodified tabs</source>
         <translation>Tanca les pestanyes no modificades</translation>
     </message>
@@ -847,261 +852,259 @@
 <context>
     <name>TextEdit</name>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="235"/>
+        <location filename="../src/editor/dtextedit.cpp" line="259"/>
         <source>Undo</source>
         <translation>Desfés</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="236"/>
+        <location filename="../src/editor/dtextedit.cpp" line="260"/>
         <source>Redo</source>
         <translation>Refés</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="237"/>
+        <location filename="../src/editor/dtextedit.cpp" line="261"/>
         <source>Cut</source>
         <translation>Retalla</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="238"/>
+        <location filename="../src/editor/dtextedit.cpp" line="262"/>
         <source>Copy</source>
         <translation>Copia</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="239"/>
+        <location filename="../src/editor/dtextedit.cpp" line="263"/>
         <source>Paste</source>
         <translation>Enganxa</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="240"/>
+        <location filename="../src/editor/dtextedit.cpp" line="264"/>
         <source>Delete</source>
         <translation>Suprimeix</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="241"/>
+        <location filename="../src/editor/dtextedit.cpp" line="265"/>
         <source>Select All</source>
         <translation>Selecciona-ho tot</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="242"/>
-        <location filename="../src/widgets/window.cpp" line="361"/>
+        <location filename="../src/editor/dtextedit.cpp" line="266"/>
+        <location filename="../src/widgets/window.cpp" line="450"/>
         <source>Find</source>
         <translation>Troba</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="243"/>
-        <location filename="../src/widgets/window.cpp" line="362"/>
+        <location filename="../src/editor/dtextedit.cpp" line="267"/>
+        <location filename="../src/widgets/window.cpp" line="451"/>
         <source>Replace</source>
         <translation>Reemplaça</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="244"/>
+        <location filename="../src/editor/dtextedit.cpp" line="268"/>
         <source>Go to Line</source>
         <translation>Ves a la línia</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="245"/>
+        <location filename="../src/editor/dtextedit.cpp" line="269"/>
         <source>Turn on Read-Only mode</source>
         <translation>Activa el mode només de lectura</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="246"/>
+        <location filename="../src/editor/dtextedit.cpp" line="270"/>
         <source>Turn off Read-Only mode</source>
         <translation>Desactiva el mode només de lectura</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="247"/>
+        <location filename="../src/editor/dtextedit.cpp" line="271"/>
         <source>Fullscreen</source>
         <translation>Pantalla completa</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="248"/>
+        <location filename="../src/editor/dtextedit.cpp" line="272"/>
         <source>Exit fullscreen</source>
         <translation>Surt de la pantalla completa</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="249"/>
+        <location filename="../src/editor/dtextedit.cpp" line="273"/>
         <source>Display in file manager</source>
         <translation>Mostra-ho al gestor de fitxers</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="250"/>
-        <location filename="../src/editor/dtextedit.cpp" line="302"/>
+        <location filename="../src/editor/dtextedit.cpp" line="274"/>
+        <location filename="../src/editor/dtextedit.cpp" line="326"/>
         <source>Add Comment</source>
         <translation>Afegeix-hi un comentari</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="251"/>
+        <location filename="../src/editor/dtextedit.cpp" line="275"/>
         <source>Text to Speech</source>
         <translation>Text a veu</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="252"/>
+        <location filename="../src/editor/dtextedit.cpp" line="276"/>
         <source>Stop reading</source>
         <translation>Atura la lectura</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="253"/>
+        <location filename="../src/editor/dtextedit.cpp" line="277"/>
         <source>Speech to Text</source>
         <translation>Veu a text</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="254"/>
+        <location filename="../src/editor/dtextedit.cpp" line="278"/>
         <source>Translate</source>
         <translation>Tradueix</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="255"/>
+        <location filename="../src/editor/dtextedit.cpp" line="279"/>
         <source>Column Mode</source>
         <translation>Mode de columna</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="256"/>
+        <location filename="../src/editor/dtextedit.cpp" line="280"/>
         <source>Add bookmark</source>
         <translation>Afegeix-hi un marcador</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="257"/>
+        <location filename="../src/editor/dtextedit.cpp" line="281"/>
         <source>Remove Bookmark</source>
         <translation>Elimina el marcador</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="258"/>
+        <location filename="../src/editor/dtextedit.cpp" line="282"/>
         <source>Previous bookmark</source>
         <translation>Marcador anterior</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="259"/>
+        <location filename="../src/editor/dtextedit.cpp" line="283"/>
         <source>Next bookmark</source>
         <translation>Marcador següent</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="260"/>
+        <location filename="../src/editor/dtextedit.cpp" line="284"/>
         <source>Remove All Bookmarks</source>
         <translation>Elimina tots els marcadors</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="261"/>
+        <location filename="../src/editor/dtextedit.cpp" line="285"/>
         <source>Fold All</source>
         <translation>Plega-ho tot</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="262"/>
+        <location filename="../src/editor/dtextedit.cpp" line="286"/>
         <source>Fold Current Level</source>
         <translation>Plega el nivell actual</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="263"/>
+        <location filename="../src/editor/dtextedit.cpp" line="287"/>
         <source>Unfold All</source>
         <translation>Desplega-ho tot</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="264"/>
+        <location filename="../src/editor/dtextedit.cpp" line="288"/>
         <source>Unfold Current Level</source>
         <translation>Desplega el nivell actual</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="269"/>
+        <location filename="../src/editor/dtextedit.cpp" line="293"/>
         <source>Color Mark</source>
         <translation>Marca de color</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="273"/>
+        <location filename="../src/editor/dtextedit.cpp" line="297"/>
         <source>Clear All Marks</source>
         <translation>Neteja totes les marques</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="274"/>
+        <location filename="../src/editor/dtextedit.cpp" line="298"/>
         <source>Clear Last Mark</source>
         <translation>Neteja la darrera marca</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="283"/>
+        <location filename="../src/editor/dtextedit.cpp" line="307"/>
         <source>Mark</source>
         <translation>Marca</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="295"/>
+        <location filename="../src/editor/dtextedit.cpp" line="319"/>
         <source>Mark All</source>
         <translation>Marca-ho tot</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="303"/>
+        <location filename="../src/editor/dtextedit.cpp" line="327"/>
         <source>Remove Comment</source>
         <translation>Elimina el comentari</translation>
     </message>
     <message>
-        <source>Failed to paste text: it is too large</source>
-        <translation type="vanished">No s&apos;ha pogut enganxar el text: és massa gros.</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="2581"/>
+        <location filename="../src/editor/dtextedit.cpp" line="2672"/>
         <source>Copy failed: not enough memory</source>
         <translation>La còpia ha fallat: no hi ha prou memòria.</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="2665"/>
+        <location filename="../src/editor/dtextedit.cpp" line="2756"/>
         <source>Press ALT and click lines to edit in column mode</source>
         <translation>Premeu ALT i feu clic a les línies per editar-lo en mode columna</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="346"/>
+        <location filename="../src/editor/dtextedit.cpp" line="370"/>
         <source>Change Case</source>
         <translation>Canvia&apos;n la caixa</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="347"/>
+        <location filename="../src/editor/dtextedit.cpp" line="371"/>
         <source>Upper Case</source>
         <translation>Majúscules</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="348"/>
+        <location filename="../src/editor/dtextedit.cpp" line="372"/>
         <source>Lower Case</source>
         <translation>Minúscules</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="349"/>
+        <location filename="../src/editor/dtextedit.cpp" line="373"/>
         <source>Capitalize</source>
         <translation>Posa en majúscules</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="64"/>
+        <location filename="../src/widgets/bottombar.cpp" line="49"/>
         <source>None</source>
         <translation>Cap</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1184"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1222"/>
         <source>Selected line(s) copied</source>
         <translation>S&apos;han copiat les línies seleccionades.</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1190"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1228"/>
         <source>Current line copied</source>
         <translation>S&apos;ha copiat la línia actual.</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1210"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1248"/>
         <source>Selected line(s) clipped</source>
         <translation>S&apos;han retallat les línies seleccionades.</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1222"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1259"/>
         <source>Current line clipped</source>
         <translation>S&apos;ha retallat la línia actual.</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="2591"/>
+        <location filename="../src/editor/dtextedit.cpp" line="2682"/>
         <source>Paste failed: not enough memory</source>
         <translation>Ha fallat l&apos;acció d&apos;enganxar: no hi ha prou memòria.</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3439"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3617"/>
         <source>Read-Only mode is off</source>
         <translation>Mode de lectura desactivat</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3446"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3465"/>
-        <location filename="../src/editor/dtextedit.cpp" line="6150"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3624"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3643"/>
+        <location filename="../src/editor/dtextedit.cpp" line="6656"/>
+        <location filename="../src/editor/dtextedit.cpp" line="6664"/>
+        <location filename="../src/editor/dtextedit.cpp" line="6675"/>
         <source>Read-Only mode is on</source>
         <translation>Mode de lectura activat</translation>
     </message>
@@ -1109,7 +1112,7 @@
 <context>
     <name>WarningNotices</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="36"/>
+        <location filename="../src/controls/warningnotices.cpp" line="19"/>
         <source>Reload</source>
         <translation>Torna-ho a carregar</translation>
     </message>
@@ -1117,129 +1120,130 @@
 <context>
     <name>Window</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="38"/>
-        <location filename="../src/widgets/window.cpp" line="357"/>
+        <location filename="../src/controls/warningnotices.cpp" line="21"/>
+        <location filename="../src/widgets/window.cpp" line="446"/>
         <source>Save as</source>
         <translation>Desa com a</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="353"/>
+        <location filename="../src/widgets/window.cpp" line="442"/>
         <source>New window</source>
         <translation>Finestra nova</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="354"/>
+        <location filename="../src/widgets/window.cpp" line="443"/>
         <source>New tab</source>
         <translation>Pestanya nova</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="355"/>
+        <location filename="../src/widgets/window.cpp" line="444"/>
         <source>Open file</source>
         <translation>Obre un fitxer</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="356"/>
-        <location filename="../src/widgets/window.cpp" line="2217"/>
+        <location filename="../src/widgets/window.cpp" line="445"/>
+        <location filename="../src/widgets/window.cpp" line="2796"/>
         <source>Save</source>
         <translation>Desa</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="358"/>
+        <location filename="../src/widgets/window.cpp" line="447"/>
         <source>Print</source>
         <translation>Imprimeix</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="359"/>
+        <location filename="../src/widgets/window.cpp" line="448"/>
         <source>Switch theme</source>
         <translation>Canvia el tema</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="360"/>
-        <location filename="../src/widgets/window.cpp" line="1542"/>
+        <location filename="../src/widgets/window.cpp" line="449"/>
+        <location filename="../src/widgets/window.cpp" line="1871"/>
         <source>Settings</source>
         <translation>Paràmetres</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="471"/>
-        <location filename="../src/widgets/window.cpp" line="2468"/>
+        <location filename="../src/widgets/window.cpp" line="563"/>
+        <location filename="../src/widgets/window.cpp" line="3047"/>
         <source>Read-Only</source>
         <translation>Només de lectura</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="487"/>
+        <location filename="../src/widgets/window.cpp" line="579"/>
         <source>You do not have permission to open %1</source>
         <translation>No teniu permís per obrir %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="522"/>
+        <location filename="../src/widgets/window.cpp" line="619"/>
+        <location filename="../src/widgets/window.cpp" line="2359"/>
         <source>Invalid file: %1</source>
         <translation>Fitxer no vàlid: %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="602"/>
-        <location filename="../src/widgets/window.cpp" line="644"/>
+        <location filename="../src/widgets/window.cpp" line="733"/>
+        <location filename="../src/widgets/window.cpp" line="779"/>
         <source>Do you want to save this file?</source>
         <translation>Voleu desar aquest fitxer?</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="894"/>
+        <location filename="../src/widgets/window.cpp" line="1027"/>
         <source>You do not have permission to save %1</source>
         <translation>No teniu permís per desar %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="918"/>
+        <location filename="../src/widgets/window.cpp" line="1051"/>
         <source>Saved successfully</source>
         <translation>S&apos;ha desat correctament</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="954"/>
-        <location filename="../src/widgets/window.cpp" line="1021"/>
-        <location filename="../src/widgets/window.cpp" line="1062"/>
+        <location filename="../src/widgets/window.cpp" line="1087"/>
+        <location filename="../src/widgets/window.cpp" line="1160"/>
+        <location filename="../src/widgets/window.cpp" line="1201"/>
         <source>Save File</source>
         <translation>Desa el fitxer</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1023"/>
+        <location filename="../src/widgets/window.cpp" line="1162"/>
         <source>Encoding</source>
         <translation>Codificació</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1211"/>
+        <location filename="../src/widgets/window.cpp" line="1350"/>
         <source>Read-Only mode is on</source>
         <translation>Mode de lectura activat</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1441"/>
+        <location filename="../src/widgets/window.cpp" line="1770"/>
         <source>Current location remembered</source>
         <translation>Es recorda la ubicació actual.</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1492"/>
+        <location filename="../src/widgets/window.cpp" line="1821"/>
         <source>Ctrl+&apos;=&apos;</source>
         <translation>Ctrl + =</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1495"/>
+        <location filename="../src/widgets/window.cpp" line="1824"/>
         <source>Ctrl+&apos;-&apos;</source>
         <translation>Ctrl + -</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1524"/>
+        <location filename="../src/widgets/window.cpp" line="1853"/>
         <source>Editor</source>
         <translation>Editor</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1890"/>
+        <location filename="../src/widgets/window.cpp" line="2451"/>
         <source>Untitled %1</source>
         <translation>Sense títol: %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2215"/>
+        <location filename="../src/widgets/window.cpp" line="2794"/>
         <source>Cancel</source>
         <translation>Cancel·la</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2216"/>
+        <location filename="../src/widgets/window.cpp" line="2795"/>
         <source>Discard</source>
         <translation>Descarta</translation>
     </message>

--- a/translations/deepin-editor_cs.ts
+++ b/translations/deepin-editor_cs.ts
@@ -2,17 +2,17 @@
 <context>
     <name>BottomBar</name>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="39"/>
+        <location filename="../src/widgets/bottombar.cpp" line="24"/>
         <source>Row</source>
         <translation>Řádek</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="40"/>
+        <location filename="../src/widgets/bottombar.cpp" line="25"/>
         <source>Column</source>
         <translation>Sloupec</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="41"/>
+        <location filename="../src/widgets/bottombar.cpp" line="26"/>
         <source>Characters %1</source>
         <translation>Znaků %1</translation>
     </message>
@@ -20,9 +20,9 @@
 <context>
     <name>DDropdownMenu</name>
     <message>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="300"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="344"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="349"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="290"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="341"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="346"/>
         <source>None</source>
         <translation>Žádné</translation>
     </message>
@@ -30,80 +30,85 @@
 <context>
     <name>EditWrapper</name>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="201"/>
-        <location filename="../src/editor/editwrapper.cpp" line="264"/>
-        <location filename="../src/editor/editwrapper.cpp" line="321"/>
-        <location filename="../src/editor/editwrapper.cpp" line="536"/>
+        <location filename="../src/editor/editwrapper.cpp" line="246"/>
+        <location filename="../src/editor/editwrapper.cpp" line="314"/>
+        <location filename="../src/editor/editwrapper.cpp" line="439"/>
+        <location filename="../src/editor/editwrapper.cpp" line="702"/>
         <source>Save</source>
         <translation>Uložit</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="316"/>
+        <location filename="../src/editor/editwrapper.cpp" line="434"/>
         <source>Do you want to save this file?</source>
         <translation>Chcete tento soubor uložit?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="262"/>
-        <location filename="../src/editor/editwrapper.cpp" line="319"/>
+        <location filename="../src/editor/editwrapper.cpp" line="312"/>
+        <location filename="../src/editor/editwrapper.cpp" line="437"/>
         <source>Cancel</source>
         <translation>Zrušit</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="259"/>
+        <location filename="../src/editor/editwrapper.cpp" line="309"/>
         <source>Encoding changed. Do you want to save the file now?</source>
         <translation>Kódování změněno. Chcete tento soubor uložit nyní?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="320"/>
+        <location filename="../src/editor/editwrapper.cpp" line="438"/>
         <source>Discard</source>
         <translation>Zahodit</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="445"/>
+        <location filename="../src/editor/editwrapper.cpp" line="564"/>
         <source>You do not have permission to save %1</source>
         <translation>Nemáte oprávnění pro uložení %1</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="607"/>
+        <location filename="../src/editor/editwrapper.cpp" line="774"/>
         <source>File removed on the disk. Save it now?</source>
         <translation>Soubor byl mezitím na disku odstraněn. Uložit ho nyní?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="612"/>
+        <location filename="../src/editor/editwrapper.cpp" line="779"/>
         <source>File has changed on disk. Reload?</source>
         <translation>Soubor byl mezitím na disku změněn. Načíst znovu?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="634"/>
-        <location filename="../src/widgets/bottombar.cpp" line="60"/>
+        <location filename="../src/editor/editwrapper.cpp" line="801"/>
+        <location filename="../src/widgets/bottombar.cpp" line="45"/>
         <source>INSERT</source>
         <translation>VLOŽIT</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="637"/>
+        <location filename="../src/editor/editwrapper.cpp" line="804"/>
         <source>OVERWRITE</source>
         <translation>PŘEPSAT</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="640"/>
+        <location filename="../src/editor/editwrapper.cpp" line="807"/>
         <source>R/O</source>
         <translation>Pouze pro čtení</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="945"/>
+        <source>The file cannot be read, which may be too large or has been damaged!</source>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
     <name>FindBar</name>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="40"/>
+        <location filename="../src/controls/findbar.cpp" line="22"/>
         <source>Find</source>
         <translation>Najít</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="44"/>
+        <location filename="../src/controls/findbar.cpp" line="26"/>
         <source>Previous</source>
         <translation>Předchozí</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="46"/>
+        <location filename="../src/controls/findbar.cpp" line="28"/>
         <source>Next</source>
         <translation>Další</translation>
     </message>
@@ -111,7 +116,7 @@
 <context>
     <name>JumpLineBar</name>
     <message>
-        <location filename="../src/controls/jumplinebar.cpp" line="40"/>
+        <location filename="../src/controls/jumplinebar.cpp" line="28"/>
         <source>Go to Line: </source>
         <translation>Jít na řádek:</translation>
     </message>
@@ -119,12 +124,12 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/editorapplication.cpp" line="27"/>
+        <location filename="../src/editorapplication.cpp" line="11"/>
         <source>Text Editor is a powerful tool for viewing and editing text files.</source>
         <translation>Textový editor je mocný nástroj na prohlížení a upravování textových souborů.</translation>
     </message>
     <message>
-        <location filename="../src/editorapplication.cpp" line="38"/>
+        <location filename="../src/editorapplication.cpp" line="22"/>
         <source>Text Editor</source>
         <translation>Textový editor</translation>
     </message>
@@ -132,572 +137,572 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/editorapplication.cpp" line="35"/>
+        <location filename="../src/editorapplication.cpp" line="19"/>
         <source>Text Editor</source>
         <translation>Textový editor</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="203"/>
-        <location filename="../src/editor/editwrapper.cpp" line="538"/>
-        <location filename="../src/widgets/window.cpp" line="956"/>
-        <location filename="../src/widgets/window.cpp" line="973"/>
-        <location filename="../src/widgets/window.cpp" line="1064"/>
-        <location filename="../src/widgets/window.cpp" line="1079"/>
+        <location filename="../src/editor/editwrapper.cpp" line="248"/>
+        <location filename="../src/editor/editwrapper.cpp" line="704"/>
+        <location filename="../src/widgets/window.cpp" line="1089"/>
+        <location filename="../src/widgets/window.cpp" line="1111"/>
+        <location filename="../src/widgets/window.cpp" line="1203"/>
+        <location filename="../src/widgets/window.cpp" line="1218"/>
         <source>Encoding</source>
         <translation>Kódování znaků</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="24"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="9"/>
         <source>Basic</source>
         <translation>Základní</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="25"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="10"/>
         <source>Font Style</source>
         <translation>Styl písma</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="26"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="11"/>
         <source>Font</source>
         <translation>Písmo</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="27"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="12"/>
         <source>Font Size</source>
         <translation>Velikost písma</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="28"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="13"/>
         <source>Shortcuts</source>
         <translation>Klávesové zkratky</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="29"/>
-        <location filename="../src/controls/settingsdialog.cpp" line="30"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="14"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="15"/>
         <source>Keymap</source>
         <translation>Přiřazení kláves</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="31"/>
-        <location filename="../src/controls/settingsdialog.cpp" line="107"/>
-        <location filename="../src/widgets/window.cpp" line="1482"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="16"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="92"/>
+        <location filename="../src/widgets/window.cpp" line="1811"/>
         <source>Window</source>
         <translation>Okno</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="32"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="17"/>
         <source>New tab</source>
         <translation>Nová karta</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="33"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="18"/>
         <source>New window</source>
         <translation>Nové okno</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="34"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="19"/>
         <source>Save</source>
         <translation>Uložit</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="35"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="20"/>
         <source>Save as</source>
         <translation>Uložit jako</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="36"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="21"/>
         <source>Next tab</source>
         <translation>Další karta</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="37"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="22"/>
         <source>Previous tab</source>
         <translation>Předchozí karta</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="38"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="23"/>
         <source>Close tab</source>
         <translation>Zavřít kartu</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="39"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="24"/>
         <source>Close other tabs</source>
         <translation>Zavřít ostatní karty</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="40"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="25"/>
         <source>Restore tab</source>
         <translation>Obnovit kartu</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="41"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="26"/>
         <source>Open file</source>
         <translation>Otevřít soubor</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="42"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="27"/>
         <source>Increment font size</source>
         <translation>Zvětšit velikost písma</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="43"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="28"/>
         <source>Decrement font size</source>
         <translation>Zmenšit velikost písma</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="44"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="29"/>
         <source>Reset font size</source>
         <translation>Vrátit velikost písma na výchozí</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="45"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="30"/>
         <source>Help</source>
         <translation>Nápověda</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="46"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="31"/>
         <source>Toggle fullscreen</source>
         <translation>Přepnout na celou obrazovku</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="47"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="32"/>
         <source>Find</source>
         <translation>Najít</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="48"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="33"/>
         <source>Replace</source>
         <translation>Nahradit</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="49"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="34"/>
         <source>Go to line</source>
         <translation>Jít na řádek</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="50"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="35"/>
         <source>Save cursor position</source>
         <translation>Uložit pozici kurzoru</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="51"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="36"/>
         <source>Reset cursor position</source>
         <translation>Vrátit polohu kurzoru na výchozí</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="52"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="37"/>
         <source>Exit</source>
         <translation>Ukončit</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="53"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="38"/>
         <source>Display shortcuts</source>
         <translation>Zobrazit klávesové zkratky</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="54"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="39"/>
         <source>Print</source>
         <translation>Tisk</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="55"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="40"/>
         <source>Editor</source>
         <translation>Editor</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="56"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="41"/>
         <source>Increase indent</source>
         <translation>Zvětšit odsazení</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="57"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="42"/>
         <source>Decrease indent</source>
         <translation>Zmenšit odsazení</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="58"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="43"/>
         <source>Forward character</source>
         <translation>O znak dopředu</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="59"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="44"/>
         <source>Backward character</source>
         <translation>O znak dozadu</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="60"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="45"/>
         <source>Forward word</source>
         <translation>O slovo dopředu</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="61"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="46"/>
         <source>Backward word</source>
         <translation>O slovo dozadu</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="62"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="47"/>
         <source>Next line</source>
         <translation>Další řádek</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="63"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="48"/>
         <source>Previous line</source>
         <translation>Předchozí řádek</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="64"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="49"/>
         <source>New line</source>
         <translation>Nový řádek</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="65"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="50"/>
         <source>New line above</source>
         <translation>Nový řádek nad</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="66"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="51"/>
         <source>New line below</source>
         <translation>Nový řádek pod</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="67"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="52"/>
         <source>Duplicate line</source>
         <translation>Zduplikovat řádek</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="68"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="53"/>
         <source>Delete to end of line</source>
         <translation>Smazat po konec řádku</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="69"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="54"/>
         <source>Delete current line</source>
         <translation>Smazat stávající řádek</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="70"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="55"/>
         <source>Swap line up</source>
         <translation>Prohodit řádek s tím nad ním</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="71"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="56"/>
         <source>Swap line down</source>
         <translation>Prohodit řádek s tím pod ním</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="72"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="57"/>
         <source>Scroll up one line</source>
         <translation>Posunout se o řádek nahoru</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="73"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="58"/>
         <source>Scroll down one line</source>
         <translation>Posunout se o řádek dolů</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="74"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="59"/>
         <source>Page up</source>
         <translation>O stránku nahoru</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="75"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="60"/>
         <source>Page down</source>
         <translation>O stránku dolů</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="76"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="61"/>
         <source>Move to end of line</source>
         <translation>Přesunout na konec řádku</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="77"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="62"/>
         <source>Move to start of line</source>
         <translation>Přesunout na začátek řádku</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="78"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="63"/>
         <source>Move to end of text</source>
         <translation>Přesunout na konec textu</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="79"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="64"/>
         <source>Move to start of text</source>
         <translation>Přesunout na začátek textu</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="80"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="65"/>
         <source>Move to line indentation</source>
         <translation>Přesunout na odsazení řádku</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="81"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="66"/>
         <source>Upper case</source>
         <translation>Velká písmena</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="82"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="67"/>
         <source>Lower case</source>
         <translation>Malá písmena</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="83"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="68"/>
         <source>Capitalize</source>
         <translation>Vše velkými písmeny</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="84"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="69"/>
         <source>Delete backward word</source>
         <translation>Smazat slovo za kurzorem</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="85"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="70"/>
         <source>Delete forward word</source>
         <translation>Smazat slovo před kurzorem</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="86"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="71"/>
         <source>Forward over a pair</source>
         <translation>Dopředu přes dvojici</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="87"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="72"/>
         <source>Backward over a pair</source>
         <translation>Dozadu přes dvojici</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="88"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="73"/>
         <source>Select all</source>
         <translation>Vybrat vše</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="89"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="74"/>
         <source>Copy</source>
         <translation>Kopírovat</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="90"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="75"/>
         <source>Cut</source>
         <translation>Vyjmout</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="91"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="76"/>
         <source>Paste</source>
         <translation>Vložit</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="92"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="77"/>
         <source>Transpose character</source>
         <translation>Přemístit znak</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="93"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="78"/>
         <source>Mark</source>
         <translation>Označit</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="94"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="79"/>
         <source>Unmark</source>
         <translation>Odznačit</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="95"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="80"/>
         <source>Copy line</source>
         <translation>Kopírovat řádek</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="96"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="81"/>
         <source>Cut line</source>
         <translation>Vyjmout řádek</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="97"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="82"/>
         <source>Merge lines</source>
         <translation>Sloučit řádky</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="98"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="83"/>
         <source>Read-Only mode</source>
         <translation>Režim pouze pro čtení</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="99"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="84"/>
         <source>Add comment</source>
         <translation>Přidat komentář</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="100"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="85"/>
         <source>Remove comment</source>
         <translation>Odebrat komentář</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="101"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="86"/>
         <source>Undo</source>
         <translation>Zpět</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="102"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="87"/>
         <source>Redo</source>
         <translation>Znovu</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="103"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="88"/>
         <source>Add/Remove bookmark</source>
         <translation>Přidat/Odebrat záložku</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="104"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="89"/>
         <source>Move to previous bookmark</source>
         <translation>Přesunout na předchozí záložku</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="105"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="90"/>
         <source>Move to next bookmark</source>
         <translation>Přesunout na další záložku</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="106"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="91"/>
         <source>Advanced</source>
         <translation>Pokročilé</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="108"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="93"/>
         <source>Window size</source>
         <translation>Velikost okna</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="109"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="94"/>
         <source>Tab width</source>
         <translation>Šířka zarážky (tabulátor)</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="111"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="96"/>
         <source>Word wrap</source>
         <translation>Zalamování slov</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="112"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="97"/>
         <source>Code folding flag</source>
         <translation>Příznak sbalení kódu</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="113"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="98"/>
         <source>Show line numbers</source>
         <translation>Zobrazovat čísla řádek</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="114"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="99"/>
         <source>Show bookmarks icon</source>
         <translation>Zobrazovat ikony záložek</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="115"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="100"/>
         <source>Show whitespaces and tabs</source>
         <translation>Zobrazovat prázdné znaky a tabulátory</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="116"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="101"/>
         <source>Highlight current line</source>
         <translation>Zvýraznit stávající řádek</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="117"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="102"/>
         <source>Color mark</source>
         <translation>Barevná značka</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="120"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="105"/>
         <source>Unicode</source>
         <translation>Unicode</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="121"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="106"/>
         <source>WesternEuropean</source>
         <translation>Západoevropské</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="122"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="107"/>
         <source>CentralEuropean</source>
         <translation>Středoevropské</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="123"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="108"/>
         <source>Baltic</source>
         <translation>Baltské</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="124"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="109"/>
         <source>Cyrillic</source>
         <translation>Cyrilice</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="125"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="110"/>
         <source>Arabic</source>
         <translation>Arabské</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="130"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="115"/>
         <source>Celtic</source>
         <translation>Keltské</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="131"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="116"/>
         <source>SouthEasternEuropean</source>
         <translation>Jihovýchodoevropské</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="126"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="111"/>
         <source>Greek</source>
         <translation>Řecké</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="127"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="112"/>
         <source>Hebrew</source>
         <translation>Hebrejské</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="132"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="117"/>
         <source>ChineseSimplified</source>
         <translation>Zjednodušená čínština</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="133"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="118"/>
         <source>ChineseTraditional</source>
         <translation>Tradiční čínština</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="134"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="119"/>
         <source>Japanese</source>
         <translation>Japonské</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="135"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="120"/>
         <source>Korean</source>
         <translation>Korejské</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="129"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="114"/>
         <source>Thai</source>
         <translation>Thajské</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="128"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="113"/>
         <source>Turkish</source>
         <translation>Turecké</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="136"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="121"/>
         <source>Vietnamese</source>
         <translation>Vietnamské</translation>
     </message>
     <message>
-        <location filename="../src/startmanager.cpp" line="762"/>
+        <location filename="../src/startmanager.cpp" line="832"/>
         <source>File not saved</source>
         <translation>Soubor neuložen</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="974"/>
-        <location filename="../src/widgets/window.cpp" line="1065"/>
-        <location filename="../src/widgets/window.cpp" line="1080"/>
+        <location filename="../src/widgets/window.cpp" line="1112"/>
+        <location filename="../src/widgets/window.cpp" line="1204"/>
+        <location filename="../src/widgets/window.cpp" line="1219"/>
         <source>Line Endings</source>
         <translation>Konce řádků</translation>
     </message>
@@ -705,32 +710,32 @@
 <context>
     <name>ReplaceBar</name>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="39"/>
+        <location filename="../src/controls/replacebar.cpp" line="21"/>
         <source>Find</source>
         <translation>Najít</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="43"/>
+        <location filename="../src/controls/replacebar.cpp" line="25"/>
         <source>Replace With</source>
         <translation>Nahradit za</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="47"/>
+        <location filename="../src/controls/replacebar.cpp" line="29"/>
         <source>Replace</source>
         <translation>Nahradit</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="50"/>
+        <location filename="../src/controls/replacebar.cpp" line="32"/>
         <source>Skip</source>
         <translation>Přeskočit</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="53"/>
+        <location filename="../src/controls/replacebar.cpp" line="35"/>
         <source>Replace Rest</source>
         <translation>Nahradit zbytek</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="56"/>
+        <location filename="../src/controls/replacebar.cpp" line="38"/>
         <source>Replace All</source>
         <translation>Nahradit vše</translation>
     </message>
@@ -747,58 +752,58 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../src/common/settings.cpp" line="91"/>
+        <location filename="../src/common/settings.cpp" line="115"/>
         <source>Standard</source>
         <translation>Standardní</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="91"/>
+        <location filename="../src/common/settings.cpp" line="115"/>
         <source>Customize</source>
         <translation>Přizpůsobit</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="104"/>
+        <location filename="../src/common/settings.cpp" line="128"/>
         <source>Normal</source>
         <translation>Normální</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="104"/>
+        <location filename="../src/common/settings.cpp" line="128"/>
         <source>Maximum</source>
         <translation>Největší</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="104"/>
+        <location filename="../src/common/settings.cpp" line="128"/>
         <source>Fullscreen</source>
         <translation>Na celou obrazovku</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="292"/>
+        <location filename="../src/common/settings.cpp" line="316"/>
         <source>This shortcut conflicts with system shortcut %1</source>
         <translation>Tato zkratka je v konfliktu se systémovou %1</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="294"/>
+        <location filename="../src/common/settings.cpp" line="318"/>
         <source>This shortcut conflicts with %1, click on Replace to make this shortcut effective immediately</source>
-        <translation>Tato zkratka koliduje s %1 – klikněte na Nahradit, pokud chcete, aby začala platit pro tuto akci</translation>
+        <translation>Tato zkratka koliduje s %1 – klepněte na Nahradit, pokud chcete, aby začala platit pro tuto akci</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="410"/>
-        <location filename="../src/common/settings.cpp" line="418"/>
+        <location filename="../src/common/settings.cpp" line="464"/>
+        <location filename="../src/common/settings.cpp" line="472"/>
         <source>The shortcut %1 is invalid, please set another one.</source>
         <translation>Zkratka %1 není platná – prosím nastavte jinou.</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="445"/>
+        <location filename="../src/common/settings.cpp" line="507"/>
         <source>Cancel</source>
         <translation>Zrušit</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="446"/>
+        <location filename="../src/common/settings.cpp" line="508"/>
         <source>Replace</source>
         <translation>Nahradit</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="448"/>
+        <location filename="../src/common/settings.cpp" line="510"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
@@ -806,7 +811,7 @@
 <context>
     <name>StartManager</name>
     <message>
-        <location filename="../src/startmanager.cpp" line="340"/>
+        <location filename="../src/startmanager.cpp" line="350"/>
         <source>Untitled %1</source>
         <translation>Bez názvu %1</translation>
     </message>
@@ -814,32 +819,32 @@
 <context>
     <name>Tabbar</name>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="515"/>
+        <location filename="../src/controls/tabbar.cpp" line="540"/>
         <source>Close tab</source>
         <translation>Zavřít kartu</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="516"/>
+        <location filename="../src/controls/tabbar.cpp" line="541"/>
         <source>Close other tabs</source>
         <translation>Zavřít ostatní karty</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="517"/>
+        <location filename="../src/controls/tabbar.cpp" line="542"/>
         <source>More options</source>
         <translation>Další volby</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="518"/>
+        <location filename="../src/controls/tabbar.cpp" line="543"/>
         <source>Close tabs to the left</source>
         <translation>Zavřít karty nalevo</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="519"/>
+        <location filename="../src/controls/tabbar.cpp" line="544"/>
         <source>Close tabs to the right</source>
         <translation>Zavřít karty napravo</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="520"/>
+        <location filename="../src/controls/tabbar.cpp" line="545"/>
         <source>Close unmodified tabs</source>
         <translation>Zavřít karty, kterých obsah se nezměnil</translation>
     </message>
@@ -847,261 +852,259 @@
 <context>
     <name>TextEdit</name>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="235"/>
+        <location filename="../src/editor/dtextedit.cpp" line="259"/>
         <source>Undo</source>
         <translation>Zpět</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="236"/>
+        <location filename="../src/editor/dtextedit.cpp" line="260"/>
         <source>Redo</source>
         <translation>Znovu</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="237"/>
+        <location filename="../src/editor/dtextedit.cpp" line="261"/>
         <source>Cut</source>
         <translation>Vyjmout</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="238"/>
+        <location filename="../src/editor/dtextedit.cpp" line="262"/>
         <source>Copy</source>
         <translation>Zkopírovat</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="239"/>
+        <location filename="../src/editor/dtextedit.cpp" line="263"/>
         <source>Paste</source>
         <translation>Vložit</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="240"/>
+        <location filename="../src/editor/dtextedit.cpp" line="264"/>
         <source>Delete</source>
         <translation>Smazat</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="241"/>
+        <location filename="../src/editor/dtextedit.cpp" line="265"/>
         <source>Select All</source>
         <translation>Vybrat vše</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="242"/>
-        <location filename="../src/widgets/window.cpp" line="361"/>
+        <location filename="../src/editor/dtextedit.cpp" line="266"/>
+        <location filename="../src/widgets/window.cpp" line="450"/>
         <source>Find</source>
         <translation>Najít</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="243"/>
-        <location filename="../src/widgets/window.cpp" line="362"/>
+        <location filename="../src/editor/dtextedit.cpp" line="267"/>
+        <location filename="../src/widgets/window.cpp" line="451"/>
         <source>Replace</source>
         <translation>Nahradit</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="244"/>
+        <location filename="../src/editor/dtextedit.cpp" line="268"/>
         <source>Go to Line</source>
         <translation>Jít na řádek</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="245"/>
+        <location filename="../src/editor/dtextedit.cpp" line="269"/>
         <source>Turn on Read-Only mode</source>
         <translation>Zapnout režim pouze pro čtení</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="246"/>
+        <location filename="../src/editor/dtextedit.cpp" line="270"/>
         <source>Turn off Read-Only mode</source>
         <translation>Vypnout režim pouze pro čtení</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="247"/>
+        <location filename="../src/editor/dtextedit.cpp" line="271"/>
         <source>Fullscreen</source>
         <translation>Na celou obrazovku</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="248"/>
+        <location filename="../src/editor/dtextedit.cpp" line="272"/>
         <source>Exit fullscreen</source>
         <translation>Opustit zobrazení na celou obrazovku</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="249"/>
+        <location filename="../src/editor/dtextedit.cpp" line="273"/>
         <source>Display in file manager</source>
         <translation>Zobrazit ve správci souborů</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="250"/>
-        <location filename="../src/editor/dtextedit.cpp" line="302"/>
+        <location filename="../src/editor/dtextedit.cpp" line="274"/>
+        <location filename="../src/editor/dtextedit.cpp" line="326"/>
         <source>Add Comment</source>
         <translation>Přidat komentář</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="251"/>
+        <location filename="../src/editor/dtextedit.cpp" line="275"/>
         <source>Text to Speech</source>
         <translation>Text na řeč</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="252"/>
+        <location filename="../src/editor/dtextedit.cpp" line="276"/>
         <source>Stop reading</source>
         <translation>Zastavit předčítání</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="253"/>
+        <location filename="../src/editor/dtextedit.cpp" line="277"/>
         <source>Speech to Text</source>
         <translation>Řeč na text</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="254"/>
+        <location filename="../src/editor/dtextedit.cpp" line="278"/>
         <source>Translate</source>
         <translation>Přeložit</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="255"/>
+        <location filename="../src/editor/dtextedit.cpp" line="279"/>
         <source>Column Mode</source>
         <translation>Sloupcový režim</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="256"/>
+        <location filename="../src/editor/dtextedit.cpp" line="280"/>
         <source>Add bookmark</source>
         <translation>Přidat záložku</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="257"/>
+        <location filename="../src/editor/dtextedit.cpp" line="281"/>
         <source>Remove Bookmark</source>
         <translation>Odebrat záložku</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="258"/>
+        <location filename="../src/editor/dtextedit.cpp" line="282"/>
         <source>Previous bookmark</source>
         <translation>Předchozí záložka</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="259"/>
+        <location filename="../src/editor/dtextedit.cpp" line="283"/>
         <source>Next bookmark</source>
         <translation>Další záložka</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="260"/>
+        <location filename="../src/editor/dtextedit.cpp" line="284"/>
         <source>Remove All Bookmarks</source>
         <translation>Odebrat veškeré záložky</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="261"/>
+        <location filename="../src/editor/dtextedit.cpp" line="285"/>
         <source>Fold All</source>
         <translation>Sbalit vše</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="262"/>
+        <location filename="../src/editor/dtextedit.cpp" line="286"/>
         <source>Fold Current Level</source>
         <translation>Sbalit stávající úroveň</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="263"/>
+        <location filename="../src/editor/dtextedit.cpp" line="287"/>
         <source>Unfold All</source>
         <translation>Rozbalit vše</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="264"/>
+        <location filename="../src/editor/dtextedit.cpp" line="288"/>
         <source>Unfold Current Level</source>
         <translation>Rozbalit stávající úroveň</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="269"/>
+        <location filename="../src/editor/dtextedit.cpp" line="293"/>
         <source>Color Mark</source>
         <translation>Barevná značka</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="273"/>
+        <location filename="../src/editor/dtextedit.cpp" line="297"/>
         <source>Clear All Marks</source>
         <translation>Vymazat všechny značky</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="274"/>
+        <location filename="../src/editor/dtextedit.cpp" line="298"/>
         <source>Clear Last Mark</source>
         <translation>Vymazat poslední značku</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="283"/>
+        <location filename="../src/editor/dtextedit.cpp" line="307"/>
         <source>Mark</source>
         <translation>Označit</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="295"/>
+        <location filename="../src/editor/dtextedit.cpp" line="319"/>
         <source>Mark All</source>
         <translation>Označit vše</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="303"/>
+        <location filename="../src/editor/dtextedit.cpp" line="327"/>
         <source>Remove Comment</source>
         <translation>Odebrat komentář</translation>
     </message>
     <message>
-        <source>Failed to paste text: it is too large</source>
-        <translation type="vanished">Nepodařilo se vložit text: je příliš dlouhý</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="2581"/>
+        <location filename="../src/editor/dtextedit.cpp" line="2672"/>
         <source>Copy failed: not enough memory</source>
         <translation>Kopírování se nezdařilo: nedostatek paměti</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="2665"/>
+        <location filename="../src/editor/dtextedit.cpp" line="2756"/>
         <source>Press ALT and click lines to edit in column mode</source>
         <translation>Pro upravování ve sloupcovém režimu stiskněte ALT a klepejte na řádky</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="346"/>
+        <location filename="../src/editor/dtextedit.cpp" line="370"/>
         <source>Change Case</source>
         <translation>Změnit velikost písmen</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="347"/>
+        <location filename="../src/editor/dtextedit.cpp" line="371"/>
         <source>Upper Case</source>
         <translation>Velká písmena</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="348"/>
+        <location filename="../src/editor/dtextedit.cpp" line="372"/>
         <source>Lower Case</source>
         <translation>Malá písmena</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="349"/>
+        <location filename="../src/editor/dtextedit.cpp" line="373"/>
         <source>Capitalize</source>
         <translation>Vše velkými písmeny</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="64"/>
+        <location filename="../src/widgets/bottombar.cpp" line="49"/>
         <source>None</source>
         <translation>Žádné</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1184"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1222"/>
         <source>Selected line(s) copied</source>
         <translation>Vybraný řádek (řádky) zkopírován</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1190"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1228"/>
         <source>Current line copied</source>
         <translation>Stávající řádek zkopírován</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1210"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1248"/>
         <source>Selected line(s) clipped</source>
         <translation>Vybraný řádek (řádky) zkrácen</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1222"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1259"/>
         <source>Current line clipped</source>
         <translation>Stávající řádek zkrácen</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="2591"/>
+        <location filename="../src/editor/dtextedit.cpp" line="2682"/>
         <source>Paste failed: not enough memory</source>
         <translation>Vložení se nezdařilo: nedostatek paměti</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3439"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3617"/>
         <source>Read-Only mode is off</source>
         <translation>Režim pouze pro čtení je vypnut</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3446"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3465"/>
-        <location filename="../src/editor/dtextedit.cpp" line="6150"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3624"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3643"/>
+        <location filename="../src/editor/dtextedit.cpp" line="6656"/>
+        <location filename="../src/editor/dtextedit.cpp" line="6664"/>
+        <location filename="../src/editor/dtextedit.cpp" line="6675"/>
         <source>Read-Only mode is on</source>
         <translation>Režim pouze pro čtení je zapnut</translation>
     </message>
@@ -1109,7 +1112,7 @@
 <context>
     <name>WarningNotices</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="36"/>
+        <location filename="../src/controls/warningnotices.cpp" line="19"/>
         <source>Reload</source>
         <translation>Načíst znovu</translation>
     </message>
@@ -1117,129 +1120,130 @@
 <context>
     <name>Window</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="38"/>
-        <location filename="../src/widgets/window.cpp" line="357"/>
+        <location filename="../src/controls/warningnotices.cpp" line="21"/>
+        <location filename="../src/widgets/window.cpp" line="446"/>
         <source>Save as</source>
         <translation>Uložit jako</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="353"/>
+        <location filename="../src/widgets/window.cpp" line="442"/>
         <source>New window</source>
         <translation>Nové okno</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="354"/>
+        <location filename="../src/widgets/window.cpp" line="443"/>
         <source>New tab</source>
         <translation>Nová karta</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="355"/>
+        <location filename="../src/widgets/window.cpp" line="444"/>
         <source>Open file</source>
         <translation>Otevřít soubor</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="356"/>
-        <location filename="../src/widgets/window.cpp" line="2217"/>
+        <location filename="../src/widgets/window.cpp" line="445"/>
+        <location filename="../src/widgets/window.cpp" line="2796"/>
         <source>Save</source>
         <translation>Uložit</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="358"/>
+        <location filename="../src/widgets/window.cpp" line="447"/>
         <source>Print</source>
         <translation>Tisk</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="359"/>
+        <location filename="../src/widgets/window.cpp" line="448"/>
         <source>Switch theme</source>
         <translation>Přepnout vzhled</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="360"/>
-        <location filename="../src/widgets/window.cpp" line="1542"/>
+        <location filename="../src/widgets/window.cpp" line="449"/>
+        <location filename="../src/widgets/window.cpp" line="1871"/>
         <source>Settings</source>
         <translation>Nastavení</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="471"/>
-        <location filename="../src/widgets/window.cpp" line="2468"/>
+        <location filename="../src/widgets/window.cpp" line="563"/>
+        <location filename="../src/widgets/window.cpp" line="3047"/>
         <source>Read-Only</source>
         <translation>Pouze pro čtení</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="487"/>
+        <location filename="../src/widgets/window.cpp" line="579"/>
         <source>You do not have permission to open %1</source>
         <translation>Nemáte oprávnění pro otevření %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="522"/>
+        <location filename="../src/widgets/window.cpp" line="619"/>
+        <location filename="../src/widgets/window.cpp" line="2359"/>
         <source>Invalid file: %1</source>
         <translation>Neplatný soubor: %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="602"/>
-        <location filename="../src/widgets/window.cpp" line="644"/>
+        <location filename="../src/widgets/window.cpp" line="733"/>
+        <location filename="../src/widgets/window.cpp" line="779"/>
         <source>Do you want to save this file?</source>
         <translation>Chcete tento soubor uložit?</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="894"/>
+        <location filename="../src/widgets/window.cpp" line="1027"/>
         <source>You do not have permission to save %1</source>
         <translation>Nemáte oprávnění pro uložení %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="918"/>
+        <location filename="../src/widgets/window.cpp" line="1051"/>
         <source>Saved successfully</source>
         <translation>Úspěšně uloženo</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="954"/>
-        <location filename="../src/widgets/window.cpp" line="1021"/>
-        <location filename="../src/widgets/window.cpp" line="1062"/>
+        <location filename="../src/widgets/window.cpp" line="1087"/>
+        <location filename="../src/widgets/window.cpp" line="1160"/>
+        <location filename="../src/widgets/window.cpp" line="1201"/>
         <source>Save File</source>
         <translation>Uložit soubor</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1023"/>
+        <location filename="../src/widgets/window.cpp" line="1162"/>
         <source>Encoding</source>
         <translation>Kódování znaků</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1211"/>
+        <location filename="../src/widgets/window.cpp" line="1350"/>
         <source>Read-Only mode is on</source>
         <translation>Režim pouze pro čtení je zapnut</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1441"/>
+        <location filename="../src/widgets/window.cpp" line="1770"/>
         <source>Current location remembered</source>
         <translation>Stávající pozice zapamatována</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1492"/>
+        <location filename="../src/widgets/window.cpp" line="1821"/>
         <source>Ctrl+&apos;=&apos;</source>
         <translation>Ctrl + =</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1495"/>
+        <location filename="../src/widgets/window.cpp" line="1824"/>
         <source>Ctrl+&apos;-&apos;</source>
         <translation>Ctlr + -</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1524"/>
+        <location filename="../src/widgets/window.cpp" line="1853"/>
         <source>Editor</source>
         <translation>Editor</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1890"/>
+        <location filename="../src/widgets/window.cpp" line="2451"/>
         <source>Untitled %1</source>
         <translation>Bez názvu %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2215"/>
+        <location filename="../src/widgets/window.cpp" line="2794"/>
         <source>Cancel</source>
         <translation>Zrušit</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2216"/>
+        <location filename="../src/widgets/window.cpp" line="2795"/>
         <source>Discard</source>
         <translation>Zahodit</translation>
     </message>

--- a/translations/deepin-editor_de.ts
+++ b/translations/deepin-editor_de.ts
@@ -2,17 +2,17 @@
 <context>
     <name>BottomBar</name>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="39"/>
+        <location filename="../src/widgets/bottombar.cpp" line="24"/>
         <source>Row</source>
         <translation>Zeile</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="40"/>
+        <location filename="../src/widgets/bottombar.cpp" line="25"/>
         <source>Column</source>
         <translation>Spalte</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="41"/>
+        <location filename="../src/widgets/bottombar.cpp" line="26"/>
         <source>Characters %1</source>
         <translation>Zeichen %1</translation>
     </message>
@@ -20,9 +20,9 @@
 <context>
     <name>DDropdownMenu</name>
     <message>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="300"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="344"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="349"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="290"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="341"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="346"/>
         <source>None</source>
         <translation>Keines</translation>
     </message>
@@ -30,80 +30,85 @@
 <context>
     <name>EditWrapper</name>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="201"/>
-        <location filename="../src/editor/editwrapper.cpp" line="264"/>
-        <location filename="../src/editor/editwrapper.cpp" line="321"/>
-        <location filename="../src/editor/editwrapper.cpp" line="536"/>
+        <location filename="../src/editor/editwrapper.cpp" line="246"/>
+        <location filename="../src/editor/editwrapper.cpp" line="314"/>
+        <location filename="../src/editor/editwrapper.cpp" line="439"/>
+        <location filename="../src/editor/editwrapper.cpp" line="702"/>
         <source>Save</source>
         <translation>Speichern</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="316"/>
+        <location filename="../src/editor/editwrapper.cpp" line="434"/>
         <source>Do you want to save this file?</source>
         <translation>Möchten Sie diese Datei speichern?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="262"/>
-        <location filename="../src/editor/editwrapper.cpp" line="319"/>
+        <location filename="../src/editor/editwrapper.cpp" line="312"/>
+        <location filename="../src/editor/editwrapper.cpp" line="437"/>
         <source>Cancel</source>
         <translation>Abbrechen</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="259"/>
+        <location filename="../src/editor/editwrapper.cpp" line="309"/>
         <source>Encoding changed. Do you want to save the file now?</source>
         <translation>Kodierung geändert. Wollen Sie die Datei jetzt speichern?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="320"/>
+        <location filename="../src/editor/editwrapper.cpp" line="438"/>
         <source>Discard</source>
         <translation>Verwerfen</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="445"/>
+        <location filename="../src/editor/editwrapper.cpp" line="564"/>
         <source>You do not have permission to save %1</source>
         <translation>Berechtigung zum Speichern von %1 fehlt</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="607"/>
+        <location filename="../src/editor/editwrapper.cpp" line="774"/>
         <source>File removed on the disk. Save it now?</source>
         <translation>Die Datei wurde von der Festplatte entfernt. Soll die Datei jetzt gespeichert werden. </translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="612"/>
+        <location filename="../src/editor/editwrapper.cpp" line="779"/>
         <source>File has changed on disk. Reload?</source>
         <translation>Die Datei wurde verändert.. Soll die Datei neu geladen werden?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="634"/>
-        <location filename="../src/widgets/bottombar.cpp" line="60"/>
+        <location filename="../src/editor/editwrapper.cpp" line="801"/>
+        <location filename="../src/widgets/bottombar.cpp" line="45"/>
         <source>INSERT</source>
         <translation>EINFÜGEN</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="637"/>
+        <location filename="../src/editor/editwrapper.cpp" line="804"/>
         <source>OVERWRITE</source>
         <translation>ÜBERSCHREIBEN</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="640"/>
+        <location filename="../src/editor/editwrapper.cpp" line="807"/>
         <source>R/O</source>
         <translation>R/O</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="945"/>
+        <source>The file cannot be read, which may be too large or has been damaged!</source>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
     <name>FindBar</name>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="40"/>
+        <location filename="../src/controls/findbar.cpp" line="22"/>
         <source>Find</source>
         <translation>Suchen</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="44"/>
+        <location filename="../src/controls/findbar.cpp" line="26"/>
         <source>Previous</source>
         <translation>Vorheriges</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="46"/>
+        <location filename="../src/controls/findbar.cpp" line="28"/>
         <source>Next</source>
         <translation>Nächstes</translation>
     </message>
@@ -111,7 +116,7 @@
 <context>
     <name>JumpLineBar</name>
     <message>
-        <location filename="../src/controls/jumplinebar.cpp" line="40"/>
+        <location filename="../src/controls/jumplinebar.cpp" line="28"/>
         <source>Go to Line: </source>
         <translation>Gehe zu Zeile:</translation>
     </message>
@@ -119,12 +124,12 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/editorapplication.cpp" line="27"/>
+        <location filename="../src/editorapplication.cpp" line="11"/>
         <source>Text Editor is a powerful tool for viewing and editing text files.</source>
         <translation>Der Texteditor ist ein leistungsstarkes Tool zum Anzeigen und Bearbeiten von Textdateien.</translation>
     </message>
     <message>
-        <location filename="../src/editorapplication.cpp" line="38"/>
+        <location filename="../src/editorapplication.cpp" line="22"/>
         <source>Text Editor</source>
         <translation>Texteditor</translation>
     </message>
@@ -132,572 +137,572 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/editorapplication.cpp" line="35"/>
+        <location filename="../src/editorapplication.cpp" line="19"/>
         <source>Text Editor</source>
         <translation>Texteditor</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="203"/>
-        <location filename="../src/editor/editwrapper.cpp" line="538"/>
-        <location filename="../src/widgets/window.cpp" line="956"/>
-        <location filename="../src/widgets/window.cpp" line="973"/>
-        <location filename="../src/widgets/window.cpp" line="1064"/>
-        <location filename="../src/widgets/window.cpp" line="1079"/>
+        <location filename="../src/editor/editwrapper.cpp" line="248"/>
+        <location filename="../src/editor/editwrapper.cpp" line="704"/>
+        <location filename="../src/widgets/window.cpp" line="1089"/>
+        <location filename="../src/widgets/window.cpp" line="1111"/>
+        <location filename="../src/widgets/window.cpp" line="1203"/>
+        <location filename="../src/widgets/window.cpp" line="1218"/>
         <source>Encoding</source>
         <translation>Kodierung</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="24"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="9"/>
         <source>Basic</source>
         <translation>Basis</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="25"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="10"/>
         <source>Font Style</source>
         <translation>Schriftstil</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="26"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="11"/>
         <source>Font</source>
         <translation>Schriftart</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="27"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="12"/>
         <source>Font Size</source>
         <translation>Schriftgröße</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="28"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="13"/>
         <source>Shortcuts</source>
         <translation>Tastaturkürzel</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="29"/>
-        <location filename="../src/controls/settingsdialog.cpp" line="30"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="14"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="15"/>
         <source>Keymap</source>
         <translation>Tastaturbelegung</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="31"/>
-        <location filename="../src/controls/settingsdialog.cpp" line="107"/>
-        <location filename="../src/widgets/window.cpp" line="1482"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="16"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="92"/>
+        <location filename="../src/widgets/window.cpp" line="1811"/>
         <source>Window</source>
         <translation>Fenster</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="32"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="17"/>
         <source>New tab</source>
         <translation>Neuer Tab</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="33"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="18"/>
         <source>New window</source>
         <translation>Neues Fenster</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="34"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="19"/>
         <source>Save</source>
         <translation>Speichern</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="35"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="20"/>
         <source>Save as</source>
         <translation>Speichern unter</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="36"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="21"/>
         <source>Next tab</source>
         <translation>Nächster Tab</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="37"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="22"/>
         <source>Previous tab</source>
         <translation>Vorheriger Tab</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="38"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="23"/>
         <source>Close tab</source>
         <translation>Tab schließen</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="39"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="24"/>
         <source>Close other tabs</source>
         <translation>Andere Tabs schließen</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="40"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="25"/>
         <source>Restore tab</source>
         <translation>Tab wiederherstellen</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="41"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="26"/>
         <source>Open file</source>
         <translation>Datei öffnen</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="42"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="27"/>
         <source>Increment font size</source>
         <translation>Schriftgröße erhöhen</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="43"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="28"/>
         <source>Decrement font size</source>
         <translation>Schriftgröße verringern</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="44"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="29"/>
         <source>Reset font size</source>
         <translation>Schriftgröße zurücksetzen</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="45"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="30"/>
         <source>Help</source>
         <translation>Hilfe</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="46"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="31"/>
         <source>Toggle fullscreen</source>
         <translation>Vollbildmodus umschalten</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="47"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="32"/>
         <source>Find</source>
         <translation>Suchen</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="48"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="33"/>
         <source>Replace</source>
         <translation>Ersetzen</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="49"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="34"/>
         <source>Go to line</source>
         <translation>Gehe zu Zeile</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="50"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="35"/>
         <source>Save cursor position</source>
         <translation>Position des Schreibmarkers speichern</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="51"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="36"/>
         <source>Reset cursor position</source>
         <translation>Position des Schreibmarkers zurücksetzen</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="52"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="37"/>
         <source>Exit</source>
         <translation>Beenden</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="53"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="38"/>
         <source>Display shortcuts</source>
         <translation>Tastaturkürzel anzeigen</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="54"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="39"/>
         <source>Print</source>
         <translation>Drucken</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="55"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="40"/>
         <source>Editor</source>
         <translation>Editor</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="56"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="41"/>
         <source>Increase indent</source>
         <translation>Einrückung vergrößern</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="57"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="42"/>
         <source>Decrease indent</source>
         <translation>Einrückung verringern</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="58"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="43"/>
         <source>Forward character</source>
         <translation>Ein Zeichen vorwärts</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="59"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="44"/>
         <source>Backward character</source>
         <translation>Ein Zeichen rückwärts</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="60"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="45"/>
         <source>Forward word</source>
         <translation>Ein Wort vorwärts</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="61"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="46"/>
         <source>Backward word</source>
         <translation>Ein Wort rückwärts</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="62"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="47"/>
         <source>Next line</source>
         <translation>Nächste Zeile</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="63"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="48"/>
         <source>Previous line</source>
         <translation>Vorherige Zeile</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="64"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="49"/>
         <source>New line</source>
         <translation>Neue Zeile</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="65"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="50"/>
         <source>New line above</source>
         <translation>Neue Zeile davor</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="66"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="51"/>
         <source>New line below</source>
         <translation>Neue Zeile danach</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="67"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="52"/>
         <source>Duplicate line</source>
         <translation>Zeile duplizieren</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="68"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="53"/>
         <source>Delete to end of line</source>
         <translation>Ende der Zeile löschen</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="69"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="54"/>
         <source>Delete current line</source>
         <translation>Aktuelle Zeile entfernen</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="70"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="55"/>
         <source>Swap line up</source>
         <translation>Zeile nach oben verschieben</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="71"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="56"/>
         <source>Swap line down</source>
         <translation>Zeile nach unten verschieben</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="72"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="57"/>
         <source>Scroll up one line</source>
         <translation>Eine Zeile hoch</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="73"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="58"/>
         <source>Scroll down one line</source>
         <translation>Eine Zeile runter</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="74"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="59"/>
         <source>Page up</source>
         <translation>Eine Seite nach oben</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="75"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="60"/>
         <source>Page down</source>
         <translation>Eine Seite nach unten</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="76"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="61"/>
         <source>Move to end of line</source>
         <translation>Zum Ende der Zeile bewegen</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="77"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="62"/>
         <source>Move to start of line</source>
         <translation>Zum Anfang der Zeile bewegen</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="78"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="63"/>
         <source>Move to end of text</source>
         <translation>Zum Ende des Texts bewegen</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="79"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="64"/>
         <source>Move to start of text</source>
         <translation>Zum Anfang des Texts bewegen</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="80"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="65"/>
         <source>Move to line indentation</source>
         <translation>Zur Zeileneinrückung bewegen</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="81"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="66"/>
         <source>Upper case</source>
         <translation>Großbuchstaben</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="82"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="67"/>
         <source>Lower case</source>
         <translation>Kleinbuchstaben</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="83"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="68"/>
         <source>Capitalize</source>
         <translation>Großschreibung</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="84"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="69"/>
         <source>Delete backward word</source>
         <translation>Ein Wort rückwärts entfernen</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="85"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="70"/>
         <source>Delete forward word</source>
         <translation>Ein Wort vorwärts entfernen</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="86"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="71"/>
         <source>Forward over a pair</source>
         <translation>Vorwärts über ein Paar</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="87"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="72"/>
         <source>Backward over a pair</source>
         <translation>Rückwärts über ein Paar</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="88"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="73"/>
         <source>Select all</source>
         <translation>Alles markieren</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="89"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="74"/>
         <source>Copy</source>
         <translation>Kopieren</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="90"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="75"/>
         <source>Cut</source>
         <translation>Ausschneiden</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="91"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="76"/>
         <source>Paste</source>
         <translation>Einfügen</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="92"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="77"/>
         <source>Transpose character</source>
         <translation>Zeichen transponieren</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="93"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="78"/>
         <source>Mark</source>
         <translation>Markieren</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="94"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="79"/>
         <source>Unmark</source>
         <translation>Markierung aufheben</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="95"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="80"/>
         <source>Copy line</source>
         <translation>Zeile kopieren</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="96"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="81"/>
         <source>Cut line</source>
         <translation>Zeile ausschneiden</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="97"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="82"/>
         <source>Merge lines</source>
         <translation>Zeilen zusammenfügen</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="98"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="83"/>
         <source>Read-Only mode</source>
         <translation>Nur-Lese-Modus</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="99"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="84"/>
         <source>Add comment</source>
         <translation>Kommentar hinzufügen</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="100"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="85"/>
         <source>Remove comment</source>
         <translation>Kommentar entfernen</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="101"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="86"/>
         <source>Undo</source>
         <translation>Rückgängig</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="102"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="87"/>
         <source>Redo</source>
         <translation>Wiederherstellen</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="103"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="88"/>
         <source>Add/Remove bookmark</source>
         <translation>Lesezeichen hinzufügen/entfernen</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="104"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="89"/>
         <source>Move to previous bookmark</source>
         <translation>Zum vorherigen Lesezeichen wechseln</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="105"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="90"/>
         <source>Move to next bookmark</source>
         <translation>Zum nächsten Lesezeichen wechseln</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="106"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="91"/>
         <source>Advanced</source>
         <translation>Erweitert</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="108"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="93"/>
         <source>Window size</source>
         <translation>Fenstergröße</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="109"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="94"/>
         <source>Tab width</source>
         <translation>Tabulatorbreite</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="111"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="96"/>
         <source>Word wrap</source>
         <translation>Zeilenumbruch</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="112"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="97"/>
         <source>Code folding flag</source>
         <translation>Code-Einklapp-Schalter</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="113"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="98"/>
         <source>Show line numbers</source>
         <translation>Zeilennummern anzeigen</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="114"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="99"/>
         <source>Show bookmarks icon</source>
         <translation>Lesezeichensymbol anzeigen</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="115"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="100"/>
         <source>Show whitespaces and tabs</source>
         <translation>Leerzeichen und Tabulatoren anzeigen</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="116"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="101"/>
         <source>Highlight current line</source>
         <translation>Aktuelle Zeile markieren</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="117"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="102"/>
         <source>Color mark</source>
         <translation>Farbmarkierung</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="120"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="105"/>
         <source>Unicode</source>
         <translation>Unicode</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="121"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="106"/>
         <source>WesternEuropean</source>
         <translation>Westeuropäisch</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="122"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="107"/>
         <source>CentralEuropean</source>
         <translation>Mitteleuropäisch</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="123"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="108"/>
         <source>Baltic</source>
         <translation>Baltisch</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="124"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="109"/>
         <source>Cyrillic</source>
         <translation>Kyrillisch</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="125"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="110"/>
         <source>Arabic</source>
         <translation>Arabisch</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="130"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="115"/>
         <source>Celtic</source>
         <translation>Keltisch</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="131"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="116"/>
         <source>SouthEasternEuropean</source>
         <translation>Südosteuropäisch</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="126"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="111"/>
         <source>Greek</source>
         <translation>Griechisch</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="127"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="112"/>
         <source>Hebrew</source>
         <translation>Hebräisch</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="132"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="117"/>
         <source>ChineseSimplified</source>
         <translation>ChinesischVereinfacht</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="133"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="118"/>
         <source>ChineseTraditional</source>
         <translation>ChinesischTraditionell</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="134"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="119"/>
         <source>Japanese</source>
         <translation>Japanisch</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="135"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="120"/>
         <source>Korean</source>
         <translation>Koreanisch</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="129"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="114"/>
         <source>Thai</source>
         <translation>Thailändisch</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="128"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="113"/>
         <source>Turkish</source>
         <translation>Türkisch</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="136"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="121"/>
         <source>Vietnamese</source>
         <translation>Vietnamesisch</translation>
     </message>
     <message>
-        <location filename="../src/startmanager.cpp" line="762"/>
+        <location filename="../src/startmanager.cpp" line="832"/>
         <source>File not saved</source>
         <translation>Datei nicht gespeichert</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="974"/>
-        <location filename="../src/widgets/window.cpp" line="1065"/>
-        <location filename="../src/widgets/window.cpp" line="1080"/>
+        <location filename="../src/widgets/window.cpp" line="1112"/>
+        <location filename="../src/widgets/window.cpp" line="1204"/>
+        <location filename="../src/widgets/window.cpp" line="1219"/>
         <source>Line Endings</source>
         <translation>Zeilenenden</translation>
     </message>
@@ -705,32 +710,32 @@
 <context>
     <name>ReplaceBar</name>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="39"/>
+        <location filename="../src/controls/replacebar.cpp" line="21"/>
         <source>Find</source>
         <translation>Suchen</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="43"/>
+        <location filename="../src/controls/replacebar.cpp" line="25"/>
         <source>Replace With</source>
         <translation>Ersetzen mit</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="47"/>
+        <location filename="../src/controls/replacebar.cpp" line="29"/>
         <source>Replace</source>
         <translation>Ersetzen</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="50"/>
+        <location filename="../src/controls/replacebar.cpp" line="32"/>
         <source>Skip</source>
         <translation>Überspringen</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="53"/>
+        <location filename="../src/controls/replacebar.cpp" line="35"/>
         <source>Replace Rest</source>
         <translation>Rest ersetzen</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="56"/>
+        <location filename="../src/controls/replacebar.cpp" line="38"/>
         <source>Replace All</source>
         <translation>Alles ersetzen</translation>
     </message>
@@ -747,58 +752,58 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../src/common/settings.cpp" line="91"/>
+        <location filename="../src/common/settings.cpp" line="115"/>
         <source>Standard</source>
         <translation>Standard</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="91"/>
+        <location filename="../src/common/settings.cpp" line="115"/>
         <source>Customize</source>
         <translation>Anpassen</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="104"/>
+        <location filename="../src/common/settings.cpp" line="128"/>
         <source>Normal</source>
         <translation>Normal</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="104"/>
+        <location filename="../src/common/settings.cpp" line="128"/>
         <source>Maximum</source>
         <translation>Maximum</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="104"/>
+        <location filename="../src/common/settings.cpp" line="128"/>
         <source>Fullscreen</source>
         <translation>Vollbild</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="292"/>
+        <location filename="../src/common/settings.cpp" line="316"/>
         <source>This shortcut conflicts with system shortcut %1</source>
         <translation>Dieses Tastaturkürzel steht im Konflikt mit dem Systemkürzel %1</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="294"/>
+        <location filename="../src/common/settings.cpp" line="318"/>
         <source>This shortcut conflicts with %1, click on Replace to make this shortcut effective immediately</source>
         <translation>Dieses Tastaturkürzel steht im Konflikt mit %1, klicke auf Ersetzen, um dieses Kürzel sofort wirksam zu machen</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="410"/>
-        <location filename="../src/common/settings.cpp" line="418"/>
+        <location filename="../src/common/settings.cpp" line="464"/>
+        <location filename="../src/common/settings.cpp" line="472"/>
         <source>The shortcut %1 is invalid, please set another one.</source>
         <translation>Das Tastaturkürzel %1 ist ungültig, bitte stelle ein anderes ein.</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="445"/>
+        <location filename="../src/common/settings.cpp" line="507"/>
         <source>Cancel</source>
         <translation>Abbrechen</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="446"/>
+        <location filename="../src/common/settings.cpp" line="508"/>
         <source>Replace</source>
         <translation>Ersetzen</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="448"/>
+        <location filename="../src/common/settings.cpp" line="510"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
@@ -806,7 +811,7 @@
 <context>
     <name>StartManager</name>
     <message>
-        <location filename="../src/startmanager.cpp" line="340"/>
+        <location filename="../src/startmanager.cpp" line="350"/>
         <source>Untitled %1</source>
         <translation>Unbenannt %1</translation>
     </message>
@@ -814,32 +819,32 @@
 <context>
     <name>Tabbar</name>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="515"/>
+        <location filename="../src/controls/tabbar.cpp" line="540"/>
         <source>Close tab</source>
         <translation>Tab schließen</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="516"/>
+        <location filename="../src/controls/tabbar.cpp" line="541"/>
         <source>Close other tabs</source>
         <translation>Schließe restliche Tabs</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="517"/>
+        <location filename="../src/controls/tabbar.cpp" line="542"/>
         <source>More options</source>
         <translation>Weitere Optionen</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="518"/>
+        <location filename="../src/controls/tabbar.cpp" line="543"/>
         <source>Close tabs to the left</source>
         <translation>Tabs nach links schließen</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="519"/>
+        <location filename="../src/controls/tabbar.cpp" line="544"/>
         <source>Close tabs to the right</source>
         <translation>Tabs nach rechts schließen</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="520"/>
+        <location filename="../src/controls/tabbar.cpp" line="545"/>
         <source>Close unmodified tabs</source>
         <translation>Unveränderte Tabs schließen</translation>
     </message>
@@ -847,261 +852,259 @@
 <context>
     <name>TextEdit</name>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="235"/>
+        <location filename="../src/editor/dtextedit.cpp" line="259"/>
         <source>Undo</source>
         <translation>Rückgängig</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="236"/>
+        <location filename="../src/editor/dtextedit.cpp" line="260"/>
         <source>Redo</source>
         <translation>Wiederherstellen</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="237"/>
+        <location filename="../src/editor/dtextedit.cpp" line="261"/>
         <source>Cut</source>
         <translation>Ausschneiden</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="238"/>
+        <location filename="../src/editor/dtextedit.cpp" line="262"/>
         <source>Copy</source>
         <translation>Kopieren</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="239"/>
+        <location filename="../src/editor/dtextedit.cpp" line="263"/>
         <source>Paste</source>
         <translation>Einfügen</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="240"/>
+        <location filename="../src/editor/dtextedit.cpp" line="264"/>
         <source>Delete</source>
         <translation>Löschen</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="241"/>
+        <location filename="../src/editor/dtextedit.cpp" line="265"/>
         <source>Select All</source>
         <translation>Alles auswählen</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="242"/>
-        <location filename="../src/widgets/window.cpp" line="361"/>
+        <location filename="../src/editor/dtextedit.cpp" line="266"/>
+        <location filename="../src/widgets/window.cpp" line="450"/>
         <source>Find</source>
         <translation>Suchen</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="243"/>
-        <location filename="../src/widgets/window.cpp" line="362"/>
+        <location filename="../src/editor/dtextedit.cpp" line="267"/>
+        <location filename="../src/widgets/window.cpp" line="451"/>
         <source>Replace</source>
         <translation>Ersetzen</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="244"/>
+        <location filename="../src/editor/dtextedit.cpp" line="268"/>
         <source>Go to Line</source>
         <translation>Gehe zu Zeile</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="245"/>
+        <location filename="../src/editor/dtextedit.cpp" line="269"/>
         <source>Turn on Read-Only mode</source>
         <translation>Nur-Lese-Modus aktivieren</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="246"/>
+        <location filename="../src/editor/dtextedit.cpp" line="270"/>
         <source>Turn off Read-Only mode</source>
         <translation>Nur-Lese-Modus deaktivieren</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="247"/>
+        <location filename="../src/editor/dtextedit.cpp" line="271"/>
         <source>Fullscreen</source>
         <translation>Vollbild</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="248"/>
+        <location filename="../src/editor/dtextedit.cpp" line="272"/>
         <source>Exit fullscreen</source>
         <translation>Vollbild beenden</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="249"/>
+        <location filename="../src/editor/dtextedit.cpp" line="273"/>
         <source>Display in file manager</source>
         <translation>Im Dateimanager anzeigen</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="250"/>
-        <location filename="../src/editor/dtextedit.cpp" line="302"/>
+        <location filename="../src/editor/dtextedit.cpp" line="274"/>
+        <location filename="../src/editor/dtextedit.cpp" line="326"/>
         <source>Add Comment</source>
         <translation>Kommentar hinzufügen</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="251"/>
+        <location filename="../src/editor/dtextedit.cpp" line="275"/>
         <source>Text to Speech</source>
         <translation>Text zu Sprache</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="252"/>
+        <location filename="../src/editor/dtextedit.cpp" line="276"/>
         <source>Stop reading</source>
         <translation>Lesen beenden</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="253"/>
+        <location filename="../src/editor/dtextedit.cpp" line="277"/>
         <source>Speech to Text</source>
         <translation>Sprache zu Text</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="254"/>
+        <location filename="../src/editor/dtextedit.cpp" line="278"/>
         <source>Translate</source>
         <translation>Übersetzen</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="255"/>
+        <location filename="../src/editor/dtextedit.cpp" line="279"/>
         <source>Column Mode</source>
         <translation>Spaltenmodus</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="256"/>
+        <location filename="../src/editor/dtextedit.cpp" line="280"/>
         <source>Add bookmark</source>
         <translation>Lesezeichen hinzufügen</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="257"/>
+        <location filename="../src/editor/dtextedit.cpp" line="281"/>
         <source>Remove Bookmark</source>
         <translation>Lesezeichen entfernen</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="258"/>
+        <location filename="../src/editor/dtextedit.cpp" line="282"/>
         <source>Previous bookmark</source>
         <translation>Vorheriges Lesezeichen</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="259"/>
+        <location filename="../src/editor/dtextedit.cpp" line="283"/>
         <source>Next bookmark</source>
         <translation>Nächstes Lesezeichen</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="260"/>
+        <location filename="../src/editor/dtextedit.cpp" line="284"/>
         <source>Remove All Bookmarks</source>
         <translation>Alle Lesezeichen entfernen</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="261"/>
+        <location filename="../src/editor/dtextedit.cpp" line="285"/>
         <source>Fold All</source>
         <translation>Alles einfalten</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="262"/>
+        <location filename="../src/editor/dtextedit.cpp" line="286"/>
         <source>Fold Current Level</source>
         <translation>Aktuelle Ebene einfalten</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="263"/>
+        <location filename="../src/editor/dtextedit.cpp" line="287"/>
         <source>Unfold All</source>
         <translation>Alles ausfalten</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="264"/>
+        <location filename="../src/editor/dtextedit.cpp" line="288"/>
         <source>Unfold Current Level</source>
         <translation>Aktuelle Ebene ausfalten</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="269"/>
+        <location filename="../src/editor/dtextedit.cpp" line="293"/>
         <source>Color Mark</source>
         <translation>Farbmarkierung</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="273"/>
+        <location filename="../src/editor/dtextedit.cpp" line="297"/>
         <source>Clear All Marks</source>
         <translation>Alle Markierungen löschen</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="274"/>
+        <location filename="../src/editor/dtextedit.cpp" line="298"/>
         <source>Clear Last Mark</source>
         <translation>Letzte Markierung löschen</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="283"/>
+        <location filename="../src/editor/dtextedit.cpp" line="307"/>
         <source>Mark</source>
         <translation>Markieren</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="295"/>
+        <location filename="../src/editor/dtextedit.cpp" line="319"/>
         <source>Mark All</source>
         <translation>Alles markieren</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="303"/>
+        <location filename="../src/editor/dtextedit.cpp" line="327"/>
         <source>Remove Comment</source>
         <translation>Kommentar entfernen</translation>
     </message>
     <message>
-        <source>Failed to paste text: it is too large</source>
-        <translation type="vanished">Der Text konnte nicht eingefügt werden, da er zu lang ist</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="2581"/>
+        <location filename="../src/editor/dtextedit.cpp" line="2672"/>
         <source>Copy failed: not enough memory</source>
         <translation>Kopieren fehlgeschlagen: nicht genügend Speicher</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="2665"/>
+        <location filename="../src/editor/dtextedit.cpp" line="2756"/>
         <source>Press ALT and click lines to edit in column mode</source>
         <translation>Drücke ALT und klicke auf Zeilen, um im Spaltenmodus zu bearbeiten</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="346"/>
+        <location filename="../src/editor/dtextedit.cpp" line="370"/>
         <source>Change Case</source>
         <translation>Groß-/Kleinschreibung ändern</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="347"/>
+        <location filename="../src/editor/dtextedit.cpp" line="371"/>
         <source>Upper Case</source>
         <translation>Großbuchstaben</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="348"/>
+        <location filename="../src/editor/dtextedit.cpp" line="372"/>
         <source>Lower Case</source>
         <translation>Kleinbuchstaben</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="349"/>
+        <location filename="../src/editor/dtextedit.cpp" line="373"/>
         <source>Capitalize</source>
         <translation>Großschreibung</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="64"/>
+        <location filename="../src/widgets/bottombar.cpp" line="49"/>
         <source>None</source>
         <translation>Keines</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1184"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1222"/>
         <source>Selected line(s) copied</source>
         <translation>Ausgewählte Zeile(n) kopiert</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1190"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1228"/>
         <source>Current line copied</source>
         <translation>Aktuelle Zeile kopiert</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1210"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1248"/>
         <source>Selected line(s) clipped</source>
         <translation>Ausgewählte Zeile(n) abgeschnitten</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1222"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1259"/>
         <source>Current line clipped</source>
         <translation>Aktuelle Zeile abgeschnitten</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="2591"/>
+        <location filename="../src/editor/dtextedit.cpp" line="2682"/>
         <source>Paste failed: not enough memory</source>
         <translation>Einfügen fehlgeschlagen: nicht genügend Speicher</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3439"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3617"/>
         <source>Read-Only mode is off</source>
         <translation>Nur-Lese-Modus ist ausgeschaltet</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3446"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3465"/>
-        <location filename="../src/editor/dtextedit.cpp" line="6150"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3624"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3643"/>
+        <location filename="../src/editor/dtextedit.cpp" line="6656"/>
+        <location filename="../src/editor/dtextedit.cpp" line="6664"/>
+        <location filename="../src/editor/dtextedit.cpp" line="6675"/>
         <source>Read-Only mode is on</source>
         <translation>Nur-Lese-Modus ist eingeschaltet</translation>
     </message>
@@ -1109,7 +1112,7 @@
 <context>
     <name>WarningNotices</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="36"/>
+        <location filename="../src/controls/warningnotices.cpp" line="19"/>
         <source>Reload</source>
         <translation>Neu laden</translation>
     </message>
@@ -1117,129 +1120,130 @@
 <context>
     <name>Window</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="38"/>
-        <location filename="../src/widgets/window.cpp" line="357"/>
+        <location filename="../src/controls/warningnotices.cpp" line="21"/>
+        <location filename="../src/widgets/window.cpp" line="446"/>
         <source>Save as</source>
         <translation>Speichern unter</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="353"/>
+        <location filename="../src/widgets/window.cpp" line="442"/>
         <source>New window</source>
         <translation>Neues Fenster</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="354"/>
+        <location filename="../src/widgets/window.cpp" line="443"/>
         <source>New tab</source>
         <translation>Neuer Tab</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="355"/>
+        <location filename="../src/widgets/window.cpp" line="444"/>
         <source>Open file</source>
         <translation>Datei öffnen</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="356"/>
-        <location filename="../src/widgets/window.cpp" line="2217"/>
+        <location filename="../src/widgets/window.cpp" line="445"/>
+        <location filename="../src/widgets/window.cpp" line="2796"/>
         <source>Save</source>
         <translation>Speichern</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="358"/>
+        <location filename="../src/widgets/window.cpp" line="447"/>
         <source>Print</source>
         <translation>Drucken</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="359"/>
+        <location filename="../src/widgets/window.cpp" line="448"/>
         <source>Switch theme</source>
         <translation>Theme wechseln</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="360"/>
-        <location filename="../src/widgets/window.cpp" line="1542"/>
+        <location filename="../src/widgets/window.cpp" line="449"/>
+        <location filename="../src/widgets/window.cpp" line="1871"/>
         <source>Settings</source>
         <translation>Einstellungen</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="471"/>
-        <location filename="../src/widgets/window.cpp" line="2468"/>
+        <location filename="../src/widgets/window.cpp" line="563"/>
+        <location filename="../src/widgets/window.cpp" line="3047"/>
         <source>Read-Only</source>
         <translation>Nur Lesen</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="487"/>
+        <location filename="../src/widgets/window.cpp" line="579"/>
         <source>You do not have permission to open %1</source>
         <translation>Berechtigung zum Öffnen von %1 fehlt</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="522"/>
+        <location filename="../src/widgets/window.cpp" line="619"/>
+        <location filename="../src/widgets/window.cpp" line="2359"/>
         <source>Invalid file: %1</source>
         <translation>Ungültige Datei: %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="602"/>
-        <location filename="../src/widgets/window.cpp" line="644"/>
+        <location filename="../src/widgets/window.cpp" line="733"/>
+        <location filename="../src/widgets/window.cpp" line="779"/>
         <source>Do you want to save this file?</source>
         <translation>Möchten Sie diese Datei speichern?</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="894"/>
+        <location filename="../src/widgets/window.cpp" line="1027"/>
         <source>You do not have permission to save %1</source>
         <translation>Berechtigung zum Speichern von %1 fehlt</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="918"/>
+        <location filename="../src/widgets/window.cpp" line="1051"/>
         <source>Saved successfully</source>
         <translation>Erfolgreich gespeichert</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="954"/>
-        <location filename="../src/widgets/window.cpp" line="1021"/>
-        <location filename="../src/widgets/window.cpp" line="1062"/>
+        <location filename="../src/widgets/window.cpp" line="1087"/>
+        <location filename="../src/widgets/window.cpp" line="1160"/>
+        <location filename="../src/widgets/window.cpp" line="1201"/>
         <source>Save File</source>
         <translation>Datei speichern</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1023"/>
+        <location filename="../src/widgets/window.cpp" line="1162"/>
         <source>Encoding</source>
         <translation>Kodierung</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1211"/>
+        <location filename="../src/widgets/window.cpp" line="1350"/>
         <source>Read-Only mode is on</source>
         <translation>Nur-Lese-Modus ist aktiviert</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1441"/>
+        <location filename="../src/widgets/window.cpp" line="1770"/>
         <source>Current location remembered</source>
         <translation>Aktueller Standort gespeichert</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1492"/>
+        <location filename="../src/widgets/window.cpp" line="1821"/>
         <source>Ctrl+&apos;=&apos;</source>
         <translation>Strg+&apos;=&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1495"/>
+        <location filename="../src/widgets/window.cpp" line="1824"/>
         <source>Ctrl+&apos;-&apos;</source>
         <translation>Strg+&apos;-&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1524"/>
+        <location filename="../src/widgets/window.cpp" line="1853"/>
         <source>Editor</source>
         <translation>Editor</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1890"/>
+        <location filename="../src/widgets/window.cpp" line="2451"/>
         <source>Untitled %1</source>
         <translation>Unbenannt %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2215"/>
+        <location filename="../src/widgets/window.cpp" line="2794"/>
         <source>Cancel</source>
         <translation>Abbrechen</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2216"/>
+        <location filename="../src/widgets/window.cpp" line="2795"/>
         <source>Discard</source>
         <translation>Verwerfen</translation>
     </message>

--- a/translations/deepin-editor_es.ts
+++ b/translations/deepin-editor_es.ts
@@ -2,17 +2,17 @@
 <context>
     <name>BottomBar</name>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="39"/>
+        <location filename="../src/widgets/bottombar.cpp" line="24"/>
         <source>Row</source>
         <translation>Fila</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="40"/>
+        <location filename="../src/widgets/bottombar.cpp" line="25"/>
         <source>Column</source>
         <translation>Columna</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="41"/>
+        <location filename="../src/widgets/bottombar.cpp" line="26"/>
         <source>Characters %1</source>
         <translation>Caracteres %1</translation>
     </message>
@@ -20,9 +20,9 @@
 <context>
     <name>DDropdownMenu</name>
     <message>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="300"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="344"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="349"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="290"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="341"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="346"/>
         <source>None</source>
         <translation>Ninguno</translation>
     </message>
@@ -30,80 +30,85 @@
 <context>
     <name>EditWrapper</name>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="201"/>
-        <location filename="../src/editor/editwrapper.cpp" line="264"/>
-        <location filename="../src/editor/editwrapper.cpp" line="321"/>
-        <location filename="../src/editor/editwrapper.cpp" line="536"/>
+        <location filename="../src/editor/editwrapper.cpp" line="246"/>
+        <location filename="../src/editor/editwrapper.cpp" line="314"/>
+        <location filename="../src/editor/editwrapper.cpp" line="439"/>
+        <location filename="../src/editor/editwrapper.cpp" line="702"/>
         <source>Save</source>
         <translation>Guardar</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="316"/>
+        <location filename="../src/editor/editwrapper.cpp" line="434"/>
         <source>Do you want to save this file?</source>
         <translation>¿Desea guardar este archivo?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="262"/>
-        <location filename="../src/editor/editwrapper.cpp" line="319"/>
+        <location filename="../src/editor/editwrapper.cpp" line="312"/>
+        <location filename="../src/editor/editwrapper.cpp" line="437"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="259"/>
+        <location filename="../src/editor/editwrapper.cpp" line="309"/>
         <source>Encoding changed. Do you want to save the file now?</source>
         <translation>La codificación ha cambiado. ¿Desea guardar el archivo ahora?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="320"/>
+        <location filename="../src/editor/editwrapper.cpp" line="438"/>
         <source>Discard</source>
         <translation>Descartar</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="445"/>
+        <location filename="../src/editor/editwrapper.cpp" line="564"/>
         <source>You do not have permission to save %1</source>
         <translation>No tienes permisos para guardar %1</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="607"/>
+        <location filename="../src/editor/editwrapper.cpp" line="774"/>
         <source>File removed on the disk. Save it now?</source>
         <translation>Archivo eliminado en el disco. ¿Desea guardarlo?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="612"/>
+        <location filename="../src/editor/editwrapper.cpp" line="779"/>
         <source>File has changed on disk. Reload?</source>
         <translation>El archivo ha cambiado en el disco. ¿Recargar?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="634"/>
-        <location filename="../src/widgets/bottombar.cpp" line="60"/>
+        <location filename="../src/editor/editwrapper.cpp" line="801"/>
+        <location filename="../src/widgets/bottombar.cpp" line="45"/>
         <source>INSERT</source>
         <translation>INSERTAR</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="637"/>
+        <location filename="../src/editor/editwrapper.cpp" line="804"/>
         <source>OVERWRITE</source>
         <translation>SOBRESCRIBIR</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="640"/>
+        <location filename="../src/editor/editwrapper.cpp" line="807"/>
         <source>R/O</source>
         <translation>R/O</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="945"/>
+        <source>The file cannot be read, which may be too large or has been damaged!</source>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
     <name>FindBar</name>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="40"/>
+        <location filename="../src/controls/findbar.cpp" line="22"/>
         <source>Find</source>
         <translation>Buscar</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="44"/>
+        <location filename="../src/controls/findbar.cpp" line="26"/>
         <source>Previous</source>
         <translation>Anterior</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="46"/>
+        <location filename="../src/controls/findbar.cpp" line="28"/>
         <source>Next</source>
         <translation>Siguiente</translation>
     </message>
@@ -111,7 +116,7 @@
 <context>
     <name>JumpLineBar</name>
     <message>
-        <location filename="../src/controls/jumplinebar.cpp" line="40"/>
+        <location filename="../src/controls/jumplinebar.cpp" line="28"/>
         <source>Go to Line: </source>
         <translation>Ir a la línea</translation>
     </message>
@@ -119,12 +124,12 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/editorapplication.cpp" line="27"/>
+        <location filename="../src/editorapplication.cpp" line="11"/>
         <source>Text Editor is a powerful tool for viewing and editing text files.</source>
         <translation>Editor de texto de Deepin es una poderosa herramienta para ver y editar archivos de texto.</translation>
     </message>
     <message>
-        <location filename="../src/editorapplication.cpp" line="38"/>
+        <location filename="../src/editorapplication.cpp" line="22"/>
         <source>Text Editor</source>
         <translation>Editor de texto</translation>
     </message>
@@ -132,572 +137,572 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/editorapplication.cpp" line="35"/>
+        <location filename="../src/editorapplication.cpp" line="19"/>
         <source>Text Editor</source>
         <translation>Editor de texto</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="203"/>
-        <location filename="../src/editor/editwrapper.cpp" line="538"/>
-        <location filename="../src/widgets/window.cpp" line="956"/>
-        <location filename="../src/widgets/window.cpp" line="973"/>
-        <location filename="../src/widgets/window.cpp" line="1064"/>
-        <location filename="../src/widgets/window.cpp" line="1079"/>
+        <location filename="../src/editor/editwrapper.cpp" line="248"/>
+        <location filename="../src/editor/editwrapper.cpp" line="704"/>
+        <location filename="../src/widgets/window.cpp" line="1089"/>
+        <location filename="../src/widgets/window.cpp" line="1111"/>
+        <location filename="../src/widgets/window.cpp" line="1203"/>
+        <location filename="../src/widgets/window.cpp" line="1218"/>
         <source>Encoding</source>
         <translation>Codificación</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="24"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="9"/>
         <source>Basic</source>
         <translation>Básico</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="25"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="10"/>
         <source>Font Style</source>
         <translation>Estilo de fuente</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="26"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="11"/>
         <source>Font</source>
         <translation>Fuente</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="27"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="12"/>
         <source>Font Size</source>
         <translation>Tamaño de fuente</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="28"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="13"/>
         <source>Shortcuts</source>
         <translation>Atajos</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="29"/>
-        <location filename="../src/controls/settingsdialog.cpp" line="30"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="14"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="15"/>
         <source>Keymap</source>
         <translation>Asignación de teclas</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="31"/>
-        <location filename="../src/controls/settingsdialog.cpp" line="107"/>
-        <location filename="../src/widgets/window.cpp" line="1482"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="16"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="92"/>
+        <location filename="../src/widgets/window.cpp" line="1811"/>
         <source>Window</source>
         <translation>Ventana</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="32"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="17"/>
         <source>New tab</source>
         <translation>Nueva pestaña</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="33"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="18"/>
         <source>New window</source>
         <translation>Nueva ventana</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="34"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="19"/>
         <source>Save</source>
         <translation>Guardar</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="35"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="20"/>
         <source>Save as</source>
         <translation>Guardar como</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="36"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="21"/>
         <source>Next tab</source>
         <translation>Pestaña siguiente</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="37"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="22"/>
         <source>Previous tab</source>
         <translation>Pestaña anterior</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="38"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="23"/>
         <source>Close tab</source>
         <translation>Cerrar pestaña</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="39"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="24"/>
         <source>Close other tabs</source>
         <translation>Cerrar otras pestañas</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="40"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="25"/>
         <source>Restore tab</source>
         <translation>Restaurar pestaña </translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="41"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="26"/>
         <source>Open file</source>
         <translation>Abrir archivo</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="42"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="27"/>
         <source>Increment font size</source>
         <translation>Aumentar tamaño de letra</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="43"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="28"/>
         <source>Decrement font size</source>
         <translation>Disminuir tamaño de letra</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="44"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="29"/>
         <source>Reset font size</source>
         <translation>Restablecer tamaño de la letra</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="45"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="30"/>
         <source>Help</source>
         <translation>Ayuda</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="46"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="31"/>
         <source>Toggle fullscreen</source>
         <translation>Cambiar a pantalla completa</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="47"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="32"/>
         <source>Find</source>
         <translation>Buscar</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="48"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="33"/>
         <source>Replace</source>
         <translation>Reemplazar</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="49"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="34"/>
         <source>Go to line</source>
         <translation>Ir a la línea</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="50"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="35"/>
         <source>Save cursor position</source>
         <translation>Guardar la posición del cursor</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="51"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="36"/>
         <source>Reset cursor position</source>
         <translation>Restablecer posición del cursor</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="52"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="37"/>
         <source>Exit</source>
         <translation>Salir</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="53"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="38"/>
         <source>Display shortcuts</source>
         <translation>Mostrar atajos</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="54"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="39"/>
         <source>Print</source>
         <translation>Imprimir</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="55"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="40"/>
         <source>Editor</source>
         <translation>Editor</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="56"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="41"/>
         <source>Increase indent</source>
         <translation>Aumentar sangría</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="57"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="42"/>
         <source>Decrease indent</source>
         <translation>Disminuir sangría</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="58"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="43"/>
         <source>Forward character</source>
         <translation>Próximo carácter</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="59"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="44"/>
         <source>Backward character</source>
         <translation>Carácter anterior</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="60"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="45"/>
         <source>Forward word</source>
         <translation>Próxima palabra</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="61"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="46"/>
         <source>Backward word</source>
         <translation>Palabra anterior</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="62"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="47"/>
         <source>Next line</source>
         <translation>Siguiente línea</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="63"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="48"/>
         <source>Previous line</source>
         <translation>Línea anterior</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="64"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="49"/>
         <source>New line</source>
         <translation>Nueva línea</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="65"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="50"/>
         <source>New line above</source>
         <translation>Nueva línea encima</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="66"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="51"/>
         <source>New line below</source>
         <translation>Nueva línea debajo</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="67"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="52"/>
         <source>Duplicate line</source>
         <translation>Duplicar línea</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="68"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="53"/>
         <source>Delete to end of line</source>
         <translation>Borrar hasta el final de la línea</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="69"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="54"/>
         <source>Delete current line</source>
         <translation>Borrar la línea actual</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="70"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="55"/>
         <source>Swap line up</source>
         <translation>Subir línea</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="71"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="56"/>
         <source>Swap line down</source>
         <translation>Bajar línea</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="72"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="57"/>
         <source>Scroll up one line</source>
         <translation>Desplazar una línea arriba</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="73"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="58"/>
         <source>Scroll down one line</source>
         <translation>Desplazar una línea abajo</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="74"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="59"/>
         <source>Page up</source>
         <translation>Página arriba</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="75"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="60"/>
         <source>Page down</source>
         <translation>Página abajo</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="76"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="61"/>
         <source>Move to end of line</source>
         <translation>Mover al final de la línea</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="77"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="62"/>
         <source>Move to start of line</source>
         <translation>Mover al inicio de la línea</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="78"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="63"/>
         <source>Move to end of text</source>
         <translation>Mover al final del texto</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="79"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="64"/>
         <source>Move to start of text</source>
         <translation>Mover al inicio del texto</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="80"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="65"/>
         <source>Move to line indentation</source>
         <translation>Mover a sangría de línea</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="81"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="66"/>
         <source>Upper case</source>
         <translation>Mayúsculas</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="82"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="67"/>
         <source>Lower case</source>
         <translation>Minúsculas</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="83"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="68"/>
         <source>Capitalize</source>
         <translation>Capitalizar</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="84"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="69"/>
         <source>Delete backward word</source>
         <translation>Borrar palabra anterior</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="85"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="70"/>
         <source>Delete forward word</source>
         <translation>Borrar siguiente palabra</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="86"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="71"/>
         <source>Forward over a pair</source>
         <translation>Adelantar sobre un par</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="87"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="72"/>
         <source>Backward over a pair</source>
         <translation>Retroceder sobre un par</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="88"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="73"/>
         <source>Select all</source>
         <translation>Seleccionar todo</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="89"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="74"/>
         <source>Copy</source>
         <translation>Copiar</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="90"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="75"/>
         <source>Cut</source>
         <translation>Cortar</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="91"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="76"/>
         <source>Paste</source>
         <translation>Pegar</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="92"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="77"/>
         <source>Transpose character</source>
         <translation>Transponer carácter</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="93"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="78"/>
         <source>Mark</source>
         <translation>Resaltar</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="94"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="79"/>
         <source>Unmark</source>
         <translation>No resaltar</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="95"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="80"/>
         <source>Copy line</source>
         <translation>Copiar línea</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="96"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="81"/>
         <source>Cut line</source>
         <translation>Cortar línea</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="97"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="82"/>
         <source>Merge lines</source>
         <translation>Fusionar líneas</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="98"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="83"/>
         <source>Read-Only mode</source>
         <translation>Modo solo lectura</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="99"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="84"/>
         <source>Add comment</source>
         <translation>Añadir comentario</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="100"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="85"/>
         <source>Remove comment</source>
         <translation>Borrar comentario</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="101"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="86"/>
         <source>Undo</source>
         <translation>Deshacer</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="102"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="87"/>
         <source>Redo</source>
         <translation>Rehacer</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="103"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="88"/>
         <source>Add/Remove bookmark</source>
         <translation>Añadir/quitar marcador</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="104"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="89"/>
         <source>Move to previous bookmark</source>
         <translation>Mover al marcador anterior</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="105"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="90"/>
         <source>Move to next bookmark</source>
         <translation>Mover al siguiente marcador</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="106"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="91"/>
         <source>Advanced</source>
         <translation>Avanzado</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="108"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="93"/>
         <source>Window size</source>
         <translation>Tamaño de ventana</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="109"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="94"/>
         <source>Tab width</source>
         <translation>Ancho de la pestaña</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="111"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="96"/>
         <source>Word wrap</source>
         <translation>Ajuste de línea</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="112"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="97"/>
         <source>Code folding flag</source>
         <translation>Marcador para contraer el código</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="113"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="98"/>
         <source>Show line numbers</source>
         <translation>Mostrar número de línea</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="114"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="99"/>
         <source>Show bookmarks icon</source>
         <translation>Mostrar iconos de marcadores</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="115"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="100"/>
         <source>Show whitespaces and tabs</source>
         <translation>Mostrar espacios en blanco y tabulaciones</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="116"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="101"/>
         <source>Highlight current line</source>
         <translation>Resaltar línea actual</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="117"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="102"/>
         <source>Color mark</source>
         <translation>Resaltador</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="120"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="105"/>
         <source>Unicode</source>
         <translation>Unicode</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="121"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="106"/>
         <source>WesternEuropean</source>
         <translation>Europeo Occidental</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="122"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="107"/>
         <source>CentralEuropean</source>
         <translation>Centro Europeo</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="123"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="108"/>
         <source>Baltic</source>
         <translation>Báltico</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="124"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="109"/>
         <source>Cyrillic</source>
         <translation>Cirílico</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="125"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="110"/>
         <source>Arabic</source>
         <translation>Árabe</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="130"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="115"/>
         <source>Celtic</source>
         <translation>Céltico</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="131"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="116"/>
         <source>SouthEasternEuropean</source>
         <translation>Europeo del Sudeste</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="126"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="111"/>
         <source>Greek</source>
         <translation>Griego</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="127"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="112"/>
         <source>Hebrew</source>
         <translation>Hebreo</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="132"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="117"/>
         <source>ChineseSimplified</source>
         <translation>Chino Simplificado</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="133"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="118"/>
         <source>ChineseTraditional</source>
         <translation>Chino Tradicional</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="134"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="119"/>
         <source>Japanese</source>
         <translation>Japonés</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="135"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="120"/>
         <source>Korean</source>
         <translation>Coreano</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="129"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="114"/>
         <source>Thai</source>
         <translation>Tailandés</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="128"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="113"/>
         <source>Turkish</source>
         <translation>Turco</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="136"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="121"/>
         <source>Vietnamese</source>
         <translation>Vietnamita</translation>
     </message>
     <message>
-        <location filename="../src/startmanager.cpp" line="762"/>
+        <location filename="../src/startmanager.cpp" line="832"/>
         <source>File not saved</source>
         <translation>No se guardó el archivo</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="974"/>
-        <location filename="../src/widgets/window.cpp" line="1065"/>
-        <location filename="../src/widgets/window.cpp" line="1080"/>
+        <location filename="../src/widgets/window.cpp" line="1112"/>
+        <location filename="../src/widgets/window.cpp" line="1204"/>
+        <location filename="../src/widgets/window.cpp" line="1219"/>
         <source>Line Endings</source>
         <translation>Finales de línea</translation>
     </message>
@@ -705,32 +710,32 @@
 <context>
     <name>ReplaceBar</name>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="39"/>
+        <location filename="../src/controls/replacebar.cpp" line="21"/>
         <source>Find</source>
         <translation>Buscar</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="43"/>
+        <location filename="../src/controls/replacebar.cpp" line="25"/>
         <source>Replace With</source>
         <translation>Reemplazar con</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="47"/>
+        <location filename="../src/controls/replacebar.cpp" line="29"/>
         <source>Replace</source>
         <translation>Reemplazar</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="50"/>
+        <location filename="../src/controls/replacebar.cpp" line="32"/>
         <source>Skip</source>
         <translation>Omitir</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="53"/>
+        <location filename="../src/controls/replacebar.cpp" line="35"/>
         <source>Replace Rest</source>
         <translation>Reemplazar el resto</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="56"/>
+        <location filename="../src/controls/replacebar.cpp" line="38"/>
         <source>Replace All</source>
         <translation>Reemplazar todo</translation>
     </message>
@@ -747,58 +752,58 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../src/common/settings.cpp" line="91"/>
+        <location filename="../src/common/settings.cpp" line="115"/>
         <source>Standard</source>
         <translation>Estándar</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="91"/>
+        <location filename="../src/common/settings.cpp" line="115"/>
         <source>Customize</source>
         <translation>Personalizar</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="104"/>
+        <location filename="../src/common/settings.cpp" line="128"/>
         <source>Normal</source>
         <translation>Normal</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="104"/>
+        <location filename="../src/common/settings.cpp" line="128"/>
         <source>Maximum</source>
         <translation>Maximizada</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="104"/>
+        <location filename="../src/common/settings.cpp" line="128"/>
         <source>Fullscreen</source>
         <translation>Pantalla completa</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="292"/>
+        <location filename="../src/common/settings.cpp" line="316"/>
         <source>This shortcut conflicts with system shortcut %1</source>
         <translation>Este atajo entra en conflicto con el atajo del sistema %1</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="294"/>
+        <location filename="../src/common/settings.cpp" line="318"/>
         <source>This shortcut conflicts with %1, click on Replace to make this shortcut effective immediately</source>
         <translation>Este atajo entra en conflicto con %1, haga clic en Reemplazar para que este atajo sea efectivo inmediatamente</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="410"/>
-        <location filename="../src/common/settings.cpp" line="418"/>
+        <location filename="../src/common/settings.cpp" line="464"/>
+        <location filename="../src/common/settings.cpp" line="472"/>
         <source>The shortcut %1 is invalid, please set another one.</source>
         <translation>El atajo %1 es inválido, por favor ponga otro.</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="445"/>
+        <location filename="../src/common/settings.cpp" line="507"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="446"/>
+        <location filename="../src/common/settings.cpp" line="508"/>
         <source>Replace</source>
         <translation>Reemplazar</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="448"/>
+        <location filename="../src/common/settings.cpp" line="510"/>
         <source>OK</source>
         <translation>Aceptar</translation>
     </message>
@@ -806,7 +811,7 @@
 <context>
     <name>StartManager</name>
     <message>
-        <location filename="../src/startmanager.cpp" line="340"/>
+        <location filename="../src/startmanager.cpp" line="350"/>
         <source>Untitled %1</source>
         <translation>Sin título %1</translation>
     </message>
@@ -814,32 +819,32 @@
 <context>
     <name>Tabbar</name>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="515"/>
+        <location filename="../src/controls/tabbar.cpp" line="540"/>
         <source>Close tab</source>
         <translation>Cerrar pestaña</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="516"/>
+        <location filename="../src/controls/tabbar.cpp" line="541"/>
         <source>Close other tabs</source>
         <translation>Cerrar otras pestañas</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="517"/>
+        <location filename="../src/controls/tabbar.cpp" line="542"/>
         <source>More options</source>
         <translation>Más opciones</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="518"/>
+        <location filename="../src/controls/tabbar.cpp" line="543"/>
         <source>Close tabs to the left</source>
         <translation>Cerrar las pestañas de la izquierda</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="519"/>
+        <location filename="../src/controls/tabbar.cpp" line="544"/>
         <source>Close tabs to the right</source>
         <translation>Cerrar las pestañas de la derecha</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="520"/>
+        <location filename="../src/controls/tabbar.cpp" line="545"/>
         <source>Close unmodified tabs</source>
         <translation>Cerrar las pestañas sin modificar</translation>
     </message>
@@ -847,261 +852,259 @@
 <context>
     <name>TextEdit</name>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="235"/>
+        <location filename="../src/editor/dtextedit.cpp" line="259"/>
         <source>Undo</source>
         <translation>Deshacer</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="236"/>
+        <location filename="../src/editor/dtextedit.cpp" line="260"/>
         <source>Redo</source>
         <translation>Rehacer</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="237"/>
+        <location filename="../src/editor/dtextedit.cpp" line="261"/>
         <source>Cut</source>
         <translation>Cortar</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="238"/>
+        <location filename="../src/editor/dtextedit.cpp" line="262"/>
         <source>Copy</source>
         <translation>Copiar</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="239"/>
+        <location filename="../src/editor/dtextedit.cpp" line="263"/>
         <source>Paste</source>
         <translation>Pegar</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="240"/>
+        <location filename="../src/editor/dtextedit.cpp" line="264"/>
         <source>Delete</source>
         <translation>Borrar</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="241"/>
+        <location filename="../src/editor/dtextedit.cpp" line="265"/>
         <source>Select All</source>
         <translation>Seleccionar todo</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="242"/>
-        <location filename="../src/widgets/window.cpp" line="361"/>
+        <location filename="../src/editor/dtextedit.cpp" line="266"/>
+        <location filename="../src/widgets/window.cpp" line="450"/>
         <source>Find</source>
         <translation>Buscar</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="243"/>
-        <location filename="../src/widgets/window.cpp" line="362"/>
+        <location filename="../src/editor/dtextedit.cpp" line="267"/>
+        <location filename="../src/widgets/window.cpp" line="451"/>
         <source>Replace</source>
         <translation>Reemplazar</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="244"/>
+        <location filename="../src/editor/dtextedit.cpp" line="268"/>
         <source>Go to Line</source>
         <translation>Ir a la línea</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="245"/>
+        <location filename="../src/editor/dtextedit.cpp" line="269"/>
         <source>Turn on Read-Only mode</source>
         <translation>Activar modo solo lectura</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="246"/>
+        <location filename="../src/editor/dtextedit.cpp" line="270"/>
         <source>Turn off Read-Only mode</source>
         <translation>Desactivar modo solo lectura</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="247"/>
+        <location filename="../src/editor/dtextedit.cpp" line="271"/>
         <source>Fullscreen</source>
         <translation>Pantalla completa</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="248"/>
+        <location filename="../src/editor/dtextedit.cpp" line="272"/>
         <source>Exit fullscreen</source>
         <translation>Salir de la pantalla completa</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="249"/>
+        <location filename="../src/editor/dtextedit.cpp" line="273"/>
         <source>Display in file manager</source>
         <translation>Mostrar en el administrador de archivos</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="250"/>
-        <location filename="../src/editor/dtextedit.cpp" line="302"/>
+        <location filename="../src/editor/dtextedit.cpp" line="274"/>
+        <location filename="../src/editor/dtextedit.cpp" line="326"/>
         <source>Add Comment</source>
         <translation>Añadir comentario</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="251"/>
+        <location filename="../src/editor/dtextedit.cpp" line="275"/>
         <source>Text to Speech</source>
         <translation>Texto a voz</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="252"/>
+        <location filename="../src/editor/dtextedit.cpp" line="276"/>
         <source>Stop reading</source>
         <translation>Detener lectura</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="253"/>
+        <location filename="../src/editor/dtextedit.cpp" line="277"/>
         <source>Speech to Text</source>
         <translation>Voz a texto</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="254"/>
+        <location filename="../src/editor/dtextedit.cpp" line="278"/>
         <source>Translate</source>
         <translation>Traducir</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="255"/>
+        <location filename="../src/editor/dtextedit.cpp" line="279"/>
         <source>Column Mode</source>
         <translation>Modo de columna</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="256"/>
+        <location filename="../src/editor/dtextedit.cpp" line="280"/>
         <source>Add bookmark</source>
         <translation>Añadir marcador</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="257"/>
+        <location filename="../src/editor/dtextedit.cpp" line="281"/>
         <source>Remove Bookmark</source>
         <translation>Quitar marcador</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="258"/>
+        <location filename="../src/editor/dtextedit.cpp" line="282"/>
         <source>Previous bookmark</source>
         <translation>Marcador anterior</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="259"/>
+        <location filename="../src/editor/dtextedit.cpp" line="283"/>
         <source>Next bookmark</source>
         <translation>Marcador siguiente</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="260"/>
+        <location filename="../src/editor/dtextedit.cpp" line="284"/>
         <source>Remove All Bookmarks</source>
         <translation>Quitar todos los marcadores</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="261"/>
+        <location filename="../src/editor/dtextedit.cpp" line="285"/>
         <source>Fold All</source>
         <translation>Ocultar todo</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="262"/>
+        <location filename="../src/editor/dtextedit.cpp" line="286"/>
         <source>Fold Current Level</source>
         <translation>Ocultar el nivel actual</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="263"/>
+        <location filename="../src/editor/dtextedit.cpp" line="287"/>
         <source>Unfold All</source>
         <translation>Mostrar todo</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="264"/>
+        <location filename="../src/editor/dtextedit.cpp" line="288"/>
         <source>Unfold Current Level</source>
         <translation>Mostrar el nivel actual</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="269"/>
+        <location filename="../src/editor/dtextedit.cpp" line="293"/>
         <source>Color Mark</source>
         <translation>Resaltador</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="273"/>
+        <location filename="../src/editor/dtextedit.cpp" line="297"/>
         <source>Clear All Marks</source>
         <translation>Borrar todo lo resaltado</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="274"/>
+        <location filename="../src/editor/dtextedit.cpp" line="298"/>
         <source>Clear Last Mark</source>
         <translation>Borrar último resalte</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="283"/>
+        <location filename="../src/editor/dtextedit.cpp" line="307"/>
         <source>Mark</source>
         <translation>Resaltar</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="295"/>
+        <location filename="../src/editor/dtextedit.cpp" line="319"/>
         <source>Mark All</source>
         <translation>Resaltar todo</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="303"/>
+        <location filename="../src/editor/dtextedit.cpp" line="327"/>
         <source>Remove Comment</source>
         <translation>Borrar comentario</translation>
     </message>
     <message>
-        <source>Failed to paste text: it is too large</source>
-        <translation type="vanished">Fallo al pegar el texto: es demasiado grande</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="2581"/>
+        <location filename="../src/editor/dtextedit.cpp" line="2672"/>
         <source>Copy failed: not enough memory</source>
         <translation>Copia fallida: no hay suficiente memoria</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="2665"/>
+        <location filename="../src/editor/dtextedit.cpp" line="2756"/>
         <source>Press ALT and click lines to edit in column mode</source>
         <translation>Presiona ALT y haz clic en las líneas para editar en el modo de columna</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="346"/>
+        <location filename="../src/editor/dtextedit.cpp" line="370"/>
         <source>Change Case</source>
         <translation>Formato de texto</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="347"/>
+        <location filename="../src/editor/dtextedit.cpp" line="371"/>
         <source>Upper Case</source>
         <translation>Mayúsculas</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="348"/>
+        <location filename="../src/editor/dtextedit.cpp" line="372"/>
         <source>Lower Case</source>
         <translation>Minúsculas</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="349"/>
+        <location filename="../src/editor/dtextedit.cpp" line="373"/>
         <source>Capitalize</source>
         <translation>Capitalizar</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="64"/>
+        <location filename="../src/widgets/bottombar.cpp" line="49"/>
         <source>None</source>
         <translation>Ninguno</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1184"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1222"/>
         <source>Selected line(s) copied</source>
         <translation>Líneas seleccionadas copiadas</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1190"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1228"/>
         <source>Current line copied</source>
         <translation>Línea actual copiada</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1210"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1248"/>
         <source>Selected line(s) clipped</source>
         <translation>Líneas seleccionadas cortadas</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1222"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1259"/>
         <source>Current line clipped</source>
         <translation>Línea actual cortada</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="2591"/>
+        <location filename="../src/editor/dtextedit.cpp" line="2682"/>
         <source>Paste failed: not enough memory</source>
         <translation>Fallo al pegar: no hay suficiente memoria</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3439"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3617"/>
         <source>Read-Only mode is off</source>
         <translation>Modo solo lectura desactivado</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3446"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3465"/>
-        <location filename="../src/editor/dtextedit.cpp" line="6150"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3624"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3643"/>
+        <location filename="../src/editor/dtextedit.cpp" line="6656"/>
+        <location filename="../src/editor/dtextedit.cpp" line="6664"/>
+        <location filename="../src/editor/dtextedit.cpp" line="6675"/>
         <source>Read-Only mode is on</source>
         <translation>Modo solo lectura activado</translation>
     </message>
@@ -1109,7 +1112,7 @@
 <context>
     <name>WarningNotices</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="36"/>
+        <location filename="../src/controls/warningnotices.cpp" line="19"/>
         <source>Reload</source>
         <translation>Recargar</translation>
     </message>
@@ -1117,129 +1120,130 @@
 <context>
     <name>Window</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="38"/>
-        <location filename="../src/widgets/window.cpp" line="357"/>
+        <location filename="../src/controls/warningnotices.cpp" line="21"/>
+        <location filename="../src/widgets/window.cpp" line="446"/>
         <source>Save as</source>
         <translation>Guardar como</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="353"/>
+        <location filename="../src/widgets/window.cpp" line="442"/>
         <source>New window</source>
         <translation>Nueva ventana</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="354"/>
+        <location filename="../src/widgets/window.cpp" line="443"/>
         <source>New tab</source>
         <translation>Nueva pestaña</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="355"/>
+        <location filename="../src/widgets/window.cpp" line="444"/>
         <source>Open file</source>
         <translation>Abrir archivo</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="356"/>
-        <location filename="../src/widgets/window.cpp" line="2217"/>
+        <location filename="../src/widgets/window.cpp" line="445"/>
+        <location filename="../src/widgets/window.cpp" line="2796"/>
         <source>Save</source>
         <translation>Guardar</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="358"/>
+        <location filename="../src/widgets/window.cpp" line="447"/>
         <source>Print</source>
         <translation>Imprimir</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="359"/>
+        <location filename="../src/widgets/window.cpp" line="448"/>
         <source>Switch theme</source>
         <translation>Cambiar el tema</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="360"/>
-        <location filename="../src/widgets/window.cpp" line="1542"/>
+        <location filename="../src/widgets/window.cpp" line="449"/>
+        <location filename="../src/widgets/window.cpp" line="1871"/>
         <source>Settings</source>
         <translation>Ajustes</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="471"/>
-        <location filename="../src/widgets/window.cpp" line="2468"/>
+        <location filename="../src/widgets/window.cpp" line="563"/>
+        <location filename="../src/widgets/window.cpp" line="3047"/>
         <source>Read-Only</source>
         <translation>Sólo lectura</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="487"/>
+        <location filename="../src/widgets/window.cpp" line="579"/>
         <source>You do not have permission to open %1</source>
         <translation>No tienes permisos para abrir %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="522"/>
+        <location filename="../src/widgets/window.cpp" line="619"/>
+        <location filename="../src/widgets/window.cpp" line="2359"/>
         <source>Invalid file: %1</source>
         <translation>Archivo inválido: %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="602"/>
-        <location filename="../src/widgets/window.cpp" line="644"/>
+        <location filename="../src/widgets/window.cpp" line="733"/>
+        <location filename="../src/widgets/window.cpp" line="779"/>
         <source>Do you want to save this file?</source>
         <translation>¿Desea guardar este archivo?</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="894"/>
+        <location filename="../src/widgets/window.cpp" line="1027"/>
         <source>You do not have permission to save %1</source>
         <translation>No tienes permisos para guardar %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="918"/>
+        <location filename="../src/widgets/window.cpp" line="1051"/>
         <source>Saved successfully</source>
         <translation>Guardado exitosamente</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="954"/>
-        <location filename="../src/widgets/window.cpp" line="1021"/>
-        <location filename="../src/widgets/window.cpp" line="1062"/>
+        <location filename="../src/widgets/window.cpp" line="1087"/>
+        <location filename="../src/widgets/window.cpp" line="1160"/>
+        <location filename="../src/widgets/window.cpp" line="1201"/>
         <source>Save File</source>
         <translation>Guardar el archivo</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1023"/>
+        <location filename="../src/widgets/window.cpp" line="1162"/>
         <source>Encoding</source>
         <translation>Codificación</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1211"/>
+        <location filename="../src/widgets/window.cpp" line="1350"/>
         <source>Read-Only mode is on</source>
         <translation>Modo solo lectura activado</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1441"/>
+        <location filename="../src/widgets/window.cpp" line="1770"/>
         <source>Current location remembered</source>
         <translation>Guardar ubicación actual</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1492"/>
+        <location filename="../src/widgets/window.cpp" line="1821"/>
         <source>Ctrl+&apos;=&apos;</source>
         <translation>Ctrl+&apos;=&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1495"/>
+        <location filename="../src/widgets/window.cpp" line="1824"/>
         <source>Ctrl+&apos;-&apos;</source>
         <translation>Ctrl+&apos;-&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1524"/>
+        <location filename="../src/widgets/window.cpp" line="1853"/>
         <source>Editor</source>
         <translation>Editor</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1890"/>
+        <location filename="../src/widgets/window.cpp" line="2451"/>
         <source>Untitled %1</source>
         <translation>Sin título %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2215"/>
+        <location filename="../src/widgets/window.cpp" line="2794"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2216"/>
+        <location filename="../src/widgets/window.cpp" line="2795"/>
         <source>Discard</source>
         <translation>Descartar</translation>
     </message>

--- a/translations/deepin-editor_fi.ts
+++ b/translations/deepin-editor_fi.ts
@@ -2,17 +2,17 @@
 <context>
     <name>BottomBar</name>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="39"/>
+        <location filename="../src/widgets/bottombar.cpp" line="24"/>
         <source>Row</source>
         <translation>Rivi</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="40"/>
+        <location filename="../src/widgets/bottombar.cpp" line="25"/>
         <source>Column</source>
         <translation>Sarake</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="41"/>
+        <location filename="../src/widgets/bottombar.cpp" line="26"/>
         <source>Characters %1</source>
         <translation>Merkit %1</translation>
     </message>
@@ -20,9 +20,9 @@
 <context>
     <name>DDropdownMenu</name>
     <message>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="300"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="344"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="349"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="290"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="341"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="346"/>
         <source>None</source>
         <translation>Tyhjä</translation>
     </message>
@@ -30,80 +30,85 @@
 <context>
     <name>EditWrapper</name>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="201"/>
-        <location filename="../src/editor/editwrapper.cpp" line="264"/>
-        <location filename="../src/editor/editwrapper.cpp" line="321"/>
-        <location filename="../src/editor/editwrapper.cpp" line="536"/>
+        <location filename="../src/editor/editwrapper.cpp" line="246"/>
+        <location filename="../src/editor/editwrapper.cpp" line="314"/>
+        <location filename="../src/editor/editwrapper.cpp" line="439"/>
+        <location filename="../src/editor/editwrapper.cpp" line="702"/>
         <source>Save</source>
         <translation>Tallenna</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="316"/>
+        <location filename="../src/editor/editwrapper.cpp" line="434"/>
         <source>Do you want to save this file?</source>
         <translation>Haluatko tallentaa tämän tiedoston?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="262"/>
-        <location filename="../src/editor/editwrapper.cpp" line="319"/>
+        <location filename="../src/editor/editwrapper.cpp" line="312"/>
+        <location filename="../src/editor/editwrapper.cpp" line="437"/>
         <source>Cancel</source>
         <translation>Peru</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="259"/>
+        <location filename="../src/editor/editwrapper.cpp" line="309"/>
         <source>Encoding changed. Do you want to save the file now?</source>
         <translation>Koodaus muutettu. Haluatko tallentaa tiedoston nyt?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="320"/>
+        <location filename="../src/editor/editwrapper.cpp" line="438"/>
         <source>Discard</source>
         <translation>Hylkää</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="445"/>
+        <location filename="../src/editor/editwrapper.cpp" line="564"/>
         <source>You do not have permission to save %1</source>
         <translation>Sinulla ei ole lupaa tallentaa %1</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="607"/>
+        <location filename="../src/editor/editwrapper.cpp" line="774"/>
         <source>File removed on the disk. Save it now?</source>
         <translation>Tiedosto on poistettu. Tallenna se nyt?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="612"/>
+        <location filename="../src/editor/editwrapper.cpp" line="779"/>
         <source>File has changed on disk. Reload?</source>
         <translation>Tiedosto on muuttunut. Päivitä?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="634"/>
-        <location filename="../src/widgets/bottombar.cpp" line="60"/>
+        <location filename="../src/editor/editwrapper.cpp" line="801"/>
+        <location filename="../src/widgets/bottombar.cpp" line="45"/>
         <source>INSERT</source>
         <translation>Lisää</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="637"/>
+        <location filename="../src/editor/editwrapper.cpp" line="804"/>
         <source>OVERWRITE</source>
         <translation>Ylikirjoita</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="640"/>
+        <location filename="../src/editor/editwrapper.cpp" line="807"/>
         <source>R/O</source>
         <translation>R/O</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="945"/>
+        <source>The file cannot be read, which may be too large or has been damaged!</source>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
     <name>FindBar</name>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="40"/>
+        <location filename="../src/controls/findbar.cpp" line="22"/>
         <source>Find</source>
         <translation>Etsi</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="44"/>
+        <location filename="../src/controls/findbar.cpp" line="26"/>
         <source>Previous</source>
         <translation>Edellinen</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="46"/>
+        <location filename="../src/controls/findbar.cpp" line="28"/>
         <source>Next</source>
         <translation>Seuraava</translation>
     </message>
@@ -111,7 +116,7 @@
 <context>
     <name>JumpLineBar</name>
     <message>
-        <location filename="../src/controls/jumplinebar.cpp" line="40"/>
+        <location filename="../src/controls/jumplinebar.cpp" line="28"/>
         <source>Go to Line: </source>
         <translation>Siirry riville:</translation>
     </message>
@@ -119,12 +124,12 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/editorapplication.cpp" line="27"/>
+        <location filename="../src/editorapplication.cpp" line="11"/>
         <source>Text Editor is a powerful tool for viewing and editing text files.</source>
         <translation>Tekstieditori on tehokas työkalu tekstitiedostojen katselemiseen ja muokkaamiseen.</translation>
     </message>
     <message>
-        <location filename="../src/editorapplication.cpp" line="38"/>
+        <location filename="../src/editorapplication.cpp" line="22"/>
         <source>Text Editor</source>
         <translation>Tekstieditori</translation>
     </message>
@@ -132,572 +137,572 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/editorapplication.cpp" line="35"/>
+        <location filename="../src/editorapplication.cpp" line="19"/>
         <source>Text Editor</source>
         <translation>Tekstieditori</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="203"/>
-        <location filename="../src/editor/editwrapper.cpp" line="538"/>
-        <location filename="../src/widgets/window.cpp" line="956"/>
-        <location filename="../src/widgets/window.cpp" line="973"/>
-        <location filename="../src/widgets/window.cpp" line="1064"/>
-        <location filename="../src/widgets/window.cpp" line="1079"/>
+        <location filename="../src/editor/editwrapper.cpp" line="248"/>
+        <location filename="../src/editor/editwrapper.cpp" line="704"/>
+        <location filename="../src/widgets/window.cpp" line="1089"/>
+        <location filename="../src/widgets/window.cpp" line="1111"/>
+        <location filename="../src/widgets/window.cpp" line="1203"/>
+        <location filename="../src/widgets/window.cpp" line="1218"/>
         <source>Encoding</source>
         <translation>Koodaus</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="24"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="9"/>
         <source>Basic</source>
         <translation>Perustiedot</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="25"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="10"/>
         <source>Font Style</source>
         <translation>Kirjasimen tyyli</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="26"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="11"/>
         <source>Font</source>
         <translation>Kirjasin</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="27"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="12"/>
         <source>Font Size</source>
         <translation>Kirjasimen koko</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="28"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="13"/>
         <source>Shortcuts</source>
         <translation>Pikanäppäimet</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="29"/>
-        <location filename="../src/controls/settingsdialog.cpp" line="30"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="14"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="15"/>
         <source>Keymap</source>
         <translation>Näppäinkartta</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="31"/>
-        <location filename="../src/controls/settingsdialog.cpp" line="107"/>
-        <location filename="../src/widgets/window.cpp" line="1482"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="16"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="92"/>
+        <location filename="../src/widgets/window.cpp" line="1811"/>
         <source>Window</source>
         <translation>Ikkuna</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="32"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="17"/>
         <source>New tab</source>
         <translation>Uusi välilehti</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="33"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="18"/>
         <source>New window</source>
         <translation>Uusi ikkuna</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="34"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="19"/>
         <source>Save</source>
         <translation>Tallenna</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="35"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="20"/>
         <source>Save as</source>
         <translation>Tallenna nimellä</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="36"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="21"/>
         <source>Next tab</source>
         <translation>Seuraava välilehti</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="37"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="22"/>
         <source>Previous tab</source>
         <translation>Edellinen välilehti</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="38"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="23"/>
         <source>Close tab</source>
         <translation>Sulje välilehti</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="39"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="24"/>
         <source>Close other tabs</source>
         <translation>Sulje välilehdet</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="40"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="25"/>
         <source>Restore tab</source>
         <translation>Palauta välilehti</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="41"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="26"/>
         <source>Open file</source>
         <translation>Avaa tiedosto</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="42"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="27"/>
         <source>Increment font size</source>
         <translation>Kasvata fonttikokoa</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="43"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="28"/>
         <source>Decrement font size</source>
         <translation>Vähennä fonttikokoa</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="44"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="29"/>
         <source>Reset font size</source>
         <translation>Nollaa kirjasimen koko</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="45"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="30"/>
         <source>Help</source>
         <translation>Apua</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="46"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="31"/>
         <source>Toggle fullscreen</source>
         <translation>Siirry koko näyttöön</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="47"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="32"/>
         <source>Find</source>
         <translation>Etsi</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="48"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="33"/>
         <source>Replace</source>
         <translation>Korvaa</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="49"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="34"/>
         <source>Go to line</source>
         <translation>Siirry riville</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="50"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="35"/>
         <source>Save cursor position</source>
         <translation>Tallenna kohdistimen sijainti</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="51"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="36"/>
         <source>Reset cursor position</source>
         <translation>Nollaa kohdistimen sijainti</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="52"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="37"/>
         <source>Exit</source>
         <translation>Poistu</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="53"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="38"/>
         <source>Display shortcuts</source>
         <translation>Näytä pikavalinnat</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="54"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="39"/>
         <source>Print</source>
         <translation>Tulosta</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="55"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="40"/>
         <source>Editor</source>
         <translation>Editori</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="56"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="41"/>
         <source>Increase indent</source>
         <translation>Suurenna sisennys</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="57"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="42"/>
         <source>Decrease indent</source>
         <translation>Pienennä sisennys</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="58"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="43"/>
         <source>Forward character</source>
         <translation>Merkki eteen</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="59"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="44"/>
         <source>Backward character</source>
         <translation>Merkki taakse</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="60"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="45"/>
         <source>Forward word</source>
         <translation>Sanan eteen</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="61"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="46"/>
         <source>Backward word</source>
         <translation>Sanan taakse</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="62"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="47"/>
         <source>Next line</source>
         <translation>Seuraava rivi</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="63"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="48"/>
         <source>Previous line</source>
         <translation>Edellinen rivi</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="64"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="49"/>
         <source>New line</source>
         <translation>Uusi rivi</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="65"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="50"/>
         <source>New line above</source>
         <translation>Uusi rivi eteen</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="66"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="51"/>
         <source>New line below</source>
         <translation>Uusi rivi taakse</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="67"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="52"/>
         <source>Duplicate line</source>
         <translation>Monista rivi</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="68"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="53"/>
         <source>Delete to end of line</source>
         <translation>Poista rivin loppuun</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="69"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="54"/>
         <source>Delete current line</source>
         <translation>Poista nykyinen rivi</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="70"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="55"/>
         <source>Swap line up</source>
         <translation>Vaihda rivi ylös</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="71"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="56"/>
         <source>Swap line down</source>
         <translation>Vaihda rivi alas</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="72"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="57"/>
         <source>Scroll up one line</source>
         <translation>Vieritä rivi ylöspäin</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="73"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="58"/>
         <source>Scroll down one line</source>
         <translation>Vieritä rivi alaspäin</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="74"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="59"/>
         <source>Page up</source>
         <translation>Sivu ylös</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="75"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="60"/>
         <source>Page down</source>
         <translation>Sivu alas</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="76"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="61"/>
         <source>Move to end of line</source>
         <translation>Siirry rivin loppuun</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="77"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="62"/>
         <source>Move to start of line</source>
         <translation>Siirry rivin alkuun</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="78"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="63"/>
         <source>Move to end of text</source>
         <translation>Siirry tekstin loppuun</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="79"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="64"/>
         <source>Move to start of text</source>
         <translation>Siirry tekstin alkuun</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="80"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="65"/>
         <source>Move to line indentation</source>
         <translation>Lisää sisennys</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="81"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="66"/>
         <source>Upper case</source>
         <translation>Isot kirjaimet</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="82"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="67"/>
         <source>Lower case</source>
         <translation>Pienet kirjaimet</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="83"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="68"/>
         <source>Capitalize</source>
         <translation>Suuret kirjaimet</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="84"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="69"/>
         <source>Delete backward word</source>
         <translation>Poista taaksepäin</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="85"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="70"/>
         <source>Delete forward word</source>
         <translation>Poista eteenpäin</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="86"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="71"/>
         <source>Forward over a pair</source>
         <translation>Etenevä</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="87"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="72"/>
         <source>Backward over a pair</source>
         <translation>Takautuva</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="88"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="73"/>
         <source>Select all</source>
         <translation>Valitse kaikki</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="89"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="74"/>
         <source>Copy</source>
         <translation>Kopioi</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="90"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="75"/>
         <source>Cut</source>
         <translation>Leikkaa</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="91"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="76"/>
         <source>Paste</source>
         <translation>Liitä</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="92"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="77"/>
         <source>Transpose character</source>
         <translation>Siirrä merkki</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="93"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="78"/>
         <source>Mark</source>
         <translation>Merkki</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="94"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="79"/>
         <source>Unmark</source>
         <translation>Poista merkintä</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="95"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="80"/>
         <source>Copy line</source>
         <translation>Kopioi rivi</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="96"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="81"/>
         <source>Cut line</source>
         <translation>Leikkaa rivi</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="97"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="82"/>
         <source>Merge lines</source>
         <translation>Yhdistä rivit</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="98"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="83"/>
         <source>Read-Only mode</source>
         <translation>Vain lukutila</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="99"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="84"/>
         <source>Add comment</source>
         <translation>Lisää kommentti</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="100"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="85"/>
         <source>Remove comment</source>
         <translation>Poista kommentti</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="101"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="86"/>
         <source>Undo</source>
         <translation>Kumoa</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="102"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="87"/>
         <source>Redo</source>
         <translation>Uudelleen</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="103"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="88"/>
         <source>Add/Remove bookmark</source>
         <translation>Lisää/poista kirjanmerkki</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="104"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="89"/>
         <source>Move to previous bookmark</source>
         <translation>Siirry edelliseen kirjanmerkkiin</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="105"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="90"/>
         <source>Move to next bookmark</source>
         <translation>Siirry seuraavaan kirjanmerkkiin</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="106"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="91"/>
         <source>Advanced</source>
         <translation>Edistynyt</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="108"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="93"/>
         <source>Window size</source>
         <translation>Ikkunan koko</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="109"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="94"/>
         <source>Tab width</source>
         <translation>Välilehden leveys</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="111"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="96"/>
         <source>Word wrap</source>
         <translation>Rivitys</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="112"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="97"/>
         <source>Code folding flag</source>
         <translation>Koodin taiton merkit</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="113"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="98"/>
         <source>Show line numbers</source>
         <translation>Näytä rivinumerot</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="114"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="99"/>
         <source>Show bookmarks icon</source>
         <translation>Näytä kirjanmerkit kuvake</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="115"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="100"/>
         <source>Show whitespaces and tabs</source>
         <translation>Näytä välilyönnit ja tabulaattorit</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="116"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="101"/>
         <source>Highlight current line</source>
         <translation>Korosta nykyinen rivi</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="117"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="102"/>
         <source>Color mark</source>
         <translation>Värimerkki</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="120"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="105"/>
         <source>Unicode</source>
         <translation>Unicode</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="121"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="106"/>
         <source>WesternEuropean</source>
         <translation>Länsi-Eurooppa</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="122"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="107"/>
         <source>CentralEuropean</source>
         <translation>Keski-Eurooppa</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="123"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="108"/>
         <source>Baltic</source>
         <translation>Baltia</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="124"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="109"/>
         <source>Cyrillic</source>
         <translation>Kyrillinen</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="125"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="110"/>
         <source>Arabic</source>
         <translation>Arabia</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="130"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="115"/>
         <source>Celtic</source>
         <translation>Kelttiläinen</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="131"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="116"/>
         <source>SouthEasternEuropean</source>
         <translation>Kaakkois-Eurooppa</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="126"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="111"/>
         <source>Greek</source>
         <translation>Kreikka</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="127"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="112"/>
         <source>Hebrew</source>
         <translation>Hebrea</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="132"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="117"/>
         <source>ChineseSimplified</source>
         <translation>Kiina-yksinkertaistettu</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="133"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="118"/>
         <source>ChineseTraditional</source>
         <translation>Kiina-perinteinen</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="134"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="119"/>
         <source>Japanese</source>
         <translation>Japani</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="135"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="120"/>
         <source>Korean</source>
         <translation>Korea</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="129"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="114"/>
         <source>Thai</source>
         <translation>Thai</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="128"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="113"/>
         <source>Turkish</source>
         <translation>Turkki</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="136"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="121"/>
         <source>Vietnamese</source>
         <translation>Vietnami</translation>
     </message>
     <message>
-        <location filename="../src/startmanager.cpp" line="762"/>
+        <location filename="../src/startmanager.cpp" line="832"/>
         <source>File not saved</source>
         <translation>Tiedostoa ei tallennettu</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="974"/>
-        <location filename="../src/widgets/window.cpp" line="1065"/>
-        <location filename="../src/widgets/window.cpp" line="1080"/>
+        <location filename="../src/widgets/window.cpp" line="1112"/>
+        <location filename="../src/widgets/window.cpp" line="1204"/>
+        <location filename="../src/widgets/window.cpp" line="1219"/>
         <source>Line Endings</source>
         <translation>Rivin loppu</translation>
     </message>
@@ -705,32 +710,32 @@
 <context>
     <name>ReplaceBar</name>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="39"/>
+        <location filename="../src/controls/replacebar.cpp" line="21"/>
         <source>Find</source>
         <translation>Etsi</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="43"/>
+        <location filename="../src/controls/replacebar.cpp" line="25"/>
         <source>Replace With</source>
         <translation>Korvaa</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="47"/>
+        <location filename="../src/controls/replacebar.cpp" line="29"/>
         <source>Replace</source>
         <translation>Korvaa</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="50"/>
+        <location filename="../src/controls/replacebar.cpp" line="32"/>
         <source>Skip</source>
         <translation>Ohita</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="53"/>
+        <location filename="../src/controls/replacebar.cpp" line="35"/>
         <source>Replace Rest</source>
         <translation>Korvaa loput</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="56"/>
+        <location filename="../src/controls/replacebar.cpp" line="38"/>
         <source>Replace All</source>
         <translation>Korvaa kaikki</translation>
     </message>
@@ -747,58 +752,58 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../src/common/settings.cpp" line="91"/>
+        <location filename="../src/common/settings.cpp" line="115"/>
         <source>Standard</source>
         <translation>Standardi</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="91"/>
+        <location filename="../src/common/settings.cpp" line="115"/>
         <source>Customize</source>
         <translation>Muokkaa</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="104"/>
+        <location filename="../src/common/settings.cpp" line="128"/>
         <source>Normal</source>
         <translation>Normaali</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="104"/>
+        <location filename="../src/common/settings.cpp" line="128"/>
         <source>Maximum</source>
         <translation>Maksimi</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="104"/>
+        <location filename="../src/common/settings.cpp" line="128"/>
         <source>Fullscreen</source>
         <translation>Koko näyttö</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="292"/>
+        <location filename="../src/common/settings.cpp" line="316"/>
         <source>This shortcut conflicts with system shortcut %1</source>
         <translation>Tämä pikanäppäin on ristiriidassa järjestelmän %1 kanssa</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="294"/>
+        <location filename="../src/common/settings.cpp" line="318"/>
         <source>This shortcut conflicts with %1, click on Replace to make this shortcut effective immediately</source>
         <translation>Tämä on ristiriidassa %1 kanssa, valitse Korvaa, jotta tämä pikanäppäin tulee voimaan välittömästi</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="410"/>
-        <location filename="../src/common/settings.cpp" line="418"/>
+        <location filename="../src/common/settings.cpp" line="464"/>
+        <location filename="../src/common/settings.cpp" line="472"/>
         <source>The shortcut %1 is invalid, please set another one.</source>
         <translation>Pikanäppäin %1 on virheellinen, aseta toinen.</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="445"/>
+        <location filename="../src/common/settings.cpp" line="507"/>
         <source>Cancel</source>
         <translation>Peru</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="446"/>
+        <location filename="../src/common/settings.cpp" line="508"/>
         <source>Replace</source>
         <translation>Korvaa</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="448"/>
+        <location filename="../src/common/settings.cpp" line="510"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
@@ -806,7 +811,7 @@
 <context>
     <name>StartManager</name>
     <message>
-        <location filename="../src/startmanager.cpp" line="340"/>
+        <location filename="../src/startmanager.cpp" line="350"/>
         <source>Untitled %1</source>
         <translation>Nimetön %1</translation>
     </message>
@@ -814,32 +819,32 @@
 <context>
     <name>Tabbar</name>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="515"/>
+        <location filename="../src/controls/tabbar.cpp" line="540"/>
         <source>Close tab</source>
         <translation>Sulje välilehti</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="516"/>
+        <location filename="../src/controls/tabbar.cpp" line="541"/>
         <source>Close other tabs</source>
         <translation>Sulje välilehdet</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="517"/>
+        <location filename="../src/controls/tabbar.cpp" line="542"/>
         <source>More options</source>
         <translation>Lisää vaihtoehtoja</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="518"/>
+        <location filename="../src/controls/tabbar.cpp" line="543"/>
         <source>Close tabs to the left</source>
         <translation>Sulje välilehdet vasemmalla</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="519"/>
+        <location filename="../src/controls/tabbar.cpp" line="544"/>
         <source>Close tabs to the right</source>
         <translation>Sulje välilehdet oikealla</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="520"/>
+        <location filename="../src/controls/tabbar.cpp" line="545"/>
         <source>Close unmodified tabs</source>
         <translation>Sulje muuttumattomat välilehdet</translation>
     </message>
@@ -847,261 +852,259 @@
 <context>
     <name>TextEdit</name>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="235"/>
+        <location filename="../src/editor/dtextedit.cpp" line="259"/>
         <source>Undo</source>
         <translation>Kumoa</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="236"/>
+        <location filename="../src/editor/dtextedit.cpp" line="260"/>
         <source>Redo</source>
         <translation>Uudelleen</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="237"/>
+        <location filename="../src/editor/dtextedit.cpp" line="261"/>
         <source>Cut</source>
         <translation>Leikkaa</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="238"/>
+        <location filename="../src/editor/dtextedit.cpp" line="262"/>
         <source>Copy</source>
         <translation>Kopioi</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="239"/>
+        <location filename="../src/editor/dtextedit.cpp" line="263"/>
         <source>Paste</source>
         <translation>Liitä</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="240"/>
+        <location filename="../src/editor/dtextedit.cpp" line="264"/>
         <source>Delete</source>
         <translation>Poista</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="241"/>
+        <location filename="../src/editor/dtextedit.cpp" line="265"/>
         <source>Select All</source>
         <translation>Valitse kaikki</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="242"/>
-        <location filename="../src/widgets/window.cpp" line="361"/>
+        <location filename="../src/editor/dtextedit.cpp" line="266"/>
+        <location filename="../src/widgets/window.cpp" line="450"/>
         <source>Find</source>
         <translation>Etsi</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="243"/>
-        <location filename="../src/widgets/window.cpp" line="362"/>
+        <location filename="../src/editor/dtextedit.cpp" line="267"/>
+        <location filename="../src/widgets/window.cpp" line="451"/>
         <source>Replace</source>
         <translation>Korvaa</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="244"/>
+        <location filename="../src/editor/dtextedit.cpp" line="268"/>
         <source>Go to Line</source>
         <translation>Siirry riville</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="245"/>
+        <location filename="../src/editor/dtextedit.cpp" line="269"/>
         <source>Turn on Read-Only mode</source>
         <translation>Vain lukutila</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="246"/>
+        <location filename="../src/editor/dtextedit.cpp" line="270"/>
         <source>Turn off Read-Only mode</source>
         <translation>Poista vain lukutila</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="247"/>
+        <location filename="../src/editor/dtextedit.cpp" line="271"/>
         <source>Fullscreen</source>
         <translation>Koko näyttö</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="248"/>
+        <location filename="../src/editor/dtextedit.cpp" line="272"/>
         <source>Exit fullscreen</source>
         <translation>Poistu koko näytöstä</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="249"/>
+        <location filename="../src/editor/dtextedit.cpp" line="273"/>
         <source>Display in file manager</source>
         <translation>Näytä tiedostojenhallinnassa</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="250"/>
-        <location filename="../src/editor/dtextedit.cpp" line="302"/>
+        <location filename="../src/editor/dtextedit.cpp" line="274"/>
+        <location filename="../src/editor/dtextedit.cpp" line="326"/>
         <source>Add Comment</source>
         <translation>Lisää kommentti</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="251"/>
+        <location filename="../src/editor/dtextedit.cpp" line="275"/>
         <source>Text to Speech</source>
         <translation>Teksti puheeksi</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="252"/>
+        <location filename="../src/editor/dtextedit.cpp" line="276"/>
         <source>Stop reading</source>
         <translation>Lopeta lukeminen</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="253"/>
+        <location filename="../src/editor/dtextedit.cpp" line="277"/>
         <source>Speech to Text</source>
         <translation>Puhe tekstiksi</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="254"/>
+        <location filename="../src/editor/dtextedit.cpp" line="278"/>
         <source>Translate</source>
         <translation>Kääntäjä</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="255"/>
+        <location filename="../src/editor/dtextedit.cpp" line="279"/>
         <source>Column Mode</source>
         <translation>Saraketila</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="256"/>
+        <location filename="../src/editor/dtextedit.cpp" line="280"/>
         <source>Add bookmark</source>
         <translation>Lisää kirjanmerkki</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="257"/>
+        <location filename="../src/editor/dtextedit.cpp" line="281"/>
         <source>Remove Bookmark</source>
         <translation>Poista kirjanmerkki</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="258"/>
+        <location filename="../src/editor/dtextedit.cpp" line="282"/>
         <source>Previous bookmark</source>
         <translation>Edellinen kirjanmerkki</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="259"/>
+        <location filename="../src/editor/dtextedit.cpp" line="283"/>
         <source>Next bookmark</source>
         <translation>Seuraava kirjanmerkki</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="260"/>
+        <location filename="../src/editor/dtextedit.cpp" line="284"/>
         <source>Remove All Bookmarks</source>
         <translation>Poista kaikki kirjanmerkkit</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="261"/>
+        <location filename="../src/editor/dtextedit.cpp" line="285"/>
         <source>Fold All</source>
         <translation>Taita kaikki</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="262"/>
+        <location filename="../src/editor/dtextedit.cpp" line="286"/>
         <source>Fold Current Level</source>
         <translation>Taita nykyinen taso</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="263"/>
+        <location filename="../src/editor/dtextedit.cpp" line="287"/>
         <source>Unfold All</source>
         <translation>Avaa kaikki</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="264"/>
+        <location filename="../src/editor/dtextedit.cpp" line="288"/>
         <source>Unfold Current Level</source>
         <translation>Avaa nykyinen taso</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="269"/>
+        <location filename="../src/editor/dtextedit.cpp" line="293"/>
         <source>Color Mark</source>
         <translation>Värimerkki</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="273"/>
+        <location filename="../src/editor/dtextedit.cpp" line="297"/>
         <source>Clear All Marks</source>
         <translation>Poista kaikki merkit</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="274"/>
+        <location filename="../src/editor/dtextedit.cpp" line="298"/>
         <source>Clear Last Mark</source>
         <translation>Poista viimeinen merkki</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="283"/>
+        <location filename="../src/editor/dtextedit.cpp" line="307"/>
         <source>Mark</source>
         <translation>Merkki</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="295"/>
+        <location filename="../src/editor/dtextedit.cpp" line="319"/>
         <source>Mark All</source>
         <translation>Merkitse kaikki</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="303"/>
+        <location filename="../src/editor/dtextedit.cpp" line="327"/>
         <source>Remove Comment</source>
         <translation>Poista kommentti</translation>
     </message>
     <message>
-        <source>Failed to paste text: it is too large</source>
-        <translation type="vanished">Tekstin liittäminen epäonnistui: se on liian iso</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="2581"/>
+        <location filename="../src/editor/dtextedit.cpp" line="2672"/>
         <source>Copy failed: not enough memory</source>
         <translation>Kopiointi epäonnistui: muisti ei riitä</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="2665"/>
+        <location filename="../src/editor/dtextedit.cpp" line="2756"/>
         <source>Press ALT and click lines to edit in column mode</source>
         <translation>Paina ALT-näppäintä ja napsauta riviä, jos haluat muokata sitä saraketilassa</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="346"/>
+        <location filename="../src/editor/dtextedit.cpp" line="370"/>
         <source>Change Case</source>
         <translation>Vaihda kirjainkokoa</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="347"/>
+        <location filename="../src/editor/dtextedit.cpp" line="371"/>
         <source>Upper Case</source>
         <translation>Isot kirjaimet</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="348"/>
+        <location filename="../src/editor/dtextedit.cpp" line="372"/>
         <source>Lower Case</source>
         <translation>Pienet kirjaimet</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="349"/>
+        <location filename="../src/editor/dtextedit.cpp" line="373"/>
         <source>Capitalize</source>
         <translation>Suuret kirjaimet</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="64"/>
+        <location filename="../src/widgets/bottombar.cpp" line="49"/>
         <source>None</source>
         <translation>Tyhjä</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1184"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1222"/>
         <source>Selected line(s) copied</source>
         <translation>Valitut rivit kopioitu</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1190"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1228"/>
         <source>Current line copied</source>
         <translation>Nykyinen rivi kopioitu</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1210"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1248"/>
         <source>Selected line(s) clipped</source>
         <translation>Valitut rivit leikattu</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1222"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1259"/>
         <source>Current line clipped</source>
         <translation>Nykyinen rivi leikattu</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="2591"/>
+        <location filename="../src/editor/dtextedit.cpp" line="2682"/>
         <source>Paste failed: not enough memory</source>
         <translation>Liittäminen epäonnistui: muisti ei riitä</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3439"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3617"/>
         <source>Read-Only mode is off</source>
         <translation>Lukutila on pois päältä</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3446"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3465"/>
-        <location filename="../src/editor/dtextedit.cpp" line="6150"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3624"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3643"/>
+        <location filename="../src/editor/dtextedit.cpp" line="6656"/>
+        <location filename="../src/editor/dtextedit.cpp" line="6664"/>
+        <location filename="../src/editor/dtextedit.cpp" line="6675"/>
         <source>Read-Only mode is on</source>
         <translation>Lukutila on päällä</translation>
     </message>
@@ -1109,7 +1112,7 @@
 <context>
     <name>WarningNotices</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="36"/>
+        <location filename="../src/controls/warningnotices.cpp" line="19"/>
         <source>Reload</source>
         <translation>Päivitä</translation>
     </message>
@@ -1117,129 +1120,130 @@
 <context>
     <name>Window</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="38"/>
-        <location filename="../src/widgets/window.cpp" line="357"/>
+        <location filename="../src/controls/warningnotices.cpp" line="21"/>
+        <location filename="../src/widgets/window.cpp" line="446"/>
         <source>Save as</source>
         <translation>Tallenna nimellä</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="353"/>
+        <location filename="../src/widgets/window.cpp" line="442"/>
         <source>New window</source>
         <translation>Uusi ikkuna</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="354"/>
+        <location filename="../src/widgets/window.cpp" line="443"/>
         <source>New tab</source>
         <translation>Uusi välilehti</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="355"/>
+        <location filename="../src/widgets/window.cpp" line="444"/>
         <source>Open file</source>
         <translation>Avaa tiedosto</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="356"/>
-        <location filename="../src/widgets/window.cpp" line="2217"/>
+        <location filename="../src/widgets/window.cpp" line="445"/>
+        <location filename="../src/widgets/window.cpp" line="2796"/>
         <source>Save</source>
         <translation>Tallenna</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="358"/>
+        <location filename="../src/widgets/window.cpp" line="447"/>
         <source>Print</source>
         <translation>Tulosta</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="359"/>
+        <location filename="../src/widgets/window.cpp" line="448"/>
         <source>Switch theme</source>
         <translation>Vaihda teema</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="360"/>
-        <location filename="../src/widgets/window.cpp" line="1542"/>
+        <location filename="../src/widgets/window.cpp" line="449"/>
+        <location filename="../src/widgets/window.cpp" line="1871"/>
         <source>Settings</source>
         <translation>Asetukset</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="471"/>
-        <location filename="../src/widgets/window.cpp" line="2468"/>
+        <location filename="../src/widgets/window.cpp" line="563"/>
+        <location filename="../src/widgets/window.cpp" line="3047"/>
         <source>Read-Only</source>
         <translation>Luettavissa</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="487"/>
+        <location filename="../src/widgets/window.cpp" line="579"/>
         <source>You do not have permission to open %1</source>
         <translation>Sinulla ei ole lupaa avata %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="522"/>
+        <location filename="../src/widgets/window.cpp" line="619"/>
+        <location filename="../src/widgets/window.cpp" line="2359"/>
         <source>Invalid file: %1</source>
         <translation>Virheellinen tiedosto: %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="602"/>
-        <location filename="../src/widgets/window.cpp" line="644"/>
+        <location filename="../src/widgets/window.cpp" line="733"/>
+        <location filename="../src/widgets/window.cpp" line="779"/>
         <source>Do you want to save this file?</source>
         <translation>Haluatko tallentaa tämän tiedoston?</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="894"/>
+        <location filename="../src/widgets/window.cpp" line="1027"/>
         <source>You do not have permission to save %1</source>
         <translation>Sinulla ei ole lupaa tallentaa %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="918"/>
+        <location filename="../src/widgets/window.cpp" line="1051"/>
         <source>Saved successfully</source>
         <translation>Tallennus onnistui</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="954"/>
-        <location filename="../src/widgets/window.cpp" line="1021"/>
-        <location filename="../src/widgets/window.cpp" line="1062"/>
+        <location filename="../src/widgets/window.cpp" line="1087"/>
+        <location filename="../src/widgets/window.cpp" line="1160"/>
+        <location filename="../src/widgets/window.cpp" line="1201"/>
         <source>Save File</source>
         <translation>Tallenna tiedosto</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1023"/>
+        <location filename="../src/widgets/window.cpp" line="1162"/>
         <source>Encoding</source>
         <translation>Koodaus</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1211"/>
+        <location filename="../src/widgets/window.cpp" line="1350"/>
         <source>Read-Only mode is on</source>
         <translation>Lukutila on päällä</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1441"/>
+        <location filename="../src/widgets/window.cpp" line="1770"/>
         <source>Current location remembered</source>
         <translation>Nykyinen sijainti muistetaan</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1492"/>
+        <location filename="../src/widgets/window.cpp" line="1821"/>
         <source>Ctrl+&apos;=&apos;</source>
         <translation>Ctrl+&apos;=&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1495"/>
+        <location filename="../src/widgets/window.cpp" line="1824"/>
         <source>Ctrl+&apos;-&apos;</source>
         <translation>Ctrl+&apos;-&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1524"/>
+        <location filename="../src/widgets/window.cpp" line="1853"/>
         <source>Editor</source>
         <translation>Editori</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1890"/>
+        <location filename="../src/widgets/window.cpp" line="2451"/>
         <source>Untitled %1</source>
         <translation>Nimetön %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2215"/>
+        <location filename="../src/widgets/window.cpp" line="2794"/>
         <source>Cancel</source>
         <translation>Peru</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2216"/>
+        <location filename="../src/widgets/window.cpp" line="2795"/>
         <source>Discard</source>
         <translation>Hylkää</translation>
     </message>

--- a/translations/deepin-editor_fr.ts
+++ b/translations/deepin-editor_fr.ts
@@ -2,17 +2,17 @@
 <context>
     <name>BottomBar</name>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="39"/>
+        <location filename="../src/widgets/bottombar.cpp" line="24"/>
         <source>Row</source>
         <translation>Ligne</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="40"/>
+        <location filename="../src/widgets/bottombar.cpp" line="25"/>
         <source>Column</source>
         <translation>Colonne</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="41"/>
+        <location filename="../src/widgets/bottombar.cpp" line="26"/>
         <source>Characters %1</source>
         <translation>Caractères %1</translation>
     </message>
@@ -20,9 +20,9 @@
 <context>
     <name>DDropdownMenu</name>
     <message>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="300"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="344"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="349"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="290"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="341"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="346"/>
         <source>None</source>
         <translation>Aucun</translation>
     </message>
@@ -30,80 +30,85 @@
 <context>
     <name>EditWrapper</name>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="201"/>
-        <location filename="../src/editor/editwrapper.cpp" line="264"/>
-        <location filename="../src/editor/editwrapper.cpp" line="321"/>
-        <location filename="../src/editor/editwrapper.cpp" line="536"/>
+        <location filename="../src/editor/editwrapper.cpp" line="246"/>
+        <location filename="../src/editor/editwrapper.cpp" line="314"/>
+        <location filename="../src/editor/editwrapper.cpp" line="439"/>
+        <location filename="../src/editor/editwrapper.cpp" line="702"/>
         <source>Save</source>
         <translation>Sauvegarder</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="316"/>
+        <location filename="../src/editor/editwrapper.cpp" line="434"/>
         <source>Do you want to save this file?</source>
         <translation>Voulez-vous enregistrer ce fichier ?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="262"/>
-        <location filename="../src/editor/editwrapper.cpp" line="319"/>
+        <location filename="../src/editor/editwrapper.cpp" line="312"/>
+        <location filename="../src/editor/editwrapper.cpp" line="437"/>
         <source>Cancel</source>
         <translation>Annuler</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="259"/>
+        <location filename="../src/editor/editwrapper.cpp" line="309"/>
         <source>Encoding changed. Do you want to save the file now?</source>
         <translation>L&apos;encodage a changé. Voulez-vous enregistrer le fichier maintenant ?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="320"/>
+        <location filename="../src/editor/editwrapper.cpp" line="438"/>
         <source>Discard</source>
         <translation>Abandonner</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="445"/>
+        <location filename="../src/editor/editwrapper.cpp" line="564"/>
         <source>You do not have permission to save %1</source>
         <translation>Vous n&apos;avez pas la permission de sauvegarder %1</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="607"/>
+        <location filename="../src/editor/editwrapper.cpp" line="774"/>
         <source>File removed on the disk. Save it now?</source>
         <translation>Fichier supprimé du disque. L&apos;enregistrer maintenant ?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="612"/>
+        <location filename="../src/editor/editwrapper.cpp" line="779"/>
         <source>File has changed on disk. Reload?</source>
         <translation>Le fichier a été modifié sur le disque. Recharger ?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="634"/>
-        <location filename="../src/widgets/bottombar.cpp" line="60"/>
+        <location filename="../src/editor/editwrapper.cpp" line="801"/>
+        <location filename="../src/widgets/bottombar.cpp" line="45"/>
         <source>INSERT</source>
         <translation>INSÉRER</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="637"/>
+        <location filename="../src/editor/editwrapper.cpp" line="804"/>
         <source>OVERWRITE</source>
         <translation>ÉCRASER</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="640"/>
+        <location filename="../src/editor/editwrapper.cpp" line="807"/>
         <source>R/O</source>
         <translation>L/S</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="945"/>
+        <source>The file cannot be read, which may be too large or has been damaged!</source>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
     <name>FindBar</name>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="40"/>
+        <location filename="../src/controls/findbar.cpp" line="22"/>
         <source>Find</source>
         <translation>Rechercher</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="44"/>
+        <location filename="../src/controls/findbar.cpp" line="26"/>
         <source>Previous</source>
         <translation>Précédent</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="46"/>
+        <location filename="../src/controls/findbar.cpp" line="28"/>
         <source>Next</source>
         <translation>Suivant</translation>
     </message>
@@ -111,7 +116,7 @@
 <context>
     <name>JumpLineBar</name>
     <message>
-        <location filename="../src/controls/jumplinebar.cpp" line="40"/>
+        <location filename="../src/controls/jumplinebar.cpp" line="28"/>
         <source>Go to Line: </source>
         <translation>Aller à la ligne :</translation>
     </message>
@@ -119,12 +124,12 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/editorapplication.cpp" line="27"/>
+        <location filename="../src/editorapplication.cpp" line="11"/>
         <source>Text Editor is a powerful tool for viewing and editing text files.</source>
         <translation>L&apos;éditeur de texte est un outil pour afficher et modifier des fichiers texte.</translation>
     </message>
     <message>
-        <location filename="../src/editorapplication.cpp" line="38"/>
+        <location filename="../src/editorapplication.cpp" line="22"/>
         <source>Text Editor</source>
         <translation>Éditeur de texte</translation>
     </message>
@@ -132,572 +137,572 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/editorapplication.cpp" line="35"/>
+        <location filename="../src/editorapplication.cpp" line="19"/>
         <source>Text Editor</source>
         <translation>Éditeur de texte</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="203"/>
-        <location filename="../src/editor/editwrapper.cpp" line="538"/>
-        <location filename="../src/widgets/window.cpp" line="956"/>
-        <location filename="../src/widgets/window.cpp" line="973"/>
-        <location filename="../src/widgets/window.cpp" line="1064"/>
-        <location filename="../src/widgets/window.cpp" line="1079"/>
+        <location filename="../src/editor/editwrapper.cpp" line="248"/>
+        <location filename="../src/editor/editwrapper.cpp" line="704"/>
+        <location filename="../src/widgets/window.cpp" line="1089"/>
+        <location filename="../src/widgets/window.cpp" line="1111"/>
+        <location filename="../src/widgets/window.cpp" line="1203"/>
+        <location filename="../src/widgets/window.cpp" line="1218"/>
         <source>Encoding</source>
         <translation>Encodage</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="24"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="9"/>
         <source>Basic</source>
         <translation>De base</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="25"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="10"/>
         <source>Font Style</source>
         <translation>Style d&apos;écriture</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="26"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="11"/>
         <source>Font</source>
         <translation>Police</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="27"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="12"/>
         <source>Font Size</source>
         <translation>Taille de la police</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="28"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="13"/>
         <source>Shortcuts</source>
         <translation>Raccourcis</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="29"/>
-        <location filename="../src/controls/settingsdialog.cpp" line="30"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="14"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="15"/>
         <source>Keymap</source>
         <translation>Préréglage</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="31"/>
-        <location filename="../src/controls/settingsdialog.cpp" line="107"/>
-        <location filename="../src/widgets/window.cpp" line="1482"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="16"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="92"/>
+        <location filename="../src/widgets/window.cpp" line="1811"/>
         <source>Window</source>
         <translation>Fenêtre</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="32"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="17"/>
         <source>New tab</source>
         <translation>Nouvel onglet</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="33"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="18"/>
         <source>New window</source>
         <translation>Nouvelle fenêtre</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="34"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="19"/>
         <source>Save</source>
         <translation>Enregistrer</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="35"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="20"/>
         <source>Save as</source>
         <translation>Enregistrer sous</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="36"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="21"/>
         <source>Next tab</source>
         <translation>Onglet suivant</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="37"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="22"/>
         <source>Previous tab</source>
         <translation>Onglet précédent</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="38"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="23"/>
         <source>Close tab</source>
         <translation>Fermer l&apos;onglet</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="39"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="24"/>
         <source>Close other tabs</source>
         <translation>Fermer les autres onglets</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="40"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="25"/>
         <source>Restore tab</source>
         <translation>Restaurer l&apos;onglet</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="41"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="26"/>
         <source>Open file</source>
         <translation>Ouvrir un fichier</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="42"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="27"/>
         <source>Increment font size</source>
         <translation>Augmenter la taille de police</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="43"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="28"/>
         <source>Decrement font size</source>
         <translation>Diminuer la taille de police</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="44"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="29"/>
         <source>Reset font size</source>
         <translation>Réinitialiser la taille de la police</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="45"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="30"/>
         <source>Help</source>
         <translation>Aide</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="46"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="31"/>
         <source>Toggle fullscreen</source>
         <translation>Basculer en plein écran</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="47"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="32"/>
         <source>Find</source>
         <translation>Rechercher</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="48"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="33"/>
         <source>Replace</source>
         <translation>Remplacer</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="49"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="34"/>
         <source>Go to line</source>
         <translation>Aller à la ligne</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="50"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="35"/>
         <source>Save cursor position</source>
         <translation>Sauvegarder position curseur</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="51"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="36"/>
         <source>Reset cursor position</source>
         <translation>Réinitialiser position curseur</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="52"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="37"/>
         <source>Exit</source>
         <translation>Quitter</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="53"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="38"/>
         <source>Display shortcuts</source>
         <translation>Afficher les raccourcis</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="54"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="39"/>
         <source>Print</source>
         <translation>Imprimer</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="55"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="40"/>
         <source>Editor</source>
         <translation>Éditeur</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="56"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="41"/>
         <source>Increase indent</source>
         <translation>Augmenter espace</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="57"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="42"/>
         <source>Decrease indent</source>
         <translation>Diminuer espace</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="58"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="43"/>
         <source>Forward character</source>
         <translation>Caractère suivant</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="59"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="44"/>
         <source>Backward character</source>
         <translation>Caractère précédent</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="60"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="45"/>
         <source>Forward word</source>
         <translation>Mot suivant</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="61"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="46"/>
         <source>Backward word</source>
         <translation>Mot précédent</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="62"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="47"/>
         <source>Next line</source>
         <translation>Ligne suivante</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="63"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="48"/>
         <source>Previous line</source>
         <translation>Ligne précédente</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="64"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="49"/>
         <source>New line</source>
         <translation>Nouvelle ligne</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="65"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="50"/>
         <source>New line above</source>
         <translation>Nouvelle ligne au dessus</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="66"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="51"/>
         <source>New line below</source>
         <translation>Nouvelle ligne en dessous</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="67"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="52"/>
         <source>Duplicate line</source>
         <translation>Dupliquer la ligne</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="68"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="53"/>
         <source>Delete to end of line</source>
         <translation>Supprimer jusqu&apos;à fin ligne</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="69"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="54"/>
         <source>Delete current line</source>
         <translation>Supprimer la ligne actuelle</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="70"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="55"/>
         <source>Swap line up</source>
         <translation>Basculer ligne vers haut</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="71"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="56"/>
         <source>Swap line down</source>
         <translation>Basculer ligne vers bas</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="72"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="57"/>
         <source>Scroll up one line</source>
         <translation>Faire défiler la ligne vers le haut</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="73"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="58"/>
         <source>Scroll down one line</source>
         <translation>Faire défiler la ligne vers le bas</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="74"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="59"/>
         <source>Page up</source>
         <translation>Page précédente</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="75"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="60"/>
         <source>Page down</source>
         <translation>Page suivante</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="76"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="61"/>
         <source>Move to end of line</source>
         <translation>Déplacer à la fin ligne</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="77"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="62"/>
         <source>Move to start of line</source>
         <translation>Déplacer au début ligne</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="78"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="63"/>
         <source>Move to end of text</source>
         <translation>Basculer à la fin du texte</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="79"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="64"/>
         <source>Move to start of text</source>
         <translation>Basculer au début du texte</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="80"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="65"/>
         <source>Move to line indentation</source>
         <translation>Basculer à l&apos;index ligne</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="81"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="66"/>
         <source>Upper case</source>
         <translation>Majuscule</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="82"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="67"/>
         <source>Lower case</source>
         <translation>Minuscule</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="83"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="68"/>
         <source>Capitalize</source>
         <translation>Mettre en majuscule</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="84"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="69"/>
         <source>Delete backward word</source>
         <translation>Supprimer mot précédent</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="85"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="70"/>
         <source>Delete forward word</source>
         <translation>Supprimer le mot suivant</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="86"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="71"/>
         <source>Forward over a pair</source>
         <translation>Basculer à la fin sélection</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="87"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="72"/>
         <source>Backward over a pair</source>
         <translation>Basculer au début sélection</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="88"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="73"/>
         <source>Select all</source>
         <translation>Tout sélectionner</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="89"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="74"/>
         <source>Copy</source>
         <translation>Copier</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="90"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="75"/>
         <source>Cut</source>
         <translation>Couper</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="91"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="76"/>
         <source>Paste</source>
         <translation>Coller</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="92"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="77"/>
         <source>Transpose character</source>
         <translation>Caractère de transposition</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="93"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="78"/>
         <source>Mark</source>
         <translation>Cocher</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="94"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="79"/>
         <source>Unmark</source>
         <translation>Décocher</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="95"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="80"/>
         <source>Copy line</source>
         <translation>Copier la ligne</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="96"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="81"/>
         <source>Cut line</source>
         <translation>Couper la ligne</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="97"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="82"/>
         <source>Merge lines</source>
         <translation>Fusionner les lignes</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="98"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="83"/>
         <source>Read-Only mode</source>
         <translation>Mode lecture seule</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="99"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="84"/>
         <source>Add comment</source>
         <translation>Ajouter un commentaire</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="100"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="85"/>
         <source>Remove comment</source>
         <translation>Supprimer le commentaire</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="101"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="86"/>
         <source>Undo</source>
         <translation>Annuler</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="102"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="87"/>
         <source>Redo</source>
         <translation>Rétablir</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="103"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="88"/>
         <source>Add/Remove bookmark</source>
         <translation>Ajouter/Supprimer un signet</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="104"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="89"/>
         <source>Move to previous bookmark</source>
         <translation>Passer au signet précédent</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="105"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="90"/>
         <source>Move to next bookmark</source>
         <translation>Passer au signet suivant</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="106"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="91"/>
         <source>Advanced</source>
         <translation>Avancés</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="108"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="93"/>
         <source>Window size</source>
         <translation>Taille de la fenêtre</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="109"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="94"/>
         <source>Tab width</source>
         <translation>Largeur de tabulation</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="111"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="96"/>
         <source>Word wrap</source>
         <translation>Retour automatique à la ligne</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="112"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="97"/>
         <source>Code folding flag</source>
         <translation>Drapeau de pliage de code</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="113"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="98"/>
         <source>Show line numbers</source>
         <translation>Afficher les numéros de ligne</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="114"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="99"/>
         <source>Show bookmarks icon</source>
         <translation>Afficher l&apos;icône des signets</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="115"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="100"/>
         <source>Show whitespaces and tabs</source>
         <translation>Afficher les espaces et les tabulations</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="116"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="101"/>
         <source>Highlight current line</source>
         <translation>Mettre en évidence la ligne actuelle</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="117"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="102"/>
         <source>Color mark</source>
         <translation>Marque de couleur</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="120"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="105"/>
         <source>Unicode</source>
         <translation>Unicode</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="121"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="106"/>
         <source>WesternEuropean</source>
         <translation>Europe de l&apos;ouest</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="122"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="107"/>
         <source>CentralEuropean</source>
         <translation>Europe centrale</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="123"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="108"/>
         <source>Baltic</source>
         <translation>Baltique</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="124"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="109"/>
         <source>Cyrillic</source>
         <translation>Cyrillique</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="125"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="110"/>
         <source>Arabic</source>
         <translation>Arabe</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="130"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="115"/>
         <source>Celtic</source>
         <translation>Celtique</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="131"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="116"/>
         <source>SouthEasternEuropean</source>
         <translation>Europe du sud-est</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="126"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="111"/>
         <source>Greek</source>
         <translation>Grec</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="127"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="112"/>
         <source>Hebrew</source>
         <translation>Hébreu</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="132"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="117"/>
         <source>ChineseSimplified</source>
         <translation>Chinois simplifié</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="133"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="118"/>
         <source>ChineseTraditional</source>
         <translation>Chinois traditionnel</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="134"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="119"/>
         <source>Japanese</source>
         <translation>Japonais</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="135"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="120"/>
         <source>Korean</source>
         <translation>Coréen</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="129"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="114"/>
         <source>Thai</source>
         <translation>Thaïlandais</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="128"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="113"/>
         <source>Turkish</source>
         <translation>Turc</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="136"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="121"/>
         <source>Vietnamese</source>
         <translation>Vietnamien</translation>
     </message>
     <message>
-        <location filename="../src/startmanager.cpp" line="762"/>
+        <location filename="../src/startmanager.cpp" line="832"/>
         <source>File not saved</source>
         <translation>Fichier non sauvegardé</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="974"/>
-        <location filename="../src/widgets/window.cpp" line="1065"/>
-        <location filename="../src/widgets/window.cpp" line="1080"/>
+        <location filename="../src/widgets/window.cpp" line="1112"/>
+        <location filename="../src/widgets/window.cpp" line="1204"/>
+        <location filename="../src/widgets/window.cpp" line="1219"/>
         <source>Line Endings</source>
         <translation>Fin de ligne</translation>
     </message>
@@ -705,32 +710,32 @@
 <context>
     <name>ReplaceBar</name>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="39"/>
+        <location filename="../src/controls/replacebar.cpp" line="21"/>
         <source>Find</source>
         <translation>Rechercher</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="43"/>
+        <location filename="../src/controls/replacebar.cpp" line="25"/>
         <source>Replace With</source>
         <translation>Remplacer par</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="47"/>
+        <location filename="../src/controls/replacebar.cpp" line="29"/>
         <source>Replace</source>
         <translation>Remplacer</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="50"/>
+        <location filename="../src/controls/replacebar.cpp" line="32"/>
         <source>Skip</source>
         <translation>Passer</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="53"/>
+        <location filename="../src/controls/replacebar.cpp" line="35"/>
         <source>Replace Rest</source>
         <translation>Remplacer la suite</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="56"/>
+        <location filename="../src/controls/replacebar.cpp" line="38"/>
         <source>Replace All</source>
         <translation>Tout remplacer</translation>
     </message>
@@ -747,58 +752,58 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../src/common/settings.cpp" line="91"/>
+        <location filename="../src/common/settings.cpp" line="115"/>
         <source>Standard</source>
         <translation>Standard</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="91"/>
+        <location filename="../src/common/settings.cpp" line="115"/>
         <source>Customize</source>
         <translation>Personnaliser</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="104"/>
+        <location filename="../src/common/settings.cpp" line="128"/>
         <source>Normal</source>
         <translation>Normal</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="104"/>
+        <location filename="../src/common/settings.cpp" line="128"/>
         <source>Maximum</source>
         <translation>Maximum</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="104"/>
+        <location filename="../src/common/settings.cpp" line="128"/>
         <source>Fullscreen</source>
         <translation>Plein écran</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="292"/>
+        <location filename="../src/common/settings.cpp" line="316"/>
         <source>This shortcut conflicts with system shortcut %1</source>
         <translation>Ce raccourci entre en conflit avec le raccourci système %1</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="294"/>
+        <location filename="../src/common/settings.cpp" line="318"/>
         <source>This shortcut conflicts with %1, click on Replace to make this shortcut effective immediately</source>
         <translation>Ce raccourci entre en conflit avec %1, cliquez sur Remplacer pour rendre ce raccourci effectif immédiatement</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="410"/>
-        <location filename="../src/common/settings.cpp" line="418"/>
+        <location filename="../src/common/settings.cpp" line="464"/>
+        <location filename="../src/common/settings.cpp" line="472"/>
         <source>The shortcut %1 is invalid, please set another one.</source>
         <translation>Le raccourci %1 n&apos;est pas valide, veuillez en définir un autre.</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="445"/>
+        <location filename="../src/common/settings.cpp" line="507"/>
         <source>Cancel</source>
         <translation>Annuler</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="446"/>
+        <location filename="../src/common/settings.cpp" line="508"/>
         <source>Replace</source>
         <translation>Remplacer</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="448"/>
+        <location filename="../src/common/settings.cpp" line="510"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
@@ -806,7 +811,7 @@
 <context>
     <name>StartManager</name>
     <message>
-        <location filename="../src/startmanager.cpp" line="340"/>
+        <location filename="../src/startmanager.cpp" line="350"/>
         <source>Untitled %1</source>
         <translation>Sans titre %1</translation>
     </message>
@@ -814,32 +819,32 @@
 <context>
     <name>Tabbar</name>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="515"/>
+        <location filename="../src/controls/tabbar.cpp" line="540"/>
         <source>Close tab</source>
         <translation>Fermer l&apos;onglet</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="516"/>
+        <location filename="../src/controls/tabbar.cpp" line="541"/>
         <source>Close other tabs</source>
         <translation>Fermer les autres onglets</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="517"/>
+        <location filename="../src/controls/tabbar.cpp" line="542"/>
         <source>More options</source>
         <translation>Plus d&apos;options</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="518"/>
+        <location filename="../src/controls/tabbar.cpp" line="543"/>
         <source>Close tabs to the left</source>
         <translation>Fermer les onglets à gauche</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="519"/>
+        <location filename="../src/controls/tabbar.cpp" line="544"/>
         <source>Close tabs to the right</source>
         <translation>Fermer les onglets à droite</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="520"/>
+        <location filename="../src/controls/tabbar.cpp" line="545"/>
         <source>Close unmodified tabs</source>
         <translation>Fermer les onglets non modifiés</translation>
     </message>
@@ -847,261 +852,259 @@
 <context>
     <name>TextEdit</name>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="235"/>
+        <location filename="../src/editor/dtextedit.cpp" line="259"/>
         <source>Undo</source>
         <translation>Annuler</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="236"/>
+        <location filename="../src/editor/dtextedit.cpp" line="260"/>
         <source>Redo</source>
         <translation>Rétablir</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="237"/>
+        <location filename="../src/editor/dtextedit.cpp" line="261"/>
         <source>Cut</source>
         <translation>Couper</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="238"/>
+        <location filename="../src/editor/dtextedit.cpp" line="262"/>
         <source>Copy</source>
         <translation>Copier</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="239"/>
+        <location filename="../src/editor/dtextedit.cpp" line="263"/>
         <source>Paste</source>
         <translation>Coller</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="240"/>
+        <location filename="../src/editor/dtextedit.cpp" line="264"/>
         <source>Delete</source>
         <translation>Supprimer</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="241"/>
+        <location filename="../src/editor/dtextedit.cpp" line="265"/>
         <source>Select All</source>
         <translation>Tout sélectionner</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="242"/>
-        <location filename="../src/widgets/window.cpp" line="361"/>
+        <location filename="../src/editor/dtextedit.cpp" line="266"/>
+        <location filename="../src/widgets/window.cpp" line="450"/>
         <source>Find</source>
         <translation>Rechercher</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="243"/>
-        <location filename="../src/widgets/window.cpp" line="362"/>
+        <location filename="../src/editor/dtextedit.cpp" line="267"/>
+        <location filename="../src/widgets/window.cpp" line="451"/>
         <source>Replace</source>
         <translation>Remplacer</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="244"/>
+        <location filename="../src/editor/dtextedit.cpp" line="268"/>
         <source>Go to Line</source>
         <translation>Aller à la ligne</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="245"/>
+        <location filename="../src/editor/dtextedit.cpp" line="269"/>
         <source>Turn on Read-Only mode</source>
         <translation>Activer le mode lecture seule</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="246"/>
+        <location filename="../src/editor/dtextedit.cpp" line="270"/>
         <source>Turn off Read-Only mode</source>
         <translation>Désactiver le mode lecture seule</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="247"/>
+        <location filename="../src/editor/dtextedit.cpp" line="271"/>
         <source>Fullscreen</source>
         <translation>Plein écran</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="248"/>
+        <location filename="../src/editor/dtextedit.cpp" line="272"/>
         <source>Exit fullscreen</source>
         <translation>Quitter le mode plein écran</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="249"/>
+        <location filename="../src/editor/dtextedit.cpp" line="273"/>
         <source>Display in file manager</source>
         <translation>Afficher dans l&apos;explorateur de fichiers</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="250"/>
-        <location filename="../src/editor/dtextedit.cpp" line="302"/>
+        <location filename="../src/editor/dtextedit.cpp" line="274"/>
+        <location filename="../src/editor/dtextedit.cpp" line="326"/>
         <source>Add Comment</source>
         <translation>Ajouter un commentaire</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="251"/>
+        <location filename="../src/editor/dtextedit.cpp" line="275"/>
         <source>Text to Speech</source>
         <translation>Texte vers voix</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="252"/>
+        <location filename="../src/editor/dtextedit.cpp" line="276"/>
         <source>Stop reading</source>
         <translation>Arrêter de lire</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="253"/>
+        <location filename="../src/editor/dtextedit.cpp" line="277"/>
         <source>Speech to Text</source>
         <translation>Voix vers texte</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="254"/>
+        <location filename="../src/editor/dtextedit.cpp" line="278"/>
         <source>Translate</source>
         <translation>Traduire</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="255"/>
+        <location filename="../src/editor/dtextedit.cpp" line="279"/>
         <source>Column Mode</source>
         <translation>Mode colonne</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="256"/>
+        <location filename="../src/editor/dtextedit.cpp" line="280"/>
         <source>Add bookmark</source>
         <translation>Ajouter un signet</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="257"/>
+        <location filename="../src/editor/dtextedit.cpp" line="281"/>
         <source>Remove Bookmark</source>
         <translation>Supprimer le signet</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="258"/>
+        <location filename="../src/editor/dtextedit.cpp" line="282"/>
         <source>Previous bookmark</source>
         <translation>Signet précédent</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="259"/>
+        <location filename="../src/editor/dtextedit.cpp" line="283"/>
         <source>Next bookmark</source>
         <translation>Signet suivant</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="260"/>
+        <location filename="../src/editor/dtextedit.cpp" line="284"/>
         <source>Remove All Bookmarks</source>
         <translation>Supprimer tous les signets</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="261"/>
+        <location filename="../src/editor/dtextedit.cpp" line="285"/>
         <source>Fold All</source>
         <translation>Tout plier</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="262"/>
+        <location filename="../src/editor/dtextedit.cpp" line="286"/>
         <source>Fold Current Level</source>
         <translation>Plier le niveau actuel</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="263"/>
+        <location filename="../src/editor/dtextedit.cpp" line="287"/>
         <source>Unfold All</source>
         <translation>Tout déplier</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="264"/>
+        <location filename="../src/editor/dtextedit.cpp" line="288"/>
         <source>Unfold Current Level</source>
         <translation>Déplier le niveau actuel</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="269"/>
+        <location filename="../src/editor/dtextedit.cpp" line="293"/>
         <source>Color Mark</source>
         <translation>Marque de couleur</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="273"/>
+        <location filename="../src/editor/dtextedit.cpp" line="297"/>
         <source>Clear All Marks</source>
         <translation>Effacer toutes les marques</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="274"/>
+        <location filename="../src/editor/dtextedit.cpp" line="298"/>
         <source>Clear Last Mark</source>
         <translation>Effacer la dernière marque</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="283"/>
+        <location filename="../src/editor/dtextedit.cpp" line="307"/>
         <source>Mark</source>
         <translation>Cocher</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="295"/>
+        <location filename="../src/editor/dtextedit.cpp" line="319"/>
         <source>Mark All</source>
         <translation>Marquer tout</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="303"/>
+        <location filename="../src/editor/dtextedit.cpp" line="327"/>
         <source>Remove Comment</source>
         <translation>Supprimer le commentaire</translation>
     </message>
     <message>
-        <source>Failed to paste text: it is too large</source>
-        <translation type="vanished">Impossible de coller: le texte est trop long </translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="2581"/>
+        <location filename="../src/editor/dtextedit.cpp" line="2672"/>
         <source>Copy failed: not enough memory</source>
         <translation>Copie ratée: pas assez de mémoire</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="2665"/>
+        <location filename="../src/editor/dtextedit.cpp" line="2756"/>
         <source>Press ALT and click lines to edit in column mode</source>
         <translation>Appuyer sur ALT et cliquer sur les lignes pour éditer en mode colonne</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="346"/>
+        <location filename="../src/editor/dtextedit.cpp" line="370"/>
         <source>Change Case</source>
         <translation>Changer de case</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="347"/>
+        <location filename="../src/editor/dtextedit.cpp" line="371"/>
         <source>Upper Case</source>
         <translation>Mettre en majuscules</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="348"/>
+        <location filename="../src/editor/dtextedit.cpp" line="372"/>
         <source>Lower Case</source>
         <translation>Mettre en minuscules</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="349"/>
+        <location filename="../src/editor/dtextedit.cpp" line="373"/>
         <source>Capitalize</source>
         <translation>Mettre en majuscules</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="64"/>
+        <location filename="../src/widgets/bottombar.cpp" line="49"/>
         <source>None</source>
         <translation>Aucun</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1184"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1222"/>
         <source>Selected line(s) copied</source>
         <translation>Ligne(s) sélectionnée(s) copiée(s)</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1190"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1228"/>
         <source>Current line copied</source>
         <translation>Ligne actuelle copiée</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1210"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1248"/>
         <source>Selected line(s) clipped</source>
         <translation>Ligne(s) sélectionnée(s) coupée(s)</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1222"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1259"/>
         <source>Current line clipped</source>
         <translation>Ligne actuelle coupée</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="2591"/>
+        <location filename="../src/editor/dtextedit.cpp" line="2682"/>
         <source>Paste failed: not enough memory</source>
         <translation>Échec du collage : mémoire insuffisante</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3439"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3617"/>
         <source>Read-Only mode is off</source>
         <translation>Le mode lecture seule est désactivé</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3446"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3465"/>
-        <location filename="../src/editor/dtextedit.cpp" line="6150"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3624"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3643"/>
+        <location filename="../src/editor/dtextedit.cpp" line="6656"/>
+        <location filename="../src/editor/dtextedit.cpp" line="6664"/>
+        <location filename="../src/editor/dtextedit.cpp" line="6675"/>
         <source>Read-Only mode is on</source>
         <translation>Le mode lecture seule est activé</translation>
     </message>
@@ -1109,7 +1112,7 @@
 <context>
     <name>WarningNotices</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="36"/>
+        <location filename="../src/controls/warningnotices.cpp" line="19"/>
         <source>Reload</source>
         <translation>Recharger</translation>
     </message>
@@ -1117,129 +1120,130 @@
 <context>
     <name>Window</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="38"/>
-        <location filename="../src/widgets/window.cpp" line="357"/>
+        <location filename="../src/controls/warningnotices.cpp" line="21"/>
+        <location filename="../src/widgets/window.cpp" line="446"/>
         <source>Save as</source>
         <translation>Enregistrer sous</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="353"/>
+        <location filename="../src/widgets/window.cpp" line="442"/>
         <source>New window</source>
         <translation>Nouvelle fenêtre</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="354"/>
+        <location filename="../src/widgets/window.cpp" line="443"/>
         <source>New tab</source>
         <translation>Nouvel onglet</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="355"/>
+        <location filename="../src/widgets/window.cpp" line="444"/>
         <source>Open file</source>
         <translation>Ouvrir un fichier</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="356"/>
-        <location filename="../src/widgets/window.cpp" line="2217"/>
+        <location filename="../src/widgets/window.cpp" line="445"/>
+        <location filename="../src/widgets/window.cpp" line="2796"/>
         <source>Save</source>
         <translation>Enregistrer</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="358"/>
+        <location filename="../src/widgets/window.cpp" line="447"/>
         <source>Print</source>
         <translation>Imprimer</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="359"/>
+        <location filename="../src/widgets/window.cpp" line="448"/>
         <source>Switch theme</source>
         <translation>Changer de thème</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="360"/>
-        <location filename="../src/widgets/window.cpp" line="1542"/>
+        <location filename="../src/widgets/window.cpp" line="449"/>
+        <location filename="../src/widgets/window.cpp" line="1871"/>
         <source>Settings</source>
         <translation>Paramètres</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="471"/>
-        <location filename="../src/widgets/window.cpp" line="2468"/>
+        <location filename="../src/widgets/window.cpp" line="563"/>
+        <location filename="../src/widgets/window.cpp" line="3047"/>
         <source>Read-Only</source>
         <translation>Lecture seule</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="487"/>
+        <location filename="../src/widgets/window.cpp" line="579"/>
         <source>You do not have permission to open %1</source>
         <translation>Vous n&apos;avez pas la permission d&apos;ouvrir %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="522"/>
+        <location filename="../src/widgets/window.cpp" line="619"/>
+        <location filename="../src/widgets/window.cpp" line="2359"/>
         <source>Invalid file: %1</source>
         <translation>Fichier invalide : %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="602"/>
-        <location filename="../src/widgets/window.cpp" line="644"/>
+        <location filename="../src/widgets/window.cpp" line="733"/>
+        <location filename="../src/widgets/window.cpp" line="779"/>
         <source>Do you want to save this file?</source>
         <translation>Voulez-vous enregistrer ce fichier ?</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="894"/>
+        <location filename="../src/widgets/window.cpp" line="1027"/>
         <source>You do not have permission to save %1</source>
         <translation>Vous n&apos;avez pas la permission de sauvegarder %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="918"/>
+        <location filename="../src/widgets/window.cpp" line="1051"/>
         <source>Saved successfully</source>
         <translation>Enregistré avec succès</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="954"/>
-        <location filename="../src/widgets/window.cpp" line="1021"/>
-        <location filename="../src/widgets/window.cpp" line="1062"/>
+        <location filename="../src/widgets/window.cpp" line="1087"/>
+        <location filename="../src/widgets/window.cpp" line="1160"/>
+        <location filename="../src/widgets/window.cpp" line="1201"/>
         <source>Save File</source>
         <translation>Sauvegarder le fichier</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1023"/>
+        <location filename="../src/widgets/window.cpp" line="1162"/>
         <source>Encoding</source>
         <translation>Encodage</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1211"/>
+        <location filename="../src/widgets/window.cpp" line="1350"/>
         <source>Read-Only mode is on</source>
         <translation>Le mode lecture seule est activé</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1441"/>
+        <location filename="../src/widgets/window.cpp" line="1770"/>
         <source>Current location remembered</source>
         <translation>Location actuelle sauvegardée</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1492"/>
+        <location filename="../src/widgets/window.cpp" line="1821"/>
         <source>Ctrl+&apos;=&apos;</source>
         <translation>Ctrl + &apos;=&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1495"/>
+        <location filename="../src/widgets/window.cpp" line="1824"/>
         <source>Ctrl+&apos;-&apos;</source>
         <translation>Ctrl + &apos;-&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1524"/>
+        <location filename="../src/widgets/window.cpp" line="1853"/>
         <source>Editor</source>
         <translation>Éditeur</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1890"/>
+        <location filename="../src/widgets/window.cpp" line="2451"/>
         <source>Untitled %1</source>
         <translation>Sans titre %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2215"/>
+        <location filename="../src/widgets/window.cpp" line="2794"/>
         <source>Cancel</source>
         <translation>Annuler</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2216"/>
+        <location filename="../src/widgets/window.cpp" line="2795"/>
         <source>Discard</source>
         <translation>Abandonner</translation>
     </message>

--- a/translations/deepin-editor_hu.ts
+++ b/translations/deepin-editor_hu.ts
@@ -2,17 +2,17 @@
 <context>
     <name>BottomBar</name>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="39"/>
+        <location filename="../src/widgets/bottombar.cpp" line="24"/>
         <source>Row</source>
         <translation>Sor</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="40"/>
+        <location filename="../src/widgets/bottombar.cpp" line="25"/>
         <source>Column</source>
         <translation>Oszlop</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="41"/>
+        <location filename="../src/widgets/bottombar.cpp" line="26"/>
         <source>Characters %1</source>
         <translation>%1 karakter</translation>
     </message>
@@ -20,9 +20,9 @@
 <context>
     <name>DDropdownMenu</name>
     <message>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="300"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="344"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="349"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="290"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="341"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="346"/>
         <source>None</source>
         <translation>Semmi</translation>
     </message>
@@ -30,80 +30,85 @@
 <context>
     <name>EditWrapper</name>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="201"/>
-        <location filename="../src/editor/editwrapper.cpp" line="264"/>
-        <location filename="../src/editor/editwrapper.cpp" line="321"/>
-        <location filename="../src/editor/editwrapper.cpp" line="536"/>
+        <location filename="../src/editor/editwrapper.cpp" line="246"/>
+        <location filename="../src/editor/editwrapper.cpp" line="314"/>
+        <location filename="../src/editor/editwrapper.cpp" line="439"/>
+        <location filename="../src/editor/editwrapper.cpp" line="702"/>
         <source>Save</source>
         <translation>Mentés</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="316"/>
+        <location filename="../src/editor/editwrapper.cpp" line="434"/>
         <source>Do you want to save this file?</source>
         <translation>El akarja menteni ezt a fájlt?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="262"/>
-        <location filename="../src/editor/editwrapper.cpp" line="319"/>
+        <location filename="../src/editor/editwrapper.cpp" line="312"/>
+        <location filename="../src/editor/editwrapper.cpp" line="437"/>
         <source>Cancel</source>
         <translation>Mégsem</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="259"/>
+        <location filename="../src/editor/editwrapper.cpp" line="309"/>
         <source>Encoding changed. Do you want to save the file now?</source>
         <translation>A kódolás megváltozott. El akarja menteni a fájlt most?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="320"/>
+        <location filename="../src/editor/editwrapper.cpp" line="438"/>
         <source>Discard</source>
         <translation>Elvetés</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="445"/>
+        <location filename="../src/editor/editwrapper.cpp" line="564"/>
         <source>You do not have permission to save %1</source>
         <translation>Nincs engedélye a %1 mentéséhez</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="607"/>
+        <location filename="../src/editor/editwrapper.cpp" line="774"/>
         <source>File removed on the disk. Save it now?</source>
         <translation>A fájl eltávolítva a lemezről. Elmenti most?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="612"/>
+        <location filename="../src/editor/editwrapper.cpp" line="779"/>
         <source>File has changed on disk. Reload?</source>
         <translation>A fájl megváltozott a lemezen. Újra betölti?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="634"/>
-        <location filename="../src/widgets/bottombar.cpp" line="60"/>
+        <location filename="../src/editor/editwrapper.cpp" line="801"/>
+        <location filename="../src/widgets/bottombar.cpp" line="45"/>
         <source>INSERT</source>
         <translation>BESZÚRÁS</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="637"/>
+        <location filename="../src/editor/editwrapper.cpp" line="804"/>
         <source>OVERWRITE</source>
         <translation>FELÜLÍRÁS</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="640"/>
+        <location filename="../src/editor/editwrapper.cpp" line="807"/>
         <source>R/O</source>
         <translation>Írásvédett</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="945"/>
+        <source>The file cannot be read, which may be too large or has been damaged!</source>
+        <translation>A fájl nem olvasható, mert túl nagy a mérete, vagy sérült!</translation>
     </message>
 </context>
 <context>
     <name>FindBar</name>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="40"/>
+        <location filename="../src/controls/findbar.cpp" line="22"/>
         <source>Find</source>
         <translation>Találat</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="44"/>
+        <location filename="../src/controls/findbar.cpp" line="26"/>
         <source>Previous</source>
         <translation>Előző</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="46"/>
+        <location filename="../src/controls/findbar.cpp" line="28"/>
         <source>Next</source>
         <translation>Következő</translation>
     </message>
@@ -111,7 +116,7 @@
 <context>
     <name>JumpLineBar</name>
     <message>
-        <location filename="../src/controls/jumplinebar.cpp" line="40"/>
+        <location filename="../src/controls/jumplinebar.cpp" line="28"/>
         <source>Go to Line: </source>
         <translation>Ugrás megadott sorra:</translation>
     </message>
@@ -119,12 +124,12 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/editorapplication.cpp" line="27"/>
+        <location filename="../src/editorapplication.cpp" line="11"/>
         <source>Text Editor is a powerful tool for viewing and editing text files.</source>
         <translation>A Szövegszerkesztő egy hatékony eszköz a szöveges fájlok megtekintésére és szerkesztésére.</translation>
     </message>
     <message>
-        <location filename="../src/editorapplication.cpp" line="38"/>
+        <location filename="../src/editorapplication.cpp" line="22"/>
         <source>Text Editor</source>
         <translation>Szövegszerkesztő</translation>
     </message>
@@ -132,572 +137,572 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/editorapplication.cpp" line="35"/>
+        <location filename="../src/editorapplication.cpp" line="19"/>
         <source>Text Editor</source>
         <translation>Szövegszerkesztő</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="203"/>
-        <location filename="../src/editor/editwrapper.cpp" line="538"/>
-        <location filename="../src/widgets/window.cpp" line="956"/>
-        <location filename="../src/widgets/window.cpp" line="973"/>
-        <location filename="../src/widgets/window.cpp" line="1064"/>
-        <location filename="../src/widgets/window.cpp" line="1079"/>
+        <location filename="../src/editor/editwrapper.cpp" line="248"/>
+        <location filename="../src/editor/editwrapper.cpp" line="704"/>
+        <location filename="../src/widgets/window.cpp" line="1089"/>
+        <location filename="../src/widgets/window.cpp" line="1111"/>
+        <location filename="../src/widgets/window.cpp" line="1203"/>
+        <location filename="../src/widgets/window.cpp" line="1218"/>
         <source>Encoding</source>
         <translation>Kódolás</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="24"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="9"/>
         <source>Basic</source>
         <translation>Alapvető</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="25"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="10"/>
         <source>Font Style</source>
         <translation>Betűstílus</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="26"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="11"/>
         <source>Font</source>
         <translation>Betűtípus</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="27"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="12"/>
         <source>Font Size</source>
         <translation>Betűméret</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="28"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="13"/>
         <source>Shortcuts</source>
         <translation>Gyorsbillentyűk</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="29"/>
-        <location filename="../src/controls/settingsdialog.cpp" line="30"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="14"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="15"/>
         <source>Keymap</source>
         <translation>Karakterkiosztás</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="31"/>
-        <location filename="../src/controls/settingsdialog.cpp" line="107"/>
-        <location filename="../src/widgets/window.cpp" line="1482"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="16"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="92"/>
+        <location filename="../src/widgets/window.cpp" line="1811"/>
         <source>Window</source>
         <translation>Ablak</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="32"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="17"/>
         <source>New tab</source>
         <translation>Új lap</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="33"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="18"/>
         <source>New window</source>
         <translation>Új ablak</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="34"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="19"/>
         <source>Save</source>
         <translation>Mentés</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="35"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="20"/>
         <source>Save as</source>
         <translation>Mentés másként</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="36"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="21"/>
         <source>Next tab</source>
         <translation>Következő lap</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="37"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="22"/>
         <source>Previous tab</source>
         <translation>Előző lap</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="38"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="23"/>
         <source>Close tab</source>
         <translation>Lap bezárása</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="39"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="24"/>
         <source>Close other tabs</source>
         <translation>Többi lap bezárása</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="40"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="25"/>
         <source>Restore tab</source>
         <translation>Lap visszaállítása</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="41"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="26"/>
         <source>Open file</source>
         <translation>Fájl megnyitása</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="42"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="27"/>
         <source>Increment font size</source>
         <translation>Betűméret növelése</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="43"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="28"/>
         <source>Decrement font size</source>
         <translation>Betűméret csökkentése</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="44"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="29"/>
         <source>Reset font size</source>
         <translation>Betűméret visszaállítása</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="45"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="30"/>
         <source>Help</source>
         <translation>Segítség</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="46"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="31"/>
         <source>Toggle fullscreen</source>
         <translation>Teljes képernyős mód</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="47"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="32"/>
         <source>Find</source>
         <translation>Találat</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="48"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="33"/>
         <source>Replace</source>
         <translation>Csere</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="49"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="34"/>
         <source>Go to line</source>
         <translation>Ugrás megadott sorra</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="50"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="35"/>
         <source>Save cursor position</source>
         <translation>Kurzor pozíciójának mentése</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="51"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="36"/>
         <source>Reset cursor position</source>
         <translation>Kurzor pozíciójának visszaállítása</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="52"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="37"/>
         <source>Exit</source>
         <translation>Kilépés</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="53"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="38"/>
         <source>Display shortcuts</source>
         <translation>Gyorsbillentyűk megjelenítése</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="54"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="39"/>
         <source>Print</source>
         <translation>Nyomtatás</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="55"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="40"/>
         <source>Editor</source>
         <translation>Szerkesztő</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="56"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="41"/>
         <source>Increase indent</source>
         <translation>Behúzás növelése</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="57"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="42"/>
         <source>Decrease indent</source>
         <translation>Behúzás csökkentése</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="58"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="43"/>
         <source>Forward character</source>
         <translation>Előre mutató karakter</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="59"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="44"/>
         <source>Backward character</source>
         <translation>Visszafelé mutató karakter</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="60"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="45"/>
         <source>Forward word</source>
         <translation>Szó előre</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="61"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="46"/>
         <source>Backward word</source>
         <translation>Szó hátra</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="62"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="47"/>
         <source>Next line</source>
         <translation>Következő sor</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="63"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="48"/>
         <source>Previous line</source>
         <translation>Előző sor</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="64"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="49"/>
         <source>New line</source>
         <translation>Új sor</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="65"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="50"/>
         <source>New line above</source>
         <translation>Új sor felülre</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="66"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="51"/>
         <source>New line below</source>
         <translation>Új sor alulra</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="67"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="52"/>
         <source>Duplicate line</source>
         <translation>Sor duplikálása</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="68"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="53"/>
         <source>Delete to end of line</source>
         <translation>Sorvég törlése</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="69"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="54"/>
         <source>Delete current line</source>
         <translation>Aktuális sor törlése</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="70"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="55"/>
         <source>Swap line up</source>
         <translation>Sor cseréje felfelé</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="71"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="56"/>
         <source>Swap line down</source>
         <translation>Sor cseréje lefelé</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="72"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="57"/>
         <source>Scroll up one line</source>
         <translation>Egy sorral felfelé</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="73"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="58"/>
         <source>Scroll down one line</source>
         <translation>Egy sorral lefelé</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="74"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="59"/>
         <source>Page up</source>
         <translation>Lapozás felfelé</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="75"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="60"/>
         <source>Page down</source>
         <translation>Lapozás lefelé</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="76"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="61"/>
         <source>Move to end of line</source>
         <translation>Ugrás a sor végére</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="77"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="62"/>
         <source>Move to start of line</source>
         <translation>Ugrás a sor elejére</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="78"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="63"/>
         <source>Move to end of text</source>
         <translation>Ugrás a szöveg végére</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="79"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="64"/>
         <source>Move to start of text</source>
         <translation>Ugrás a szöveg elejére</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="80"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="65"/>
         <source>Move to line indentation</source>
         <translation>Ugrás a sorbehúzáshoz</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="81"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="66"/>
         <source>Upper case</source>
         <translation>Nagybetűs</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="82"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="67"/>
         <source>Lower case</source>
         <translation>Kisbetűs</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="83"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="68"/>
         <source>Capitalize</source>
         <translation>Kapitális</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="84"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="69"/>
         <source>Delete backward word</source>
         <translation>Hátul lévő szó törlése</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="85"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="70"/>
         <source>Delete forward word</source>
         <translation>Elől lévő szó törlése</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="86"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="71"/>
         <source>Forward over a pair</source>
         <translation>Előre kettővel</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="87"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="72"/>
         <source>Backward over a pair</source>
         <translation>Vissza kettővel</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="88"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="73"/>
         <source>Select all</source>
         <translation>Összes kijelölése</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="89"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="74"/>
         <source>Copy</source>
         <translation>Másolás</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="90"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="75"/>
         <source>Cut</source>
         <translation>Kivágás</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="91"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="76"/>
         <source>Paste</source>
         <translation>Beillesztés</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="92"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="77"/>
         <source>Transpose character</source>
         <translation>Karakter átalakítása</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="93"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="78"/>
         <source>Mark</source>
         <translation>Jelölés</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="94"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="79"/>
         <source>Unmark</source>
         <translation>Jelölés törlése</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="95"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="80"/>
         <source>Copy line</source>
         <translation>Sor másolása</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="96"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="81"/>
         <source>Cut line</source>
         <translation>Sor kivágása</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="97"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="82"/>
         <source>Merge lines</source>
         <translation>Sorok összefűzése</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="98"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="83"/>
         <source>Read-Only mode</source>
         <translation>Csak olvasható mód</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="99"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="84"/>
         <source>Add comment</source>
         <translation>Megjegyzés hozzáadása</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="100"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="85"/>
         <source>Remove comment</source>
         <translation>Megjegyzés eltávolítása</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="101"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="86"/>
         <source>Undo</source>
         <translation>Visszavonás</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="102"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="87"/>
         <source>Redo</source>
         <translation>Visszavonás újra</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="103"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="88"/>
         <source>Add/Remove bookmark</source>
         <translation>Könyvjelző hozzáadása/eltávolítása</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="104"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="89"/>
         <source>Move to previous bookmark</source>
         <translation>Ugrás az előző könyvjelzőre</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="105"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="90"/>
         <source>Move to next bookmark</source>
         <translation>Ugrás a következő könyvjelzőre</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="106"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="91"/>
         <source>Advanced</source>
         <translation>Haladó</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="108"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="93"/>
         <source>Window size</source>
         <translation>Ablakméret</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="109"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="94"/>
         <source>Tab width</source>
         <translation>Tabulátor szélesség</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="111"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="96"/>
         <source>Word wrap</source>
         <translation>Sortörés</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="112"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="97"/>
         <source>Code folding flag</source>
         <translation>Kód hajtogatási zászló</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="113"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="98"/>
         <source>Show line numbers</source>
         <translation>Sorok számának mutatása</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="114"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="99"/>
         <source>Show bookmarks icon</source>
         <translation>Könyvjelző ikon megjelenítése</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="115"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="100"/>
         <source>Show whitespaces and tabs</source>
         <translation>Szóközök és fülek megjelenítése</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="116"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="101"/>
         <source>Highlight current line</source>
         <translation>Aktuális sor kijelölése</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="117"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="102"/>
         <source>Color mark</source>
         <translation>Színes jelölő</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="120"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="105"/>
         <source>Unicode</source>
         <translation>Unicode</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="121"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="106"/>
         <source>WesternEuropean</source>
         <translation>Nyugat-európai</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="122"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="107"/>
         <source>CentralEuropean</source>
         <translation>Közép-európai</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="123"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="108"/>
         <source>Baltic</source>
         <translation>Balti</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="124"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="109"/>
         <source>Cyrillic</source>
         <translation>Cirill</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="125"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="110"/>
         <source>Arabic</source>
         <translation>Arab</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="130"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="115"/>
         <source>Celtic</source>
         <translation>Kelta</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="131"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="116"/>
         <source>SouthEasternEuropean</source>
         <translation>Délkelet-európai</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="126"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="111"/>
         <source>Greek</source>
         <translation>Görög</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="127"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="112"/>
         <source>Hebrew</source>
         <translation>Héber</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="132"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="117"/>
         <source>ChineseSimplified</source>
         <translation>Egyszerűsített kínai</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="133"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="118"/>
         <source>ChineseTraditional</source>
         <translation>Tradicionális kínai</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="134"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="119"/>
         <source>Japanese</source>
         <translation>Japán</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="135"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="120"/>
         <source>Korean</source>
         <translation>Kóreai</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="129"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="114"/>
         <source>Thai</source>
         <translation>Thai</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="128"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="113"/>
         <source>Turkish</source>
         <translation>Török</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="136"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="121"/>
         <source>Vietnamese</source>
         <translation>Vietnámi</translation>
     </message>
     <message>
-        <location filename="../src/startmanager.cpp" line="762"/>
+        <location filename="../src/startmanager.cpp" line="832"/>
         <source>File not saved</source>
         <translation>A fájl nincs elmentve</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="974"/>
-        <location filename="../src/widgets/window.cpp" line="1065"/>
-        <location filename="../src/widgets/window.cpp" line="1080"/>
+        <location filename="../src/widgets/window.cpp" line="1112"/>
+        <location filename="../src/widgets/window.cpp" line="1204"/>
+        <location filename="../src/widgets/window.cpp" line="1219"/>
         <source>Line Endings</source>
         <translation>Sorvégek</translation>
     </message>
@@ -705,32 +710,32 @@
 <context>
     <name>ReplaceBar</name>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="39"/>
+        <location filename="../src/controls/replacebar.cpp" line="21"/>
         <source>Find</source>
         <translation>Találat</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="43"/>
+        <location filename="../src/controls/replacebar.cpp" line="25"/>
         <source>Replace With</source>
         <translation>Csere a </translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="47"/>
+        <location filename="../src/controls/replacebar.cpp" line="29"/>
         <source>Replace</source>
         <translation>Csere</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="50"/>
+        <location filename="../src/controls/replacebar.cpp" line="32"/>
         <source>Skip</source>
         <translation>Kihagyás</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="53"/>
+        <location filename="../src/controls/replacebar.cpp" line="35"/>
         <source>Replace Rest</source>
         <translation>Aktuális cseréje</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="56"/>
+        <location filename="../src/controls/replacebar.cpp" line="38"/>
         <source>Replace All</source>
         <translation>Összes cseréje</translation>
     </message>
@@ -747,58 +752,58 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../src/common/settings.cpp" line="91"/>
+        <location filename="../src/common/settings.cpp" line="115"/>
         <source>Standard</source>
         <translation>Alapértelmezett</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="91"/>
+        <location filename="../src/common/settings.cpp" line="115"/>
         <source>Customize</source>
         <translation>Testreszabás</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="104"/>
+        <location filename="../src/common/settings.cpp" line="128"/>
         <source>Normal</source>
         <translation>Normál</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="104"/>
+        <location filename="../src/common/settings.cpp" line="128"/>
         <source>Maximum</source>
         <translation>Maximum</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="104"/>
+        <location filename="../src/common/settings.cpp" line="128"/>
         <source>Fullscreen</source>
         <translation>Teljes képernyő</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="292"/>
+        <location filename="../src/common/settings.cpp" line="316"/>
         <source>This shortcut conflicts with system shortcut %1</source>
         <translation>Ez a gyorsbillentyű ütközik a %1 rendszer gyorsbillentyűvel</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="294"/>
+        <location filename="../src/common/settings.cpp" line="318"/>
         <source>This shortcut conflicts with %1, click on Replace to make this shortcut effective immediately</source>
         <translation>Ez a gyorsbillentyű ütközik a következővel: %1, kattintson a Csere gombra a gyorsbillentyű azonnali használatához</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="410"/>
-        <location filename="../src/common/settings.cpp" line="418"/>
+        <location filename="../src/common/settings.cpp" line="464"/>
+        <location filename="../src/common/settings.cpp" line="472"/>
         <source>The shortcut %1 is invalid, please set another one.</source>
         <translation>A %1 gyorsbillentyű érvénytelen, kérjük állítson be egy másikat.</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="445"/>
+        <location filename="../src/common/settings.cpp" line="507"/>
         <source>Cancel</source>
         <translation>Mégsem</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="446"/>
+        <location filename="../src/common/settings.cpp" line="508"/>
         <source>Replace</source>
         <translation>Csere</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="448"/>
+        <location filename="../src/common/settings.cpp" line="510"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
@@ -806,7 +811,7 @@
 <context>
     <name>StartManager</name>
     <message>
-        <location filename="../src/startmanager.cpp" line="340"/>
+        <location filename="../src/startmanager.cpp" line="350"/>
         <source>Untitled %1</source>
         <translation>Cím nélküli %1</translation>
     </message>
@@ -814,32 +819,32 @@
 <context>
     <name>Tabbar</name>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="515"/>
+        <location filename="../src/controls/tabbar.cpp" line="540"/>
         <source>Close tab</source>
         <translation>Lap bezárása</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="516"/>
+        <location filename="../src/controls/tabbar.cpp" line="541"/>
         <source>Close other tabs</source>
         <translation>Többi lap bezárása</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="517"/>
+        <location filename="../src/controls/tabbar.cpp" line="542"/>
         <source>More options</source>
         <translation>További beállítások</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="518"/>
+        <location filename="../src/controls/tabbar.cpp" line="543"/>
         <source>Close tabs to the left</source>
         <translation>Lapok balra zárása</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="519"/>
+        <location filename="../src/controls/tabbar.cpp" line="544"/>
         <source>Close tabs to the right</source>
         <translation>Lapok jobbra zárása</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="520"/>
+        <location filename="../src/controls/tabbar.cpp" line="545"/>
         <source>Close unmodified tabs</source>
         <translation>Módosítatlan lapok bezárása</translation>
     </message>
@@ -847,261 +852,259 @@
 <context>
     <name>TextEdit</name>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="235"/>
+        <location filename="../src/editor/dtextedit.cpp" line="259"/>
         <source>Undo</source>
         <translation>Visszavonás</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="236"/>
+        <location filename="../src/editor/dtextedit.cpp" line="260"/>
         <source>Redo</source>
         <translation>Újra visszavonás</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="237"/>
+        <location filename="../src/editor/dtextedit.cpp" line="261"/>
         <source>Cut</source>
         <translation>Kivágás</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="238"/>
+        <location filename="../src/editor/dtextedit.cpp" line="262"/>
         <source>Copy</source>
         <translation>Másolás</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="239"/>
+        <location filename="../src/editor/dtextedit.cpp" line="263"/>
         <source>Paste</source>
         <translation>Beillesztés</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="240"/>
+        <location filename="../src/editor/dtextedit.cpp" line="264"/>
         <source>Delete</source>
         <translation>Törlés</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="241"/>
+        <location filename="../src/editor/dtextedit.cpp" line="265"/>
         <source>Select All</source>
         <translation>Összes kijelölése</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="242"/>
-        <location filename="../src/widgets/window.cpp" line="361"/>
+        <location filename="../src/editor/dtextedit.cpp" line="266"/>
+        <location filename="../src/widgets/window.cpp" line="450"/>
         <source>Find</source>
         <translation>Találat</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="243"/>
-        <location filename="../src/widgets/window.cpp" line="362"/>
+        <location filename="../src/editor/dtextedit.cpp" line="267"/>
+        <location filename="../src/widgets/window.cpp" line="451"/>
         <source>Replace</source>
         <translation>Csere</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="244"/>
+        <location filename="../src/editor/dtextedit.cpp" line="268"/>
         <source>Go to Line</source>
         <translation>Ugrás megadott sorra</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="245"/>
+        <location filename="../src/editor/dtextedit.cpp" line="269"/>
         <source>Turn on Read-Only mode</source>
         <translation>Csak olvasható mód bekapcsolása</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="246"/>
+        <location filename="../src/editor/dtextedit.cpp" line="270"/>
         <source>Turn off Read-Only mode</source>
         <translation>Csak olvasható mód kikapcsolása</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="247"/>
+        <location filename="../src/editor/dtextedit.cpp" line="271"/>
         <source>Fullscreen</source>
         <translation>Teljes képernyő</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="248"/>
+        <location filename="../src/editor/dtextedit.cpp" line="272"/>
         <source>Exit fullscreen</source>
         <translation>Kilépés a teljes képernyőből</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="249"/>
+        <location filename="../src/editor/dtextedit.cpp" line="273"/>
         <source>Display in file manager</source>
         <translation>Megjelenítés a fájlkezelőben</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="250"/>
-        <location filename="../src/editor/dtextedit.cpp" line="302"/>
+        <location filename="../src/editor/dtextedit.cpp" line="274"/>
+        <location filename="../src/editor/dtextedit.cpp" line="326"/>
         <source>Add Comment</source>
         <translation>Megjegyzés hozzáadása</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="251"/>
+        <location filename="../src/editor/dtextedit.cpp" line="275"/>
         <source>Text to Speech</source>
         <translation>Szövegből beszéd</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="252"/>
+        <location filename="../src/editor/dtextedit.cpp" line="276"/>
         <source>Stop reading</source>
         <translation>Olvasás megállítása</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="253"/>
+        <location filename="../src/editor/dtextedit.cpp" line="277"/>
         <source>Speech to Text</source>
         <translation>Beszédből szöveg</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="254"/>
+        <location filename="../src/editor/dtextedit.cpp" line="278"/>
         <source>Translate</source>
         <translation>Fordítás</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="255"/>
+        <location filename="../src/editor/dtextedit.cpp" line="279"/>
         <source>Column Mode</source>
         <translation>Oszlop mód</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="256"/>
+        <location filename="../src/editor/dtextedit.cpp" line="280"/>
         <source>Add bookmark</source>
         <translation>Könyvjelző hozzáadása</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="257"/>
+        <location filename="../src/editor/dtextedit.cpp" line="281"/>
         <source>Remove Bookmark</source>
         <translation>Könyvjelző eltávolítása</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="258"/>
+        <location filename="../src/editor/dtextedit.cpp" line="282"/>
         <source>Previous bookmark</source>
         <translation>Előző könyvjelző</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="259"/>
+        <location filename="../src/editor/dtextedit.cpp" line="283"/>
         <source>Next bookmark</source>
         <translation>Következő könyvjelző</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="260"/>
+        <location filename="../src/editor/dtextedit.cpp" line="284"/>
         <source>Remove All Bookmarks</source>
         <translation>Összes könyvjelző eltávolítása</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="261"/>
+        <location filename="../src/editor/dtextedit.cpp" line="285"/>
         <source>Fold All</source>
         <translation>Összes hajtogatása</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="262"/>
+        <location filename="../src/editor/dtextedit.cpp" line="286"/>
         <source>Fold Current Level</source>
         <translation>Jelenlegi szint hajtogatása</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="263"/>
+        <location filename="../src/editor/dtextedit.cpp" line="287"/>
         <source>Unfold All</source>
         <translation>Összes kihajtogatása</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="264"/>
+        <location filename="../src/editor/dtextedit.cpp" line="288"/>
         <source>Unfold Current Level</source>
         <translation>Jelenlegi szint kihajtogatása</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="269"/>
+        <location filename="../src/editor/dtextedit.cpp" line="293"/>
         <source>Color Mark</source>
         <translation>Színes jelölő</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="273"/>
+        <location filename="../src/editor/dtextedit.cpp" line="297"/>
         <source>Clear All Marks</source>
         <translation>Összes jelölő törlése</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="274"/>
+        <location filename="../src/editor/dtextedit.cpp" line="298"/>
         <source>Clear Last Mark</source>
         <translation>Utolsó jelölés törlése</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="283"/>
+        <location filename="../src/editor/dtextedit.cpp" line="307"/>
         <source>Mark</source>
         <translation>Jelölő</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="295"/>
+        <location filename="../src/editor/dtextedit.cpp" line="319"/>
         <source>Mark All</source>
         <translation>Összes jelölése</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="303"/>
+        <location filename="../src/editor/dtextedit.cpp" line="327"/>
         <source>Remove Comment</source>
         <translation>Megjegyzés eltávolítása</translation>
     </message>
     <message>
-        <source>Failed to paste text: it is too large</source>
-        <translation type="vanished">Nem sikerült beilleszteni a szöveget: túl nagy méret</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="2581"/>
+        <location filename="../src/editor/dtextedit.cpp" line="2672"/>
         <source>Copy failed: not enough memory</source>
         <translation>A másolás sikertelen: nincs elég memória</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="2665"/>
+        <location filename="../src/editor/dtextedit.cpp" line="2756"/>
         <source>Press ALT and click lines to edit in column mode</source>
         <translation>Nyomja meg az ALT gombot, és kattintson a sorokra az oszlop módban történő szerkesztéshez</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="346"/>
+        <location filename="../src/editor/dtextedit.cpp" line="370"/>
         <source>Change Case</source>
         <translation>Kisbetű/nagybetű váltása</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="347"/>
+        <location filename="../src/editor/dtextedit.cpp" line="371"/>
         <source>Upper Case</source>
         <translation>Nagybetűs</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="348"/>
+        <location filename="../src/editor/dtextedit.cpp" line="372"/>
         <source>Lower Case</source>
         <translation>Kisbetűs</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="349"/>
+        <location filename="../src/editor/dtextedit.cpp" line="373"/>
         <source>Capitalize</source>
         <translation>Kapitális</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="64"/>
+        <location filename="../src/widgets/bottombar.cpp" line="49"/>
         <source>None</source>
         <translation>Semmi</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1184"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1222"/>
         <source>Selected line(s) copied</source>
         <translation>A kijelölt sor(ok) átmásolva</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1190"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1228"/>
         <source>Current line copied</source>
         <translation>A jelenlegi sor átmásolva</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1210"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1248"/>
         <source>Selected line(s) clipped</source>
         <translation>A kijelölt sor(ok) kivágva</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1222"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1259"/>
         <source>Current line clipped</source>
         <translation>A jelenlegi sor kivágva</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="2591"/>
+        <location filename="../src/editor/dtextedit.cpp" line="2682"/>
         <source>Paste failed: not enough memory</source>
         <translation>A beillesztés sikertelen: Nincs elegendő memória</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3439"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3617"/>
         <source>Read-Only mode is off</source>
         <translation>Csak olvasható mód kikapcsolva</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3446"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3465"/>
-        <location filename="../src/editor/dtextedit.cpp" line="6150"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3624"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3643"/>
+        <location filename="../src/editor/dtextedit.cpp" line="6656"/>
+        <location filename="../src/editor/dtextedit.cpp" line="6664"/>
+        <location filename="../src/editor/dtextedit.cpp" line="6675"/>
         <source>Read-Only mode is on</source>
         <translation>Csak olvasható mód bekapcsolva</translation>
     </message>
@@ -1109,7 +1112,7 @@
 <context>
     <name>WarningNotices</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="36"/>
+        <location filename="../src/controls/warningnotices.cpp" line="19"/>
         <source>Reload</source>
         <translation>Újratöltés</translation>
     </message>
@@ -1117,129 +1120,130 @@
 <context>
     <name>Window</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="38"/>
-        <location filename="../src/widgets/window.cpp" line="357"/>
+        <location filename="../src/controls/warningnotices.cpp" line="21"/>
+        <location filename="../src/widgets/window.cpp" line="446"/>
         <source>Save as</source>
         <translation>Mentés másként</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="353"/>
+        <location filename="../src/widgets/window.cpp" line="442"/>
         <source>New window</source>
         <translation>Új ablak</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="354"/>
+        <location filename="../src/widgets/window.cpp" line="443"/>
         <source>New tab</source>
         <translation>Új lap</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="355"/>
+        <location filename="../src/widgets/window.cpp" line="444"/>
         <source>Open file</source>
         <translation>Fájl megnyitása</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="356"/>
-        <location filename="../src/widgets/window.cpp" line="2217"/>
+        <location filename="../src/widgets/window.cpp" line="445"/>
+        <location filename="../src/widgets/window.cpp" line="2796"/>
         <source>Save</source>
         <translation>Mentés</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="358"/>
+        <location filename="../src/widgets/window.cpp" line="447"/>
         <source>Print</source>
         <translation>Nyomtatás</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="359"/>
+        <location filename="../src/widgets/window.cpp" line="448"/>
         <source>Switch theme</source>
         <translation>Téma váltása</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="360"/>
-        <location filename="../src/widgets/window.cpp" line="1542"/>
+        <location filename="../src/widgets/window.cpp" line="449"/>
+        <location filename="../src/widgets/window.cpp" line="1871"/>
         <source>Settings</source>
         <translation>Beállítások</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="471"/>
-        <location filename="../src/widgets/window.cpp" line="2468"/>
+        <location filename="../src/widgets/window.cpp" line="563"/>
+        <location filename="../src/widgets/window.cpp" line="3047"/>
         <source>Read-Only</source>
         <translation>Csak olvasható</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="487"/>
+        <location filename="../src/widgets/window.cpp" line="579"/>
         <source>You do not have permission to open %1</source>
         <translation>Nincs engedélye a %1 megnyitásához</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="522"/>
+        <location filename="../src/widgets/window.cpp" line="619"/>
+        <location filename="../src/widgets/window.cpp" line="2359"/>
         <source>Invalid file: %1</source>
         <translation>Érvénytelen fájl: %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="602"/>
-        <location filename="../src/widgets/window.cpp" line="644"/>
+        <location filename="../src/widgets/window.cpp" line="733"/>
+        <location filename="../src/widgets/window.cpp" line="779"/>
         <source>Do you want to save this file?</source>
         <translation>El akarja menteni ezt a fájlt?</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="894"/>
+        <location filename="../src/widgets/window.cpp" line="1027"/>
         <source>You do not have permission to save %1</source>
         <translation>Nincs engedélye a %1 mentéséhez</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="918"/>
+        <location filename="../src/widgets/window.cpp" line="1051"/>
         <source>Saved successfully</source>
         <translation>A mentés sikeres</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="954"/>
-        <location filename="../src/widgets/window.cpp" line="1021"/>
-        <location filename="../src/widgets/window.cpp" line="1062"/>
+        <location filename="../src/widgets/window.cpp" line="1087"/>
+        <location filename="../src/widgets/window.cpp" line="1160"/>
+        <location filename="../src/widgets/window.cpp" line="1201"/>
         <source>Save File</source>
         <translation>Fájl mentése</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1023"/>
+        <location filename="../src/widgets/window.cpp" line="1162"/>
         <source>Encoding</source>
         <translation>Kódolás</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1211"/>
+        <location filename="../src/widgets/window.cpp" line="1350"/>
         <source>Read-Only mode is on</source>
         <translation>Csak olvasható mód bekapcsolva</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1441"/>
+        <location filename="../src/widgets/window.cpp" line="1770"/>
         <source>Current location remembered</source>
         <translation>A jelenlegi hely megjegyezve</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1492"/>
+        <location filename="../src/widgets/window.cpp" line="1821"/>
         <source>Ctrl+&apos;=&apos;</source>
         <translation>Ctrl+&apos;=&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1495"/>
+        <location filename="../src/widgets/window.cpp" line="1824"/>
         <source>Ctrl+&apos;-&apos;</source>
         <translation>Ctrl+&apos;-&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1524"/>
+        <location filename="../src/widgets/window.cpp" line="1853"/>
         <source>Editor</source>
         <translation>Szerkesztő</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1890"/>
+        <location filename="../src/widgets/window.cpp" line="2451"/>
         <source>Untitled %1</source>
         <translation>Cím nélküli %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2215"/>
+        <location filename="../src/widgets/window.cpp" line="2794"/>
         <source>Cancel</source>
         <translation>Mégsem</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2216"/>
+        <location filename="../src/widgets/window.cpp" line="2795"/>
         <source>Discard</source>
         <translation>Elvetés</translation>
     </message>

--- a/translations/deepin-editor_it.ts
+++ b/translations/deepin-editor_it.ts
@@ -2,17 +2,17 @@
 <context>
     <name>BottomBar</name>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="39"/>
+        <location filename="../src/widgets/bottombar.cpp" line="24"/>
         <source>Row</source>
         <translation>Riga</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="40"/>
+        <location filename="../src/widgets/bottombar.cpp" line="25"/>
         <source>Column</source>
         <translation>Colonna</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="41"/>
+        <location filename="../src/widgets/bottombar.cpp" line="26"/>
         <source>Characters %1</source>
         <translation>Caratteri %1</translation>
     </message>
@@ -20,9 +20,9 @@
 <context>
     <name>DDropdownMenu</name>
     <message>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="300"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="344"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="349"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="290"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="341"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="346"/>
         <source>None</source>
         <translation>No</translation>
     </message>
@@ -30,81 +30,86 @@
 <context>
     <name>EditWrapper</name>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="201"/>
-        <location filename="../src/editor/editwrapper.cpp" line="264"/>
-        <location filename="../src/editor/editwrapper.cpp" line="321"/>
-        <location filename="../src/editor/editwrapper.cpp" line="536"/>
+        <location filename="../src/editor/editwrapper.cpp" line="246"/>
+        <location filename="../src/editor/editwrapper.cpp" line="314"/>
+        <location filename="../src/editor/editwrapper.cpp" line="439"/>
+        <location filename="../src/editor/editwrapper.cpp" line="702"/>
         <source>Save</source>
         <translation>Salva</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="316"/>
+        <location filename="../src/editor/editwrapper.cpp" line="434"/>
         <source>Do you want to save this file?</source>
         <translation>Desideri salvare questo file?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="262"/>
-        <location filename="../src/editor/editwrapper.cpp" line="319"/>
+        <location filename="../src/editor/editwrapper.cpp" line="312"/>
+        <location filename="../src/editor/editwrapper.cpp" line="437"/>
         <source>Cancel</source>
         <translation>Annulla</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="259"/>
+        <location filename="../src/editor/editwrapper.cpp" line="309"/>
         <source>Encoding changed. Do you want to save the file now?</source>
         <translation> 
 La codifica è cambiata. Vuoi salvare il file ora?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="320"/>
+        <location filename="../src/editor/editwrapper.cpp" line="438"/>
         <source>Discard</source>
         <translation>Scarta</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="445"/>
+        <location filename="../src/editor/editwrapper.cpp" line="564"/>
         <source>You do not have permission to save %1</source>
         <translation>Non hai i permessi per salvare %1</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="607"/>
+        <location filename="../src/editor/editwrapper.cpp" line="774"/>
         <source>File removed on the disk. Save it now?</source>
         <translation>File rimosso dal disco, salvarlo ora?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="612"/>
+        <location filename="../src/editor/editwrapper.cpp" line="779"/>
         <source>File has changed on disk. Reload?</source>
         <translation>File modificato sul Disco, ricaricarlo?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="634"/>
-        <location filename="../src/widgets/bottombar.cpp" line="60"/>
+        <location filename="../src/editor/editwrapper.cpp" line="801"/>
+        <location filename="../src/widgets/bottombar.cpp" line="45"/>
         <source>INSERT</source>
         <translation>INSERT</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="637"/>
+        <location filename="../src/editor/editwrapper.cpp" line="804"/>
         <source>OVERWRITE</source>
         <translation>OVERWRITE</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="640"/>
+        <location filename="../src/editor/editwrapper.cpp" line="807"/>
         <source>R/O</source>
         <translation>R/O</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="945"/>
+        <source>The file cannot be read, which may be too large or has been damaged!</source>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
     <name>FindBar</name>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="40"/>
+        <location filename="../src/controls/findbar.cpp" line="22"/>
         <source>Find</source>
         <translation>Trova</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="44"/>
+        <location filename="../src/controls/findbar.cpp" line="26"/>
         <source>Previous</source>
         <translation>Precedente</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="46"/>
+        <location filename="../src/controls/findbar.cpp" line="28"/>
         <source>Next</source>
         <translation>Prossima</translation>
     </message>
@@ -112,7 +117,7 @@ La codifica è cambiata. Vuoi salvare il file ora?</translation>
 <context>
     <name>JumpLineBar</name>
     <message>
-        <location filename="../src/controls/jumplinebar.cpp" line="40"/>
+        <location filename="../src/controls/jumplinebar.cpp" line="28"/>
         <source>Go to Line: </source>
         <translation>Vai alla linea: </translation>
     </message>
@@ -120,13 +125,13 @@ La codifica è cambiata. Vuoi salvare il file ora?</translation>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/editorapplication.cpp" line="27"/>
+        <location filename="../src/editorapplication.cpp" line="11"/>
         <source>Text Editor is a powerful tool for viewing and editing text files.</source>
         <translation>Editor di Testo è uno strumento utile a visualizzare ed editare testi.
 Localizzazione italiana a cura di Massimo A. Carofano.</translation>
     </message>
     <message>
-        <location filename="../src/editorapplication.cpp" line="38"/>
+        <location filename="../src/editorapplication.cpp" line="22"/>
         <source>Text Editor</source>
         <translation>Editor di Testo</translation>
     </message>
@@ -134,572 +139,572 @@ Localizzazione italiana a cura di Massimo A. Carofano.</translation>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/editorapplication.cpp" line="35"/>
+        <location filename="../src/editorapplication.cpp" line="19"/>
         <source>Text Editor</source>
         <translation>Editor di Testo</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="203"/>
-        <location filename="../src/editor/editwrapper.cpp" line="538"/>
-        <location filename="../src/widgets/window.cpp" line="956"/>
-        <location filename="../src/widgets/window.cpp" line="973"/>
-        <location filename="../src/widgets/window.cpp" line="1064"/>
-        <location filename="../src/widgets/window.cpp" line="1079"/>
+        <location filename="../src/editor/editwrapper.cpp" line="248"/>
+        <location filename="../src/editor/editwrapper.cpp" line="704"/>
+        <location filename="../src/widgets/window.cpp" line="1089"/>
+        <location filename="../src/widgets/window.cpp" line="1111"/>
+        <location filename="../src/widgets/window.cpp" line="1203"/>
+        <location filename="../src/widgets/window.cpp" line="1218"/>
         <source>Encoding</source>
         <translation>Codifica</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="24"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="9"/>
         <source>Basic</source>
         <translation>Base</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="25"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="10"/>
         <source>Font Style</source>
         <translation>Stile Font</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="26"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="11"/>
         <source>Font</source>
         <translation>Font</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="27"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="12"/>
         <source>Font Size</source>
         <translation>Dimensione Font</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="28"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="13"/>
         <source>Shortcuts</source>
         <translation>Scorciatoie</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="29"/>
-        <location filename="../src/controls/settingsdialog.cpp" line="30"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="14"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="15"/>
         <source>Keymap</source>
         <translation>Mappa caratteri</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="31"/>
-        <location filename="../src/controls/settingsdialog.cpp" line="107"/>
-        <location filename="../src/widgets/window.cpp" line="1482"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="16"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="92"/>
+        <location filename="../src/widgets/window.cpp" line="1811"/>
         <source>Window</source>
         <translation>Finestra</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="32"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="17"/>
         <source>New tab</source>
         <translation>Nuova scheda</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="33"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="18"/>
         <source>New window</source>
         <translation>Nuova finestra</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="34"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="19"/>
         <source>Save</source>
         <translation>Salva</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="35"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="20"/>
         <source>Save as</source>
         <translation>Salva con nome</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="36"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="21"/>
         <source>Next tab</source>
         <translation>Prossima scheda</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="37"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="22"/>
         <source>Previous tab</source>
         <translation>Scheda precedente</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="38"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="23"/>
         <source>Close tab</source>
         <translation>Chiudi scheda</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="39"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="24"/>
         <source>Close other tabs</source>
         <translation>Chiudi le altre schede</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="40"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="25"/>
         <source>Restore tab</source>
         <translation>Ripristina scheda</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="41"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="26"/>
         <source>Open file</source>
         <translation>Apri file</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="42"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="27"/>
         <source>Increment font size</source>
         <translation>Aumenta dimensione font</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="43"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="28"/>
         <source>Decrement font size</source>
         <translation>Diminuisci dimensione font</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="44"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="29"/>
         <source>Reset font size</source>
         <translation>Ripristina dimensione font</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="45"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="30"/>
         <source>Help</source>
         <translation>Aiuto</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="46"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="31"/>
         <source>Toggle fullscreen</source>
         <translation>Passa a schermo intero</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="47"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="32"/>
         <source>Find</source>
         <translation>Trova</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="48"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="33"/>
         <source>Replace</source>
         <translation>Sostituisci</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="49"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="34"/>
         <source>Go to line</source>
         <translation>Vai alla linea</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="50"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="35"/>
         <source>Save cursor position</source>
         <translation>Salva la posizione del cursore</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="51"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="36"/>
         <source>Reset cursor position</source>
         <translation>Ripristina la posizione del cursore</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="52"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="37"/>
         <source>Exit</source>
         <translation>Esci</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="53"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="38"/>
         <source>Display shortcuts</source>
         <translation>Mostra scorciatoie</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="54"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="39"/>
         <source>Print</source>
         <translation>Stampa</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="55"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="40"/>
         <source>Editor</source>
         <translation>Editor</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="56"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="41"/>
         <source>Increase indent</source>
         <translation>Aumenta il rientro</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="57"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="42"/>
         <source>Decrease indent</source>
         <translation>Diminuisci il rientro</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="58"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="43"/>
         <source>Forward character</source>
         <translation>Prossimo carattere</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="59"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="44"/>
         <source>Backward character</source>
         <translation>Carattere precedente</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="60"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="45"/>
         <source>Forward word</source>
         <translation>Parola successiva</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="61"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="46"/>
         <source>Backward word</source>
         <translation>Parola precedente</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="62"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="47"/>
         <source>Next line</source>
         <translation>Prossima linea</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="63"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="48"/>
         <source>Previous line</source>
         <translation>Linea precedente</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="64"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="49"/>
         <source>New line</source>
         <translation>Nuova riga</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="65"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="50"/>
         <source>New line above</source>
         <translation>Nuova riga sopra</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="66"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="51"/>
         <source>New line below</source>
         <translation>Nuova riga sotto</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="67"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="52"/>
         <source>Duplicate line</source>
         <translation>Duplica riga</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="68"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="53"/>
         <source>Delete to end of line</source>
         <translation>Elimina dalla fine della riga</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="69"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="54"/>
         <source>Delete current line</source>
         <translation>Elimina riga corrente</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="70"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="55"/>
         <source>Swap line up</source>
         <translation>Inverti riga superiore</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="71"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="56"/>
         <source>Swap line down</source>
         <translation>Inverti riga inferiore</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="72"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="57"/>
         <source>Scroll up one line</source>
         <translation>Passa alla riga sopra</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="73"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="58"/>
         <source>Scroll down one line</source>
         <translation>Passa alla riga sotto</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="74"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="59"/>
         <source>Page up</source>
         <translation>Pagina su</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="75"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="60"/>
         <source>Page down</source>
         <translation>Pagina giu</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="76"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="61"/>
         <source>Move to end of line</source>
         <translation>Muovi alla fine della riga</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="77"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="62"/>
         <source>Move to start of line</source>
         <translation>Muovi all&apos;inizio della riga</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="78"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="63"/>
         <source>Move to end of text</source>
         <translation>Muovi alla fine del testo</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="79"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="64"/>
         <source>Move to start of text</source>
         <translation>Muovi all&apos;inizio del testo</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="80"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="65"/>
         <source>Move to line indentation</source>
         <translation>Muovi al rientro di riga</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="81"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="66"/>
         <source>Upper case</source>
         <translation>Lettere maiuscole</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="82"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="67"/>
         <source>Lower case</source>
         <translation>Lettere minuscole</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="83"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="68"/>
         <source>Capitalize</source>
         <translation>Maiuscola</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="84"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="69"/>
         <source>Delete backward word</source>
         <translation>Elimina parola precedente</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="85"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="70"/>
         <source>Delete forward word</source>
         <translation>Elimina parola successiva</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="86"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="71"/>
         <source>Forward over a pair</source>
         <translation>Avanti paritario</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="87"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="72"/>
         <source>Backward over a pair</source>
         <translation>Indietro paritario</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="88"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="73"/>
         <source>Select all</source>
         <translation>Seleziona tutto</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="89"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="74"/>
         <source>Copy</source>
         <translation>Copia</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="90"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="75"/>
         <source>Cut</source>
         <translation>Taglia</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="91"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="76"/>
         <source>Paste</source>
         <translation>Incolla</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="92"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="77"/>
         <source>Transpose character</source>
         <translation>Trasponi caratteri</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="93"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="78"/>
         <source>Mark</source>
         <translation>Evidenzia</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="94"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="79"/>
         <source>Unmark</source>
         <translation>Non in evidenza</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="95"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="80"/>
         <source>Copy line</source>
         <translation>Copia riga</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="96"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="81"/>
         <source>Cut line</source>
         <translation>Taglia riga</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="97"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="82"/>
         <source>Merge lines</source>
         <translation>Unisci righe</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="98"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="83"/>
         <source>Read-Only mode</source>
         <translation>Modalità sola lettura</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="99"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="84"/>
         <source>Add comment</source>
         <translation>Aggiungi commento</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="100"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="85"/>
         <source>Remove comment</source>
         <translation>Rimuovi commento</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="101"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="86"/>
         <source>Undo</source>
         <translation>Annulla</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="102"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="87"/>
         <source>Redo</source>
         <translation>Riapplica</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="103"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="88"/>
         <source>Add/Remove bookmark</source>
         <translation>Aggiungi/rimuovi segnalibro</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="104"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="89"/>
         <source>Move to previous bookmark</source>
         <translation>Torna al segnalibro precedente</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="105"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="90"/>
         <source>Move to next bookmark</source>
         <translation>Vai al prossimo segnalibro</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="106"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="91"/>
         <source>Advanced</source>
         <translation>Avanzate</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="108"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="93"/>
         <source>Window size</source>
         <translation>Dimensione finestra</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="109"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="94"/>
         <source>Tab width</source>
         <translation>Larghezza scheda</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="111"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="96"/>
         <source>Word wrap</source>
         <translation>A capo automatico</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="112"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="97"/>
         <source>Code folding flag</source>
         <translation>Opzioni di collasso del codice</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="113"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="98"/>
         <source>Show line numbers</source>
         <translation>Mostra numero riga</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="114"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="99"/>
         <source>Show bookmarks icon</source>
         <translation>Mostra icona segnalibri</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="115"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="100"/>
         <source>Show whitespaces and tabs</source>
         <translation>Mostra spazi bianchi e schede</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="116"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="101"/>
         <source>Highlight current line</source>
         <translation>Evidenzia la riga corrente</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="117"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="102"/>
         <source>Color mark</source>
         <translation>Colori come marcatori</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="120"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="105"/>
         <source>Unicode</source>
         <translation>Unicode</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="121"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="106"/>
         <source>WesternEuropean</source>
         <translation>Europa occidentale</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="122"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="107"/>
         <source>CentralEuropean</source>
         <translation>Europa centrale</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="123"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="108"/>
         <source>Baltic</source>
         <translation>Baltici</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="124"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="109"/>
         <source>Cyrillic</source>
         <translation>Cirillico</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="125"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="110"/>
         <source>Arabic</source>
         <translation>Arabic</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="130"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="115"/>
         <source>Celtic</source>
         <translation>Celtico</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="131"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="116"/>
         <source>SouthEasternEuropean</source>
         <translation>Sud est Europa</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="126"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="111"/>
         <source>Greek</source>
         <translation>Greek</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="127"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="112"/>
         <source>Hebrew</source>
         <translation>Hebrew</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="132"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="117"/>
         <source>ChineseSimplified</source>
         <translation>Cinese Semplificato</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="133"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="118"/>
         <source>ChineseTraditional</source>
         <translation>Cinese Tradizionale</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="134"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="119"/>
         <source>Japanese</source>
         <translation>Japanese</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="135"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="120"/>
         <source>Korean</source>
         <translation>Korean</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="129"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="114"/>
         <source>Thai</source>
         <translation>Thai</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="128"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="113"/>
         <source>Turkish</source>
         <translation>Turkish</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="136"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="121"/>
         <source>Vietnamese</source>
         <translation>Vietnamese</translation>
     </message>
     <message>
-        <location filename="../src/startmanager.cpp" line="762"/>
+        <location filename="../src/startmanager.cpp" line="832"/>
         <source>File not saved</source>
         <translation>File non salvato</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="974"/>
-        <location filename="../src/widgets/window.cpp" line="1065"/>
-        <location filename="../src/widgets/window.cpp" line="1080"/>
+        <location filename="../src/widgets/window.cpp" line="1112"/>
+        <location filename="../src/widgets/window.cpp" line="1204"/>
+        <location filename="../src/widgets/window.cpp" line="1219"/>
         <source>Line Endings</source>
         <translation>Fine delle righe</translation>
     </message>
@@ -707,32 +712,32 @@ Localizzazione italiana a cura di Massimo A. Carofano.</translation>
 <context>
     <name>ReplaceBar</name>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="39"/>
+        <location filename="../src/controls/replacebar.cpp" line="21"/>
         <source>Find</source>
         <translation>Trova</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="43"/>
+        <location filename="../src/controls/replacebar.cpp" line="25"/>
         <source>Replace With</source>
         <translation>Sostituisci con</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="47"/>
+        <location filename="../src/controls/replacebar.cpp" line="29"/>
         <source>Replace</source>
         <translation>Sostituisci</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="50"/>
+        <location filename="../src/controls/replacebar.cpp" line="32"/>
         <source>Skip</source>
         <translation>Salta</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="53"/>
+        <location filename="../src/controls/replacebar.cpp" line="35"/>
         <source>Replace Rest</source>
         <translation>Sostituisci il resto</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="56"/>
+        <location filename="../src/controls/replacebar.cpp" line="38"/>
         <source>Replace All</source>
         <translation>Sostituisci tutto</translation>
     </message>
@@ -749,58 +754,58 @@ Localizzazione italiana a cura di Massimo A. Carofano.</translation>
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../src/common/settings.cpp" line="91"/>
+        <location filename="../src/common/settings.cpp" line="115"/>
         <source>Standard</source>
         <translation>Standard</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="91"/>
+        <location filename="../src/common/settings.cpp" line="115"/>
         <source>Customize</source>
         <translation>Personalizzato</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="104"/>
+        <location filename="../src/common/settings.cpp" line="128"/>
         <source>Normal</source>
         <translation>Normale</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="104"/>
+        <location filename="../src/common/settings.cpp" line="128"/>
         <source>Maximum</source>
         <translation>Massimo</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="104"/>
+        <location filename="../src/common/settings.cpp" line="128"/>
         <source>Fullscreen</source>
         <translation>Pieno schermo</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="292"/>
+        <location filename="../src/common/settings.cpp" line="316"/>
         <source>This shortcut conflicts with system shortcut %1</source>
         <translation>Questa scorciatoia è in conflitto con la scorciatoia di sistema %1</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="294"/>
+        <location filename="../src/common/settings.cpp" line="318"/>
         <source>This shortcut conflicts with %1, click on Replace to make this shortcut effective immediately</source>
         <translation>Questa scorciatoia è in conflitto con %1, clicca su Sostituisci per rendere questa come effettiva</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="410"/>
-        <location filename="../src/common/settings.cpp" line="418"/>
+        <location filename="../src/common/settings.cpp" line="464"/>
+        <location filename="../src/common/settings.cpp" line="472"/>
         <source>The shortcut %1 is invalid, please set another one.</source>
         <translation>La scorciatoia %1 non è valida, inseriscine una nuova.</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="445"/>
+        <location filename="../src/common/settings.cpp" line="507"/>
         <source>Cancel</source>
         <translation>Annulla</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="446"/>
+        <location filename="../src/common/settings.cpp" line="508"/>
         <source>Replace</source>
         <translation>Sostituisci</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="448"/>
+        <location filename="../src/common/settings.cpp" line="510"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
@@ -808,7 +813,7 @@ Localizzazione italiana a cura di Massimo A. Carofano.</translation>
 <context>
     <name>StartManager</name>
     <message>
-        <location filename="../src/startmanager.cpp" line="340"/>
+        <location filename="../src/startmanager.cpp" line="350"/>
         <source>Untitled %1</source>
         <translation>%1 senza titolo</translation>
     </message>
@@ -816,32 +821,32 @@ Localizzazione italiana a cura di Massimo A. Carofano.</translation>
 <context>
     <name>Tabbar</name>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="515"/>
+        <location filename="../src/controls/tabbar.cpp" line="540"/>
         <source>Close tab</source>
         <translation>Chiudi scheda</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="516"/>
+        <location filename="../src/controls/tabbar.cpp" line="541"/>
         <source>Close other tabs</source>
         <translation>Chiudi le altre schede</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="517"/>
+        <location filename="../src/controls/tabbar.cpp" line="542"/>
         <source>More options</source>
         <translation>Ulteriori opzioni</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="518"/>
+        <location filename="../src/controls/tabbar.cpp" line="543"/>
         <source>Close tabs to the left</source>
         <translation>Chiudi le schede sulla sinistra</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="519"/>
+        <location filename="../src/controls/tabbar.cpp" line="544"/>
         <source>Close tabs to the right</source>
         <translation>Chiudi le schede sulla destra</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="520"/>
+        <location filename="../src/controls/tabbar.cpp" line="545"/>
         <source>Close unmodified tabs</source>
         <translation>Chiudi schede non modificate</translation>
     </message>
@@ -849,261 +854,259 @@ Localizzazione italiana a cura di Massimo A. Carofano.</translation>
 <context>
     <name>TextEdit</name>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="235"/>
+        <location filename="../src/editor/dtextedit.cpp" line="259"/>
         <source>Undo</source>
         <translation>Annulla</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="236"/>
+        <location filename="../src/editor/dtextedit.cpp" line="260"/>
         <source>Redo</source>
         <translation>Ripeti</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="237"/>
+        <location filename="../src/editor/dtextedit.cpp" line="261"/>
         <source>Cut</source>
         <translation>Taglia</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="238"/>
+        <location filename="../src/editor/dtextedit.cpp" line="262"/>
         <source>Copy</source>
         <translation>Copia</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="239"/>
+        <location filename="../src/editor/dtextedit.cpp" line="263"/>
         <source>Paste</source>
         <translation>Incolla</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="240"/>
+        <location filename="../src/editor/dtextedit.cpp" line="264"/>
         <source>Delete</source>
         <translation>Elimina</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="241"/>
+        <location filename="../src/editor/dtextedit.cpp" line="265"/>
         <source>Select All</source>
         <translation>Seleziona tutto</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="242"/>
-        <location filename="../src/widgets/window.cpp" line="361"/>
+        <location filename="../src/editor/dtextedit.cpp" line="266"/>
+        <location filename="../src/widgets/window.cpp" line="450"/>
         <source>Find</source>
         <translation>Trova</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="243"/>
-        <location filename="../src/widgets/window.cpp" line="362"/>
+        <location filename="../src/editor/dtextedit.cpp" line="267"/>
+        <location filename="../src/widgets/window.cpp" line="451"/>
         <source>Replace</source>
         <translation>Sostituisci</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="244"/>
+        <location filename="../src/editor/dtextedit.cpp" line="268"/>
         <source>Go to Line</source>
         <translation>Vai alla linea</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="245"/>
+        <location filename="../src/editor/dtextedit.cpp" line="269"/>
         <source>Turn on Read-Only mode</source>
         <translation>Attiva la modalità Sola Lettura</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="246"/>
+        <location filename="../src/editor/dtextedit.cpp" line="270"/>
         <source>Turn off Read-Only mode</source>
         <translation>Disattiva la modalità Sola Lettura</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="247"/>
+        <location filename="../src/editor/dtextedit.cpp" line="271"/>
         <source>Fullscreen</source>
         <translation>Schermo intero</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="248"/>
+        <location filename="../src/editor/dtextedit.cpp" line="272"/>
         <source>Exit fullscreen</source>
         <translation>Esci dallo schermo intero</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="249"/>
+        <location filename="../src/editor/dtextedit.cpp" line="273"/>
         <source>Display in file manager</source>
         <translation>Visualizza nel gestore file</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="250"/>
-        <location filename="../src/editor/dtextedit.cpp" line="302"/>
+        <location filename="../src/editor/dtextedit.cpp" line="274"/>
+        <location filename="../src/editor/dtextedit.cpp" line="326"/>
         <source>Add Comment</source>
         <translation>Aggiungi commento</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="251"/>
+        <location filename="../src/editor/dtextedit.cpp" line="275"/>
         <source>Text to Speech</source>
         <translation>Da testo a voce</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="252"/>
+        <location filename="../src/editor/dtextedit.cpp" line="276"/>
         <source>Stop reading</source>
         <translation>Interrompi lettura</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="253"/>
+        <location filename="../src/editor/dtextedit.cpp" line="277"/>
         <source>Speech to Text</source>
         <translation>Da voce a testo</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="254"/>
+        <location filename="../src/editor/dtextedit.cpp" line="278"/>
         <source>Translate</source>
         <translation>Traduci</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="255"/>
+        <location filename="../src/editor/dtextedit.cpp" line="279"/>
         <source>Column Mode</source>
         <translation>Modlità colonna</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="256"/>
+        <location filename="../src/editor/dtextedit.cpp" line="280"/>
         <source>Add bookmark</source>
         <translation>Aggiungi segnalibro</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="257"/>
+        <location filename="../src/editor/dtextedit.cpp" line="281"/>
         <source>Remove Bookmark</source>
         <translation>Rimuovi segnalibro</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="258"/>
+        <location filename="../src/editor/dtextedit.cpp" line="282"/>
         <source>Previous bookmark</source>
         <translation>Segnalibro precedente</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="259"/>
+        <location filename="../src/editor/dtextedit.cpp" line="283"/>
         <source>Next bookmark</source>
         <translation>Prossimo segnalibro</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="260"/>
+        <location filename="../src/editor/dtextedit.cpp" line="284"/>
         <source>Remove All Bookmarks</source>
         <translation>Rimuovi tutti i segnalibri</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="261"/>
+        <location filename="../src/editor/dtextedit.cpp" line="285"/>
         <source>Fold All</source>
         <translation>Collassa tutti i livelli</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="262"/>
+        <location filename="../src/editor/dtextedit.cpp" line="286"/>
         <source>Fold Current Level</source>
         <translation>Collassa l&apos;attuale livello</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="263"/>
+        <location filename="../src/editor/dtextedit.cpp" line="287"/>
         <source>Unfold All</source>
         <translation>Espandi tutti i livelli</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="264"/>
+        <location filename="../src/editor/dtextedit.cpp" line="288"/>
         <source>Unfold Current Level</source>
         <translation>Espandi il livello corrente</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="269"/>
+        <location filename="../src/editor/dtextedit.cpp" line="293"/>
         <source>Color Mark</source>
         <translation>Colori come marcatori</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="273"/>
+        <location filename="../src/editor/dtextedit.cpp" line="297"/>
         <source>Clear All Marks</source>
         <translation>Rimuovi le evidenziazioni</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="274"/>
+        <location filename="../src/editor/dtextedit.cpp" line="298"/>
         <source>Clear Last Mark</source>
         <translation>Rimuovi ultima evidenziazione</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="283"/>
+        <location filename="../src/editor/dtextedit.cpp" line="307"/>
         <source>Mark</source>
         <translation>Evidenzia</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="295"/>
+        <location filename="../src/editor/dtextedit.cpp" line="319"/>
         <source>Mark All</source>
         <translation>Evidenzia tutto</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="303"/>
+        <location filename="../src/editor/dtextedit.cpp" line="327"/>
         <source>Remove Comment</source>
         <translation>Rimuovi commenti</translation>
     </message>
     <message>
-        <source>Failed to paste text: it is too large</source>
-        <translation type="vanished">Impossibile incollare il testo, è troppo grande</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="2581"/>
+        <location filename="../src/editor/dtextedit.cpp" line="2672"/>
         <source>Copy failed: not enough memory</source>
         <translation>Copia fallita: memoria non sufficiente</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="2665"/>
+        <location filename="../src/editor/dtextedit.cpp" line="2756"/>
         <source>Press ALT and click lines to edit in column mode</source>
         <translation>Premi ALT e clicca sulle linee per editare in modalità colonna</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="346"/>
+        <location filename="../src/editor/dtextedit.cpp" line="370"/>
         <source>Change Case</source>
         <translation>Cambia maiuscole</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="347"/>
+        <location filename="../src/editor/dtextedit.cpp" line="371"/>
         <source>Upper Case</source>
         <translation>Maiuscolo</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="348"/>
+        <location filename="../src/editor/dtextedit.cpp" line="372"/>
         <source>Lower Case</source>
         <translation>Minuscolo</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="349"/>
+        <location filename="../src/editor/dtextedit.cpp" line="373"/>
         <source>Capitalize</source>
         <translation>Maiuscola iniziale</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="64"/>
+        <location filename="../src/widgets/bottombar.cpp" line="49"/>
         <source>None</source>
         <translation>No</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1184"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1222"/>
         <source>Selected line(s) copied</source>
         <translation>Linea(e) selezionate copiate</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1190"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1228"/>
         <source>Current line copied</source>
         <translation>Linea corrente copiata</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1210"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1248"/>
         <source>Selected line(s) clipped</source>
         <translation>Linea(e) selezionate copiate negli appunti</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1222"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1259"/>
         <source>Current line clipped</source>
         <translation>Linea corrente copiata negli appunti</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="2591"/>
+        <location filename="../src/editor/dtextedit.cpp" line="2682"/>
         <source>Paste failed: not enough memory</source>
         <translation>Copia fallita: memoria non sufficiente</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3439"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3617"/>
         <source>Read-Only mode is off</source>
         <translation>La modalità sola lettura è disattivata</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3446"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3465"/>
-        <location filename="../src/editor/dtextedit.cpp" line="6150"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3624"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3643"/>
+        <location filename="../src/editor/dtextedit.cpp" line="6656"/>
+        <location filename="../src/editor/dtextedit.cpp" line="6664"/>
+        <location filename="../src/editor/dtextedit.cpp" line="6675"/>
         <source>Read-Only mode is on</source>
         <translation>La modalità sola lettura è attiva</translation>
     </message>
@@ -1111,7 +1114,7 @@ Localizzazione italiana a cura di Massimo A. Carofano.</translation>
 <context>
     <name>WarningNotices</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="36"/>
+        <location filename="../src/controls/warningnotices.cpp" line="19"/>
         <source>Reload</source>
         <translation>Ricarica</translation>
     </message>
@@ -1119,129 +1122,130 @@ Localizzazione italiana a cura di Massimo A. Carofano.</translation>
 <context>
     <name>Window</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="38"/>
-        <location filename="../src/widgets/window.cpp" line="357"/>
+        <location filename="../src/controls/warningnotices.cpp" line="21"/>
+        <location filename="../src/widgets/window.cpp" line="446"/>
         <source>Save as</source>
         <translation>Salva con nome</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="353"/>
+        <location filename="../src/widgets/window.cpp" line="442"/>
         <source>New window</source>
         <translation>Nuova finestra</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="354"/>
+        <location filename="../src/widgets/window.cpp" line="443"/>
         <source>New tab</source>
         <translation>Nuova scheda</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="355"/>
+        <location filename="../src/widgets/window.cpp" line="444"/>
         <source>Open file</source>
         <translation>Apri file</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="356"/>
-        <location filename="../src/widgets/window.cpp" line="2217"/>
+        <location filename="../src/widgets/window.cpp" line="445"/>
+        <location filename="../src/widgets/window.cpp" line="2796"/>
         <source>Save</source>
         <translation>Salva</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="358"/>
+        <location filename="../src/widgets/window.cpp" line="447"/>
         <source>Print</source>
         <translation>Stampa</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="359"/>
+        <location filename="../src/widgets/window.cpp" line="448"/>
         <source>Switch theme</source>
         <translation>Cambia tema</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="360"/>
-        <location filename="../src/widgets/window.cpp" line="1542"/>
+        <location filename="../src/widgets/window.cpp" line="449"/>
+        <location filename="../src/widgets/window.cpp" line="1871"/>
         <source>Settings</source>
         <translation>Impostazioni</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="471"/>
-        <location filename="../src/widgets/window.cpp" line="2468"/>
+        <location filename="../src/widgets/window.cpp" line="563"/>
+        <location filename="../src/widgets/window.cpp" line="3047"/>
         <source>Read-Only</source>
         <translation>Sola lettura</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="487"/>
+        <location filename="../src/widgets/window.cpp" line="579"/>
         <source>You do not have permission to open %1</source>
         <translation>Non hai i permessi per aprire %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="522"/>
+        <location filename="../src/widgets/window.cpp" line="619"/>
+        <location filename="../src/widgets/window.cpp" line="2359"/>
         <source>Invalid file: %1</source>
         <translation>File non valido: %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="602"/>
-        <location filename="../src/widgets/window.cpp" line="644"/>
+        <location filename="../src/widgets/window.cpp" line="733"/>
+        <location filename="../src/widgets/window.cpp" line="779"/>
         <source>Do you want to save this file?</source>
         <translation>Desideri salvare questo file?</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="894"/>
+        <location filename="../src/widgets/window.cpp" line="1027"/>
         <source>You do not have permission to save %1</source>
         <translation>Non hai i permessi per salvare %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="918"/>
+        <location filename="../src/widgets/window.cpp" line="1051"/>
         <source>Saved successfully</source>
         <translation>Salvato con successo</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="954"/>
-        <location filename="../src/widgets/window.cpp" line="1021"/>
-        <location filename="../src/widgets/window.cpp" line="1062"/>
+        <location filename="../src/widgets/window.cpp" line="1087"/>
+        <location filename="../src/widgets/window.cpp" line="1160"/>
+        <location filename="../src/widgets/window.cpp" line="1201"/>
         <source>Save File</source>
         <translation>Salva file</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1023"/>
+        <location filename="../src/widgets/window.cpp" line="1162"/>
         <source>Encoding</source>
         <translation>Codifica</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1211"/>
+        <location filename="../src/widgets/window.cpp" line="1350"/>
         <source>Read-Only mode is on</source>
         <translation>La modalità sola lettura è attiva</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1441"/>
+        <location filename="../src/widgets/window.cpp" line="1770"/>
         <source>Current location remembered</source>
         <translation>Locazione corrente memorizzata</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1492"/>
+        <location filename="../src/widgets/window.cpp" line="1821"/>
         <source>Ctrl+&apos;=&apos;</source>
         <translation>Ctrl+&apos;=&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1495"/>
+        <location filename="../src/widgets/window.cpp" line="1824"/>
         <source>Ctrl+&apos;-&apos;</source>
         <translation>Ctrl+&apos;-&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1524"/>
+        <location filename="../src/widgets/window.cpp" line="1853"/>
         <source>Editor</source>
         <translation>Editor</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1890"/>
+        <location filename="../src/widgets/window.cpp" line="2451"/>
         <source>Untitled %1</source>
         <translation>%1 senza titolo</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2215"/>
+        <location filename="../src/widgets/window.cpp" line="2794"/>
         <source>Cancel</source>
         <translation>Annulla</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2216"/>
+        <location filename="../src/widgets/window.cpp" line="2795"/>
         <source>Discard</source>
         <translation>Scarta</translation>
     </message>

--- a/translations/deepin-editor_ms.ts
+++ b/translations/deepin-editor_ms.ts
@@ -2,17 +2,17 @@
 <context>
     <name>BottomBar</name>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="39"/>
+        <location filename="../src/widgets/bottombar.cpp" line="24"/>
         <source>Row</source>
         <translation>Baris</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="40"/>
+        <location filename="../src/widgets/bottombar.cpp" line="25"/>
         <source>Column</source>
         <translation>Lajur</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="41"/>
+        <location filename="../src/widgets/bottombar.cpp" line="26"/>
         <source>Characters %1</source>
         <translation>Aksara %1</translation>
     </message>
@@ -20,9 +20,9 @@
 <context>
     <name>DDropdownMenu</name>
     <message>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="300"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="344"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="349"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="290"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="341"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="346"/>
         <source>None</source>
         <translation>Tiada</translation>
     </message>
@@ -30,80 +30,85 @@
 <context>
     <name>EditWrapper</name>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="201"/>
-        <location filename="../src/editor/editwrapper.cpp" line="264"/>
-        <location filename="../src/editor/editwrapper.cpp" line="321"/>
-        <location filename="../src/editor/editwrapper.cpp" line="536"/>
+        <location filename="../src/editor/editwrapper.cpp" line="246"/>
+        <location filename="../src/editor/editwrapper.cpp" line="314"/>
+        <location filename="../src/editor/editwrapper.cpp" line="439"/>
+        <location filename="../src/editor/editwrapper.cpp" line="702"/>
         <source>Save</source>
         <translation>Simpan</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="316"/>
+        <location filename="../src/editor/editwrapper.cpp" line="434"/>
         <source>Do you want to save this file?</source>
         <translation>Anda mahu menyimpan fail ini?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="262"/>
-        <location filename="../src/editor/editwrapper.cpp" line="319"/>
+        <location filename="../src/editor/editwrapper.cpp" line="312"/>
+        <location filename="../src/editor/editwrapper.cpp" line="437"/>
         <source>Cancel</source>
         <translation>Batal</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="259"/>
+        <location filename="../src/editor/editwrapper.cpp" line="309"/>
         <source>Encoding changed. Do you want to save the file now?</source>
         <translation>Pengekodan berubah. Anda mahu menyimpan fail sekarang?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="320"/>
+        <location filename="../src/editor/editwrapper.cpp" line="438"/>
         <source>Discard</source>
         <translation>Singkir</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="445"/>
+        <location filename="../src/editor/editwrapper.cpp" line="564"/>
         <source>You do not have permission to save %1</source>
         <translation>Anda tidak mempunyai keizinan untuk menyimpan %1</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="607"/>
+        <location filename="../src/editor/editwrapper.cpp" line="774"/>
         <source>File removed on the disk. Save it now?</source>
         <translation>Fail dalam cakera telah dibuang. Simpan ia sekarang?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="612"/>
+        <location filename="../src/editor/editwrapper.cpp" line="779"/>
         <source>File has changed on disk. Reload?</source>
         <translation>Fail telah berubah di dalam cakera. Muat semula?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="634"/>
-        <location filename="../src/widgets/bottombar.cpp" line="60"/>
+        <location filename="../src/editor/editwrapper.cpp" line="801"/>
+        <location filename="../src/widgets/bottombar.cpp" line="45"/>
         <source>INSERT</source>
         <translation>SISIP</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="637"/>
+        <location filename="../src/editor/editwrapper.cpp" line="804"/>
         <source>OVERWRITE</source>
         <translation>TULISGANTI</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="640"/>
+        <location filename="../src/editor/editwrapper.cpp" line="807"/>
         <source>R/O</source>
         <translation>R/O</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="945"/>
+        <source>The file cannot be read, which may be too large or has been damaged!</source>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
     <name>FindBar</name>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="40"/>
+        <location filename="../src/controls/findbar.cpp" line="22"/>
         <source>Find</source>
         <translation>Cari</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="44"/>
+        <location filename="../src/controls/findbar.cpp" line="26"/>
         <source>Previous</source>
         <translation>Terdahulu</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="46"/>
+        <location filename="../src/controls/findbar.cpp" line="28"/>
         <source>Next</source>
         <translation>Berikutnya</translation>
     </message>
@@ -111,7 +116,7 @@
 <context>
     <name>JumpLineBar</name>
     <message>
-        <location filename="../src/controls/jumplinebar.cpp" line="40"/>
+        <location filename="../src/controls/jumplinebar.cpp" line="28"/>
         <source>Go to Line: </source>
         <translation>Pergi ke Baris:</translation>
     </message>
@@ -119,12 +124,12 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/editorapplication.cpp" line="27"/>
+        <location filename="../src/editorapplication.cpp" line="11"/>
         <source>Text Editor is a powerful tool for viewing and editing text files.</source>
         <translation>Penyunting Teks ialah sebuah alat melihat dan menyunting fail teks yang hebat.</translation>
     </message>
     <message>
-        <location filename="../src/editorapplication.cpp" line="38"/>
+        <location filename="../src/editorapplication.cpp" line="22"/>
         <source>Text Editor</source>
         <translation>Penyunting Teks</translation>
     </message>
@@ -132,572 +137,572 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/editorapplication.cpp" line="35"/>
+        <location filename="../src/editorapplication.cpp" line="19"/>
         <source>Text Editor</source>
         <translation>Penyunting Teks</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="203"/>
-        <location filename="../src/editor/editwrapper.cpp" line="538"/>
-        <location filename="../src/widgets/window.cpp" line="956"/>
-        <location filename="../src/widgets/window.cpp" line="973"/>
-        <location filename="../src/widgets/window.cpp" line="1064"/>
-        <location filename="../src/widgets/window.cpp" line="1079"/>
+        <location filename="../src/editor/editwrapper.cpp" line="248"/>
+        <location filename="../src/editor/editwrapper.cpp" line="704"/>
+        <location filename="../src/widgets/window.cpp" line="1089"/>
+        <location filename="../src/widgets/window.cpp" line="1111"/>
+        <location filename="../src/widgets/window.cpp" line="1203"/>
+        <location filename="../src/widgets/window.cpp" line="1218"/>
         <source>Encoding</source>
         <translation>Pengekodan</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="24"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="9"/>
         <source>Basic</source>
         <translation>Asas</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="25"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="10"/>
         <source>Font Style</source>
         <translation>Gaya Fon</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="26"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="11"/>
         <source>Font</source>
         <translation>Fon</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="27"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="12"/>
         <source>Font Size</source>
         <translation>Saiz Fon</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="28"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="13"/>
         <source>Shortcuts</source>
         <translation>Pintasan</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="29"/>
-        <location filename="../src/controls/settingsdialog.cpp" line="30"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="14"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="15"/>
         <source>Keymap</source>
         <translation>Peta Kunci</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="31"/>
-        <location filename="../src/controls/settingsdialog.cpp" line="107"/>
-        <location filename="../src/widgets/window.cpp" line="1482"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="16"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="92"/>
+        <location filename="../src/widgets/window.cpp" line="1811"/>
         <source>Window</source>
         <translation>Tetingkap</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="32"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="17"/>
         <source>New tab</source>
         <translation>Tab baharu</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="33"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="18"/>
         <source>New window</source>
         <translation>Tetingkap baharu</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="34"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="19"/>
         <source>Save</source>
         <translation>Simpan</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="35"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="20"/>
         <source>Save as</source>
         <translation>Simpan sebagai</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="36"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="21"/>
         <source>Next tab</source>
         <translation>Tab berikutnya</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="37"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="22"/>
         <source>Previous tab</source>
         <translation>Tab terdahulu</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="38"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="23"/>
         <source>Close tab</source>
         <translation>Tutup tab</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="39"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="24"/>
         <source>Close other tabs</source>
         <translation>Tutup tab lain</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="40"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="25"/>
         <source>Restore tab</source>
         <translation>Pulihkan tab</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="41"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="26"/>
         <source>Open file</source>
         <translation>Buka fail</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="42"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="27"/>
         <source>Increment font size</source>
         <translation>Tingkatkan saiz fon</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="43"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="28"/>
         <source>Decrement font size</source>
         <translation>Kurangkan saiz fon</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="44"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="29"/>
         <source>Reset font size</source>
         <translation>Tetap semula saiz fon</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="45"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="30"/>
         <source>Help</source>
         <translation>Bantuan</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="46"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="31"/>
         <source>Toggle fullscreen</source>
         <translation>Togol skrin penuh</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="47"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="32"/>
         <source>Find</source>
         <translation>Cari</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="48"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="33"/>
         <source>Replace</source>
         <translation>Ganti</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="49"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="34"/>
         <source>Go to line</source>
         <translation>Pergi ke baris</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="50"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="35"/>
         <source>Save cursor position</source>
         <translation>Simpan kedudukan kursor</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="51"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="36"/>
         <source>Reset cursor position</source>
         <translation>Tetap semula kedudukan kursor</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="52"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="37"/>
         <source>Exit</source>
         <translation>Keluar</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="53"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="38"/>
         <source>Display shortcuts</source>
         <translation>Papar pintasan</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="54"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="39"/>
         <source>Print</source>
         <translation>Cetak</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="55"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="40"/>
         <source>Editor</source>
         <translation>Penyunting</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="56"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="41"/>
         <source>Increase indent</source>
         <translation>Tingkatkan inden</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="57"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="42"/>
         <source>Decrease indent</source>
         <translation>Kurangkan inden</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="58"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="43"/>
         <source>Forward character</source>
         <translation>Aksara maju</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="59"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="44"/>
         <source>Backward character</source>
         <translation>Aksara undur</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="60"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="45"/>
         <source>Forward word</source>
         <translation>Maju perkataan</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="61"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="46"/>
         <source>Backward word</source>
         <translation>Undur perkataan</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="62"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="47"/>
         <source>Next line</source>
         <translation>Baris berikutnya</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="63"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="48"/>
         <source>Previous line</source>
         <translation>Baris terdahulu</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="64"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="49"/>
         <source>New line</source>
         <translation>Baris baharu</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="65"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="50"/>
         <source>New line above</source>
         <translation>Baris baharu di atas</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="66"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="51"/>
         <source>New line below</source>
         <translation>Baris baharu di bawah</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="67"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="52"/>
         <source>Duplicate line</source>
         <translation>Gandakan baris</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="68"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="53"/>
         <source>Delete to end of line</source>
         <translation>Padam ke penghujung baris</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="69"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="54"/>
         <source>Delete current line</source>
         <translation>Padam baris semasa</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="70"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="55"/>
         <source>Swap line up</source>
         <translation>Silih baris ke atas</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="71"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="56"/>
         <source>Swap line down</source>
         <translation>Silih baris ke bawah</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="72"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="57"/>
         <source>Scroll up one line</source>
         <translation>Tatal ke atas satu baris</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="73"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="58"/>
         <source>Scroll down one line</source>
         <translation>Tatal ke bawah satu baris</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="74"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="59"/>
         <source>Page up</source>
         <translation>Halaman ke atas</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="75"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="60"/>
         <source>Page down</source>
         <translation>Halaman ke bawah</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="76"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="61"/>
         <source>Move to end of line</source>
         <translation>Gerak ke penghujung baris</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="77"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="62"/>
         <source>Move to start of line</source>
         <translation>Gerak ke permulaan baris</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="78"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="63"/>
         <source>Move to end of text</source>
         <translation>Gerak ke penghujung teks</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="79"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="64"/>
         <source>Move to start of text</source>
         <translation>Gerak ke permulaan teks</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="80"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="65"/>
         <source>Move to line indentation</source>
         <translation>Alih ke indentasi baris</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="81"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="66"/>
         <source>Upper case</source>
         <translation>Huruf besar</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="82"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="67"/>
         <source>Lower case</source>
         <translation>Huruf kecil</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="83"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="68"/>
         <source>Capitalize</source>
         <translation>Huruf Besarkan</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="84"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="69"/>
         <source>Delete backward word</source>
         <translation>Padam perkataan mengundur</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="85"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="70"/>
         <source>Delete forward word</source>
         <translation>Padam perkataan ke hadapan</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="86"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="71"/>
         <source>Forward over a pair</source>
         <translation>Majukan melangkaui pasangan</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="87"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="72"/>
         <source>Backward over a pair</source>
         <translation>Undur melangkaui pasangan</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="88"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="73"/>
         <source>Select all</source>
         <translation>Pilih semua</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="89"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="74"/>
         <source>Copy</source>
         <translation>Salin</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="90"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="75"/>
         <source>Cut</source>
         <translation>Potong</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="91"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="76"/>
         <source>Paste</source>
         <translation>Tampal</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="92"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="77"/>
         <source>Transpose character</source>
         <translation>Transposisi aksara</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="93"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="78"/>
         <source>Mark</source>
         <translation>Tanda</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="94"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="79"/>
         <source>Unmark</source>
         <translation>Nyahtanda</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="95"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="80"/>
         <source>Copy line</source>
         <translation>Salin baris</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="96"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="81"/>
         <source>Cut line</source>
         <translation>Potong baris</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="97"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="82"/>
         <source>Merge lines</source>
         <translation>Gabung baris</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="98"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="83"/>
         <source>Read-Only mode</source>
         <translation>Mod Baca-Sahaja</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="99"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="84"/>
         <source>Add comment</source>
         <translation>Tambah ulasan</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="100"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="85"/>
         <source>Remove comment</source>
         <translation>Buang ulasan</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="101"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="86"/>
         <source>Undo</source>
         <translation>Buat Asal</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="102"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="87"/>
         <source>Redo</source>
         <translation>Buat Semula</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="103"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="88"/>
         <source>Add/Remove bookmark</source>
         <translation>Tambah/Buang tanda buku</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="104"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="89"/>
         <source>Move to previous bookmark</source>
         <translation>Alih ke tanda buku terdahulu</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="105"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="90"/>
         <source>Move to next bookmark</source>
         <translation>Alih ke tanda buku berikutnya</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="106"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="91"/>
         <source>Advanced</source>
         <translation>Lanjutan</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="108"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="93"/>
         <source>Window size</source>
         <translation>Saiz tetingkap</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="109"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="94"/>
         <source>Tab width</source>
         <translation>Lebar tab</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="111"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="96"/>
         <source>Word wrap</source>
         <translation>Lilit perkataan</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="112"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="97"/>
         <source>Code folding flag</source>
         <translation>Bendera melipat kod</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="113"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="98"/>
         <source>Show line numbers</source>
         <translation>Tunjuk nombor baris</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="114"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="99"/>
         <source>Show bookmarks icon</source>
         <translation>Tunjuk ikon tanda buku</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="115"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="100"/>
         <source>Show whitespaces and tabs</source>
         <translation>Tunjuk jarak dan tab</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="116"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="101"/>
         <source>Highlight current line</source>
         <translation>Sorot baris semasa</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="117"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="102"/>
         <source>Color mark</source>
         <translation>Tanda warna</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="120"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="105"/>
         <source>Unicode</source>
         <translation>Unikod</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="121"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="106"/>
         <source>WesternEuropean</source>
         <translation>Eropah Barat</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="122"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="107"/>
         <source>CentralEuropean</source>
         <translation>Eropah Tengah</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="123"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="108"/>
         <source>Baltic</source>
         <translation>Baltik</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="124"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="109"/>
         <source>Cyrillic</source>
         <translation>Cyril</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="125"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="110"/>
         <source>Arabic</source>
         <translation>Arab</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="130"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="115"/>
         <source>Celtic</source>
         <translation>Celt</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="131"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="116"/>
         <source>SouthEasternEuropean</source>
         <translation>Eropah Tenggara</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="126"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="111"/>
         <source>Greek</source>
         <translation>Yunani</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="127"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="112"/>
         <source>Hebrew</source>
         <translation>Ibrani</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="132"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="117"/>
         <source>ChineseSimplified</source>
         <translation>Cina Ringkas</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="133"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="118"/>
         <source>ChineseTraditional</source>
         <translation>Cina Tradisional</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="134"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="119"/>
         <source>Japanese</source>
         <translation>Jepun</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="135"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="120"/>
         <source>Korean</source>
         <translation>Korea</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="129"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="114"/>
         <source>Thai</source>
         <translation>Siam</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="128"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="113"/>
         <source>Turkish</source>
         <translation>Turki</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="136"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="121"/>
         <source>Vietnamese</source>
         <translation>Vietnam</translation>
     </message>
     <message>
-        <location filename="../src/startmanager.cpp" line="762"/>
+        <location filename="../src/startmanager.cpp" line="832"/>
         <source>File not saved</source>
         <translation>Fail tidak disimpan</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="974"/>
-        <location filename="../src/widgets/window.cpp" line="1065"/>
-        <location filename="../src/widgets/window.cpp" line="1080"/>
+        <location filename="../src/widgets/window.cpp" line="1112"/>
+        <location filename="../src/widgets/window.cpp" line="1204"/>
+        <location filename="../src/widgets/window.cpp" line="1219"/>
         <source>Line Endings</source>
         <translation>Penghujung Baris</translation>
     </message>
@@ -705,32 +710,32 @@
 <context>
     <name>ReplaceBar</name>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="39"/>
+        <location filename="../src/controls/replacebar.cpp" line="21"/>
         <source>Find</source>
         <translation>Cari</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="43"/>
+        <location filename="../src/controls/replacebar.cpp" line="25"/>
         <source>Replace With</source>
         <translation>Ganti Dengan</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="47"/>
+        <location filename="../src/controls/replacebar.cpp" line="29"/>
         <source>Replace</source>
         <translation>Ganti</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="50"/>
+        <location filename="../src/controls/replacebar.cpp" line="32"/>
         <source>Skip</source>
         <translation>Langkau</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="53"/>
+        <location filename="../src/controls/replacebar.cpp" line="35"/>
         <source>Replace Rest</source>
         <translation>Ganti Selebihnya</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="56"/>
+        <location filename="../src/controls/replacebar.cpp" line="38"/>
         <source>Replace All</source>
         <translation>Ganti Semua</translation>
     </message>
@@ -747,58 +752,58 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../src/common/settings.cpp" line="91"/>
+        <location filename="../src/common/settings.cpp" line="115"/>
         <source>Standard</source>
         <translation>Piawai</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="91"/>
+        <location filename="../src/common/settings.cpp" line="115"/>
         <source>Customize</source>
         <translation>Suai</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="104"/>
+        <location filename="../src/common/settings.cpp" line="128"/>
         <source>Normal</source>
         <translation>Biasa</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="104"/>
+        <location filename="../src/common/settings.cpp" line="128"/>
         <source>Maximum</source>
         <translation>Maksimum</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="104"/>
+        <location filename="../src/common/settings.cpp" line="128"/>
         <source>Fullscreen</source>
         <translation>Skrin Penuh</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="292"/>
+        <location filename="../src/common/settings.cpp" line="316"/>
         <source>This shortcut conflicts with system shortcut %1</source>
         <translation>Pintasan ini berkonflik dengan pintasan sistem %1</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="294"/>
+        <location filename="../src/common/settings.cpp" line="318"/>
         <source>This shortcut conflicts with %1, click on Replace to make this shortcut effective immediately</source>
         <translation>Pintasan ini berkonflik dengan %1, klik Ganti untuk menjadikan pintasan ini berkesan serta-merta</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="410"/>
-        <location filename="../src/common/settings.cpp" line="418"/>
+        <location filename="../src/common/settings.cpp" line="464"/>
+        <location filename="../src/common/settings.cpp" line="472"/>
         <source>The shortcut %1 is invalid, please set another one.</source>
         <translation>Pintasan %1 tidak sah, sila tetapkan yang lain.</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="445"/>
+        <location filename="../src/common/settings.cpp" line="507"/>
         <source>Cancel</source>
         <translation>Batal</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="446"/>
+        <location filename="../src/common/settings.cpp" line="508"/>
         <source>Replace</source>
         <translation>Ganti</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="448"/>
+        <location filename="../src/common/settings.cpp" line="510"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
@@ -806,7 +811,7 @@
 <context>
     <name>StartManager</name>
     <message>
-        <location filename="../src/startmanager.cpp" line="340"/>
+        <location filename="../src/startmanager.cpp" line="350"/>
         <source>Untitled %1</source>
         <translation>%1 Tidak Bertajuk</translation>
     </message>
@@ -814,32 +819,32 @@
 <context>
     <name>Tabbar</name>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="515"/>
+        <location filename="../src/controls/tabbar.cpp" line="540"/>
         <source>Close tab</source>
         <translation>Tutup tab</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="516"/>
+        <location filename="../src/controls/tabbar.cpp" line="541"/>
         <source>Close other tabs</source>
         <translation>Tutup tab lain</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="517"/>
+        <location filename="../src/controls/tabbar.cpp" line="542"/>
         <source>More options</source>
         <translation>Lagi pilihan</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="518"/>
+        <location filename="../src/controls/tabbar.cpp" line="543"/>
         <source>Close tabs to the left</source>
         <translation>Tutup tab di sebelah kiri</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="519"/>
+        <location filename="../src/controls/tabbar.cpp" line="544"/>
         <source>Close tabs to the right</source>
         <translation>Tutup tab di sebelah kanan</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="520"/>
+        <location filename="../src/controls/tabbar.cpp" line="545"/>
         <source>Close unmodified tabs</source>
         <translation>Tutup tab yang tidak diubah suai</translation>
     </message>
@@ -847,261 +852,259 @@
 <context>
     <name>TextEdit</name>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="235"/>
+        <location filename="../src/editor/dtextedit.cpp" line="259"/>
         <source>Undo</source>
         <translation>Buat Asal</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="236"/>
+        <location filename="../src/editor/dtextedit.cpp" line="260"/>
         <source>Redo</source>
         <translation>Buat Semula</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="237"/>
+        <location filename="../src/editor/dtextedit.cpp" line="261"/>
         <source>Cut</source>
         <translation>Potong</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="238"/>
+        <location filename="../src/editor/dtextedit.cpp" line="262"/>
         <source>Copy</source>
         <translation>Salin</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="239"/>
+        <location filename="../src/editor/dtextedit.cpp" line="263"/>
         <source>Paste</source>
         <translation>Tampal</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="240"/>
+        <location filename="../src/editor/dtextedit.cpp" line="264"/>
         <source>Delete</source>
         <translation>Padam</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="241"/>
+        <location filename="../src/editor/dtextedit.cpp" line="265"/>
         <source>Select All</source>
         <translation>Pilih Semua</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="242"/>
-        <location filename="../src/widgets/window.cpp" line="361"/>
+        <location filename="../src/editor/dtextedit.cpp" line="266"/>
+        <location filename="../src/widgets/window.cpp" line="450"/>
         <source>Find</source>
         <translation>Cari</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="243"/>
-        <location filename="../src/widgets/window.cpp" line="362"/>
+        <location filename="../src/editor/dtextedit.cpp" line="267"/>
+        <location filename="../src/widgets/window.cpp" line="451"/>
         <source>Replace</source>
         <translation>Ganti</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="244"/>
+        <location filename="../src/editor/dtextedit.cpp" line="268"/>
         <source>Go to Line</source>
         <translation>Pergi ke Baris</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="245"/>
+        <location filename="../src/editor/dtextedit.cpp" line="269"/>
         <source>Turn on Read-Only mode</source>
         <translation>Hidupkan mod Baca-Sahaja</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="246"/>
+        <location filename="../src/editor/dtextedit.cpp" line="270"/>
         <source>Turn off Read-Only mode</source>
         <translation>Matikan mod Baca-Sahaja</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="247"/>
+        <location filename="../src/editor/dtextedit.cpp" line="271"/>
         <source>Fullscreen</source>
         <translation>Skrin Penuh</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="248"/>
+        <location filename="../src/editor/dtextedit.cpp" line="272"/>
         <source>Exit fullscreen</source>
         <translation>Keluar dari skrin penuh</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="249"/>
+        <location filename="../src/editor/dtextedit.cpp" line="273"/>
         <source>Display in file manager</source>
         <translation>Papar dalam pengurus fail</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="250"/>
-        <location filename="../src/editor/dtextedit.cpp" line="302"/>
+        <location filename="../src/editor/dtextedit.cpp" line="274"/>
+        <location filename="../src/editor/dtextedit.cpp" line="326"/>
         <source>Add Comment</source>
         <translation>Tambah Ulasan</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="251"/>
+        <location filename="../src/editor/dtextedit.cpp" line="275"/>
         <source>Text to Speech</source>
         <translation>Teks ke Pertuturan</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="252"/>
+        <location filename="../src/editor/dtextedit.cpp" line="276"/>
         <source>Stop reading</source>
         <translation>Berhenti membaca</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="253"/>
+        <location filename="../src/editor/dtextedit.cpp" line="277"/>
         <source>Speech to Text</source>
         <translation>Pertuturan ke Teks</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="254"/>
+        <location filename="../src/editor/dtextedit.cpp" line="278"/>
         <source>Translate</source>
         <translation>Terjemah</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="255"/>
+        <location filename="../src/editor/dtextedit.cpp" line="279"/>
         <source>Column Mode</source>
         <translation>Mod Lajur</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="256"/>
+        <location filename="../src/editor/dtextedit.cpp" line="280"/>
         <source>Add bookmark</source>
         <translation>Tambah tanda buku</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="257"/>
+        <location filename="../src/editor/dtextedit.cpp" line="281"/>
         <source>Remove Bookmark</source>
         <translation>Buang Tanda Buku</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="258"/>
+        <location filename="../src/editor/dtextedit.cpp" line="282"/>
         <source>Previous bookmark</source>
         <translation>Tanda buku terdahulu</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="259"/>
+        <location filename="../src/editor/dtextedit.cpp" line="283"/>
         <source>Next bookmark</source>
         <translation>Tanda buku berikutnya</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="260"/>
+        <location filename="../src/editor/dtextedit.cpp" line="284"/>
         <source>Remove All Bookmarks</source>
         <translation>Buang Semua Tanda Buku</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="261"/>
+        <location filename="../src/editor/dtextedit.cpp" line="285"/>
         <source>Fold All</source>
         <translation>Lipat Semua</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="262"/>
+        <location filename="../src/editor/dtextedit.cpp" line="286"/>
         <source>Fold Current Level</source>
         <translation>Lipat Aras Semasa</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="263"/>
+        <location filename="../src/editor/dtextedit.cpp" line="287"/>
         <source>Unfold All</source>
         <translation>Nyahlipat Semua</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="264"/>
+        <location filename="../src/editor/dtextedit.cpp" line="288"/>
         <source>Unfold Current Level</source>
         <translation>Nyahlipat Aras Semasa</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="269"/>
+        <location filename="../src/editor/dtextedit.cpp" line="293"/>
         <source>Color Mark</source>
         <translation>Tanda Warna</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="273"/>
+        <location filename="../src/editor/dtextedit.cpp" line="297"/>
         <source>Clear All Marks</source>
         <translation>Kosongkan Semua Tanda</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="274"/>
+        <location filename="../src/editor/dtextedit.cpp" line="298"/>
         <source>Clear Last Mark</source>
         <translation>Kosongkan Tanda Terakhir</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="283"/>
+        <location filename="../src/editor/dtextedit.cpp" line="307"/>
         <source>Mark</source>
         <translation>Tanda</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="295"/>
+        <location filename="../src/editor/dtextedit.cpp" line="319"/>
         <source>Mark All</source>
         <translation>Tanda Semua</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="303"/>
+        <location filename="../src/editor/dtextedit.cpp" line="327"/>
         <source>Remove Comment</source>
         <translation>Buang Ulasan</translation>
     </message>
     <message>
-        <source>Failed to paste text: it is too large</source>
-        <translation type="vanished">Gagal menampal teks: ia terlalu besar</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="2581"/>
+        <location filename="../src/editor/dtextedit.cpp" line="2672"/>
         <source>Copy failed: not enough memory</source>
         <translation>Gagal salin: ingatan tidak mencukupi</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="2665"/>
+        <location filename="../src/editor/dtextedit.cpp" line="2756"/>
         <source>Press ALT and click lines to edit in column mode</source>
         <translation>Tekan ALT dan klik baris untuk menyunting dalam mod lajur</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="346"/>
+        <location filename="../src/editor/dtextedit.cpp" line="370"/>
         <source>Change Case</source>
         <translation>Ubah Kata</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="347"/>
+        <location filename="../src/editor/dtextedit.cpp" line="371"/>
         <source>Upper Case</source>
         <translation>Huruf Besar</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="348"/>
+        <location filename="../src/editor/dtextedit.cpp" line="372"/>
         <source>Lower Case</source>
         <translation>Huruf Kecil</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="349"/>
+        <location filename="../src/editor/dtextedit.cpp" line="373"/>
         <source>Capitalize</source>
         <translation>Huruf Besarkan</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="64"/>
+        <location filename="../src/widgets/bottombar.cpp" line="49"/>
         <source>None</source>
         <translation>Tiada</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1184"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1222"/>
         <source>Selected line(s) copied</source>
         <translation>Baris terpilih disalin</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1190"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1228"/>
         <source>Current line copied</source>
         <translation>Baris semasa disalin</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1210"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1248"/>
         <source>Selected line(s) clipped</source>
         <translation>Baris terpilih dikerat</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1222"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1259"/>
         <source>Current line clipped</source>
         <translation>Baris semasa dikerat</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="2591"/>
+        <location filename="../src/editor/dtextedit.cpp" line="2682"/>
         <source>Paste failed: not enough memory</source>
         <translation>Gagal tampal: ingatan tidak mencukupi</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3439"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3617"/>
         <source>Read-Only mode is off</source>
         <translation>Mod Baca-Sahaja dimatikan</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3446"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3465"/>
-        <location filename="../src/editor/dtextedit.cpp" line="6150"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3624"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3643"/>
+        <location filename="../src/editor/dtextedit.cpp" line="6656"/>
+        <location filename="../src/editor/dtextedit.cpp" line="6664"/>
+        <location filename="../src/editor/dtextedit.cpp" line="6675"/>
         <source>Read-Only mode is on</source>
         <translation>Mod Baca-Sahaja dihidupkan</translation>
     </message>
@@ -1109,7 +1112,7 @@
 <context>
     <name>WarningNotices</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="36"/>
+        <location filename="../src/controls/warningnotices.cpp" line="19"/>
         <source>Reload</source>
         <translation>Muat Semula</translation>
     </message>
@@ -1117,129 +1120,130 @@
 <context>
     <name>Window</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="38"/>
-        <location filename="../src/widgets/window.cpp" line="357"/>
+        <location filename="../src/controls/warningnotices.cpp" line="21"/>
+        <location filename="../src/widgets/window.cpp" line="446"/>
         <source>Save as</source>
         <translation>Simpan sebagai</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="353"/>
+        <location filename="../src/widgets/window.cpp" line="442"/>
         <source>New window</source>
         <translation>Tetingkap baharu</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="354"/>
+        <location filename="../src/widgets/window.cpp" line="443"/>
         <source>New tab</source>
         <translation>Tab baharu</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="355"/>
+        <location filename="../src/widgets/window.cpp" line="444"/>
         <source>Open file</source>
         <translation>Buka fail</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="356"/>
-        <location filename="../src/widgets/window.cpp" line="2217"/>
+        <location filename="../src/widgets/window.cpp" line="445"/>
+        <location filename="../src/widgets/window.cpp" line="2796"/>
         <source>Save</source>
         <translation>Simpan</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="358"/>
+        <location filename="../src/widgets/window.cpp" line="447"/>
         <source>Print</source>
         <translation>Cetak</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="359"/>
+        <location filename="../src/widgets/window.cpp" line="448"/>
         <source>Switch theme</source>
         <translation>Tukar tema</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="360"/>
-        <location filename="../src/widgets/window.cpp" line="1542"/>
+        <location filename="../src/widgets/window.cpp" line="449"/>
+        <location filename="../src/widgets/window.cpp" line="1871"/>
         <source>Settings</source>
         <translation>Tetapan</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="471"/>
-        <location filename="../src/widgets/window.cpp" line="2468"/>
+        <location filename="../src/widgets/window.cpp" line="563"/>
+        <location filename="../src/widgets/window.cpp" line="3047"/>
         <source>Read-Only</source>
         <translation>Baca-Sahaja</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="487"/>
+        <location filename="../src/widgets/window.cpp" line="579"/>
         <source>You do not have permission to open %1</source>
         <translation>Anda tidak mempunyai keizinan untuk membuka %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="522"/>
+        <location filename="../src/widgets/window.cpp" line="619"/>
+        <location filename="../src/widgets/window.cpp" line="2359"/>
         <source>Invalid file: %1</source>
         <translation>Fail tidak sah: %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="602"/>
-        <location filename="../src/widgets/window.cpp" line="644"/>
+        <location filename="../src/widgets/window.cpp" line="733"/>
+        <location filename="../src/widgets/window.cpp" line="779"/>
         <source>Do you want to save this file?</source>
         <translation>Anda mahu menyimpan fail ini?</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="894"/>
+        <location filename="../src/widgets/window.cpp" line="1027"/>
         <source>You do not have permission to save %1</source>
         <translation>Anda tidak mempunyai keizinan untuk menyimpan %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="918"/>
+        <location filename="../src/widgets/window.cpp" line="1051"/>
         <source>Saved successfully</source>
         <translation>Berjaya disimpan</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="954"/>
-        <location filename="../src/widgets/window.cpp" line="1021"/>
-        <location filename="../src/widgets/window.cpp" line="1062"/>
+        <location filename="../src/widgets/window.cpp" line="1087"/>
+        <location filename="../src/widgets/window.cpp" line="1160"/>
+        <location filename="../src/widgets/window.cpp" line="1201"/>
         <source>Save File</source>
         <translation>Simpan Fail</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1023"/>
+        <location filename="../src/widgets/window.cpp" line="1162"/>
         <source>Encoding</source>
         <translation>Pengekodan</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1211"/>
+        <location filename="../src/widgets/window.cpp" line="1350"/>
         <source>Read-Only mode is on</source>
         <translation>Mod Baca-Sahaja dihidupkan</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1441"/>
+        <location filename="../src/widgets/window.cpp" line="1770"/>
         <source>Current location remembered</source>
         <translation>Lokasi semasa diingati</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1492"/>
+        <location filename="../src/widgets/window.cpp" line="1821"/>
         <source>Ctrl+&apos;=&apos;</source>
         <translation>Ctrl+&apos;=&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1495"/>
+        <location filename="../src/widgets/window.cpp" line="1824"/>
         <source>Ctrl+&apos;-&apos;</source>
         <translation>Ctrl+&apos;-&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1524"/>
+        <location filename="../src/widgets/window.cpp" line="1853"/>
         <source>Editor</source>
         <translation>Penyunting</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1890"/>
+        <location filename="../src/widgets/window.cpp" line="2451"/>
         <source>Untitled %1</source>
         <translation>%1 Tidak Bertajuk</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2215"/>
+        <location filename="../src/widgets/window.cpp" line="2794"/>
         <source>Cancel</source>
         <translation>Batal</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2216"/>
+        <location filename="../src/widgets/window.cpp" line="2795"/>
         <source>Discard</source>
         <translation>Singkir</translation>
     </message>

--- a/translations/deepin-editor_nl.ts
+++ b/translations/deepin-editor_nl.ts
@@ -2,17 +2,17 @@
 <context>
     <name>BottomBar</name>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="39"/>
+        <location filename="../src/widgets/bottombar.cpp" line="24"/>
         <source>Row</source>
         <translation>Rij</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="40"/>
+        <location filename="../src/widgets/bottombar.cpp" line="25"/>
         <source>Column</source>
         <translation>Kolom</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="41"/>
+        <location filename="../src/widgets/bottombar.cpp" line="26"/>
         <source>Characters %1</source>
         <translation>%1 tekens</translation>
     </message>
@@ -20,9 +20,9 @@
 <context>
     <name>DDropdownMenu</name>
     <message>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="300"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="344"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="349"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="290"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="341"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="346"/>
         <source>None</source>
         <translation>Geen</translation>
     </message>
@@ -30,80 +30,85 @@
 <context>
     <name>EditWrapper</name>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="201"/>
-        <location filename="../src/editor/editwrapper.cpp" line="264"/>
-        <location filename="../src/editor/editwrapper.cpp" line="321"/>
-        <location filename="../src/editor/editwrapper.cpp" line="536"/>
+        <location filename="../src/editor/editwrapper.cpp" line="246"/>
+        <location filename="../src/editor/editwrapper.cpp" line="314"/>
+        <location filename="../src/editor/editwrapper.cpp" line="439"/>
+        <location filename="../src/editor/editwrapper.cpp" line="702"/>
         <source>Save</source>
         <translation>Opslaan</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="316"/>
+        <location filename="../src/editor/editwrapper.cpp" line="434"/>
         <source>Do you want to save this file?</source>
         <translation>Wil je dit bestand opslaan?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="262"/>
-        <location filename="../src/editor/editwrapper.cpp" line="319"/>
+        <location filename="../src/editor/editwrapper.cpp" line="312"/>
+        <location filename="../src/editor/editwrapper.cpp" line="437"/>
         <source>Cancel</source>
         <translation>Annuleren</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="259"/>
+        <location filename="../src/editor/editwrapper.cpp" line="309"/>
         <source>Encoding changed. Do you want to save the file now?</source>
         <translation>De tekencodering is aangepast. Wil je het bestand opslaan?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="320"/>
+        <location filename="../src/editor/editwrapper.cpp" line="438"/>
         <source>Discard</source>
         <translation>Verwerpen</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="445"/>
+        <location filename="../src/editor/editwrapper.cpp" line="564"/>
         <source>You do not have permission to save %1</source>
         <translation>Je bent niet gemachtigd om %1 op te slaan</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="607"/>
+        <location filename="../src/editor/editwrapper.cpp" line="774"/>
         <source>File removed on the disk. Save it now?</source>
         <translation>Het bestand is verwijderd van de schijf. Wil je het opslaan?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="612"/>
+        <location filename="../src/editor/editwrapper.cpp" line="779"/>
         <source>File has changed on disk. Reload?</source>
         <translation>Het bestand is aangepast op de schijf. Wil je het opnieuw laden?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="634"/>
-        <location filename="../src/widgets/bottombar.cpp" line="60"/>
+        <location filename="../src/editor/editwrapper.cpp" line="801"/>
+        <location filename="../src/widgets/bottombar.cpp" line="45"/>
         <source>INSERT</source>
         <translation>INSERT</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="637"/>
+        <location filename="../src/editor/editwrapper.cpp" line="804"/>
         <source>OVERWRITE</source>
         <translation>OVERSCHRIJVEN</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="640"/>
+        <location filename="../src/editor/editwrapper.cpp" line="807"/>
         <source>R/O</source>
         <translation>ALLEEN-LEZEN</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="945"/>
+        <source>The file cannot be read, which may be too large or has been damaged!</source>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
     <name>FindBar</name>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="40"/>
+        <location filename="../src/controls/findbar.cpp" line="22"/>
         <source>Find</source>
         <translation>Zoeken</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="44"/>
+        <location filename="../src/controls/findbar.cpp" line="26"/>
         <source>Previous</source>
         <translation>Vorige</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="46"/>
+        <location filename="../src/controls/findbar.cpp" line="28"/>
         <source>Next</source>
         <translation>Volgende</translation>
     </message>
@@ -111,7 +116,7 @@
 <context>
     <name>JumpLineBar</name>
     <message>
-        <location filename="../src/controls/jumplinebar.cpp" line="40"/>
+        <location filename="../src/controls/jumplinebar.cpp" line="28"/>
         <source>Go to Line: </source>
         <translation>Ga naar regel:</translation>
     </message>
@@ -119,12 +124,12 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/editorapplication.cpp" line="27"/>
+        <location filename="../src/editorapplication.cpp" line="11"/>
         <source>Text Editor is a powerful tool for viewing and editing text files.</source>
         <translation>Tekstbewerker is een programma vol functies om platte tekst te bekijken en bewerken.</translation>
     </message>
     <message>
-        <location filename="../src/editorapplication.cpp" line="38"/>
+        <location filename="../src/editorapplication.cpp" line="22"/>
         <source>Text Editor</source>
         <translation>Tekstbewerker</translation>
     </message>
@@ -132,572 +137,572 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/editorapplication.cpp" line="35"/>
+        <location filename="../src/editorapplication.cpp" line="19"/>
         <source>Text Editor</source>
         <translation>Tekstbewerker</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="203"/>
-        <location filename="../src/editor/editwrapper.cpp" line="538"/>
-        <location filename="../src/widgets/window.cpp" line="956"/>
-        <location filename="../src/widgets/window.cpp" line="973"/>
-        <location filename="../src/widgets/window.cpp" line="1064"/>
-        <location filename="../src/widgets/window.cpp" line="1079"/>
+        <location filename="../src/editor/editwrapper.cpp" line="248"/>
+        <location filename="../src/editor/editwrapper.cpp" line="704"/>
+        <location filename="../src/widgets/window.cpp" line="1089"/>
+        <location filename="../src/widgets/window.cpp" line="1111"/>
+        <location filename="../src/widgets/window.cpp" line="1203"/>
+        <location filename="../src/widgets/window.cpp" line="1218"/>
         <source>Encoding</source>
         <translation>Tekencodering</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="24"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="9"/>
         <source>Basic</source>
         <translation>Algemeen</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="25"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="10"/>
         <source>Font Style</source>
         <translation>Lettertypestijl</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="26"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="11"/>
         <source>Font</source>
         <translation>Lettertype</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="27"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="12"/>
         <source>Font Size</source>
         <translation>Lettergrootte</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="28"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="13"/>
         <source>Shortcuts</source>
         <translation>Sneltoetsen</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="29"/>
-        <location filename="../src/controls/settingsdialog.cpp" line="30"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="14"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="15"/>
         <source>Keymap</source>
         <translation>Sneltoetsoverzicht</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="31"/>
-        <location filename="../src/controls/settingsdialog.cpp" line="107"/>
-        <location filename="../src/widgets/window.cpp" line="1482"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="16"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="92"/>
+        <location filename="../src/widgets/window.cpp" line="1811"/>
         <source>Window</source>
         <translation>Venster</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="32"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="17"/>
         <source>New tab</source>
         <translation>Nieuw tabblad</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="33"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="18"/>
         <source>New window</source>
         <translation>Nieuw venster</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="34"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="19"/>
         <source>Save</source>
         <translation>Opslaan</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="35"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="20"/>
         <source>Save as</source>
         <translation>Opslaan als</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="36"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="21"/>
         <source>Next tab</source>
         <translation>Volgend tabblad</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="37"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="22"/>
         <source>Previous tab</source>
         <translation>Vorig tabblad</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="38"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="23"/>
         <source>Close tab</source>
         <translation>Tabblad sluiten</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="39"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="24"/>
         <source>Close other tabs</source>
         <translation>Overige tabbladen sluiten</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="40"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="25"/>
         <source>Restore tab</source>
         <translation>Tabblad herstellen</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="41"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="26"/>
         <source>Open file</source>
         <translation>Bestand openen</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="42"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="27"/>
         <source>Increment font size</source>
         <translation>Lettertype vergroten</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="43"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="28"/>
         <source>Decrement font size</source>
         <translation>Lettertype verkleinen</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="44"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="29"/>
         <source>Reset font size</source>
         <translation>Lettergrootte herstellen</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="45"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="30"/>
         <source>Help</source>
         <translation>Hulp</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="46"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="31"/>
         <source>Toggle fullscreen</source>
         <translation>Beeldvullende modus in-/uitschakelen</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="47"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="32"/>
         <source>Find</source>
         <translation>Zoeken</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="48"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="33"/>
         <source>Replace</source>
         <translation>Vervangen</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="49"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="34"/>
         <source>Go to line</source>
         <translation>Ga naar regel</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="50"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="35"/>
         <source>Save cursor position</source>
         <translation>Cursorpositie opslaan</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="51"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="36"/>
         <source>Reset cursor position</source>
         <translation>Cursorpositie herstellen</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="52"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="37"/>
         <source>Exit</source>
         <translation>Afsluiten</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="53"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="38"/>
         <source>Display shortcuts</source>
         <translation>Sneltoetsen tonen</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="54"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="39"/>
         <source>Print</source>
         <translation>Afdrukken</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="55"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="40"/>
         <source>Editor</source>
         <translation>Bewerker</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="56"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="41"/>
         <source>Increase indent</source>
         <translation>Inspringing vergroten</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="57"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="42"/>
         <source>Decrease indent</source>
         <translation>Inspringing verkleinen</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="58"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="43"/>
         <source>Forward character</source>
         <translation>Teken vooruit</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="59"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="44"/>
         <source>Backward character</source>
         <translation>Teken achteruit</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="60"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="45"/>
         <source>Forward word</source>
         <translation>Woord vooruit</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="61"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="46"/>
         <source>Backward word</source>
         <translation>Woord achteruit</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="62"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="47"/>
         <source>Next line</source>
         <translation>Volgende regel</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="63"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="48"/>
         <source>Previous line</source>
         <translation>Vorige regel</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="64"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="49"/>
         <source>New line</source>
         <translation>Nieuwe regel</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="65"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="50"/>
         <source>New line above</source>
         <translation>Nieuwe regel erboven</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="66"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="51"/>
         <source>New line below</source>
         <translation>Nieuwe regel eronder</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="67"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="52"/>
         <source>Duplicate line</source>
         <translation>Regel dupliceren</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="68"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="53"/>
         <source>Delete to end of line</source>
         <translation>Wissen tot einde van regel</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="69"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="54"/>
         <source>Delete current line</source>
         <translation>Huidige regel wissen</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="70"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="55"/>
         <source>Swap line up</source>
         <translation>Regel omhoog verwisselen</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="71"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="56"/>
         <source>Swap line down</source>
         <translation>Regel omlaag verwisselen</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="72"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="57"/>
         <source>Scroll up one line</source>
         <translation>Eén regel omhoog scrollen</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="73"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="58"/>
         <source>Scroll down one line</source>
         <translation>Eén regel omlaag scrollen</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="74"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="59"/>
         <source>Page up</source>
         <translation>Pagina omhoog</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="75"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="60"/>
         <source>Page down</source>
         <translation>Pagina omlaag</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="76"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="61"/>
         <source>Move to end of line</source>
         <translation>Verplaatsen naar einde van regel</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="77"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="62"/>
         <source>Move to start of line</source>
         <translation>Verplaatsen naar begin van regel</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="78"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="63"/>
         <source>Move to end of text</source>
         <translation>Verplaatsen naar einde van tekst</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="79"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="64"/>
         <source>Move to start of text</source>
         <translation>Verplaatsen naar begin van tekst</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="80"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="65"/>
         <source>Move to line indentation</source>
         <translation>Verplaatsen naar regelinspringing</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="81"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="66"/>
         <source>Upper case</source>
         <translation>Hoofdletters</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="82"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="67"/>
         <source>Lower case</source>
         <translation>Kleine letters</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="83"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="68"/>
         <source>Capitalize</source>
         <translation>Omzetten naar hoofdletters</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="84"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="69"/>
         <source>Delete backward word</source>
         <translation>Woord achterwaarts wissen</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="85"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="70"/>
         <source>Delete forward word</source>
         <translation>Woord voorwaarts wissen</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="86"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="71"/>
         <source>Forward over a pair</source>
         <translation>Voorwaarts over een stel</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="87"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="72"/>
         <source>Backward over a pair</source>
         <translation>Achterwaarts over een stel</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="88"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="73"/>
         <source>Select all</source>
         <translation>Alles selecteren</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="89"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="74"/>
         <source>Copy</source>
         <translation>Kopiëren</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="90"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="75"/>
         <source>Cut</source>
         <translation>Knippen</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="91"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="76"/>
         <source>Paste</source>
         <translation>Plakken</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="92"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="77"/>
         <source>Transpose character</source>
         <translation>Teken omzetten</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="93"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="78"/>
         <source>Mark</source>
         <translation>Markeren</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="94"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="79"/>
         <source>Unmark</source>
         <translation>Demarkeren</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="95"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="80"/>
         <source>Copy line</source>
         <translation>Regel kopiëren</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="96"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="81"/>
         <source>Cut line</source>
         <translation>Regel knippen</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="97"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="82"/>
         <source>Merge lines</source>
         <translation>Regels samenvoegen</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="98"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="83"/>
         <source>Read-Only mode</source>
         <translation>Alleen-lezenmodus</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="99"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="84"/>
         <source>Add comment</source>
         <translation>Opmerking toevoegen</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="100"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="85"/>
         <source>Remove comment</source>
         <translation>Opmerking verwijderen</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="101"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="86"/>
         <source>Undo</source>
         <translation>Ongedaan maken</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="102"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="87"/>
         <source>Redo</source>
         <translation>Opnieuw</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="103"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="88"/>
         <source>Add/Remove bookmark</source>
         <translation>Bladwijzer toevoegen/verwijderen</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="104"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="89"/>
         <source>Move to previous bookmark</source>
         <translation>Naar vorige bladwijzer</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="105"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="90"/>
         <source>Move to next bookmark</source>
         <translation>Naar volgende bladwijzer</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="106"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="91"/>
         <source>Advanced</source>
         <translation>Geavanceerd</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="108"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="93"/>
         <source>Window size</source>
         <translation>Venstergrootte</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="109"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="94"/>
         <source>Tab width</source>
         <translation>Tabbreedte</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="111"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="96"/>
         <source>Word wrap</source>
         <translation>Regelafbreking</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="112"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="97"/>
         <source>Code folding flag</source>
         <translation>Codefloodvlag</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="113"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="98"/>
         <source>Show line numbers</source>
         <translation>Regelnummers tonen</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="114"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="99"/>
         <source>Show bookmarks icon</source>
         <translation>Bladwijzerpictogram tonen</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="115"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="100"/>
         <source>Show whitespaces and tabs</source>
         <translation>Witruimtes en tabs tonen</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="116"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="101"/>
         <source>Highlight current line</source>
         <translation>Huidige regel markeren</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="117"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="102"/>
         <source>Color mark</source>
         <translation>Markeerkleur</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="120"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="105"/>
         <source>Unicode</source>
         <translation>Unicode</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="121"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="106"/>
         <source>WesternEuropean</source>
         <translation>West-Europees</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="122"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="107"/>
         <source>CentralEuropean</source>
         <translation>Centraal-Europees</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="123"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="108"/>
         <source>Baltic</source>
         <translation>Baltisch</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="124"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="109"/>
         <source>Cyrillic</source>
         <translation>Cyrillisch</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="125"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="110"/>
         <source>Arabic</source>
         <translation>Arabisch</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="130"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="115"/>
         <source>Celtic</source>
         <translation>Keltisch</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="131"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="116"/>
         <source>SouthEasternEuropean</source>
         <translation>Zuidoost-Europees</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="126"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="111"/>
         <source>Greek</source>
         <translation>Grieks</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="127"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="112"/>
         <source>Hebrew</source>
         <translation>Hebreeuws</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="132"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="117"/>
         <source>ChineseSimplified</source>
         <translation>Chinees (Vereenvoudigd)</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="133"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="118"/>
         <source>ChineseTraditional</source>
         <translation>Chinees (Traditioneel)</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="134"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="119"/>
         <source>Japanese</source>
         <translation>Japans</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="135"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="120"/>
         <source>Korean</source>
         <translation>Koreaans</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="129"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="114"/>
         <source>Thai</source>
         <translation>Thais</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="128"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="113"/>
         <source>Turkish</source>
         <translation>Turks</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="136"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="121"/>
         <source>Vietnamese</source>
         <translation>Vietnamees</translation>
     </message>
     <message>
-        <location filename="../src/startmanager.cpp" line="762"/>
+        <location filename="../src/startmanager.cpp" line="832"/>
         <source>File not saved</source>
         <translation>Bestand is niet opgeslagen</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="974"/>
-        <location filename="../src/widgets/window.cpp" line="1065"/>
-        <location filename="../src/widgets/window.cpp" line="1080"/>
+        <location filename="../src/widgets/window.cpp" line="1112"/>
+        <location filename="../src/widgets/window.cpp" line="1204"/>
+        <location filename="../src/widgets/window.cpp" line="1219"/>
         <source>Line Endings</source>
         <translation>Regeleindes</translation>
     </message>
@@ -705,32 +710,32 @@
 <context>
     <name>ReplaceBar</name>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="39"/>
+        <location filename="../src/controls/replacebar.cpp" line="21"/>
         <source>Find</source>
         <translation>Zoeken</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="43"/>
+        <location filename="../src/controls/replacebar.cpp" line="25"/>
         <source>Replace With</source>
         <translation>Vervangen door</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="47"/>
+        <location filename="../src/controls/replacebar.cpp" line="29"/>
         <source>Replace</source>
         <translation>Vervangen</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="50"/>
+        <location filename="../src/controls/replacebar.cpp" line="32"/>
         <source>Skip</source>
         <translation>Overslaan</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="53"/>
+        <location filename="../src/controls/replacebar.cpp" line="35"/>
         <source>Replace Rest</source>
         <translation>Overige vervangen</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="56"/>
+        <location filename="../src/controls/replacebar.cpp" line="38"/>
         <source>Replace All</source>
         <translation>Alles vervangen</translation>
     </message>
@@ -747,58 +752,58 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../src/common/settings.cpp" line="91"/>
+        <location filename="../src/common/settings.cpp" line="115"/>
         <source>Standard</source>
         <translation>Standaard</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="91"/>
+        <location filename="../src/common/settings.cpp" line="115"/>
         <source>Customize</source>
         <translation>Aanpassen</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="104"/>
+        <location filename="../src/common/settings.cpp" line="128"/>
         <source>Normal</source>
         <translation>Normaal</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="104"/>
+        <location filename="../src/common/settings.cpp" line="128"/>
         <source>Maximum</source>
         <translation>Maximaal</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="104"/>
+        <location filename="../src/common/settings.cpp" line="128"/>
         <source>Fullscreen</source>
         <translation>Beeldvullende modus</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="292"/>
+        <location filename="../src/common/settings.cpp" line="316"/>
         <source>This shortcut conflicts with system shortcut %1</source>
         <translation>Deze sneltoets is wordt al gebruikt door de algemene sneltoets %1</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="294"/>
+        <location filename="../src/common/settings.cpp" line="318"/>
         <source>This shortcut conflicts with %1, click on Replace to make this shortcut effective immediately</source>
         <translation>Deze sneltoets is al in gebruik door %1 - klik om deze sneltoets in plaats daarvan te gebruiken</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="410"/>
-        <location filename="../src/common/settings.cpp" line="418"/>
+        <location filename="../src/common/settings.cpp" line="464"/>
+        <location filename="../src/common/settings.cpp" line="472"/>
         <source>The shortcut %1 is invalid, please set another one.</source>
         <translation>De sneltoets &apos;%1&apos; is ongeldig. Stel een andere in.</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="445"/>
+        <location filename="../src/common/settings.cpp" line="507"/>
         <source>Cancel</source>
         <translation>Annuleren</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="446"/>
+        <location filename="../src/common/settings.cpp" line="508"/>
         <source>Replace</source>
         <translation>Vervangen</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="448"/>
+        <location filename="../src/common/settings.cpp" line="510"/>
         <source>OK</source>
         <translation>Oké</translation>
     </message>
@@ -806,7 +811,7 @@
 <context>
     <name>StartManager</name>
     <message>
-        <location filename="../src/startmanager.cpp" line="340"/>
+        <location filename="../src/startmanager.cpp" line="350"/>
         <source>Untitled %1</source>
         <translation>Naamloos %1</translation>
     </message>
@@ -814,32 +819,32 @@
 <context>
     <name>Tabbar</name>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="515"/>
+        <location filename="../src/controls/tabbar.cpp" line="540"/>
         <source>Close tab</source>
         <translation>Tabblad sluiten</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="516"/>
+        <location filename="../src/controls/tabbar.cpp" line="541"/>
         <source>Close other tabs</source>
         <translation>Overige tabbladen sluiten</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="517"/>
+        <location filename="../src/controls/tabbar.cpp" line="542"/>
         <source>More options</source>
         <translation>Meer opties</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="518"/>
+        <location filename="../src/controls/tabbar.cpp" line="543"/>
         <source>Close tabs to the left</source>
         <translation>Tabbladen links sluiten</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="519"/>
+        <location filename="../src/controls/tabbar.cpp" line="544"/>
         <source>Close tabs to the right</source>
         <translation>Tabbladen rechts sluiten</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="520"/>
+        <location filename="../src/controls/tabbar.cpp" line="545"/>
         <source>Close unmodified tabs</source>
         <translation>Onaangepaste tabbladen sluiten</translation>
     </message>
@@ -847,261 +852,259 @@
 <context>
     <name>TextEdit</name>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="235"/>
+        <location filename="../src/editor/dtextedit.cpp" line="259"/>
         <source>Undo</source>
         <translation>Ongedaan maken</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="236"/>
+        <location filename="../src/editor/dtextedit.cpp" line="260"/>
         <source>Redo</source>
         <translation>Opnieuw</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="237"/>
+        <location filename="../src/editor/dtextedit.cpp" line="261"/>
         <source>Cut</source>
         <translation>Knippen</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="238"/>
+        <location filename="../src/editor/dtextedit.cpp" line="262"/>
         <source>Copy</source>
         <translation>Kopiëren</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="239"/>
+        <location filename="../src/editor/dtextedit.cpp" line="263"/>
         <source>Paste</source>
         <translation>Plakken</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="240"/>
+        <location filename="../src/editor/dtextedit.cpp" line="264"/>
         <source>Delete</source>
         <translation>Verwijderen</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="241"/>
+        <location filename="../src/editor/dtextedit.cpp" line="265"/>
         <source>Select All</source>
         <translation>Alles selecteren</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="242"/>
-        <location filename="../src/widgets/window.cpp" line="361"/>
+        <location filename="../src/editor/dtextedit.cpp" line="266"/>
+        <location filename="../src/widgets/window.cpp" line="450"/>
         <source>Find</source>
         <translation>Zoeken</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="243"/>
-        <location filename="../src/widgets/window.cpp" line="362"/>
+        <location filename="../src/editor/dtextedit.cpp" line="267"/>
+        <location filename="../src/widgets/window.cpp" line="451"/>
         <source>Replace</source>
         <translation>Vervangen</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="244"/>
+        <location filename="../src/editor/dtextedit.cpp" line="268"/>
         <source>Go to Line</source>
         <translation>Ga naar regel</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="245"/>
+        <location filename="../src/editor/dtextedit.cpp" line="269"/>
         <source>Turn on Read-Only mode</source>
         <translation>Alleen-lezenmodus inschakelen</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="246"/>
+        <location filename="../src/editor/dtextedit.cpp" line="270"/>
         <source>Turn off Read-Only mode</source>
         <translation>Alleen-lezenmodus uitschakelen</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="247"/>
+        <location filename="../src/editor/dtextedit.cpp" line="271"/>
         <source>Fullscreen</source>
         <translation>Beeldvullende modus</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="248"/>
+        <location filename="../src/editor/dtextedit.cpp" line="272"/>
         <source>Exit fullscreen</source>
         <translation>Beeldvullende modus verlaten</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="249"/>
+        <location filename="../src/editor/dtextedit.cpp" line="273"/>
         <source>Display in file manager</source>
         <translation>Tonen in bestandsbeheerder</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="250"/>
-        <location filename="../src/editor/dtextedit.cpp" line="302"/>
+        <location filename="../src/editor/dtextedit.cpp" line="274"/>
+        <location filename="../src/editor/dtextedit.cpp" line="326"/>
         <source>Add Comment</source>
         <translation>Opmerking toevoegen</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="251"/>
+        <location filename="../src/editor/dtextedit.cpp" line="275"/>
         <source>Text to Speech</source>
         <translation>Tekst-naar-spraak</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="252"/>
+        <location filename="../src/editor/dtextedit.cpp" line="276"/>
         <source>Stop reading</source>
         <translation>Stoppen met lezen</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="253"/>
+        <location filename="../src/editor/dtextedit.cpp" line="277"/>
         <source>Speech to Text</source>
         <translation>Spraak-naar-tekst</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="254"/>
+        <location filename="../src/editor/dtextedit.cpp" line="278"/>
         <source>Translate</source>
         <translation>Vertalen</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="255"/>
+        <location filename="../src/editor/dtextedit.cpp" line="279"/>
         <source>Column Mode</source>
         <translation>Kolommodus</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="256"/>
+        <location filename="../src/editor/dtextedit.cpp" line="280"/>
         <source>Add bookmark</source>
         <translation>Bladwijzer toevoegen</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="257"/>
+        <location filename="../src/editor/dtextedit.cpp" line="281"/>
         <source>Remove Bookmark</source>
         <translation>Bladwijzer verwijderen</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="258"/>
+        <location filename="../src/editor/dtextedit.cpp" line="282"/>
         <source>Previous bookmark</source>
         <translation>Vorige bladwijzer</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="259"/>
+        <location filename="../src/editor/dtextedit.cpp" line="283"/>
         <source>Next bookmark</source>
         <translation>Volgende bladwijzer</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="260"/>
+        <location filename="../src/editor/dtextedit.cpp" line="284"/>
         <source>Remove All Bookmarks</source>
         <translation>Alle bladwijzers verwijderen</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="261"/>
+        <location filename="../src/editor/dtextedit.cpp" line="285"/>
         <source>Fold All</source>
         <translation>Alles inklappen</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="262"/>
+        <location filename="../src/editor/dtextedit.cpp" line="286"/>
         <source>Fold Current Level</source>
         <translation>Huidig niveau inklappen</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="263"/>
+        <location filename="../src/editor/dtextedit.cpp" line="287"/>
         <source>Unfold All</source>
         <translation>Alles uitklappen</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="264"/>
+        <location filename="../src/editor/dtextedit.cpp" line="288"/>
         <source>Unfold Current Level</source>
         <translation>Huidig niveau uitklappen</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="269"/>
+        <location filename="../src/editor/dtextedit.cpp" line="293"/>
         <source>Color Mark</source>
         <translation>Markeerkleur</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="273"/>
+        <location filename="../src/editor/dtextedit.cpp" line="297"/>
         <source>Clear All Marks</source>
         <translation>Alle markeringen missen</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="274"/>
+        <location filename="../src/editor/dtextedit.cpp" line="298"/>
         <source>Clear Last Mark</source>
         <translation>Recentste markering demarkeren</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="283"/>
+        <location filename="../src/editor/dtextedit.cpp" line="307"/>
         <source>Mark</source>
         <translation>Markeren</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="295"/>
+        <location filename="../src/editor/dtextedit.cpp" line="319"/>
         <source>Mark All</source>
         <translation>Alles markeren</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="303"/>
+        <location filename="../src/editor/dtextedit.cpp" line="327"/>
         <source>Remove Comment</source>
         <translation>Opmerking verwijderen</translation>
     </message>
     <message>
-        <source>Failed to paste text: it is too large</source>
-        <translation type="vanished">De hoeveelheid tekst is te groot en kan daarom niet worden geplakt</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="2581"/>
+        <location filename="../src/editor/dtextedit.cpp" line="2672"/>
         <source>Copy failed: not enough memory</source>
         <translation>Het kopiëren is mislukt omdat er onvoldoende vrij geheugen is</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="2665"/>
+        <location filename="../src/editor/dtextedit.cpp" line="2756"/>
         <source>Press ALT and click lines to edit in column mode</source>
         <translation>Druk op Alt en klik op regels om te bewerken in kolommodus</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="346"/>
+        <location filename="../src/editor/dtextedit.cpp" line="370"/>
         <source>Change Case</source>
         <translation>Hoofdletters/Kleine letters</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="347"/>
+        <location filename="../src/editor/dtextedit.cpp" line="371"/>
         <source>Upper Case</source>
         <translation>Hoofdletters</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="348"/>
+        <location filename="../src/editor/dtextedit.cpp" line="372"/>
         <source>Lower Case</source>
         <translation>Kleine letters</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="349"/>
+        <location filename="../src/editor/dtextedit.cpp" line="373"/>
         <source>Capitalize</source>
         <translation>Omzetten naar hoofdletters</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="64"/>
+        <location filename="../src/widgets/bottombar.cpp" line="49"/>
         <source>None</source>
         <translation>Geen</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1184"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1222"/>
         <source>Selected line(s) copied</source>
         <translation>De geselecteerde regel(s) is (zijn) gekopieerd</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1190"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1228"/>
         <source>Current line copied</source>
         <translation>De huidige regel is gekopieerd</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1210"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1248"/>
         <source>Selected line(s) clipped</source>
         <translation>De geselecteerde regel(s) is (zijn) ingekort</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1222"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1259"/>
         <source>Current line clipped</source>
         <translation>De huidige regel is ingekort</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="2591"/>
+        <location filename="../src/editor/dtextedit.cpp" line="2682"/>
         <source>Paste failed: not enough memory</source>
         <translation>Het plakken is mislukt omdat er onvoldoende vrij geheugen is</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3439"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3617"/>
         <source>Read-Only mode is off</source>
         <translation>Alleen-lezenmodus is uitgeschakeld</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3446"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3465"/>
-        <location filename="../src/editor/dtextedit.cpp" line="6150"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3624"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3643"/>
+        <location filename="../src/editor/dtextedit.cpp" line="6656"/>
+        <location filename="../src/editor/dtextedit.cpp" line="6664"/>
+        <location filename="../src/editor/dtextedit.cpp" line="6675"/>
         <source>Read-Only mode is on</source>
         <translation>Alleen-lezenmodus is ingeschakeld</translation>
     </message>
@@ -1109,7 +1112,7 @@
 <context>
     <name>WarningNotices</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="36"/>
+        <location filename="../src/controls/warningnotices.cpp" line="19"/>
         <source>Reload</source>
         <translation>Opnieuw laden</translation>
     </message>
@@ -1117,129 +1120,130 @@
 <context>
     <name>Window</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="38"/>
-        <location filename="../src/widgets/window.cpp" line="357"/>
+        <location filename="../src/controls/warningnotices.cpp" line="21"/>
+        <location filename="../src/widgets/window.cpp" line="446"/>
         <source>Save as</source>
         <translation>Opslaan als</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="353"/>
+        <location filename="../src/widgets/window.cpp" line="442"/>
         <source>New window</source>
         <translation>Nieuw venster</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="354"/>
+        <location filename="../src/widgets/window.cpp" line="443"/>
         <source>New tab</source>
         <translation>Nieuw tabblad</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="355"/>
+        <location filename="../src/widgets/window.cpp" line="444"/>
         <source>Open file</source>
         <translation>Bestand openen</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="356"/>
-        <location filename="../src/widgets/window.cpp" line="2217"/>
+        <location filename="../src/widgets/window.cpp" line="445"/>
+        <location filename="../src/widgets/window.cpp" line="2796"/>
         <source>Save</source>
         <translation>Opslaan</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="358"/>
+        <location filename="../src/widgets/window.cpp" line="447"/>
         <source>Print</source>
         <translation>Afdrukken</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="359"/>
+        <location filename="../src/widgets/window.cpp" line="448"/>
         <source>Switch theme</source>
         <translation>Thema wijzigen</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="360"/>
-        <location filename="../src/widgets/window.cpp" line="1542"/>
+        <location filename="../src/widgets/window.cpp" line="449"/>
+        <location filename="../src/widgets/window.cpp" line="1871"/>
         <source>Settings</source>
         <translation>Instellingen</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="471"/>
-        <location filename="../src/widgets/window.cpp" line="2468"/>
+        <location filename="../src/widgets/window.cpp" line="563"/>
+        <location filename="../src/widgets/window.cpp" line="3047"/>
         <source>Read-Only</source>
         <translation>Alleen-lezen</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="487"/>
+        <location filename="../src/widgets/window.cpp" line="579"/>
         <source>You do not have permission to open %1</source>
         <translation>Je bent niet gemachtigd om %1 te openen</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="522"/>
+        <location filename="../src/widgets/window.cpp" line="619"/>
+        <location filename="../src/widgets/window.cpp" line="2359"/>
         <source>Invalid file: %1</source>
         <translation>Ongeldig bestand: %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="602"/>
-        <location filename="../src/widgets/window.cpp" line="644"/>
+        <location filename="../src/widgets/window.cpp" line="733"/>
+        <location filename="../src/widgets/window.cpp" line="779"/>
         <source>Do you want to save this file?</source>
         <translation>Wil je dit bestand opslaan?</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="894"/>
+        <location filename="../src/widgets/window.cpp" line="1027"/>
         <source>You do not have permission to save %1</source>
         <translation>Je bent niet gemachtigd om %1 op te slaan</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="918"/>
+        <location filename="../src/widgets/window.cpp" line="1051"/>
         <source>Saved successfully</source>
         <translation>Opgeslagen</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="954"/>
-        <location filename="../src/widgets/window.cpp" line="1021"/>
-        <location filename="../src/widgets/window.cpp" line="1062"/>
+        <location filename="../src/widgets/window.cpp" line="1087"/>
+        <location filename="../src/widgets/window.cpp" line="1160"/>
+        <location filename="../src/widgets/window.cpp" line="1201"/>
         <source>Save File</source>
         <translation>Bestand opslaan</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1023"/>
+        <location filename="../src/widgets/window.cpp" line="1162"/>
         <source>Encoding</source>
         <translation>Tekencodering</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1211"/>
+        <location filename="../src/widgets/window.cpp" line="1350"/>
         <source>Read-Only mode is on</source>
         <translation>Alleen-lezenmodus is ingeschakeld</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1441"/>
+        <location filename="../src/widgets/window.cpp" line="1770"/>
         <source>Current location remembered</source>
         <translation>De huidige locatie wordt onthouden</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1492"/>
+        <location filename="../src/widgets/window.cpp" line="1821"/>
         <source>Ctrl+&apos;=&apos;</source>
         <translation>Ctrl+&apos;=&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1495"/>
+        <location filename="../src/widgets/window.cpp" line="1824"/>
         <source>Ctrl+&apos;-&apos;</source>
         <translation>Ctrl+&apos;-&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1524"/>
+        <location filename="../src/widgets/window.cpp" line="1853"/>
         <source>Editor</source>
         <translation>Bewerker</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1890"/>
+        <location filename="../src/widgets/window.cpp" line="2451"/>
         <source>Untitled %1</source>
         <translation>Naamloos %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2215"/>
+        <location filename="../src/widgets/window.cpp" line="2794"/>
         <source>Cancel</source>
         <translation>Annuleren</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2216"/>
+        <location filename="../src/widgets/window.cpp" line="2795"/>
         <source>Discard</source>
         <translation>Verwerpen</translation>
     </message>

--- a/translations/deepin-editor_pl.ts
+++ b/translations/deepin-editor_pl.ts
@@ -2,17 +2,17 @@
 <context>
     <name>BottomBar</name>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="39"/>
+        <location filename="../src/widgets/bottombar.cpp" line="24"/>
         <source>Row</source>
         <translation>Wiersz</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="40"/>
+        <location filename="../src/widgets/bottombar.cpp" line="25"/>
         <source>Column</source>
         <translation>Kolumna</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="41"/>
+        <location filename="../src/widgets/bottombar.cpp" line="26"/>
         <source>Characters %1</source>
         <translation>Znaki %1</translation>
     </message>
@@ -20,9 +20,9 @@
 <context>
     <name>DDropdownMenu</name>
     <message>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="300"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="344"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="349"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="290"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="341"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="346"/>
         <source>None</source>
         <translation>Brak</translation>
     </message>
@@ -30,80 +30,85 @@
 <context>
     <name>EditWrapper</name>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="201"/>
-        <location filename="../src/editor/editwrapper.cpp" line="264"/>
-        <location filename="../src/editor/editwrapper.cpp" line="321"/>
-        <location filename="../src/editor/editwrapper.cpp" line="536"/>
+        <location filename="../src/editor/editwrapper.cpp" line="246"/>
+        <location filename="../src/editor/editwrapper.cpp" line="314"/>
+        <location filename="../src/editor/editwrapper.cpp" line="439"/>
+        <location filename="../src/editor/editwrapper.cpp" line="702"/>
         <source>Save</source>
         <translation>Zapisz</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="316"/>
+        <location filename="../src/editor/editwrapper.cpp" line="434"/>
         <source>Do you want to save this file?</source>
         <translation>Czy chcesz zapisać plik?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="262"/>
-        <location filename="../src/editor/editwrapper.cpp" line="319"/>
+        <location filename="../src/editor/editwrapper.cpp" line="312"/>
+        <location filename="../src/editor/editwrapper.cpp" line="437"/>
         <source>Cancel</source>
         <translation>Anuluj</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="259"/>
+        <location filename="../src/editor/editwrapper.cpp" line="309"/>
         <source>Encoding changed. Do you want to save the file now?</source>
-        <translation>Kodowanie zmienione. Czy chcesz teraz zapisać plik?</translation>
+        <translation>Kodowanie zostało zmienione. Czy chcesz teraz zapisać plik?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="320"/>
+        <location filename="../src/editor/editwrapper.cpp" line="438"/>
         <source>Discard</source>
         <translation>Odrzuć</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="445"/>
+        <location filename="../src/editor/editwrapper.cpp" line="564"/>
         <source>You do not have permission to save %1</source>
         <translation>Nie posiadasz uprawnień do zapisania %1</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="607"/>
+        <location filename="../src/editor/editwrapper.cpp" line="774"/>
         <source>File removed on the disk. Save it now?</source>
         <translation>Plik został usunięty z dysku. Czy chcesz go zapisać?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="612"/>
+        <location filename="../src/editor/editwrapper.cpp" line="779"/>
         <source>File has changed on disk. Reload?</source>
         <translation>Plik został zmieniony na dysku. Czy chcesz go ponownie wczytać?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="634"/>
-        <location filename="../src/widgets/bottombar.cpp" line="60"/>
+        <location filename="../src/editor/editwrapper.cpp" line="801"/>
+        <location filename="../src/widgets/bottombar.cpp" line="45"/>
         <source>INSERT</source>
         <translation>WSTAWIANIE</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="637"/>
+        <location filename="../src/editor/editwrapper.cpp" line="804"/>
         <source>OVERWRITE</source>
         <translation>NADPISYWANIE</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="640"/>
+        <location filename="../src/editor/editwrapper.cpp" line="807"/>
         <source>R/O</source>
         <translation>TYLKO DO ODCZYTU</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="945"/>
+        <source>The file cannot be read, which may be too large or has been damaged!</source>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
     <name>FindBar</name>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="40"/>
+        <location filename="../src/controls/findbar.cpp" line="22"/>
         <source>Find</source>
         <translation>Znajdź</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="44"/>
+        <location filename="../src/controls/findbar.cpp" line="26"/>
         <source>Previous</source>
         <translation>Poprzednie</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="46"/>
+        <location filename="../src/controls/findbar.cpp" line="28"/>
         <source>Next</source>
         <translation>Następne</translation>
     </message>
@@ -111,7 +116,7 @@
 <context>
     <name>JumpLineBar</name>
     <message>
-        <location filename="../src/controls/jumplinebar.cpp" line="40"/>
+        <location filename="../src/controls/jumplinebar.cpp" line="28"/>
         <source>Go to Line: </source>
         <translation>Przejdź do wiersza:</translation>
     </message>
@@ -119,12 +124,12 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/editorapplication.cpp" line="27"/>
+        <location filename="../src/editorapplication.cpp" line="11"/>
         <source>Text Editor is a powerful tool for viewing and editing text files.</source>
         <translation>Edytor Tekstu to potężne narzędzie do przeglądania i edycji plików tekstowych.</translation>
     </message>
     <message>
-        <location filename="../src/editorapplication.cpp" line="38"/>
+        <location filename="../src/editorapplication.cpp" line="22"/>
         <source>Text Editor</source>
         <translation>Edytor tekstu</translation>
     </message>
@@ -132,572 +137,572 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/editorapplication.cpp" line="35"/>
+        <location filename="../src/editorapplication.cpp" line="19"/>
         <source>Text Editor</source>
         <translation>Edytor tekstu</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="203"/>
-        <location filename="../src/editor/editwrapper.cpp" line="538"/>
-        <location filename="../src/widgets/window.cpp" line="956"/>
-        <location filename="../src/widgets/window.cpp" line="973"/>
-        <location filename="../src/widgets/window.cpp" line="1064"/>
-        <location filename="../src/widgets/window.cpp" line="1079"/>
+        <location filename="../src/editor/editwrapper.cpp" line="248"/>
+        <location filename="../src/editor/editwrapper.cpp" line="704"/>
+        <location filename="../src/widgets/window.cpp" line="1089"/>
+        <location filename="../src/widgets/window.cpp" line="1111"/>
+        <location filename="../src/widgets/window.cpp" line="1203"/>
+        <location filename="../src/widgets/window.cpp" line="1218"/>
         <source>Encoding</source>
         <translation>Kodowanie</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="24"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="9"/>
         <source>Basic</source>
         <translation>Podstawowe</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="25"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="10"/>
         <source>Font Style</source>
         <translation>Styl czcionki</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="26"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="11"/>
         <source>Font</source>
         <translation>Czcionka</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="27"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="12"/>
         <source>Font Size</source>
         <translation>Rozmiar czcionki</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="28"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="13"/>
         <source>Shortcuts</source>
         <translation>Skróty</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="29"/>
-        <location filename="../src/controls/settingsdialog.cpp" line="30"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="14"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="15"/>
         <source>Keymap</source>
         <translation>Mapowanie klawiszy</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="31"/>
-        <location filename="../src/controls/settingsdialog.cpp" line="107"/>
-        <location filename="../src/widgets/window.cpp" line="1482"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="16"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="92"/>
+        <location filename="../src/widgets/window.cpp" line="1811"/>
         <source>Window</source>
         <translation>Okno</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="32"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="17"/>
         <source>New tab</source>
         <translation>Nowa karta</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="33"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="18"/>
         <source>New window</source>
         <translation>Nowe okno</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="34"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="19"/>
         <source>Save</source>
         <translation>Zapisz</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="35"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="20"/>
         <source>Save as</source>
         <translation>Zapisz jako</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="36"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="21"/>
         <source>Next tab</source>
         <translation>Następna karta</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="37"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="22"/>
         <source>Previous tab</source>
         <translation>Poprzednia karta</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="38"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="23"/>
         <source>Close tab</source>
         <translation>Zamknij kartę</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="39"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="24"/>
         <source>Close other tabs</source>
         <translation>Zamknij pozostałe karty</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="40"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="25"/>
         <source>Restore tab</source>
         <translation>Przywróć kartę</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="41"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="26"/>
         <source>Open file</source>
         <translation>Otwórz plik</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="42"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="27"/>
         <source>Increment font size</source>
         <translation>Zwiększ rozmiar czcionki</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="43"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="28"/>
         <source>Decrement font size</source>
         <translation>Zmniejsz rozmiar czcionki</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="44"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="29"/>
         <source>Reset font size</source>
         <translation>Zresetuj rozmiar czcionki</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="45"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="30"/>
         <source>Help</source>
         <translation>Pomoc</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="46"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="31"/>
         <source>Toggle fullscreen</source>
         <translation>Przełącz pełny ekran</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="47"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="32"/>
         <source>Find</source>
         <translation>Znajdź</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="48"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="33"/>
         <source>Replace</source>
         <translation>Zamień</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="49"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="34"/>
         <source>Go to line</source>
         <translation>Przejdź do wiersza</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="50"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="35"/>
         <source>Save cursor position</source>
         <translation>Zapisz pozycję kursora</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="51"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="36"/>
         <source>Reset cursor position</source>
         <translation>Zresetuj pozycję kursora</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="52"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="37"/>
         <source>Exit</source>
-        <translation>Wyjście</translation>
+        <translation>Wyjdź</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="53"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="38"/>
         <source>Display shortcuts</source>
         <translation>Wyświetl skróty</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="54"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="39"/>
         <source>Print</source>
         <translation>Drukuj</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="55"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="40"/>
         <source>Editor</source>
         <translation>Edytor</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="56"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="41"/>
         <source>Increase indent</source>
         <translation>Zwiększ wcięcie</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="57"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="42"/>
         <source>Decrease indent</source>
         <translation>Zmniejsz wcięcie</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="58"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="43"/>
         <source>Forward character</source>
         <translation>Znak do przodu</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="59"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="44"/>
         <source>Backward character</source>
         <translation>Znak do tyłu</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="60"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="45"/>
         <source>Forward word</source>
         <translation>Następne słowo</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="61"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="46"/>
         <source>Backward word</source>
         <translation>Poprzednie słowo</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="62"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="47"/>
         <source>Next line</source>
         <translation>Następny wiersz</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="63"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="48"/>
         <source>Previous line</source>
         <translation>Poprzedni wiersz</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="64"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="49"/>
         <source>New line</source>
         <translation>Nowy wiersz</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="65"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="50"/>
         <source>New line above</source>
         <translation>Nowy wiersz powyżej</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="66"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="51"/>
         <source>New line below</source>
         <translation>Nowy wiersz poniżej</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="67"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="52"/>
         <source>Duplicate line</source>
         <translation>Duplikuj wiersz</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="68"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="53"/>
         <source>Delete to end of line</source>
         <translation>Usuń do końca wiersza</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="69"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="54"/>
         <source>Delete current line</source>
         <translation>Usuń bieżący wiersz</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="70"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="55"/>
         <source>Swap line up</source>
         <translation>Zamień wiersz z powyższym</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="71"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="56"/>
         <source>Swap line down</source>
         <translation>Zamień wiersz z poniższym</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="72"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="57"/>
         <source>Scroll up one line</source>
         <translation>Przewiń jeden wiersz w górę</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="73"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="58"/>
         <source>Scroll down one line</source>
         <translation>Przewiń jeden wiersz w dół</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="74"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="59"/>
         <source>Page up</source>
         <translation>Strona w górę</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="75"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="60"/>
         <source>Page down</source>
         <translation>Strona w dół</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="76"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="61"/>
         <source>Move to end of line</source>
         <translation>Przejdź do końca wiersza</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="77"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="62"/>
         <source>Move to start of line</source>
         <translation>Przejdź do początku wiersza</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="78"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="63"/>
         <source>Move to end of text</source>
         <translation>Przejdź do końca tekstu</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="79"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="64"/>
         <source>Move to start of text</source>
         <translation>Przejdź do początku tekstu</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="80"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="65"/>
         <source>Move to line indentation</source>
         <translation>Przejdź do wcięcia wiersza</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="81"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="66"/>
         <source>Upper case</source>
         <translation>Wielkie litery</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="82"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="67"/>
         <source>Lower case</source>
         <translation>Małe litery</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="83"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="68"/>
         <source>Capitalize</source>
         <translation>Wielka litera</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="84"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="69"/>
         <source>Delete backward word</source>
         <translation>Usuń poprzedzające słowo</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="85"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="70"/>
         <source>Delete forward word</source>
         <translation>Usuń następujące słowo</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="86"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="71"/>
         <source>Forward over a pair</source>
         <translation>Przenieś się za nawias</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="87"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="72"/>
         <source>Backward over a pair</source>
         <translation>Przenieś się przed nawias</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="88"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="73"/>
         <source>Select all</source>
         <translation>Zaznacz wszystko</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="89"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="74"/>
         <source>Copy</source>
         <translation>Kopiuj</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="90"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="75"/>
         <source>Cut</source>
         <translation>Wytnij</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="91"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="76"/>
         <source>Paste</source>
         <translation>Wklej</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="92"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="77"/>
         <source>Transpose character</source>
         <translation>Przenieś znak</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="93"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="78"/>
         <source>Mark</source>
         <translation>Oznacz</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="94"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="79"/>
         <source>Unmark</source>
         <translation>Odznacz</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="95"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="80"/>
         <source>Copy line</source>
         <translation>Kopiuj wiersz</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="96"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="81"/>
         <source>Cut line</source>
         <translation>Wytnij wiersz</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="97"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="82"/>
         <source>Merge lines</source>
         <translation>Połącz wiersze</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="98"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="83"/>
         <source>Read-Only mode</source>
         <translation>Tryb tylko-do-odczytu</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="99"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="84"/>
         <source>Add comment</source>
         <translation>Dodaj komentarz</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="100"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="85"/>
         <source>Remove comment</source>
         <translation>Usuń komentarz</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="101"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="86"/>
         <source>Undo</source>
         <translation>Cofnij</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="102"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="87"/>
         <source>Redo</source>
         <translation>Ponów</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="103"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="88"/>
         <source>Add/Remove bookmark</source>
         <translation>Dodaj/Usuń zakładkę</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="104"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="89"/>
         <source>Move to previous bookmark</source>
         <translation>Przejdź do poprzedniej zakładki</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="105"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="90"/>
         <source>Move to next bookmark</source>
         <translation>Przejdź do następnej zakładki</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="106"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="91"/>
         <source>Advanced</source>
         <translation>Zaawansowane</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="108"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="93"/>
         <source>Window size</source>
         <translation>Rozmiar okna</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="109"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="94"/>
         <source>Tab width</source>
         <translation>Szerokość zakładki</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="111"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="96"/>
         <source>Word wrap</source>
         <translation>Zawijanie tekstu</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="112"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="97"/>
         <source>Code folding flag</source>
         <translation>Pokaż strzałki zawijające kod</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="113"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="98"/>
         <source>Show line numbers</source>
-        <translation>Pokaż numery linii</translation>
+        <translation>Pokaż numery wierszy</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="114"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="99"/>
         <source>Show bookmarks icon</source>
         <translation>Pokaż ikonę zakładek</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="115"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="100"/>
         <source>Show whitespaces and tabs</source>
         <translation>Pokaż spacje i tabulatory</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="116"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="101"/>
         <source>Highlight current line</source>
         <translation>Podkreśl bieżący wiersz</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="117"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="102"/>
         <source>Color mark</source>
         <translation>Kolor oznaczenia</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="120"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="105"/>
         <source>Unicode</source>
         <translation>Unicode</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="121"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="106"/>
         <source>WesternEuropean</source>
         <translation>Zachodnio Europejski</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="122"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="107"/>
         <source>CentralEuropean</source>
         <translation>Europa Centralna</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="123"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="108"/>
         <source>Baltic</source>
         <translation>Bałtycki</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="124"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="109"/>
         <source>Cyrillic</source>
         <translation>Cyrylica</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="125"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="110"/>
         <source>Arabic</source>
         <translation>Arabski</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="130"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="115"/>
         <source>Celtic</source>
         <translation>Celtycki</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="131"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="116"/>
         <source>SouthEasternEuropean</source>
         <translation>Południowo-Wschodnia Europa</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="126"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="111"/>
         <source>Greek</source>
         <translation>Grecki</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="127"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="112"/>
         <source>Hebrew</source>
         <translation>Hebrajski</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="132"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="117"/>
         <source>ChineseSimplified</source>
         <translation>Chiński uproszczony</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="133"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="118"/>
         <source>ChineseTraditional</source>
         <translation>Chiński tradycyjny</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="134"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="119"/>
         <source>Japanese</source>
         <translation>Japoński</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="135"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="120"/>
         <source>Korean</source>
         <translation>Koreański</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="129"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="114"/>
         <source>Thai</source>
         <translation>Tajlandzki</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="128"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="113"/>
         <source>Turkish</source>
         <translation>Turecki</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="136"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="121"/>
         <source>Vietnamese</source>
         <translation>Wietnamski</translation>
     </message>
     <message>
-        <location filename="../src/startmanager.cpp" line="762"/>
+        <location filename="../src/startmanager.cpp" line="832"/>
         <source>File not saved</source>
         <translation>Plik nie został zapisany</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="974"/>
-        <location filename="../src/widgets/window.cpp" line="1065"/>
-        <location filename="../src/widgets/window.cpp" line="1080"/>
+        <location filename="../src/widgets/window.cpp" line="1112"/>
+        <location filename="../src/widgets/window.cpp" line="1204"/>
+        <location filename="../src/widgets/window.cpp" line="1219"/>
         <source>Line Endings</source>
         <translation>Zakończenia wiersza</translation>
     </message>
@@ -705,32 +710,32 @@
 <context>
     <name>ReplaceBar</name>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="39"/>
+        <location filename="../src/controls/replacebar.cpp" line="21"/>
         <source>Find</source>
         <translation>Znajdź</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="43"/>
+        <location filename="../src/controls/replacebar.cpp" line="25"/>
         <source>Replace With</source>
         <translation>Zamień na</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="47"/>
+        <location filename="../src/controls/replacebar.cpp" line="29"/>
         <source>Replace</source>
         <translation>Zastąp</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="50"/>
+        <location filename="../src/controls/replacebar.cpp" line="32"/>
         <source>Skip</source>
         <translation>Pomiń</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="53"/>
+        <location filename="../src/controls/replacebar.cpp" line="35"/>
         <source>Replace Rest</source>
         <translation>Zastąp pozostałe</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="56"/>
+        <location filename="../src/controls/replacebar.cpp" line="38"/>
         <source>Replace All</source>
         <translation>Zastąp wszystkie</translation>
     </message>
@@ -747,58 +752,58 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../src/common/settings.cpp" line="91"/>
+        <location filename="../src/common/settings.cpp" line="115"/>
         <source>Standard</source>
         <translation>Standardowe</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="91"/>
+        <location filename="../src/common/settings.cpp" line="115"/>
         <source>Customize</source>
         <translation>Dostosuj</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="104"/>
+        <location filename="../src/common/settings.cpp" line="128"/>
         <source>Normal</source>
-        <translation>Normalne</translation>
+        <translation>Normalny</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="104"/>
+        <location filename="../src/common/settings.cpp" line="128"/>
         <source>Maximum</source>
-        <translation>Maksymalne</translation>
+        <translation>Maksymalny</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="104"/>
+        <location filename="../src/common/settings.cpp" line="128"/>
         <source>Fullscreen</source>
         <translation>Pełny ekran</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="292"/>
+        <location filename="../src/common/settings.cpp" line="316"/>
         <source>This shortcut conflicts with system shortcut %1</source>
         <translation>Ten skrót jest w konflikcie ze skrótem systemowym %1</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="294"/>
+        <location filename="../src/common/settings.cpp" line="318"/>
         <source>This shortcut conflicts with %1, click on Replace to make this shortcut effective immediately</source>
         <translation>Ten skrót jest w konflikcie z %1, kliknij Zamień, aby skrót zaczął działać od razu</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="410"/>
-        <location filename="../src/common/settings.cpp" line="418"/>
+        <location filename="../src/common/settings.cpp" line="464"/>
+        <location filename="../src/common/settings.cpp" line="472"/>
         <source>The shortcut %1 is invalid, please set another one.</source>
         <translation>Skrót %1 jest nieprawidłowy, ustaw inny.</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="445"/>
+        <location filename="../src/common/settings.cpp" line="507"/>
         <source>Cancel</source>
         <translation>Anuluj</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="446"/>
+        <location filename="../src/common/settings.cpp" line="508"/>
         <source>Replace</source>
         <translation>Zamień</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="448"/>
+        <location filename="../src/common/settings.cpp" line="510"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
@@ -806,7 +811,7 @@
 <context>
     <name>StartManager</name>
     <message>
-        <location filename="../src/startmanager.cpp" line="340"/>
+        <location filename="../src/startmanager.cpp" line="350"/>
         <source>Untitled %1</source>
         <translation>Bez tytułu %1</translation>
     </message>
@@ -814,32 +819,32 @@
 <context>
     <name>Tabbar</name>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="515"/>
+        <location filename="../src/controls/tabbar.cpp" line="540"/>
         <source>Close tab</source>
         <translation>Zamknij kartę</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="516"/>
+        <location filename="../src/controls/tabbar.cpp" line="541"/>
         <source>Close other tabs</source>
         <translation>Zamknij pozostałe karty</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="517"/>
+        <location filename="../src/controls/tabbar.cpp" line="542"/>
         <source>More options</source>
         <translation>Więcej opcji</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="518"/>
+        <location filename="../src/controls/tabbar.cpp" line="543"/>
         <source>Close tabs to the left</source>
         <translation>Zamknij karty po lewej stronie</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="519"/>
+        <location filename="../src/controls/tabbar.cpp" line="544"/>
         <source>Close tabs to the right</source>
         <translation>Zamknij karty po prawej stronie</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="520"/>
+        <location filename="../src/controls/tabbar.cpp" line="545"/>
         <source>Close unmodified tabs</source>
         <translation>Zamknij niezmodyfikowane karty</translation>
     </message>
@@ -847,269 +852,267 @@
 <context>
     <name>TextEdit</name>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="235"/>
+        <location filename="../src/editor/dtextedit.cpp" line="259"/>
         <source>Undo</source>
         <translation>Cofnij</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="236"/>
+        <location filename="../src/editor/dtextedit.cpp" line="260"/>
         <source>Redo</source>
         <translation>Ponów</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="237"/>
+        <location filename="../src/editor/dtextedit.cpp" line="261"/>
         <source>Cut</source>
         <translation>Wytnij</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="238"/>
+        <location filename="../src/editor/dtextedit.cpp" line="262"/>
         <source>Copy</source>
         <translation>Kopiuj</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="239"/>
+        <location filename="../src/editor/dtextedit.cpp" line="263"/>
         <source>Paste</source>
         <translation>Wklej</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="240"/>
+        <location filename="../src/editor/dtextedit.cpp" line="264"/>
         <source>Delete</source>
         <translation>Usuń</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="241"/>
+        <location filename="../src/editor/dtextedit.cpp" line="265"/>
         <source>Select All</source>
         <translation>Zaznacz wszystko</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="242"/>
-        <location filename="../src/widgets/window.cpp" line="361"/>
+        <location filename="../src/editor/dtextedit.cpp" line="266"/>
+        <location filename="../src/widgets/window.cpp" line="450"/>
         <source>Find</source>
         <translation>Znajdź</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="243"/>
-        <location filename="../src/widgets/window.cpp" line="362"/>
+        <location filename="../src/editor/dtextedit.cpp" line="267"/>
+        <location filename="../src/widgets/window.cpp" line="451"/>
         <source>Replace</source>
         <translation>Zamień</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="244"/>
+        <location filename="../src/editor/dtextedit.cpp" line="268"/>
         <source>Go to Line</source>
         <translation>Przejdź do wiersza</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="245"/>
+        <location filename="../src/editor/dtextedit.cpp" line="269"/>
         <source>Turn on Read-Only mode</source>
         <translation>Włącz tryb tylko-do-odczytu</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="246"/>
+        <location filename="../src/editor/dtextedit.cpp" line="270"/>
         <source>Turn off Read-Only mode</source>
         <translation>Wyłącz tryb tylko-do-odczytu</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="247"/>
+        <location filename="../src/editor/dtextedit.cpp" line="271"/>
         <source>Fullscreen</source>
         <translation>Pełny ekran</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="248"/>
+        <location filename="../src/editor/dtextedit.cpp" line="272"/>
         <source>Exit fullscreen</source>
-        <translation>Wyłącz pełny ekran</translation>
+        <translation>Opuść pełny ekran</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="249"/>
+        <location filename="../src/editor/dtextedit.cpp" line="273"/>
         <source>Display in file manager</source>
         <translation>Wyświetl w Menedżerze plików</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="250"/>
-        <location filename="../src/editor/dtextedit.cpp" line="302"/>
+        <location filename="../src/editor/dtextedit.cpp" line="274"/>
+        <location filename="../src/editor/dtextedit.cpp" line="326"/>
         <source>Add Comment</source>
         <translation>Dodaj komentarz</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="251"/>
+        <location filename="../src/editor/dtextedit.cpp" line="275"/>
         <source>Text to Speech</source>
         <translation>Tekst na mowę</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="252"/>
+        <location filename="../src/editor/dtextedit.cpp" line="276"/>
         <source>Stop reading</source>
         <translation>Przestań czytać</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="253"/>
+        <location filename="../src/editor/dtextedit.cpp" line="277"/>
         <source>Speech to Text</source>
         <translation>Mowa na tekst</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="254"/>
+        <location filename="../src/editor/dtextedit.cpp" line="278"/>
         <source>Translate</source>
         <translation>Przetłumacz</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="255"/>
+        <location filename="../src/editor/dtextedit.cpp" line="279"/>
         <source>Column Mode</source>
         <translation>Tryb kolumnowy</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="256"/>
+        <location filename="../src/editor/dtextedit.cpp" line="280"/>
         <source>Add bookmark</source>
         <translation>Dodaj zakładkę</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="257"/>
+        <location filename="../src/editor/dtextedit.cpp" line="281"/>
         <source>Remove Bookmark</source>
         <translation>Usuń zakładkę</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="258"/>
+        <location filename="../src/editor/dtextedit.cpp" line="282"/>
         <source>Previous bookmark</source>
         <translation>Poprzednia zakładka</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="259"/>
+        <location filename="../src/editor/dtextedit.cpp" line="283"/>
         <source>Next bookmark</source>
         <translation>Następna zakładka</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="260"/>
+        <location filename="../src/editor/dtextedit.cpp" line="284"/>
         <source>Remove All Bookmarks</source>
         <translation>Usuń wszystkie zakładki</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="261"/>
+        <location filename="../src/editor/dtextedit.cpp" line="285"/>
         <source>Fold All</source>
         <translation>Zwiń wszystko</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="262"/>
+        <location filename="../src/editor/dtextedit.cpp" line="286"/>
         <source>Fold Current Level</source>
         <translation>Zwiń bieżący poziom</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="263"/>
+        <location filename="../src/editor/dtextedit.cpp" line="287"/>
         <source>Unfold All</source>
         <translation>Rozwiń wszystko</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="264"/>
+        <location filename="../src/editor/dtextedit.cpp" line="288"/>
         <source>Unfold Current Level</source>
         <translation>Rozwiń bieżący poziom</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="269"/>
+        <location filename="../src/editor/dtextedit.cpp" line="293"/>
         <source>Color Mark</source>
         <translation>Kolor oznaczenia</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="273"/>
+        <location filename="../src/editor/dtextedit.cpp" line="297"/>
         <source>Clear All Marks</source>
         <translation>Wyczyść wszystkie oznaczenia</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="274"/>
+        <location filename="../src/editor/dtextedit.cpp" line="298"/>
         <source>Clear Last Mark</source>
         <translation>Wyczyść ostatnie oznaczenie</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="283"/>
+        <location filename="../src/editor/dtextedit.cpp" line="307"/>
         <source>Mark</source>
         <translation>Oznacz</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="295"/>
+        <location filename="../src/editor/dtextedit.cpp" line="319"/>
         <source>Mark All</source>
         <translation>Oznacz wszystko</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="303"/>
+        <location filename="../src/editor/dtextedit.cpp" line="327"/>
         <source>Remove Comment</source>
         <translation>Usuń komentarz</translation>
     </message>
     <message>
-        <source>Failed to paste text: it is too large</source>
-        <translation type="vanished">Nie udało się wkleić tekstu: jest go zbyt dużo</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="2581"/>
+        <location filename="../src/editor/dtextedit.cpp" line="2672"/>
         <source>Copy failed: not enough memory</source>
         <translation>Kopiowanie nieudane: niewystarczająca ilość pamięci</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="2665"/>
+        <location filename="../src/editor/dtextedit.cpp" line="2756"/>
         <source>Press ALT and click lines to edit in column mode</source>
-        <translation>Naciśnij ALT i kliknij linie, aby edytować w trybie kolumnowym</translation>
+        <translation>Naciśnij ALT i kliknij wiersz, aby edytować w trybie kolumnowym</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="346"/>
+        <location filename="../src/editor/dtextedit.cpp" line="370"/>
         <source>Change Case</source>
         <translation>Zmień wielkość znaków</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="347"/>
+        <location filename="../src/editor/dtextedit.cpp" line="371"/>
         <source>Upper Case</source>
         <translation>Wielkie litery</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="348"/>
+        <location filename="../src/editor/dtextedit.cpp" line="372"/>
         <source>Lower Case</source>
         <translation>Małe litery</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="349"/>
+        <location filename="../src/editor/dtextedit.cpp" line="373"/>
         <source>Capitalize</source>
         <translation>Wielka litera</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="64"/>
+        <location filename="../src/widgets/bottombar.cpp" line="49"/>
         <source>None</source>
         <translation>Brak</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1184"/>
-        <source>Selected line(s) copied</source>
-        <translation>Wybrane linie zostały skopiowane</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1190"/>
-        <source>Current line copied</source>
-        <translation>Bieżąca linia została skopiowana</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1210"/>
-        <source>Selected line(s) clipped</source>
-        <translation>Obcięto wybrane linie</translation>
-    </message>
-    <message>
         <location filename="../src/editor/dtextedit.cpp" line="1222"/>
-        <source>Current line clipped</source>
-        <translation>Obcięto bieżącą linię</translation>
+        <source>Selected line(s) copied</source>
+        <translation>Skopiowano zaznaczone wiersz(e)</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="2591"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1228"/>
+        <source>Current line copied</source>
+        <translation>Skopiowano bieżący wiersz</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="1248"/>
+        <source>Selected line(s) clipped</source>
+        <translation>Wycięto zaznaczone wiersz(e)</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="1259"/>
+        <source>Current line clipped</source>
+        <translation>Wycięto bieżący wiersz</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="2682"/>
         <source>Paste failed: not enough memory</source>
         <translation>Wklejanie nieudane: niewystarczająca ilość pamięci</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3439"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3617"/>
         <source>Read-Only mode is off</source>
-        <translation>Tryb tylko-do-odczytu jest wyłączony</translation>
+        <translation>Tryb tylko-do-odczytu jest nieaktywny</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3446"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3465"/>
-        <location filename="../src/editor/dtextedit.cpp" line="6150"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3624"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3643"/>
+        <location filename="../src/editor/dtextedit.cpp" line="6656"/>
+        <location filename="../src/editor/dtextedit.cpp" line="6664"/>
+        <location filename="../src/editor/dtextedit.cpp" line="6675"/>
         <source>Read-Only mode is on</source>
-        <translation>Tryb tylko-do-odczytu jest włączony</translation>
+        <translation>Tryb tylko-do-odczytu jest aktywny</translation>
     </message>
 </context>
 <context>
     <name>WarningNotices</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="36"/>
+        <location filename="../src/controls/warningnotices.cpp" line="19"/>
         <source>Reload</source>
         <translation>Przeładuj</translation>
     </message>
@@ -1117,129 +1120,130 @@
 <context>
     <name>Window</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="38"/>
-        <location filename="../src/widgets/window.cpp" line="357"/>
+        <location filename="../src/controls/warningnotices.cpp" line="21"/>
+        <location filename="../src/widgets/window.cpp" line="446"/>
         <source>Save as</source>
         <translation>Zapisz jako</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="353"/>
+        <location filename="../src/widgets/window.cpp" line="442"/>
         <source>New window</source>
         <translation>Nowe okno</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="354"/>
+        <location filename="../src/widgets/window.cpp" line="443"/>
         <source>New tab</source>
         <translation>Nowa karta</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="355"/>
+        <location filename="../src/widgets/window.cpp" line="444"/>
         <source>Open file</source>
         <translation>Otwórz plik</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="356"/>
-        <location filename="../src/widgets/window.cpp" line="2217"/>
+        <location filename="../src/widgets/window.cpp" line="445"/>
+        <location filename="../src/widgets/window.cpp" line="2796"/>
         <source>Save</source>
         <translation>Zapisz</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="358"/>
+        <location filename="../src/widgets/window.cpp" line="447"/>
         <source>Print</source>
         <translation>Drukuj</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="359"/>
+        <location filename="../src/widgets/window.cpp" line="448"/>
         <source>Switch theme</source>
         <translation>Przełącz motyw</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="360"/>
-        <location filename="../src/widgets/window.cpp" line="1542"/>
+        <location filename="../src/widgets/window.cpp" line="449"/>
+        <location filename="../src/widgets/window.cpp" line="1871"/>
         <source>Settings</source>
         <translation>Ustawienia</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="471"/>
-        <location filename="../src/widgets/window.cpp" line="2468"/>
+        <location filename="../src/widgets/window.cpp" line="563"/>
+        <location filename="../src/widgets/window.cpp" line="3047"/>
         <source>Read-Only</source>
         <translation>Tylko-do-odczytu</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="487"/>
+        <location filename="../src/widgets/window.cpp" line="579"/>
         <source>You do not have permission to open %1</source>
         <translation>Nie posiadasz uprawnień do otwarcia %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="522"/>
+        <location filename="../src/widgets/window.cpp" line="619"/>
+        <location filename="../src/widgets/window.cpp" line="2359"/>
         <source>Invalid file: %1</source>
         <translation>Nieprawidłowy plik: %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="602"/>
-        <location filename="../src/widgets/window.cpp" line="644"/>
+        <location filename="../src/widgets/window.cpp" line="733"/>
+        <location filename="../src/widgets/window.cpp" line="779"/>
         <source>Do you want to save this file?</source>
         <translation>Czy chcesz zapisać ten plik?</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="894"/>
+        <location filename="../src/widgets/window.cpp" line="1027"/>
         <source>You do not have permission to save %1</source>
         <translation>Nie posiadasz uprawnień do zapisania %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="918"/>
+        <location filename="../src/widgets/window.cpp" line="1051"/>
         <source>Saved successfully</source>
         <translation>Zapisano pomyślnie</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="954"/>
-        <location filename="../src/widgets/window.cpp" line="1021"/>
-        <location filename="../src/widgets/window.cpp" line="1062"/>
+        <location filename="../src/widgets/window.cpp" line="1087"/>
+        <location filename="../src/widgets/window.cpp" line="1160"/>
+        <location filename="../src/widgets/window.cpp" line="1201"/>
         <source>Save File</source>
         <translation>Zapisz plik</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1023"/>
+        <location filename="../src/widgets/window.cpp" line="1162"/>
         <source>Encoding</source>
         <translation>Kodowanie</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1211"/>
+        <location filename="../src/widgets/window.cpp" line="1350"/>
         <source>Read-Only mode is on</source>
-        <translation>Tryb tylko-do-odczytu jest włączony</translation>
+        <translation>Tryb tylko-do-odczytu jest aktywny</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1441"/>
+        <location filename="../src/widgets/window.cpp" line="1770"/>
         <source>Current location remembered</source>
-        <translation>Aktualna lokalizacja została zapamiętana</translation>
+        <translation>Bieżąca pozycja kursora została zapamiętana</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1492"/>
+        <location filename="../src/widgets/window.cpp" line="1821"/>
         <source>Ctrl+&apos;=&apos;</source>
         <translation>Ctrl+&apos;=&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1495"/>
+        <location filename="../src/widgets/window.cpp" line="1824"/>
         <source>Ctrl+&apos;-&apos;</source>
         <translation>Ctrl+&apos;-&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1524"/>
+        <location filename="../src/widgets/window.cpp" line="1853"/>
         <source>Editor</source>
         <translation>Edytor</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1890"/>
+        <location filename="../src/widgets/window.cpp" line="2451"/>
         <source>Untitled %1</source>
         <translation>Bez tytułu %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2215"/>
+        <location filename="../src/widgets/window.cpp" line="2794"/>
         <source>Cancel</source>
         <translation>Anuluj</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2216"/>
+        <location filename="../src/widgets/window.cpp" line="2795"/>
         <source>Discard</source>
         <translation>Odrzuć</translation>
     </message>

--- a/translations/deepin-editor_pt.ts
+++ b/translations/deepin-editor_pt.ts
@@ -2,17 +2,17 @@
 <context>
     <name>BottomBar</name>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="39"/>
+        <location filename="../src/widgets/bottombar.cpp" line="24"/>
         <source>Row</source>
         <translation>Linha</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="40"/>
+        <location filename="../src/widgets/bottombar.cpp" line="25"/>
         <source>Column</source>
         <translation>Coluna</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="41"/>
+        <location filename="../src/widgets/bottombar.cpp" line="26"/>
         <source>Characters %1</source>
         <translation>Caracteres %1</translation>
     </message>
@@ -20,9 +20,9 @@
 <context>
     <name>DDropdownMenu</name>
     <message>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="300"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="344"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="349"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="290"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="341"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="346"/>
         <source>None</source>
         <translation>Nenhum</translation>
     </message>
@@ -30,80 +30,85 @@
 <context>
     <name>EditWrapper</name>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="201"/>
-        <location filename="../src/editor/editwrapper.cpp" line="264"/>
-        <location filename="../src/editor/editwrapper.cpp" line="321"/>
-        <location filename="../src/editor/editwrapper.cpp" line="536"/>
+        <location filename="../src/editor/editwrapper.cpp" line="246"/>
+        <location filename="../src/editor/editwrapper.cpp" line="314"/>
+        <location filename="../src/editor/editwrapper.cpp" line="439"/>
+        <location filename="../src/editor/editwrapper.cpp" line="702"/>
         <source>Save</source>
         <translation>Guardar</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="316"/>
+        <location filename="../src/editor/editwrapper.cpp" line="434"/>
         <source>Do you want to save this file?</source>
         <translation>Quer guardar este ficheiro?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="262"/>
-        <location filename="../src/editor/editwrapper.cpp" line="319"/>
+        <location filename="../src/editor/editwrapper.cpp" line="312"/>
+        <location filename="../src/editor/editwrapper.cpp" line="437"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="259"/>
+        <location filename="../src/editor/editwrapper.cpp" line="309"/>
         <source>Encoding changed. Do you want to save the file now?</source>
         <translation>A codificação foi alterada. Deseja guardar o ficheiro agora?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="320"/>
+        <location filename="../src/editor/editwrapper.cpp" line="438"/>
         <source>Discard</source>
         <translation>Descartar</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="445"/>
+        <location filename="../src/editor/editwrapper.cpp" line="564"/>
         <source>You do not have permission to save %1</source>
         <translation>Não possui permissões para guardar %1</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="607"/>
+        <location filename="../src/editor/editwrapper.cpp" line="774"/>
         <source>File removed on the disk. Save it now?</source>
         <translation>Ficheiro removido no disco. Guardar agora?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="612"/>
+        <location filename="../src/editor/editwrapper.cpp" line="779"/>
         <source>File has changed on disk. Reload?</source>
         <translation>Ficheiro foi alterado no disco. Recarregar?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="634"/>
-        <location filename="../src/widgets/bottombar.cpp" line="60"/>
+        <location filename="../src/editor/editwrapper.cpp" line="801"/>
+        <location filename="../src/widgets/bottombar.cpp" line="45"/>
         <source>INSERT</source>
         <translation>INSERIR</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="637"/>
+        <location filename="../src/editor/editwrapper.cpp" line="804"/>
         <source>OVERWRITE</source>
         <translation>SOBRESCREVER</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="640"/>
+        <location filename="../src/editor/editwrapper.cpp" line="807"/>
         <source>R/O</source>
         <translation>A/L</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="945"/>
+        <source>The file cannot be read, which may be too large or has been damaged!</source>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
     <name>FindBar</name>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="40"/>
+        <location filename="../src/controls/findbar.cpp" line="22"/>
         <source>Find</source>
         <translation>Procurar</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="44"/>
+        <location filename="../src/controls/findbar.cpp" line="26"/>
         <source>Previous</source>
         <translation>Anterior</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="46"/>
+        <location filename="../src/controls/findbar.cpp" line="28"/>
         <source>Next</source>
         <translation>Seguinte</translation>
     </message>
@@ -111,7 +116,7 @@
 <context>
     <name>JumpLineBar</name>
     <message>
-        <location filename="../src/controls/jumplinebar.cpp" line="40"/>
+        <location filename="../src/controls/jumplinebar.cpp" line="28"/>
         <source>Go to Line: </source>
         <translation>Ir para linha:</translation>
     </message>
@@ -119,12 +124,12 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/editorapplication.cpp" line="27"/>
+        <location filename="../src/editorapplication.cpp" line="11"/>
         <source>Text Editor is a powerful tool for viewing and editing text files.</source>
         <translation>O Editor de texto é uma ferramenta poderosa para visualizar e editar ficheiros de texto.</translation>
     </message>
     <message>
-        <location filename="../src/editorapplication.cpp" line="38"/>
+        <location filename="../src/editorapplication.cpp" line="22"/>
         <source>Text Editor</source>
         <translation>Editor de texto</translation>
     </message>
@@ -132,572 +137,572 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/editorapplication.cpp" line="35"/>
+        <location filename="../src/editorapplication.cpp" line="19"/>
         <source>Text Editor</source>
         <translation>Editor de texto</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="203"/>
-        <location filename="../src/editor/editwrapper.cpp" line="538"/>
-        <location filename="../src/widgets/window.cpp" line="956"/>
-        <location filename="../src/widgets/window.cpp" line="973"/>
-        <location filename="../src/widgets/window.cpp" line="1064"/>
-        <location filename="../src/widgets/window.cpp" line="1079"/>
+        <location filename="../src/editor/editwrapper.cpp" line="248"/>
+        <location filename="../src/editor/editwrapper.cpp" line="704"/>
+        <location filename="../src/widgets/window.cpp" line="1089"/>
+        <location filename="../src/widgets/window.cpp" line="1111"/>
+        <location filename="../src/widgets/window.cpp" line="1203"/>
+        <location filename="../src/widgets/window.cpp" line="1218"/>
         <source>Encoding</source>
         <translation>Codificação</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="24"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="9"/>
         <source>Basic</source>
         <translation>Básico</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="25"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="10"/>
         <source>Font Style</source>
         <translation>Estilo de fonte</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="26"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="11"/>
         <source>Font</source>
         <translation>Fonte</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="27"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="12"/>
         <source>Font Size</source>
         <translation>Tamanho da fonte</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="28"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="13"/>
         <source>Shortcuts</source>
         <translation>Atalhos</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="29"/>
-        <location filename="../src/controls/settingsdialog.cpp" line="30"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="14"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="15"/>
         <source>Keymap</source>
         <translation>Esquema de teclado</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="31"/>
-        <location filename="../src/controls/settingsdialog.cpp" line="107"/>
-        <location filename="../src/widgets/window.cpp" line="1482"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="16"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="92"/>
+        <location filename="../src/widgets/window.cpp" line="1811"/>
         <source>Window</source>
         <translation>Janela</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="32"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="17"/>
         <source>New tab</source>
         <translation>Novo separador</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="33"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="18"/>
         <source>New window</source>
         <translation>Nova janela</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="34"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="19"/>
         <source>Save</source>
         <translation>Guardar</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="35"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="20"/>
         <source>Save as</source>
         <translation>Guardar como</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="36"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="21"/>
         <source>Next tab</source>
         <translation>Separador seguinte</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="37"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="22"/>
         <source>Previous tab</source>
         <translation>Separador anterior</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="38"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="23"/>
         <source>Close tab</source>
         <translation>Fechar separador</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="39"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="24"/>
         <source>Close other tabs</source>
         <translation>Fechar outros separadores</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="40"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="25"/>
         <source>Restore tab</source>
         <translation>Restaurar separador</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="41"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="26"/>
         <source>Open file</source>
         <translation>Abrir ficheiro</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="42"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="27"/>
         <source>Increment font size</source>
         <translation>Aumentar tamanho da fonte</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="43"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="28"/>
         <source>Decrement font size</source>
         <translation>Diminuir tamanho da fonte</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="44"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="29"/>
         <source>Reset font size</source>
         <translation>Redefinir tamanho da fonte</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="45"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="30"/>
         <source>Help</source>
         <translation>Ajuda</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="46"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="31"/>
         <source>Toggle fullscreen</source>
         <translation>Ativar/Desativar ecrã inteiro</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="47"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="32"/>
         <source>Find</source>
         <translation>Procurar</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="48"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="33"/>
         <source>Replace</source>
         <translation>Substituir</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="49"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="34"/>
         <source>Go to line</source>
         <translation>Ir para linha</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="50"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="35"/>
         <source>Save cursor position</source>
         <translation>Guardar posição do cursor</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="51"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="36"/>
         <source>Reset cursor position</source>
         <translation>Redefinir posição do cursor</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="52"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="37"/>
         <source>Exit</source>
         <translation>Sair</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="53"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="38"/>
         <source>Display shortcuts</source>
         <translation>Mostrar atalhos</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="54"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="39"/>
         <source>Print</source>
         <translation>Imprimir</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="55"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="40"/>
         <source>Editor</source>
         <translation>Editor</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="56"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="41"/>
         <source>Increase indent</source>
         <translation>Aumentar indentação</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="57"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="42"/>
         <source>Decrease indent</source>
         <translation>Diminuir indentação</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="58"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="43"/>
         <source>Forward character</source>
         <translation>Avançar caracter</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="59"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="44"/>
         <source>Backward character</source>
         <translation>Recuar caracter</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="60"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="45"/>
         <source>Forward word</source>
         <translation>Avançar palavra</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="61"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="46"/>
         <source>Backward word</source>
         <translation>Recuar palavra</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="62"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="47"/>
         <source>Next line</source>
         <translation>Linha seguinte</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="63"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="48"/>
         <source>Previous line</source>
         <translation>Linha anterior</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="64"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="49"/>
         <source>New line</source>
         <translation>Nova linha</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="65"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="50"/>
         <source>New line above</source>
         <translation>Nova linha acima</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="66"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="51"/>
         <source>New line below</source>
         <translation>Nova linha abaixo</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="67"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="52"/>
         <source>Duplicate line</source>
         <translation>Duplicar linha</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="68"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="53"/>
         <source>Delete to end of line</source>
         <translation>Eliminar até ao fim da linha</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="69"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="54"/>
         <source>Delete current line</source>
         <translation>Eliminar esta linha</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="70"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="55"/>
         <source>Swap line up</source>
         <translation>Trocar para linha acima</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="71"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="56"/>
         <source>Swap line down</source>
         <translation>Trocar para linha abaixo</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="72"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="57"/>
         <source>Scroll up one line</source>
         <translation>Rolar uma linha para cima</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="73"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="58"/>
         <source>Scroll down one line</source>
         <translation>Rolar uma linha para baixo</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="74"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="59"/>
         <source>Page up</source>
         <translation>Página acima</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="75"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="60"/>
         <source>Page down</source>
         <translation>Página abaixo</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="76"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="61"/>
         <source>Move to end of line</source>
         <translation>Mover para o fim da linha</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="77"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="62"/>
         <source>Move to start of line</source>
         <translation>Mover para o início da linha</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="78"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="63"/>
         <source>Move to end of text</source>
         <translation>Mover para o fim do texto</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="79"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="64"/>
         <source>Move to start of text</source>
         <translation>Mover para o início do texto</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="80"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="65"/>
         <source>Move to line indentation</source>
         <translation>Mover para indentação da linha</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="81"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="66"/>
         <source>Upper case</source>
         <translation>Maiúsculas</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="82"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="67"/>
         <source>Lower case</source>
         <translation>Minúsculas</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="83"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="68"/>
         <source>Capitalize</source>
         <translation>Maiúsculas</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="84"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="69"/>
         <source>Delete backward word</source>
         <translation>Eliminar palavra anterior</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="85"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="70"/>
         <source>Delete forward word</source>
         <translation>Eliminar palavra seguinte</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="86"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="71"/>
         <source>Forward over a pair</source>
         <translation>Avançar em pares</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="87"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="72"/>
         <source>Backward over a pair</source>
         <translation>Recuar em pares</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="88"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="73"/>
         <source>Select all</source>
         <translation>Selecionar tudo</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="89"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="74"/>
         <source>Copy</source>
         <translation>Copiar</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="90"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="75"/>
         <source>Cut</source>
         <translation>Cortar</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="91"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="76"/>
         <source>Paste</source>
         <translation>Colar</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="92"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="77"/>
         <source>Transpose character</source>
         <translation>Transpor caracter</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="93"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="78"/>
         <source>Mark</source>
         <translation>Marcar</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="94"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="79"/>
         <source>Unmark</source>
         <translation>Desmarcar</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="95"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="80"/>
         <source>Copy line</source>
         <translation>Copiar linha</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="96"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="81"/>
         <source>Cut line</source>
         <translation>Cortar linha</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="97"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="82"/>
         <source>Merge lines</source>
         <translation>Juntar linhas</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="98"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="83"/>
         <source>Read-Only mode</source>
         <translation>Modo de Apenas-Leitura</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="99"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="84"/>
         <source>Add comment</source>
         <translation>Adicionar comentário</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="100"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="85"/>
         <source>Remove comment</source>
         <translation>Remover comentário</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="101"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="86"/>
         <source>Undo</source>
         <translation>Anular</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="102"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="87"/>
         <source>Redo</source>
         <translation>Refazer</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="103"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="88"/>
         <source>Add/Remove bookmark</source>
         <translation>Adicionador/Remover marcador</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="104"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="89"/>
         <source>Move to previous bookmark</source>
         <translation>Mover para o marcador anterior</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="105"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="90"/>
         <source>Move to next bookmark</source>
         <translation>Mover para o marcador seguinte</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="106"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="91"/>
         <source>Advanced</source>
         <translation>Avançado</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="108"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="93"/>
         <source>Window size</source>
         <translation>Tamanho da janela</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="109"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="94"/>
         <source>Tab width</source>
         <translation>Largura do separador</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="111"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="96"/>
         <source>Word wrap</source>
         <translation>Quebra de linha</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="112"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="97"/>
         <source>Code folding flag</source>
         <translation>Marcador de código minimizado</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="113"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="98"/>
         <source>Show line numbers</source>
         <translation>Mostrar números de linha</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="114"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="99"/>
         <source>Show bookmarks icon</source>
         <translation>Mostrar ícone de marcadores</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="115"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="100"/>
         <source>Show whitespaces and tabs</source>
         <translation>Mostrar espaços em branco e separadores</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="116"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="101"/>
         <source>Highlight current line</source>
         <translation>Destacar a linha atual</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="117"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="102"/>
         <source>Color mark</source>
         <translation>Marca de cor</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="120"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="105"/>
         <source>Unicode</source>
         <translation>Unicode</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="121"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="106"/>
         <source>WesternEuropean</source>
         <translation>EuropeuOcidental</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="122"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="107"/>
         <source>CentralEuropean</source>
         <translation>CentroEuropeu</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="123"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="108"/>
         <source>Baltic</source>
         <translation>Báltico</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="124"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="109"/>
         <source>Cyrillic</source>
         <translation>Cirílico</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="125"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="110"/>
         <source>Arabic</source>
         <translation>Árabe</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="130"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="115"/>
         <source>Celtic</source>
         <translation>Celta</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="131"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="116"/>
         <source>SouthEasternEuropean</source>
         <translation>SudesteEuropeu</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="126"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="111"/>
         <source>Greek</source>
         <translation>Grego</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="127"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="112"/>
         <source>Hebrew</source>
         <translation>Hebraico</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="132"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="117"/>
         <source>ChineseSimplified</source>
         <translation>ChinêsSimplificado</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="133"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="118"/>
         <source>ChineseTraditional</source>
         <translation>ChinêsTradicional</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="134"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="119"/>
         <source>Japanese</source>
         <translation>Japonês</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="135"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="120"/>
         <source>Korean</source>
         <translation>Coreano</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="129"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="114"/>
         <source>Thai</source>
         <translation>Tailandês</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="128"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="113"/>
         <source>Turkish</source>
         <translation>Turco</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="136"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="121"/>
         <source>Vietnamese</source>
         <translation>Vietnamita</translation>
     </message>
     <message>
-        <location filename="../src/startmanager.cpp" line="762"/>
+        <location filename="../src/startmanager.cpp" line="832"/>
         <source>File not saved</source>
         <translation>Ficheiro não guardado</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="974"/>
-        <location filename="../src/widgets/window.cpp" line="1065"/>
-        <location filename="../src/widgets/window.cpp" line="1080"/>
+        <location filename="../src/widgets/window.cpp" line="1112"/>
+        <location filename="../src/widgets/window.cpp" line="1204"/>
+        <location filename="../src/widgets/window.cpp" line="1219"/>
         <source>Line Endings</source>
         <translation>Terminações de linha</translation>
     </message>
@@ -705,32 +710,32 @@
 <context>
     <name>ReplaceBar</name>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="39"/>
+        <location filename="../src/controls/replacebar.cpp" line="21"/>
         <source>Find</source>
         <translation>Localizar</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="43"/>
+        <location filename="../src/controls/replacebar.cpp" line="25"/>
         <source>Replace With</source>
         <translation>Substituir por</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="47"/>
+        <location filename="../src/controls/replacebar.cpp" line="29"/>
         <source>Replace</source>
         <translation>Substituir</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="50"/>
+        <location filename="../src/controls/replacebar.cpp" line="32"/>
         <source>Skip</source>
         <translation>Ignorar</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="53"/>
+        <location filename="../src/controls/replacebar.cpp" line="35"/>
         <source>Replace Rest</source>
         <translation>Substituir restantes</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="56"/>
+        <location filename="../src/controls/replacebar.cpp" line="38"/>
         <source>Replace All</source>
         <translation>Substituir todos</translation>
     </message>
@@ -747,58 +752,58 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../src/common/settings.cpp" line="91"/>
+        <location filename="../src/common/settings.cpp" line="115"/>
         <source>Standard</source>
         <translation>Predefinição</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="91"/>
+        <location filename="../src/common/settings.cpp" line="115"/>
         <source>Customize</source>
         <translation>Personalizar</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="104"/>
+        <location filename="../src/common/settings.cpp" line="128"/>
         <source>Normal</source>
         <translation>Normal</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="104"/>
+        <location filename="../src/common/settings.cpp" line="128"/>
         <source>Maximum</source>
         <translation>Máximo</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="104"/>
+        <location filename="../src/common/settings.cpp" line="128"/>
         <source>Fullscreen</source>
         <translation>Ecrã Inteiro</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="292"/>
+        <location filename="../src/common/settings.cpp" line="316"/>
         <source>This shortcut conflicts with system shortcut %1</source>
         <translation>Este atalho entra em conflito com o atalho do sistema %1</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="294"/>
+        <location filename="../src/common/settings.cpp" line="318"/>
         <source>This shortcut conflicts with %1, click on Replace to make this shortcut effective immediately</source>
         <translation>Esta tecla de atalho entra em conflito com %1, clique em Substituir para que esta tecla de atalho entre em vigor imediatamente</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="410"/>
-        <location filename="../src/common/settings.cpp" line="418"/>
+        <location filename="../src/common/settings.cpp" line="464"/>
+        <location filename="../src/common/settings.cpp" line="472"/>
         <source>The shortcut %1 is invalid, please set another one.</source>
         <translation>O atalho %1 é inválido, defina outro.</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="445"/>
+        <location filename="../src/common/settings.cpp" line="507"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="446"/>
+        <location filename="../src/common/settings.cpp" line="508"/>
         <source>Replace</source>
         <translation>Substituir</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="448"/>
+        <location filename="../src/common/settings.cpp" line="510"/>
         <source>OK</source>
         <translation>Aceitar</translation>
     </message>
@@ -806,7 +811,7 @@
 <context>
     <name>StartManager</name>
     <message>
-        <location filename="../src/startmanager.cpp" line="340"/>
+        <location filename="../src/startmanager.cpp" line="350"/>
         <source>Untitled %1</source>
         <translation>Sem título %1</translation>
     </message>
@@ -814,32 +819,32 @@
 <context>
     <name>Tabbar</name>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="515"/>
+        <location filename="../src/controls/tabbar.cpp" line="540"/>
         <source>Close tab</source>
         <translation>Fechar separador</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="516"/>
+        <location filename="../src/controls/tabbar.cpp" line="541"/>
         <source>Close other tabs</source>
         <translation>Fechar outros separadores</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="517"/>
+        <location filename="../src/controls/tabbar.cpp" line="542"/>
         <source>More options</source>
         <translation>Mais opções</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="518"/>
+        <location filename="../src/controls/tabbar.cpp" line="543"/>
         <source>Close tabs to the left</source>
         <translation>Fechar separadores à esquerda</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="519"/>
+        <location filename="../src/controls/tabbar.cpp" line="544"/>
         <source>Close tabs to the right</source>
         <translation>Fechar separadores à direita</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="520"/>
+        <location filename="../src/controls/tabbar.cpp" line="545"/>
         <source>Close unmodified tabs</source>
         <translation>Fechar separadores não modificados</translation>
     </message>
@@ -847,261 +852,259 @@
 <context>
     <name>TextEdit</name>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="235"/>
+        <location filename="../src/editor/dtextedit.cpp" line="259"/>
         <source>Undo</source>
         <translation>Anular</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="236"/>
+        <location filename="../src/editor/dtextedit.cpp" line="260"/>
         <source>Redo</source>
         <translation>Refazer</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="237"/>
+        <location filename="../src/editor/dtextedit.cpp" line="261"/>
         <source>Cut</source>
         <translation>Cortar</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="238"/>
+        <location filename="../src/editor/dtextedit.cpp" line="262"/>
         <source>Copy</source>
         <translation>Copiar</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="239"/>
+        <location filename="../src/editor/dtextedit.cpp" line="263"/>
         <source>Paste</source>
         <translation>Colar</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="240"/>
+        <location filename="../src/editor/dtextedit.cpp" line="264"/>
         <source>Delete</source>
         <translation>Eliminar</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="241"/>
+        <location filename="../src/editor/dtextedit.cpp" line="265"/>
         <source>Select All</source>
         <translation>Selecionar tudo</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="242"/>
-        <location filename="../src/widgets/window.cpp" line="361"/>
+        <location filename="../src/editor/dtextedit.cpp" line="266"/>
+        <location filename="../src/widgets/window.cpp" line="450"/>
         <source>Find</source>
         <translation>Procurar</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="243"/>
-        <location filename="../src/widgets/window.cpp" line="362"/>
+        <location filename="../src/editor/dtextedit.cpp" line="267"/>
+        <location filename="../src/widgets/window.cpp" line="451"/>
         <source>Replace</source>
         <translation>Substituir</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="244"/>
+        <location filename="../src/editor/dtextedit.cpp" line="268"/>
         <source>Go to Line</source>
         <translation>Ir para linha</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="245"/>
+        <location filename="../src/editor/dtextedit.cpp" line="269"/>
         <source>Turn on Read-Only mode</source>
         <translation>Ativar modo de Apenas-Leitura</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="246"/>
+        <location filename="../src/editor/dtextedit.cpp" line="270"/>
         <source>Turn off Read-Only mode</source>
         <translation>Desativar modo de Apenas-Leitura</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="247"/>
+        <location filename="../src/editor/dtextedit.cpp" line="271"/>
         <source>Fullscreen</source>
         <translation>Ecrã inteiro</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="248"/>
+        <location filename="../src/editor/dtextedit.cpp" line="272"/>
         <source>Exit fullscreen</source>
         <translation>Sair de ecrã inteiro</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="249"/>
+        <location filename="../src/editor/dtextedit.cpp" line="273"/>
         <source>Display in file manager</source>
         <translation>Mostrar no gestor de ficheiros</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="250"/>
-        <location filename="../src/editor/dtextedit.cpp" line="302"/>
+        <location filename="../src/editor/dtextedit.cpp" line="274"/>
+        <location filename="../src/editor/dtextedit.cpp" line="326"/>
         <source>Add Comment</source>
         <translation>Adicionar comentário</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="251"/>
+        <location filename="../src/editor/dtextedit.cpp" line="275"/>
         <source>Text to Speech</source>
         <translation>Texto para voz</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="252"/>
+        <location filename="../src/editor/dtextedit.cpp" line="276"/>
         <source>Stop reading</source>
         <translation>Parar a leitura</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="253"/>
+        <location filename="../src/editor/dtextedit.cpp" line="277"/>
         <source>Speech to Text</source>
         <translation>Voz para texto</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="254"/>
+        <location filename="../src/editor/dtextedit.cpp" line="278"/>
         <source>Translate</source>
         <translation>Traduzir</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="255"/>
+        <location filename="../src/editor/dtextedit.cpp" line="279"/>
         <source>Column Mode</source>
         <translation>Modo de coluna</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="256"/>
+        <location filename="../src/editor/dtextedit.cpp" line="280"/>
         <source>Add bookmark</source>
         <translation>Adicionador marcador</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="257"/>
+        <location filename="../src/editor/dtextedit.cpp" line="281"/>
         <source>Remove Bookmark</source>
         <translation>Remover marcador</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="258"/>
+        <location filename="../src/editor/dtextedit.cpp" line="282"/>
         <source>Previous bookmark</source>
         <translation>Marcador anterior</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="259"/>
+        <location filename="../src/editor/dtextedit.cpp" line="283"/>
         <source>Next bookmark</source>
         <translation>Marcador seguinte</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="260"/>
+        <location filename="../src/editor/dtextedit.cpp" line="284"/>
         <source>Remove All Bookmarks</source>
         <translation>Remover todos os marcadores</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="261"/>
+        <location filename="../src/editor/dtextedit.cpp" line="285"/>
         <source>Fold All</source>
         <translation>Minimizar tudo</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="262"/>
+        <location filename="../src/editor/dtextedit.cpp" line="286"/>
         <source>Fold Current Level</source>
         <translation>Minimizar nível atual</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="263"/>
+        <location filename="../src/editor/dtextedit.cpp" line="287"/>
         <source>Unfold All</source>
         <translation>Mostrar tudo</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="264"/>
+        <location filename="../src/editor/dtextedit.cpp" line="288"/>
         <source>Unfold Current Level</source>
         <translation>Mostrar nível atual</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="269"/>
+        <location filename="../src/editor/dtextedit.cpp" line="293"/>
         <source>Color Mark</source>
         <translation>Marca de cor</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="273"/>
+        <location filename="../src/editor/dtextedit.cpp" line="297"/>
         <source>Clear All Marks</source>
         <translation>Limpar selecionados</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="274"/>
+        <location filename="../src/editor/dtextedit.cpp" line="298"/>
         <source>Clear Last Mark</source>
         <translation>Limpar último selecionado</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="283"/>
+        <location filename="../src/editor/dtextedit.cpp" line="307"/>
         <source>Mark</source>
         <translation>Marcar</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="295"/>
+        <location filename="../src/editor/dtextedit.cpp" line="319"/>
         <source>Mark All</source>
         <translation>Marcar tudo</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="303"/>
+        <location filename="../src/editor/dtextedit.cpp" line="327"/>
         <source>Remove Comment</source>
         <translation>Remover comentário</translation>
     </message>
     <message>
-        <source>Failed to paste text: it is too large</source>
-        <translation type="vanished">Falha ao colar texto: é demasiado grande</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="2581"/>
+        <location filename="../src/editor/dtextedit.cpp" line="2672"/>
         <source>Copy failed: not enough memory</source>
         <translation>Falha ao copiar: não há memória suficiente</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="2665"/>
+        <location filename="../src/editor/dtextedit.cpp" line="2756"/>
         <source>Press ALT and click lines to edit in column mode</source>
         <translation>Prima ALT e clique em linhas para editar em modo de coluna</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="346"/>
+        <location filename="../src/editor/dtextedit.cpp" line="370"/>
         <source>Change Case</source>
         <translation>Maiúsculas e Minúsculas</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="347"/>
+        <location filename="../src/editor/dtextedit.cpp" line="371"/>
         <source>Upper Case</source>
         <translation>Maiúsculas</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="348"/>
+        <location filename="../src/editor/dtextedit.cpp" line="372"/>
         <source>Lower Case</source>
         <translation>Minúsculas</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="349"/>
+        <location filename="../src/editor/dtextedit.cpp" line="373"/>
         <source>Capitalize</source>
         <translation>Maiúsculas</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="64"/>
+        <location filename="../src/widgets/bottombar.cpp" line="49"/>
         <source>None</source>
         <translation>Nenhum</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1184"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1222"/>
         <source>Selected line(s) copied</source>
         <translation>Linha(s) selecionada(s) copiada(s)</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1190"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1228"/>
         <source>Current line copied</source>
         <translation>Linha atual copiada</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1210"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1248"/>
         <source>Selected line(s) clipped</source>
         <translation>Linha(s) selecionada(s) cortada(s)</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1222"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1259"/>
         <source>Current line clipped</source>
         <translation>Linha atual cortada</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="2591"/>
+        <location filename="../src/editor/dtextedit.cpp" line="2682"/>
         <source>Paste failed: not enough memory</source>
         <translation>Falha ao colar: memória insuficiente</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3439"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3617"/>
         <source>Read-Only mode is off</source>
         <translation>O modo de Apenas-Leitura está desligado</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3446"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3465"/>
-        <location filename="../src/editor/dtextedit.cpp" line="6150"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3624"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3643"/>
+        <location filename="../src/editor/dtextedit.cpp" line="6656"/>
+        <location filename="../src/editor/dtextedit.cpp" line="6664"/>
+        <location filename="../src/editor/dtextedit.cpp" line="6675"/>
         <source>Read-Only mode is on</source>
         <translation>O modo de Apenas-Leitura está ligado</translation>
     </message>
@@ -1109,7 +1112,7 @@
 <context>
     <name>WarningNotices</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="36"/>
+        <location filename="../src/controls/warningnotices.cpp" line="19"/>
         <source>Reload</source>
         <translation>Recarregar</translation>
     </message>
@@ -1117,129 +1120,130 @@
 <context>
     <name>Window</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="38"/>
-        <location filename="../src/widgets/window.cpp" line="357"/>
+        <location filename="../src/controls/warningnotices.cpp" line="21"/>
+        <location filename="../src/widgets/window.cpp" line="446"/>
         <source>Save as</source>
         <translation>Guardar como</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="353"/>
+        <location filename="../src/widgets/window.cpp" line="442"/>
         <source>New window</source>
         <translation>Nova janela</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="354"/>
+        <location filename="../src/widgets/window.cpp" line="443"/>
         <source>New tab</source>
         <translation>Novo separador</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="355"/>
+        <location filename="../src/widgets/window.cpp" line="444"/>
         <source>Open file</source>
         <translation>Abrir ficheiro</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="356"/>
-        <location filename="../src/widgets/window.cpp" line="2217"/>
+        <location filename="../src/widgets/window.cpp" line="445"/>
+        <location filename="../src/widgets/window.cpp" line="2796"/>
         <source>Save</source>
         <translation>Guardar</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="358"/>
+        <location filename="../src/widgets/window.cpp" line="447"/>
         <source>Print</source>
         <translation>Imprimir</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="359"/>
+        <location filename="../src/widgets/window.cpp" line="448"/>
         <source>Switch theme</source>
         <translation>Alterar tema</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="360"/>
-        <location filename="../src/widgets/window.cpp" line="1542"/>
+        <location filename="../src/widgets/window.cpp" line="449"/>
+        <location filename="../src/widgets/window.cpp" line="1871"/>
         <source>Settings</source>
         <translation>Definições</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="471"/>
-        <location filename="../src/widgets/window.cpp" line="2468"/>
+        <location filename="../src/widgets/window.cpp" line="563"/>
+        <location filename="../src/widgets/window.cpp" line="3047"/>
         <source>Read-Only</source>
         <translation>Apenas-Leitura</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="487"/>
+        <location filename="../src/widgets/window.cpp" line="579"/>
         <source>You do not have permission to open %1</source>
         <translation>Não possui permissões para abrir %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="522"/>
+        <location filename="../src/widgets/window.cpp" line="619"/>
+        <location filename="../src/widgets/window.cpp" line="2359"/>
         <source>Invalid file: %1</source>
         <translation>Ficheiro inválido: %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="602"/>
-        <location filename="../src/widgets/window.cpp" line="644"/>
+        <location filename="../src/widgets/window.cpp" line="733"/>
+        <location filename="../src/widgets/window.cpp" line="779"/>
         <source>Do you want to save this file?</source>
         <translation>Quer guardar este ficheiro?</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="894"/>
+        <location filename="../src/widgets/window.cpp" line="1027"/>
         <source>You do not have permission to save %1</source>
         <translation>Não possui permissões para guardar %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="918"/>
+        <location filename="../src/widgets/window.cpp" line="1051"/>
         <source>Saved successfully</source>
         <translation>Gravado com sucesso</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="954"/>
-        <location filename="../src/widgets/window.cpp" line="1021"/>
-        <location filename="../src/widgets/window.cpp" line="1062"/>
+        <location filename="../src/widgets/window.cpp" line="1087"/>
+        <location filename="../src/widgets/window.cpp" line="1160"/>
+        <location filename="../src/widgets/window.cpp" line="1201"/>
         <source>Save File</source>
         <translation>Guardar ficheiro</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1023"/>
+        <location filename="../src/widgets/window.cpp" line="1162"/>
         <source>Encoding</source>
         <translation>Codificação</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1211"/>
+        <location filename="../src/widgets/window.cpp" line="1350"/>
         <source>Read-Only mode is on</source>
         <translation>O modo de Apenas-Leitura está ligado</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1441"/>
+        <location filename="../src/widgets/window.cpp" line="1770"/>
         <source>Current location remembered</source>
         <translation>Localização atual memorizada</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1492"/>
+        <location filename="../src/widgets/window.cpp" line="1821"/>
         <source>Ctrl+&apos;=&apos;</source>
         <translation>Ctrl+&apos;=&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1495"/>
+        <location filename="../src/widgets/window.cpp" line="1824"/>
         <source>Ctrl+&apos;-&apos;</source>
         <translation>Ctrl+&apos;-&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1524"/>
+        <location filename="../src/widgets/window.cpp" line="1853"/>
         <source>Editor</source>
         <translation>Editor</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1890"/>
+        <location filename="../src/widgets/window.cpp" line="2451"/>
         <source>Untitled %1</source>
         <translation>Sem título %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2215"/>
+        <location filename="../src/widgets/window.cpp" line="2794"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2216"/>
+        <location filename="../src/widgets/window.cpp" line="2795"/>
         <source>Discard</source>
         <translation>Descartar</translation>
     </message>

--- a/translations/deepin-editor_ru.ts
+++ b/translations/deepin-editor_ru.ts
@@ -2,17 +2,17 @@
 <context>
     <name>BottomBar</name>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="39"/>
+        <location filename="../src/widgets/bottombar.cpp" line="24"/>
         <source>Row</source>
         <translation>Строка</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="40"/>
+        <location filename="../src/widgets/bottombar.cpp" line="25"/>
         <source>Column</source>
         <translation>Столбец</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="41"/>
+        <location filename="../src/widgets/bottombar.cpp" line="26"/>
         <source>Characters %1</source>
         <translation>Символы %1</translation>
     </message>
@@ -20,9 +20,9 @@
 <context>
     <name>DDropdownMenu</name>
     <message>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="300"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="344"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="349"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="290"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="341"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="346"/>
         <source>None</source>
         <translation>Ничего</translation>
     </message>
@@ -30,80 +30,85 @@
 <context>
     <name>EditWrapper</name>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="201"/>
-        <location filename="../src/editor/editwrapper.cpp" line="264"/>
-        <location filename="../src/editor/editwrapper.cpp" line="321"/>
-        <location filename="../src/editor/editwrapper.cpp" line="536"/>
+        <location filename="../src/editor/editwrapper.cpp" line="246"/>
+        <location filename="../src/editor/editwrapper.cpp" line="314"/>
+        <location filename="../src/editor/editwrapper.cpp" line="439"/>
+        <location filename="../src/editor/editwrapper.cpp" line="702"/>
         <source>Save</source>
         <translation>Сохранить</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="316"/>
+        <location filename="../src/editor/editwrapper.cpp" line="434"/>
         <source>Do you want to save this file?</source>
         <translation>Вы хотите сохранить этот документ?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="262"/>
-        <location filename="../src/editor/editwrapper.cpp" line="319"/>
+        <location filename="../src/editor/editwrapper.cpp" line="312"/>
+        <location filename="../src/editor/editwrapper.cpp" line="437"/>
         <source>Cancel</source>
         <translation>Отмена</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="259"/>
+        <location filename="../src/editor/editwrapper.cpp" line="309"/>
         <source>Encoding changed. Do you want to save the file now?</source>
         <translation>Кодирование изменилось. Вы хотите сохранить файл сейчас?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="320"/>
+        <location filename="../src/editor/editwrapper.cpp" line="438"/>
         <source>Discard</source>
         <translation>Забыть</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="445"/>
+        <location filename="../src/editor/editwrapper.cpp" line="564"/>
         <source>You do not have permission to save %1</source>
         <translation>Вы не имеете разрешения на сохранение %1</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="607"/>
+        <location filename="../src/editor/editwrapper.cpp" line="774"/>
         <source>File removed on the disk. Save it now?</source>
         <translation>Файл удален на диске. Сохранить его сейчас?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="612"/>
+        <location filename="../src/editor/editwrapper.cpp" line="779"/>
         <source>File has changed on disk. Reload?</source>
         <translation>Файл изменился на диске. Обновить?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="634"/>
-        <location filename="../src/widgets/bottombar.cpp" line="60"/>
+        <location filename="../src/editor/editwrapper.cpp" line="801"/>
+        <location filename="../src/widgets/bottombar.cpp" line="45"/>
         <source>INSERT</source>
         <translation>ВСТАВИТЬ</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="637"/>
+        <location filename="../src/editor/editwrapper.cpp" line="804"/>
         <source>OVERWRITE</source>
         <translation>ПЕРЕЗАПИСАТЬ</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="640"/>
+        <location filename="../src/editor/editwrapper.cpp" line="807"/>
         <source>R/O</source>
         <translation>Т/Ч</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="945"/>
+        <source>The file cannot be read, which may be too large or has been damaged!</source>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
     <name>FindBar</name>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="40"/>
+        <location filename="../src/controls/findbar.cpp" line="22"/>
         <source>Find</source>
         <translation>Найти</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="44"/>
+        <location filename="../src/controls/findbar.cpp" line="26"/>
         <source>Previous</source>
         <translation>Предыдущий</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="46"/>
+        <location filename="../src/controls/findbar.cpp" line="28"/>
         <source>Next</source>
         <translation>Следующий</translation>
     </message>
@@ -111,7 +116,7 @@
 <context>
     <name>JumpLineBar</name>
     <message>
-        <location filename="../src/controls/jumplinebar.cpp" line="40"/>
+        <location filename="../src/controls/jumplinebar.cpp" line="28"/>
         <source>Go to Line: </source>
         <translation>Перейти к Строке:</translation>
     </message>
@@ -119,12 +124,12 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/editorapplication.cpp" line="27"/>
+        <location filename="../src/editorapplication.cpp" line="11"/>
         <source>Text Editor is a powerful tool for viewing and editing text files.</source>
         <translation>Текстовый редактор - это мощный инструмент для просмотра и редактирования текстовых файлов.</translation>
     </message>
     <message>
-        <location filename="../src/editorapplication.cpp" line="38"/>
+        <location filename="../src/editorapplication.cpp" line="22"/>
         <source>Text Editor</source>
         <translation>Текстовый Редактор</translation>
     </message>
@@ -132,572 +137,572 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/editorapplication.cpp" line="35"/>
+        <location filename="../src/editorapplication.cpp" line="19"/>
         <source>Text Editor</source>
         <translation>Текстовый редактор</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="203"/>
-        <location filename="../src/editor/editwrapper.cpp" line="538"/>
-        <location filename="../src/widgets/window.cpp" line="956"/>
-        <location filename="../src/widgets/window.cpp" line="973"/>
-        <location filename="../src/widgets/window.cpp" line="1064"/>
-        <location filename="../src/widgets/window.cpp" line="1079"/>
+        <location filename="../src/editor/editwrapper.cpp" line="248"/>
+        <location filename="../src/editor/editwrapper.cpp" line="704"/>
+        <location filename="../src/widgets/window.cpp" line="1089"/>
+        <location filename="../src/widgets/window.cpp" line="1111"/>
+        <location filename="../src/widgets/window.cpp" line="1203"/>
+        <location filename="../src/widgets/window.cpp" line="1218"/>
         <source>Encoding</source>
         <translation>Кодировка</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="24"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="9"/>
         <source>Basic</source>
         <translation>Основной</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="25"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="10"/>
         <source>Font Style</source>
         <translation>Стиль Шрифта</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="26"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="11"/>
         <source>Font</source>
         <translation>Шрифт</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="27"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="12"/>
         <source>Font Size</source>
         <translation>Размер Шрифта</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="28"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="13"/>
         <source>Shortcuts</source>
         <translation>Горячие Клавиши</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="29"/>
-        <location filename="../src/controls/settingsdialog.cpp" line="30"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="14"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="15"/>
         <source>Keymap</source>
         <translation>Раскладка</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="31"/>
-        <location filename="../src/controls/settingsdialog.cpp" line="107"/>
-        <location filename="../src/widgets/window.cpp" line="1482"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="16"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="92"/>
+        <location filename="../src/widgets/window.cpp" line="1811"/>
         <source>Window</source>
         <translation>Окно</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="32"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="17"/>
         <source>New tab</source>
         <translation>Новая вкладка</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="33"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="18"/>
         <source>New window</source>
         <translation>Новое окно</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="34"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="19"/>
         <source>Save</source>
         <translation>Сохранить</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="35"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="20"/>
         <source>Save as</source>
         <translation>Сохранить как</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="36"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="21"/>
         <source>Next tab</source>
         <translation>Следующая вкладка</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="37"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="22"/>
         <source>Previous tab</source>
         <translation>Предыдущая вкладка</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="38"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="23"/>
         <source>Close tab</source>
         <translation>Закрыть вкладку</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="39"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="24"/>
         <source>Close other tabs</source>
         <translation>Закрыть другие вкладки</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="40"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="25"/>
         <source>Restore tab</source>
         <translation>Восстановить вкладки</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="41"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="26"/>
         <source>Open file</source>
         <translation>Открыть файл</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="42"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="27"/>
         <source>Increment font size</source>
         <translation>Увеличить размер шрифта</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="43"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="28"/>
         <source>Decrement font size</source>
         <translation>Уменьшить размер шрифта</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="44"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="29"/>
         <source>Reset font size</source>
         <translation>Сбросить размер шрифта</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="45"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="30"/>
         <source>Help</source>
         <translation>Помощь</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="46"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="31"/>
         <source>Toggle fullscreen</source>
         <translation>Включить полноэкранный режим</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="47"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="32"/>
         <source>Find</source>
         <translation>Найти</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="48"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="33"/>
         <source>Replace</source>
         <translation>Заменить</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="49"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="34"/>
         <source>Go to line</source>
         <translation>Перейти к строке</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="50"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="35"/>
         <source>Save cursor position</source>
         <translation>Сохранить позицию курсора</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="51"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="36"/>
         <source>Reset cursor position</source>
         <translation>Сбросить позицию курсора</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="52"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="37"/>
         <source>Exit</source>
         <translation>Выйти</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="53"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="38"/>
         <source>Display shortcuts</source>
         <translation>Показать горячие клавиши</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="54"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="39"/>
         <source>Print</source>
         <translation>Печать</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="55"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="40"/>
         <source>Editor</source>
         <translation>Редактор</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="56"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="41"/>
         <source>Increase indent</source>
         <translation>Показать ярлыки</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="57"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="42"/>
         <source>Decrease indent</source>
         <translation>Уменьшить отступ</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="58"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="43"/>
         <source>Forward character</source>
         <translation>Символ спереди</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="59"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="44"/>
         <source>Backward character</source>
         <translation>Символ задом наперёд</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="60"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="45"/>
         <source>Forward word</source>
         <translation>Начальное слово</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="61"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="46"/>
         <source>Backward word</source>
         <translation>Последнее слово</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="62"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="47"/>
         <source>Next line</source>
         <translation>Следующая строка</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="63"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="48"/>
         <source>Previous line</source>
         <translation>Предыдущая строка</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="64"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="49"/>
         <source>New line</source>
         <translation>Новая строка</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="65"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="50"/>
         <source>New line above</source>
         <translation>Новая строка выше</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="66"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="51"/>
         <source>New line below</source>
         <translation>Новая строка ниже</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="67"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="52"/>
         <source>Duplicate line</source>
         <translation>Дублированная строка</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="68"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="53"/>
         <source>Delete to end of line</source>
         <translation>Удалить конец строки</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="69"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="54"/>
         <source>Delete current line</source>
         <translation>Удалить текущую строку</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="70"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="55"/>
         <source>Swap line up</source>
         <translation>заменить верхнюю строку</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="71"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="56"/>
         <source>Swap line down</source>
         <translation>Заменить нижнюю строку</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="72"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="57"/>
         <source>Scroll up one line</source>
         <translation>Прокрутка вверх на одну строку</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="73"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="58"/>
         <source>Scroll down one line</source>
         <translation>Прокрутка вниз на одну строку</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="74"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="59"/>
         <source>Page up</source>
         <translation>Страница вверх</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="75"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="60"/>
         <source>Page down</source>
         <translation>Страница вниз</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="76"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="61"/>
         <source>Move to end of line</source>
         <translation>Переход к конецу строки</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="77"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="62"/>
         <source>Move to start of line</source>
         <translation>Переход к началу строки</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="78"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="63"/>
         <source>Move to end of text</source>
         <translation>Переход к концу текста</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="79"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="64"/>
         <source>Move to start of text</source>
         <translation>Переход к началу текста</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="80"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="65"/>
         <source>Move to line indentation</source>
         <translation>Переход к строке отступа</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="81"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="66"/>
         <source>Upper case</source>
         <translation>Верхний регистр</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="82"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="67"/>
         <source>Lower case</source>
         <translation>Нижний регистр</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="83"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="68"/>
         <source>Capitalize</source>
         <translation>Прописной</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="84"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="69"/>
         <source>Delete backward word</source>
         <translation>Удалить слово с конца</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="85"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="70"/>
         <source>Delete forward word</source>
         <translation>Удалить слово с начала</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="86"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="71"/>
         <source>Forward over a pair</source>
         <translation>Вперед по паре</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="87"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="72"/>
         <source>Backward over a pair</source>
         <translation>Назад по паре</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="88"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="73"/>
         <source>Select all</source>
         <translation>Выбрать всё</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="89"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="74"/>
         <source>Copy</source>
         <translation>Копировать</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="90"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="75"/>
         <source>Cut</source>
         <translation>Вырезать</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="91"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="76"/>
         <source>Paste</source>
         <translation>Вставить</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="92"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="77"/>
         <source>Transpose character</source>
         <translation>Перемещаемый символ</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="93"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="78"/>
         <source>Mark</source>
         <translation>Пометить</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="94"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="79"/>
         <source>Unmark</source>
         <translation>Снять отметку</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="95"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="80"/>
         <source>Copy line</source>
         <translation>Копировать строку</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="96"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="81"/>
         <source>Cut line</source>
         <translation>Вырезать строку</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="97"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="82"/>
         <source>Merge lines</source>
         <translation>Совместить строки</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="98"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="83"/>
         <source>Read-Only mode</source>
         <translation>Режим Только Чтение</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="99"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="84"/>
         <source>Add comment</source>
         <translation>Добавить комментарий</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="100"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="85"/>
         <source>Remove comment</source>
         <translation>Удалить комментарий</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="101"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="86"/>
         <source>Undo</source>
         <translation>Отменить</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="102"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="87"/>
         <source>Redo</source>
         <translation>Готово</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="103"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="88"/>
         <source>Add/Remove bookmark</source>
         <translation>Добавить/удалить закладку</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="104"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="89"/>
         <source>Move to previous bookmark</source>
         <translation>К предыдущей закладке</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="105"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="90"/>
         <source>Move to next bookmark</source>
         <translation>К следующей закладке</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="106"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="91"/>
         <source>Advanced</source>
         <translation>Расширенные</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="108"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="93"/>
         <source>Window size</source>
         <translation>Размер окна</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="109"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="94"/>
         <source>Tab width</source>
         <translation>Ширина вкладки</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="111"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="96"/>
         <source>Word wrap</source>
         <translation>Перенос cлова</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="112"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="97"/>
         <source>Code folding flag</source>
         <translation>Флаг сворачивания кода</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="113"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="98"/>
         <source>Show line numbers</source>
         <translation>Показать номера строк</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="114"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="99"/>
         <source>Show bookmarks icon</source>
         <translation>Показать значок закладок</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="115"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="100"/>
         <source>Show whitespaces and tabs</source>
         <translation>Показать пробелы и табуляции</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="116"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="101"/>
         <source>Highlight current line</source>
         <translation>Выделить текущую строку</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="117"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="102"/>
         <source>Color mark</source>
         <translation>Цветная метка</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="120"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="105"/>
         <source>Unicode</source>
         <translation>Unicode</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="121"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="106"/>
         <source>WesternEuropean</source>
         <translation>Западноевропейский</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="122"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="107"/>
         <source>CentralEuropean</source>
         <translation>Центральноевропейский</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="123"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="108"/>
         <source>Baltic</source>
         <translation>Балтийский</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="124"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="109"/>
         <source>Cyrillic</source>
         <translation>Кириллица</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="125"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="110"/>
         <source>Arabic</source>
         <translation>Арабский</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="130"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="115"/>
         <source>Celtic</source>
         <translation>Кельтский</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="131"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="116"/>
         <source>SouthEasternEuropean</source>
         <translation>Юго-Восточная Европа</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="126"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="111"/>
         <source>Greek</source>
         <translation>Греческий</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="127"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="112"/>
         <source>Hebrew</source>
         <translation>Еврейский</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="132"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="117"/>
         <source>ChineseSimplified</source>
         <translation>Китайский упрощенный</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="133"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="118"/>
         <source>ChineseTraditional</source>
         <translation>Китайский традиционный</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="134"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="119"/>
         <source>Japanese</source>
         <translation>Японский</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="135"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="120"/>
         <source>Korean</source>
         <translation>Корейский</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="129"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="114"/>
         <source>Thai</source>
         <translation>Тайландский</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="128"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="113"/>
         <source>Turkish</source>
         <translation>Турецкий</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="136"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="121"/>
         <source>Vietnamese</source>
         <translation>Вьетнамский</translation>
     </message>
     <message>
-        <location filename="../src/startmanager.cpp" line="762"/>
+        <location filename="../src/startmanager.cpp" line="832"/>
         <source>File not saved</source>
         <translation>Файл не сохранен</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="974"/>
-        <location filename="../src/widgets/window.cpp" line="1065"/>
-        <location filename="../src/widgets/window.cpp" line="1080"/>
+        <location filename="../src/widgets/window.cpp" line="1112"/>
+        <location filename="../src/widgets/window.cpp" line="1204"/>
+        <location filename="../src/widgets/window.cpp" line="1219"/>
         <source>Line Endings</source>
         <translation>Окончание строк</translation>
     </message>
@@ -705,32 +710,32 @@
 <context>
     <name>ReplaceBar</name>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="39"/>
+        <location filename="../src/controls/replacebar.cpp" line="21"/>
         <source>Find</source>
         <translation>Найти</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="43"/>
+        <location filename="../src/controls/replacebar.cpp" line="25"/>
         <source>Replace With</source>
         <translation>Заменить На</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="47"/>
+        <location filename="../src/controls/replacebar.cpp" line="29"/>
         <source>Replace</source>
         <translation>Заменить:</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="50"/>
+        <location filename="../src/controls/replacebar.cpp" line="32"/>
         <source>Skip</source>
         <translation>Пропустить</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="53"/>
+        <location filename="../src/controls/replacebar.cpp" line="35"/>
         <source>Replace Rest</source>
         <translation>Заменить Остальное</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="56"/>
+        <location filename="../src/controls/replacebar.cpp" line="38"/>
         <source>Replace All</source>
         <translation>Заменить Всё</translation>
     </message>
@@ -747,58 +752,58 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../src/common/settings.cpp" line="91"/>
+        <location filename="../src/common/settings.cpp" line="115"/>
         <source>Standard</source>
         <translation>Стандартный</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="91"/>
+        <location filename="../src/common/settings.cpp" line="115"/>
         <source>Customize</source>
         <translation>Настроить</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="104"/>
+        <location filename="../src/common/settings.cpp" line="128"/>
         <source>Normal</source>
         <translation>Обычный</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="104"/>
+        <location filename="../src/common/settings.cpp" line="128"/>
         <source>Maximum</source>
         <translation>Максимум</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="104"/>
+        <location filename="../src/common/settings.cpp" line="128"/>
         <source>Fullscreen</source>
         <translation>Полный экран</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="292"/>
+        <location filename="../src/common/settings.cpp" line="316"/>
         <source>This shortcut conflicts with system shortcut %1</source>
         <translation>Это сочетание конфликтует с системным сочитанием %1</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="294"/>
+        <location filename="../src/common/settings.cpp" line="318"/>
         <source>This shortcut conflicts with %1, click on Replace to make this shortcut effective immediately</source>
         <translation>Это сочетание конфликтует с %1, нажмите Заменить, чтобы это сочетание вступило в силу немедленно</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="410"/>
-        <location filename="../src/common/settings.cpp" line="418"/>
+        <location filename="../src/common/settings.cpp" line="464"/>
+        <location filename="../src/common/settings.cpp" line="472"/>
         <source>The shortcut %1 is invalid, please set another one.</source>
         <translation>Сочетание %1 недействительно, установите другое.</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="445"/>
+        <location filename="../src/common/settings.cpp" line="507"/>
         <source>Cancel</source>
         <translation>Отмена</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="446"/>
+        <location filename="../src/common/settings.cpp" line="508"/>
         <source>Replace</source>
         <translation>Заменить</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="448"/>
+        <location filename="../src/common/settings.cpp" line="510"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
@@ -806,7 +811,7 @@
 <context>
     <name>StartManager</name>
     <message>
-        <location filename="../src/startmanager.cpp" line="340"/>
+        <location filename="../src/startmanager.cpp" line="350"/>
         <source>Untitled %1</source>
         <translation>Без названия %1</translation>
     </message>
@@ -814,32 +819,32 @@
 <context>
     <name>Tabbar</name>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="515"/>
+        <location filename="../src/controls/tabbar.cpp" line="540"/>
         <source>Close tab</source>
         <translation>Закрыть вкладку</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="516"/>
+        <location filename="../src/controls/tabbar.cpp" line="541"/>
         <source>Close other tabs</source>
         <translation>Закрыть другие вкладки</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="517"/>
+        <location filename="../src/controls/tabbar.cpp" line="542"/>
         <source>More options</source>
         <translation>Больше вариантов</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="518"/>
+        <location filename="../src/controls/tabbar.cpp" line="543"/>
         <source>Close tabs to the left</source>
         <translation>Закрыть вкладки слева</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="519"/>
+        <location filename="../src/controls/tabbar.cpp" line="544"/>
         <source>Close tabs to the right</source>
         <translation>Закрыть вкладки справа</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="520"/>
+        <location filename="../src/controls/tabbar.cpp" line="545"/>
         <source>Close unmodified tabs</source>
         <translation>Закрыть не изменённые вкладки</translation>
     </message>
@@ -847,261 +852,259 @@
 <context>
     <name>TextEdit</name>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="235"/>
+        <location filename="../src/editor/dtextedit.cpp" line="259"/>
         <source>Undo</source>
         <translation>Отменить</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="236"/>
+        <location filename="../src/editor/dtextedit.cpp" line="260"/>
         <source>Redo</source>
         <translation>Готово</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="237"/>
+        <location filename="../src/editor/dtextedit.cpp" line="261"/>
         <source>Cut</source>
         <translation>Вырезать</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="238"/>
+        <location filename="../src/editor/dtextedit.cpp" line="262"/>
         <source>Copy</source>
         <translation>Копировать</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="239"/>
+        <location filename="../src/editor/dtextedit.cpp" line="263"/>
         <source>Paste</source>
         <translation>Вставить</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="240"/>
+        <location filename="../src/editor/dtextedit.cpp" line="264"/>
         <source>Delete</source>
         <translation>Удалить</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="241"/>
+        <location filename="../src/editor/dtextedit.cpp" line="265"/>
         <source>Select All</source>
         <translation>Выбрать всё</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="242"/>
-        <location filename="../src/widgets/window.cpp" line="361"/>
+        <location filename="../src/editor/dtextedit.cpp" line="266"/>
+        <location filename="../src/widgets/window.cpp" line="450"/>
         <source>Find</source>
         <translation>Найти</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="243"/>
-        <location filename="../src/widgets/window.cpp" line="362"/>
+        <location filename="../src/editor/dtextedit.cpp" line="267"/>
+        <location filename="../src/widgets/window.cpp" line="451"/>
         <source>Replace</source>
         <translation>Заменить</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="244"/>
+        <location filename="../src/editor/dtextedit.cpp" line="268"/>
         <source>Go to Line</source>
         <translation>Перейти к строке</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="245"/>
+        <location filename="../src/editor/dtextedit.cpp" line="269"/>
         <source>Turn on Read-Only mode</source>
         <translation>Включить режим Только Чтение</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="246"/>
+        <location filename="../src/editor/dtextedit.cpp" line="270"/>
         <source>Turn off Read-Only mode</source>
         <translation>Отключить режим Только Чтение</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="247"/>
+        <location filename="../src/editor/dtextedit.cpp" line="271"/>
         <source>Fullscreen</source>
         <translation>Полноэкранный режим</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="248"/>
+        <location filename="../src/editor/dtextedit.cpp" line="272"/>
         <source>Exit fullscreen</source>
         <translation>Выйти из полноэкранного режима</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="249"/>
+        <location filename="../src/editor/dtextedit.cpp" line="273"/>
         <source>Display in file manager</source>
         <translation>Показать в файловом менеджере</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="250"/>
-        <location filename="../src/editor/dtextedit.cpp" line="302"/>
+        <location filename="../src/editor/dtextedit.cpp" line="274"/>
+        <location filename="../src/editor/dtextedit.cpp" line="326"/>
         <source>Add Comment</source>
         <translation>Добавить комментарий</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="251"/>
+        <location filename="../src/editor/dtextedit.cpp" line="275"/>
         <source>Text to Speech</source>
         <translation>Текст в речь</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="252"/>
+        <location filename="../src/editor/dtextedit.cpp" line="276"/>
         <source>Stop reading</source>
         <translation>Прекратить читать</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="253"/>
+        <location filename="../src/editor/dtextedit.cpp" line="277"/>
         <source>Speech to Text</source>
         <translation>Речь в текст</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="254"/>
+        <location filename="../src/editor/dtextedit.cpp" line="278"/>
         <source>Translate</source>
         <translation>Перевести</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="255"/>
+        <location filename="../src/editor/dtextedit.cpp" line="279"/>
         <source>Column Mode</source>
         <translation>Режим колонки</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="256"/>
+        <location filename="../src/editor/dtextedit.cpp" line="280"/>
         <source>Add bookmark</source>
         <translation>Добавить закладку</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="257"/>
+        <location filename="../src/editor/dtextedit.cpp" line="281"/>
         <source>Remove Bookmark</source>
         <translation>Удалить закладку</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="258"/>
+        <location filename="../src/editor/dtextedit.cpp" line="282"/>
         <source>Previous bookmark</source>
         <translation>Предыдущая закладка</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="259"/>
+        <location filename="../src/editor/dtextedit.cpp" line="283"/>
         <source>Next bookmark</source>
         <translation>Следующая закладка</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="260"/>
+        <location filename="../src/editor/dtextedit.cpp" line="284"/>
         <source>Remove All Bookmarks</source>
         <translation>Удалить все закладки</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="261"/>
+        <location filename="../src/editor/dtextedit.cpp" line="285"/>
         <source>Fold All</source>
         <translation>Свернуть всё</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="262"/>
+        <location filename="../src/editor/dtextedit.cpp" line="286"/>
         <source>Fold Current Level</source>
         <translation>Свернуть текущий уровень</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="263"/>
+        <location filename="../src/editor/dtextedit.cpp" line="287"/>
         <source>Unfold All</source>
         <translation>Развернуть всё</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="264"/>
+        <location filename="../src/editor/dtextedit.cpp" line="288"/>
         <source>Unfold Current Level</source>
         <translation>Развернуть текущий уровень</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="269"/>
+        <location filename="../src/editor/dtextedit.cpp" line="293"/>
         <source>Color Mark</source>
         <translation>Цветная метка</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="273"/>
+        <location filename="../src/editor/dtextedit.cpp" line="297"/>
         <source>Clear All Marks</source>
         <translation>Очистить все метки</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="274"/>
+        <location filename="../src/editor/dtextedit.cpp" line="298"/>
         <source>Clear Last Mark</source>
         <translation>Очистить последнюю метку</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="283"/>
+        <location filename="../src/editor/dtextedit.cpp" line="307"/>
         <source>Mark</source>
         <translation>Пометить</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="295"/>
+        <location filename="../src/editor/dtextedit.cpp" line="319"/>
         <source>Mark All</source>
         <translation>Пометить всё</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="303"/>
+        <location filename="../src/editor/dtextedit.cpp" line="327"/>
         <source>Remove Comment</source>
         <translation>Удалить комментарий</translation>
     </message>
     <message>
-        <source>Failed to paste text: it is too large</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="2581"/>
+        <location filename="../src/editor/dtextedit.cpp" line="2672"/>
         <source>Copy failed: not enough memory</source>
-        <translation type="unfinished"/>
+        <translation>Копирование не удалось: недостаточно памяти</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="2665"/>
+        <location filename="../src/editor/dtextedit.cpp" line="2756"/>
         <source>Press ALT and click lines to edit in column mode</source>
         <translation>Нажмите ALT и щелкните строки для редактирования в режиме колонки</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="346"/>
+        <location filename="../src/editor/dtextedit.cpp" line="370"/>
         <source>Change Case</source>
         <translation>Изменить регистр</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="347"/>
+        <location filename="../src/editor/dtextedit.cpp" line="371"/>
         <source>Upper Case</source>
         <translation>Верхний регистр</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="348"/>
+        <location filename="../src/editor/dtextedit.cpp" line="372"/>
         <source>Lower Case</source>
         <translation>Нижний регистр</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="349"/>
+        <location filename="../src/editor/dtextedit.cpp" line="373"/>
         <source>Capitalize</source>
         <translation>Заглавные буквы</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="64"/>
+        <location filename="../src/widgets/bottombar.cpp" line="49"/>
         <source>None</source>
         <translation>Ничего</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1184"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1222"/>
         <source>Selected line(s) copied</source>
         <translation>Выбранные строки скопированы</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1190"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1228"/>
         <source>Current line copied</source>
         <translation>Текущая строка скопирована</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1210"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1248"/>
         <source>Selected line(s) clipped</source>
         <translation>Выбранные строки обрезаны</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1222"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1259"/>
         <source>Current line clipped</source>
         <translation>Текущая строка отрезана</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="2591"/>
+        <location filename="../src/editor/dtextedit.cpp" line="2682"/>
         <source>Paste failed: not enough memory</source>
-        <translation type="unfinished"/>
+        <translation>Вставка не удалось: недостаточно памяти</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3439"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3617"/>
         <source>Read-Only mode is off</source>
         <translation>Режим Только Чтение отключён</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3446"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3465"/>
-        <location filename="../src/editor/dtextedit.cpp" line="6150"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3624"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3643"/>
+        <location filename="../src/editor/dtextedit.cpp" line="6656"/>
+        <location filename="../src/editor/dtextedit.cpp" line="6664"/>
+        <location filename="../src/editor/dtextedit.cpp" line="6675"/>
         <source>Read-Only mode is on</source>
         <translation>Режим Только Чтение включён</translation>
     </message>
@@ -1109,7 +1112,7 @@
 <context>
     <name>WarningNotices</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="36"/>
+        <location filename="../src/controls/warningnotices.cpp" line="19"/>
         <source>Reload</source>
         <translation>Обновить</translation>
     </message>
@@ -1117,129 +1120,130 @@
 <context>
     <name>Window</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="38"/>
-        <location filename="../src/widgets/window.cpp" line="357"/>
+        <location filename="../src/controls/warningnotices.cpp" line="21"/>
+        <location filename="../src/widgets/window.cpp" line="446"/>
         <source>Save as</source>
         <translation>Сохранить как</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="353"/>
+        <location filename="../src/widgets/window.cpp" line="442"/>
         <source>New window</source>
         <translation>Новое окно</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="354"/>
+        <location filename="../src/widgets/window.cpp" line="443"/>
         <source>New tab</source>
         <translation>Новая вкладка</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="355"/>
+        <location filename="../src/widgets/window.cpp" line="444"/>
         <source>Open file</source>
         <translation>Открыть файл</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="356"/>
-        <location filename="../src/widgets/window.cpp" line="2217"/>
+        <location filename="../src/widgets/window.cpp" line="445"/>
+        <location filename="../src/widgets/window.cpp" line="2796"/>
         <source>Save</source>
         <translation>Сохранить</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="358"/>
+        <location filename="../src/widgets/window.cpp" line="447"/>
         <source>Print</source>
         <translation>Печать</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="359"/>
+        <location filename="../src/widgets/window.cpp" line="448"/>
         <source>Switch theme</source>
         <translation>Переключить тему</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="360"/>
-        <location filename="../src/widgets/window.cpp" line="1542"/>
+        <location filename="../src/widgets/window.cpp" line="449"/>
+        <location filename="../src/widgets/window.cpp" line="1871"/>
         <source>Settings</source>
         <translation>Настройки</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="471"/>
-        <location filename="../src/widgets/window.cpp" line="2468"/>
+        <location filename="../src/widgets/window.cpp" line="563"/>
+        <location filename="../src/widgets/window.cpp" line="3047"/>
         <source>Read-Only</source>
         <translation>Только Чтение</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="487"/>
+        <location filename="../src/widgets/window.cpp" line="579"/>
         <source>You do not have permission to open %1</source>
         <translation>Вы не имеете разрешения на открытие %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="522"/>
+        <location filename="../src/widgets/window.cpp" line="619"/>
+        <location filename="../src/widgets/window.cpp" line="2359"/>
         <source>Invalid file: %1</source>
         <translation>Недопустимый файл: %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="602"/>
-        <location filename="../src/widgets/window.cpp" line="644"/>
+        <location filename="../src/widgets/window.cpp" line="733"/>
+        <location filename="../src/widgets/window.cpp" line="779"/>
         <source>Do you want to save this file?</source>
         <translation>Вы хотите сохранить этот документ?</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="894"/>
+        <location filename="../src/widgets/window.cpp" line="1027"/>
         <source>You do not have permission to save %1</source>
         <translation>Вы не имеете разрешения на сохранение %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="918"/>
+        <location filename="../src/widgets/window.cpp" line="1051"/>
         <source>Saved successfully</source>
         <translation>Успешно сохранено</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="954"/>
-        <location filename="../src/widgets/window.cpp" line="1021"/>
-        <location filename="../src/widgets/window.cpp" line="1062"/>
+        <location filename="../src/widgets/window.cpp" line="1087"/>
+        <location filename="../src/widgets/window.cpp" line="1160"/>
+        <location filename="../src/widgets/window.cpp" line="1201"/>
         <source>Save File</source>
         <translation>Сохранить Файл</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1023"/>
+        <location filename="../src/widgets/window.cpp" line="1162"/>
         <source>Encoding</source>
         <translation>Кодировка</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1211"/>
+        <location filename="../src/widgets/window.cpp" line="1350"/>
         <source>Read-Only mode is on</source>
         <translation>Режим Только Чтение включён</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1441"/>
+        <location filename="../src/widgets/window.cpp" line="1770"/>
         <source>Current location remembered</source>
         <translation>Текущее местоположение запомнилось</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1492"/>
+        <location filename="../src/widgets/window.cpp" line="1821"/>
         <source>Ctrl+&apos;=&apos;</source>
         <translation>Ctrl+&apos;=&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1495"/>
+        <location filename="../src/widgets/window.cpp" line="1824"/>
         <source>Ctrl+&apos;-&apos;</source>
         <translation>Ctrl+&apos;-&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1524"/>
+        <location filename="../src/widgets/window.cpp" line="1853"/>
         <source>Editor</source>
         <translation>Редактор</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1890"/>
+        <location filename="../src/widgets/window.cpp" line="2451"/>
         <source>Untitled %1</source>
         <translation>Без названия %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2215"/>
+        <location filename="../src/widgets/window.cpp" line="2794"/>
         <source>Cancel</source>
         <translation>Отмена</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2216"/>
+        <location filename="../src/widgets/window.cpp" line="2795"/>
         <source>Discard</source>
         <translation>Отмена</translation>
     </message>

--- a/translations/deepin-editor_sl.ts
+++ b/translations/deepin-editor_sl.ts
@@ -2,17 +2,17 @@
 <context>
     <name>BottomBar</name>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="39"/>
+        <location filename="../src/widgets/bottombar.cpp" line="24"/>
         <source>Row</source>
         <translation>Vrsta</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="40"/>
+        <location filename="../src/widgets/bottombar.cpp" line="25"/>
         <source>Column</source>
         <translation>Stolp</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="41"/>
+        <location filename="../src/widgets/bottombar.cpp" line="26"/>
         <source>Characters %1</source>
         <translation>Znakov %1</translation>
     </message>
@@ -20,9 +20,9 @@
 <context>
     <name>DDropdownMenu</name>
     <message>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="300"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="344"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="349"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="290"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="341"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="346"/>
         <source>None</source>
         <translation>brez</translation>
     </message>
@@ -30,80 +30,85 @@
 <context>
     <name>EditWrapper</name>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="201"/>
-        <location filename="../src/editor/editwrapper.cpp" line="264"/>
-        <location filename="../src/editor/editwrapper.cpp" line="321"/>
-        <location filename="../src/editor/editwrapper.cpp" line="536"/>
+        <location filename="../src/editor/editwrapper.cpp" line="246"/>
+        <location filename="../src/editor/editwrapper.cpp" line="314"/>
+        <location filename="../src/editor/editwrapper.cpp" line="439"/>
+        <location filename="../src/editor/editwrapper.cpp" line="702"/>
         <source>Save</source>
         <translation>Shrani</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="316"/>
+        <location filename="../src/editor/editwrapper.cpp" line="434"/>
         <source>Do you want to save this file?</source>
         <translation>Bi radi shranili to datoteko?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="262"/>
-        <location filename="../src/editor/editwrapper.cpp" line="319"/>
+        <location filename="../src/editor/editwrapper.cpp" line="312"/>
+        <location filename="../src/editor/editwrapper.cpp" line="437"/>
         <source>Cancel</source>
         <translation>Prekini</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="259"/>
+        <location filename="../src/editor/editwrapper.cpp" line="309"/>
         <source>Encoding changed. Do you want to save the file now?</source>
         <translation>Kodiranje je bilo spremenjeno. Želite sedaj shraniti to datoteko?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="320"/>
+        <location filename="../src/editor/editwrapper.cpp" line="438"/>
         <source>Discard</source>
         <translation>Opusti</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="445"/>
+        <location filename="../src/editor/editwrapper.cpp" line="564"/>
         <source>You do not have permission to save %1</source>
         <translation>Nimate pravic za shranjevanje %1</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="607"/>
+        <location filename="../src/editor/editwrapper.cpp" line="774"/>
         <source>File removed on the disk. Save it now?</source>
         <translation>Datoteka je bila odstranjena z diska. Shranim sedaj?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="612"/>
+        <location filename="../src/editor/editwrapper.cpp" line="779"/>
         <source>File has changed on disk. Reload?</source>
         <translation>Datoteka je bila spremenjena na disku. Ponovno naložim?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="634"/>
-        <location filename="../src/widgets/bottombar.cpp" line="60"/>
+        <location filename="../src/editor/editwrapper.cpp" line="801"/>
+        <location filename="../src/widgets/bottombar.cpp" line="45"/>
         <source>INSERT</source>
         <translation>VSTAVI</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="637"/>
+        <location filename="../src/editor/editwrapper.cpp" line="804"/>
         <source>OVERWRITE</source>
         <translation>PREPIŠI</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="640"/>
+        <location filename="../src/editor/editwrapper.cpp" line="807"/>
         <source>R/O</source>
         <translation>S/B</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="945"/>
+        <source>The file cannot be read, which may be too large or has been damaged!</source>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
     <name>FindBar</name>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="40"/>
+        <location filename="../src/controls/findbar.cpp" line="22"/>
         <source>Find</source>
         <translation>Najdi</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="44"/>
+        <location filename="../src/controls/findbar.cpp" line="26"/>
         <source>Previous</source>
         <translation>Nazaj</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="46"/>
+        <location filename="../src/controls/findbar.cpp" line="28"/>
         <source>Next</source>
         <translation>Naprej</translation>
     </message>
@@ -111,7 +116,7 @@
 <context>
     <name>JumpLineBar</name>
     <message>
-        <location filename="../src/controls/jumplinebar.cpp" line="40"/>
+        <location filename="../src/controls/jumplinebar.cpp" line="28"/>
         <source>Go to Line: </source>
         <translation>Skok na vrstico:</translation>
     </message>
@@ -119,12 +124,12 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/editorapplication.cpp" line="27"/>
+        <location filename="../src/editorapplication.cpp" line="11"/>
         <source>Text Editor is a powerful tool for viewing and editing text files.</source>
         <translation>Urejevalnik besedil je močno orodje za pregledovanje in urejanje besedilnih datotek.</translation>
     </message>
     <message>
-        <location filename="../src/editorapplication.cpp" line="38"/>
+        <location filename="../src/editorapplication.cpp" line="22"/>
         <source>Text Editor</source>
         <translation>Urejevalnik besedil</translation>
     </message>
@@ -132,572 +137,572 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/editorapplication.cpp" line="35"/>
+        <location filename="../src/editorapplication.cpp" line="19"/>
         <source>Text Editor</source>
         <translation>Urejevalnik besedil</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="203"/>
-        <location filename="../src/editor/editwrapper.cpp" line="538"/>
-        <location filename="../src/widgets/window.cpp" line="956"/>
-        <location filename="../src/widgets/window.cpp" line="973"/>
-        <location filename="../src/widgets/window.cpp" line="1064"/>
-        <location filename="../src/widgets/window.cpp" line="1079"/>
+        <location filename="../src/editor/editwrapper.cpp" line="248"/>
+        <location filename="../src/editor/editwrapper.cpp" line="704"/>
+        <location filename="../src/widgets/window.cpp" line="1089"/>
+        <location filename="../src/widgets/window.cpp" line="1111"/>
+        <location filename="../src/widgets/window.cpp" line="1203"/>
+        <location filename="../src/widgets/window.cpp" line="1218"/>
         <source>Encoding</source>
         <translation>Kodiranje</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="24"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="9"/>
         <source>Basic</source>
         <translation>Osnovno</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="25"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="10"/>
         <source>Font Style</source>
         <translation>Slog pisave</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="26"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="11"/>
         <source>Font</source>
         <translation>Pisava</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="27"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="12"/>
         <source>Font Size</source>
         <translation>Velikost pisave</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="28"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="13"/>
         <source>Shortcuts</source>
         <translation>Bljižnica</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="29"/>
-        <location filename="../src/controls/settingsdialog.cpp" line="30"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="14"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="15"/>
         <source>Keymap</source>
         <translation>Razpored tipk</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="31"/>
-        <location filename="../src/controls/settingsdialog.cpp" line="107"/>
-        <location filename="../src/widgets/window.cpp" line="1482"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="16"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="92"/>
+        <location filename="../src/widgets/window.cpp" line="1811"/>
         <source>Window</source>
         <translation>Okno</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="32"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="17"/>
         <source>New tab</source>
         <translation>Nov zavihek</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="33"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="18"/>
         <source>New window</source>
         <translation>Novo okno</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="34"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="19"/>
         <source>Save</source>
         <translation>ShraniShrani</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="35"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="20"/>
         <source>Save as</source>
         <translation>Shrani kot</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="36"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="21"/>
         <source>Next tab</source>
         <translation>Naslednji zavihek</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="37"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="22"/>
         <source>Previous tab</source>
         <translation>Prejšnji zavihek</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="38"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="23"/>
         <source>Close tab</source>
         <translation>Zapri zavihek</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="39"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="24"/>
         <source>Close other tabs</source>
         <translation>Zapri ostale zavihke</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="40"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="25"/>
         <source>Restore tab</source>
         <translation>Obnovi zavihek</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="41"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="26"/>
         <source>Open file</source>
         <translation>Odpir datoteko</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="42"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="27"/>
         <source>Increment font size</source>
         <translation>Povečaj velikost pisave</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="43"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="28"/>
         <source>Decrement font size</source>
         <translation>Zmanjšaj velikost pisave</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="44"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="29"/>
         <source>Reset font size</source>
         <translation>Ponastavi velikost pisave</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="45"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="30"/>
         <source>Help</source>
         <translation>Pomoč</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="46"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="31"/>
         <source>Toggle fullscreen</source>
         <translation>Preklopi celozaslonski prikaz</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="47"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="32"/>
         <source>Find</source>
         <translation>Najdi</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="48"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="33"/>
         <source>Replace</source>
         <translation>Zamenjaj</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="49"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="34"/>
         <source>Go to line</source>
         <translation>Skok na vrstico</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="50"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="35"/>
         <source>Save cursor position</source>
         <translation>Shrani položaj kurzorja</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="51"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="36"/>
         <source>Reset cursor position</source>
         <translation>Ponastavi položaj kurzorja</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="52"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="37"/>
         <source>Exit</source>
         <translation>Izhod</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="53"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="38"/>
         <source>Display shortcuts</source>
         <translation>Prikaži bljižnice</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="54"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="39"/>
         <source>Print</source>
         <translation>Tiskanje</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="55"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="40"/>
         <source>Editor</source>
         <translation>Urejevalnik</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="56"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="41"/>
         <source>Increase indent</source>
         <translation>Povečaj zamik</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="57"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="42"/>
         <source>Decrease indent</source>
         <translation>Zmanjšaj zamik</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="58"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="43"/>
         <source>Forward character</source>
         <translation>Znak naprej</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="59"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="44"/>
         <source>Backward character</source>
         <translation>Znak nazaj</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="60"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="45"/>
         <source>Forward word</source>
         <translation>Besedo naprej</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="61"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="46"/>
         <source>Backward word</source>
         <translation>Besedo nazaj</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="62"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="47"/>
         <source>Next line</source>
         <translation>Naslednja vrstica</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="63"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="48"/>
         <source>Previous line</source>
         <translation>Prejšnja vrstica</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="64"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="49"/>
         <source>New line</source>
         <translation>Nova vrstica</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="65"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="50"/>
         <source>New line above</source>
         <translation>Nova vrstica zograj</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="66"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="51"/>
         <source>New line below</source>
         <translation>Nova vrstica spodaj</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="67"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="52"/>
         <source>Duplicate line</source>
         <translation>Podvoji vrstico</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="68"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="53"/>
         <source>Delete to end of line</source>
         <translation>Izbriši do konca vrstice</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="69"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="54"/>
         <source>Delete current line</source>
         <translation>Izbriši trenutno vrstico</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="70"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="55"/>
         <source>Swap line up</source>
         <translation>Zamenja vrstico navzgor</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="71"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="56"/>
         <source>Swap line down</source>
         <translation>Zamenjaj vrstico navzdol</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="72"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="57"/>
         <source>Scroll up one line</source>
         <translation>Pomakni eno vrstico navzgor</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="73"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="58"/>
         <source>Scroll down one line</source>
         <translation>Pomakni eno vrstico navzdol</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="74"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="59"/>
         <source>Page up</source>
         <translation>Prejšnja stran</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="75"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="60"/>
         <source>Page down</source>
         <translation>Naslednja stran</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="76"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="61"/>
         <source>Move to end of line</source>
         <translation>Na konec vrstice</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="77"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="62"/>
         <source>Move to start of line</source>
         <translation>Na začetek vrstice</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="78"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="63"/>
         <source>Move to end of text</source>
         <translation>Na konec besedila</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="79"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="64"/>
         <source>Move to start of text</source>
         <translation>Na začetek besedila</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="80"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="65"/>
         <source>Move to line indentation</source>
         <translation>Na zamik vrstice</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="81"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="66"/>
         <source>Upper case</source>
         <translation>Velike črke</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="82"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="67"/>
         <source>Lower case</source>
         <translation>Male črke</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="83"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="68"/>
         <source>Capitalize</source>
         <translation>Velika začetnica</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="84"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="69"/>
         <source>Delete backward word</source>
         <translation>Izbriši prejšnjo besedo</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="85"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="70"/>
         <source>Delete forward word</source>
         <translation>briši naslednjo besedo</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="86"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="71"/>
         <source>Forward over a pair</source>
         <translation>Naprej preko para</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="87"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="72"/>
         <source>Backward over a pair</source>
         <translation>Nazaj preko para</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="88"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="73"/>
         <source>Select all</source>
         <translation>Izberi vse</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="89"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="74"/>
         <source>Copy</source>
         <translation>Kopiraj</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="90"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="75"/>
         <source>Cut</source>
         <translation>Izreži</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="91"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="76"/>
         <source>Paste</source>
         <translation>Prilepi</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="92"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="77"/>
         <source>Transpose character</source>
         <translation>Spremeni velikost znaka</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="93"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="78"/>
         <source>Mark</source>
         <translation>Označi</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="94"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="79"/>
         <source>Unmark</source>
         <translation>Odznači</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="95"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="80"/>
         <source>Copy line</source>
         <translation>Kopiraj vrstico</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="96"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="81"/>
         <source>Cut line</source>
         <translation>Izreži vrstico</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="97"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="82"/>
         <source>Merge lines</source>
         <translation>Združi vrstice</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="98"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="83"/>
         <source>Read-Only mode</source>
         <translation>Samo branje</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="99"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="84"/>
         <source>Add comment</source>
         <translation>Dodaj komentar</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="100"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="85"/>
         <source>Remove comment</source>
         <translation>Odstrani komentar</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="101"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="86"/>
         <source>Undo</source>
         <translation>razveljavi</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="102"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="87"/>
         <source>Redo</source>
         <translation>Uveljavi</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="103"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="88"/>
         <source>Add/Remove bookmark</source>
         <translation>Dodaj/odstrani zaznamek</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="104"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="89"/>
         <source>Move to previous bookmark</source>
         <translation>Na prejšnji zaznamek</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="105"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="90"/>
         <source>Move to next bookmark</source>
         <translation>Na naslednji zaznamek</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="106"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="91"/>
         <source>Advanced</source>
         <translation>Napredno</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="108"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="93"/>
         <source>Window size</source>
         <translation>Velikost okna</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="109"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="94"/>
         <source>Tab width</source>
         <translation>Širina zavihka</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="111"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="96"/>
         <source>Word wrap</source>
         <translation>Deljenje besed</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="112"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="97"/>
         <source>Code folding flag</source>
         <translation>Zastavica za zlaganje kode</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="113"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="98"/>
         <source>Show line numbers</source>
         <translation>Prikaži teilko vrstice</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="114"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="99"/>
         <source>Show bookmarks icon</source>
         <translation>Prikaži ikone zaznamkov</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="115"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="100"/>
         <source>Show whitespaces and tabs</source>
         <translation>Prikaži presledke in tabulatorje</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="116"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="101"/>
         <source>Highlight current line</source>
         <translation>Osvetli trenutno vrstico</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="117"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="102"/>
         <source>Color mark</source>
         <translation>barvna oznaka</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="120"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="105"/>
         <source>Unicode</source>
         <translation>Unicode</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="121"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="106"/>
         <source>WesternEuropean</source>
         <translation>Zahodnoevropski</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="122"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="107"/>
         <source>CentralEuropean</source>
         <translation>Srednjeevropski</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="123"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="108"/>
         <source>Baltic</source>
         <translation>Baltik</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="124"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="109"/>
         <source>Cyrillic</source>
         <translation>Cirilica</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="125"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="110"/>
         <source>Arabic</source>
         <translation>Arabsko</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="130"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="115"/>
         <source>Celtic</source>
         <translation>Keltsko</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="131"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="116"/>
         <source>SouthEasternEuropean</source>
         <translation>JugovzhodnaEvropa</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="126"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="111"/>
         <source>Greek</source>
         <translation>Grško</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="127"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="112"/>
         <source>Hebrew</source>
         <translation>Hebrejsko</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="132"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="117"/>
         <source>ChineseSimplified</source>
         <translation>KitajščinaPoenostavljena</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="133"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="118"/>
         <source>ChineseTraditional</source>
         <translation>KitajščinaTradicionalna</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="134"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="119"/>
         <source>Japanese</source>
         <translation>Japonsko</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="135"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="120"/>
         <source>Korean</source>
         <translation>Korejsko</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="129"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="114"/>
         <source>Thai</source>
         <translation>Tajsko</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="128"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="113"/>
         <source>Turkish</source>
         <translation>Turško</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="136"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="121"/>
         <source>Vietnamese</source>
         <translation>Vietnamsko</translation>
     </message>
     <message>
-        <location filename="../src/startmanager.cpp" line="762"/>
+        <location filename="../src/startmanager.cpp" line="832"/>
         <source>File not saved</source>
         <translation>Datoteka ni bila shranjena</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="974"/>
-        <location filename="../src/widgets/window.cpp" line="1065"/>
-        <location filename="../src/widgets/window.cpp" line="1080"/>
+        <location filename="../src/widgets/window.cpp" line="1112"/>
+        <location filename="../src/widgets/window.cpp" line="1204"/>
+        <location filename="../src/widgets/window.cpp" line="1219"/>
         <source>Line Endings</source>
         <translation>Zaključki vrstic</translation>
     </message>
@@ -705,32 +710,32 @@
 <context>
     <name>ReplaceBar</name>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="39"/>
+        <location filename="../src/controls/replacebar.cpp" line="21"/>
         <source>Find</source>
         <translation>Najdi</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="43"/>
+        <location filename="../src/controls/replacebar.cpp" line="25"/>
         <source>Replace With</source>
         <translation>Zamenjaj z</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="47"/>
+        <location filename="../src/controls/replacebar.cpp" line="29"/>
         <source>Replace</source>
         <translation>Zamenjaj</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="50"/>
+        <location filename="../src/controls/replacebar.cpp" line="32"/>
         <source>Skip</source>
         <translation>Preskoči</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="53"/>
+        <location filename="../src/controls/replacebar.cpp" line="35"/>
         <source>Replace Rest</source>
         <translation>Zamenjaj ostalo</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="56"/>
+        <location filename="../src/controls/replacebar.cpp" line="38"/>
         <source>Replace All</source>
         <translation>Zamenjaj vse</translation>
     </message>
@@ -747,58 +752,58 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../src/common/settings.cpp" line="91"/>
+        <location filename="../src/common/settings.cpp" line="115"/>
         <source>Standard</source>
         <translation>Standardno</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="91"/>
+        <location filename="../src/common/settings.cpp" line="115"/>
         <source>Customize</source>
         <translation>Prilagodi</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="104"/>
+        <location filename="../src/common/settings.cpp" line="128"/>
         <source>Normal</source>
         <translation>Normalno</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="104"/>
+        <location filename="../src/common/settings.cpp" line="128"/>
         <source>Maximum</source>
         <translation>Maksimalno</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="104"/>
+        <location filename="../src/common/settings.cpp" line="128"/>
         <source>Fullscreen</source>
         <translation>Celozaslonsko</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="292"/>
+        <location filename="../src/common/settings.cpp" line="316"/>
         <source>This shortcut conflicts with system shortcut %1</source>
         <translation>Ta bljižnica je enaka sistemski bližnjici %1</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="294"/>
+        <location filename="../src/common/settings.cpp" line="318"/>
         <source>This shortcut conflicts with %1, click on Replace to make this shortcut effective immediately</source>
         <translation>Ta bližnjica je enaka kot %1. Kliknite na Zamenjaj, da jo nemudoma vklopite</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="410"/>
-        <location filename="../src/common/settings.cpp" line="418"/>
+        <location filename="../src/common/settings.cpp" line="464"/>
+        <location filename="../src/common/settings.cpp" line="472"/>
         <source>The shortcut %1 is invalid, please set another one.</source>
         <translation>Bližnjica %1 ni veljavna. Določite drugo.</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="445"/>
+        <location filename="../src/common/settings.cpp" line="507"/>
         <source>Cancel</source>
         <translation>Prekini</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="446"/>
+        <location filename="../src/common/settings.cpp" line="508"/>
         <source>Replace</source>
         <translation>Zamenjaj</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="448"/>
+        <location filename="../src/common/settings.cpp" line="510"/>
         <source>OK</source>
         <translation>V redu</translation>
     </message>
@@ -806,7 +811,7 @@
 <context>
     <name>StartManager</name>
     <message>
-        <location filename="../src/startmanager.cpp" line="340"/>
+        <location filename="../src/startmanager.cpp" line="350"/>
         <source>Untitled %1</source>
         <translation>Neimenovano %1</translation>
     </message>
@@ -814,32 +819,32 @@
 <context>
     <name>Tabbar</name>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="515"/>
+        <location filename="../src/controls/tabbar.cpp" line="540"/>
         <source>Close tab</source>
         <translation>Zapri zavihek</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="516"/>
+        <location filename="../src/controls/tabbar.cpp" line="541"/>
         <source>Close other tabs</source>
         <translation>Zapri ostale zavihke</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="517"/>
+        <location filename="../src/controls/tabbar.cpp" line="542"/>
         <source>More options</source>
         <translation>Več možnosti</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="518"/>
+        <location filename="../src/controls/tabbar.cpp" line="543"/>
         <source>Close tabs to the left</source>
         <translation>Zapri zavihke na levi</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="519"/>
+        <location filename="../src/controls/tabbar.cpp" line="544"/>
         <source>Close tabs to the right</source>
         <translation>Zapri zavihke na desni</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="520"/>
+        <location filename="../src/controls/tabbar.cpp" line="545"/>
         <source>Close unmodified tabs</source>
         <translation>Zapri nespremenjene zavihke</translation>
     </message>
@@ -847,261 +852,259 @@
 <context>
     <name>TextEdit</name>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="235"/>
+        <location filename="../src/editor/dtextedit.cpp" line="259"/>
         <source>Undo</source>
         <translation>razveljavi</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="236"/>
+        <location filename="../src/editor/dtextedit.cpp" line="260"/>
         <source>Redo</source>
         <translation>Uveljavi</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="237"/>
+        <location filename="../src/editor/dtextedit.cpp" line="261"/>
         <source>Cut</source>
         <translation>Izreži</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="238"/>
+        <location filename="../src/editor/dtextedit.cpp" line="262"/>
         <source>Copy</source>
         <translation>Kopiraj</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="239"/>
+        <location filename="../src/editor/dtextedit.cpp" line="263"/>
         <source>Paste</source>
         <translation>Prilepi</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="240"/>
+        <location filename="../src/editor/dtextedit.cpp" line="264"/>
         <source>Delete</source>
         <translation>Izbriši</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="241"/>
+        <location filename="../src/editor/dtextedit.cpp" line="265"/>
         <source>Select All</source>
         <translation>Označi vse</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="242"/>
-        <location filename="../src/widgets/window.cpp" line="361"/>
+        <location filename="../src/editor/dtextedit.cpp" line="266"/>
+        <location filename="../src/widgets/window.cpp" line="450"/>
         <source>Find</source>
         <translation>Najdi</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="243"/>
-        <location filename="../src/widgets/window.cpp" line="362"/>
+        <location filename="../src/editor/dtextedit.cpp" line="267"/>
+        <location filename="../src/widgets/window.cpp" line="451"/>
         <source>Replace</source>
         <translation>Zamenjaj</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="244"/>
+        <location filename="../src/editor/dtextedit.cpp" line="268"/>
         <source>Go to Line</source>
         <translation>Skok na vrstico</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="245"/>
+        <location filename="../src/editor/dtextedit.cpp" line="269"/>
         <source>Turn on Read-Only mode</source>
         <translation>Vklopi samo branje</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="246"/>
+        <location filename="../src/editor/dtextedit.cpp" line="270"/>
         <source>Turn off Read-Only mode</source>
         <translation>Izklopi samo branje</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="247"/>
+        <location filename="../src/editor/dtextedit.cpp" line="271"/>
         <source>Fullscreen</source>
         <translation>Celozaslonsko</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="248"/>
+        <location filename="../src/editor/dtextedit.cpp" line="272"/>
         <source>Exit fullscreen</source>
         <translation>Zapri celozaslonski način</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="249"/>
+        <location filename="../src/editor/dtextedit.cpp" line="273"/>
         <source>Display in file manager</source>
         <translation>Prikaži v upravljalniku datotek</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="250"/>
-        <location filename="../src/editor/dtextedit.cpp" line="302"/>
+        <location filename="../src/editor/dtextedit.cpp" line="274"/>
+        <location filename="../src/editor/dtextedit.cpp" line="326"/>
         <source>Add Comment</source>
         <translation>Dodaj komentar</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="251"/>
+        <location filename="../src/editor/dtextedit.cpp" line="275"/>
         <source>Text to Speech</source>
         <translation>Besedilo v govor</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="252"/>
+        <location filename="../src/editor/dtextedit.cpp" line="276"/>
         <source>Stop reading</source>
         <translation>Zaustavi branje</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="253"/>
+        <location filename="../src/editor/dtextedit.cpp" line="277"/>
         <source>Speech to Text</source>
         <translation>Govor v besedilo</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="254"/>
+        <location filename="../src/editor/dtextedit.cpp" line="278"/>
         <source>Translate</source>
         <translation>Prevedi</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="255"/>
+        <location filename="../src/editor/dtextedit.cpp" line="279"/>
         <source>Column Mode</source>
         <translation>Stolpčni način</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="256"/>
+        <location filename="../src/editor/dtextedit.cpp" line="280"/>
         <source>Add bookmark</source>
         <translation>Dodaj zaznamek</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="257"/>
+        <location filename="../src/editor/dtextedit.cpp" line="281"/>
         <source>Remove Bookmark</source>
         <translation>Odstrani zaznamek</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="258"/>
+        <location filename="../src/editor/dtextedit.cpp" line="282"/>
         <source>Previous bookmark</source>
         <translation>Prejšnji zaznamek</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="259"/>
+        <location filename="../src/editor/dtextedit.cpp" line="283"/>
         <source>Next bookmark</source>
         <translation>Naslednji zaznamek</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="260"/>
+        <location filename="../src/editor/dtextedit.cpp" line="284"/>
         <source>Remove All Bookmarks</source>
         <translation>Odstrani vse zaznamke</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="261"/>
+        <location filename="../src/editor/dtextedit.cpp" line="285"/>
         <source>Fold All</source>
         <translation>Zloži vse</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="262"/>
+        <location filename="../src/editor/dtextedit.cpp" line="286"/>
         <source>Fold Current Level</source>
         <translation>Zloži trenutni nivo</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="263"/>
+        <location filename="../src/editor/dtextedit.cpp" line="287"/>
         <source>Unfold All</source>
         <translation>Razpri vse</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="264"/>
+        <location filename="../src/editor/dtextedit.cpp" line="288"/>
         <source>Unfold Current Level</source>
         <translation>Razpri trenutni nivo</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="269"/>
+        <location filename="../src/editor/dtextedit.cpp" line="293"/>
         <source>Color Mark</source>
         <translation>Barvna oznaka</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="273"/>
+        <location filename="../src/editor/dtextedit.cpp" line="297"/>
         <source>Clear All Marks</source>
         <translation>Odstrani vse oznake</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="274"/>
+        <location filename="../src/editor/dtextedit.cpp" line="298"/>
         <source>Clear Last Mark</source>
         <translation>Odstrani zadnjo oznako</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="283"/>
+        <location filename="../src/editor/dtextedit.cpp" line="307"/>
         <source>Mark</source>
         <translation>Označi</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="295"/>
+        <location filename="../src/editor/dtextedit.cpp" line="319"/>
         <source>Mark All</source>
         <translation>Označi vse</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="303"/>
+        <location filename="../src/editor/dtextedit.cpp" line="327"/>
         <source>Remove Comment</source>
         <translation>Odstrani komentar</translation>
     </message>
     <message>
-        <source>Failed to paste text: it is too large</source>
-        <translation type="vanished">Besedilo je preveliko za prilepljenje</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="2581"/>
+        <location filename="../src/editor/dtextedit.cpp" line="2672"/>
         <source>Copy failed: not enough memory</source>
         <translation>Kopiranje ni uspelo: ni dovolj pomnilnika</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="2665"/>
+        <location filename="../src/editor/dtextedit.cpp" line="2756"/>
         <source>Press ALT and click lines to edit in column mode</source>
         <translation>Pritisnite ALT in kliknite na vrstice za urejanje v stolpcu</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="346"/>
+        <location filename="../src/editor/dtextedit.cpp" line="370"/>
         <source>Change Case</source>
         <translation>Spremeni velikost črk</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="347"/>
+        <location filename="../src/editor/dtextedit.cpp" line="371"/>
         <source>Upper Case</source>
         <translation>Velike črke</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="348"/>
+        <location filename="../src/editor/dtextedit.cpp" line="372"/>
         <source>Lower Case</source>
         <translation>Male črke</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="349"/>
+        <location filename="../src/editor/dtextedit.cpp" line="373"/>
         <source>Capitalize</source>
         <translation>Velika začetnica</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="64"/>
+        <location filename="../src/widgets/bottombar.cpp" line="49"/>
         <source>None</source>
         <translation>brez</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1184"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1222"/>
         <source>Selected line(s) copied</source>
         <translation>Izbrane vrstice so bile kopirane</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1190"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1228"/>
         <source>Current line copied</source>
         <translation>Trenutna vrstica je bila skopirana</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1210"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1248"/>
         <source>Selected line(s) clipped</source>
         <translation>Izbrane vrstice so bile porezane</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1222"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1259"/>
         <source>Current line clipped</source>
         <translation>Trenutna vrstica je bila porezana</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="2591"/>
+        <location filename="../src/editor/dtextedit.cpp" line="2682"/>
         <source>Paste failed: not enough memory</source>
         <translation>Kopiranje ni uspelo: ni dovolj pomnilnika</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3439"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3617"/>
         <source>Read-Only mode is off</source>
         <translation>Samo branje je izklopljeno</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3446"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3465"/>
-        <location filename="../src/editor/dtextedit.cpp" line="6150"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3624"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3643"/>
+        <location filename="../src/editor/dtextedit.cpp" line="6656"/>
+        <location filename="../src/editor/dtextedit.cpp" line="6664"/>
+        <location filename="../src/editor/dtextedit.cpp" line="6675"/>
         <source>Read-Only mode is on</source>
         <translation>Vklopljeno je samo branje</translation>
     </message>
@@ -1109,7 +1112,7 @@
 <context>
     <name>WarningNotices</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="36"/>
+        <location filename="../src/controls/warningnotices.cpp" line="19"/>
         <source>Reload</source>
         <translation>Ponovno naloži</translation>
     </message>
@@ -1117,129 +1120,130 @@
 <context>
     <name>Window</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="38"/>
-        <location filename="../src/widgets/window.cpp" line="357"/>
+        <location filename="../src/controls/warningnotices.cpp" line="21"/>
+        <location filename="../src/widgets/window.cpp" line="446"/>
         <source>Save as</source>
         <translation>Shrani kot</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="353"/>
+        <location filename="../src/widgets/window.cpp" line="442"/>
         <source>New window</source>
         <translation>Novo okno</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="354"/>
+        <location filename="../src/widgets/window.cpp" line="443"/>
         <source>New tab</source>
         <translation>Nov zavihek</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="355"/>
+        <location filename="../src/widgets/window.cpp" line="444"/>
         <source>Open file</source>
         <translation>Odpir datoteko</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="356"/>
-        <location filename="../src/widgets/window.cpp" line="2217"/>
+        <location filename="../src/widgets/window.cpp" line="445"/>
+        <location filename="../src/widgets/window.cpp" line="2796"/>
         <source>Save</source>
         <translation>Shrani</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="358"/>
+        <location filename="../src/widgets/window.cpp" line="447"/>
         <source>Print</source>
         <translation>Tiskanje</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="359"/>
+        <location filename="../src/widgets/window.cpp" line="448"/>
         <source>Switch theme</source>
         <translation>Zamenjaj temo</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="360"/>
-        <location filename="../src/widgets/window.cpp" line="1542"/>
+        <location filename="../src/widgets/window.cpp" line="449"/>
+        <location filename="../src/widgets/window.cpp" line="1871"/>
         <source>Settings</source>
         <translation>nastavitve</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="471"/>
-        <location filename="../src/widgets/window.cpp" line="2468"/>
+        <location filename="../src/widgets/window.cpp" line="563"/>
+        <location filename="../src/widgets/window.cpp" line="3047"/>
         <source>Read-Only</source>
         <translation>Samo branje</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="487"/>
+        <location filename="../src/widgets/window.cpp" line="579"/>
         <source>You do not have permission to open %1</source>
         <translation>Nimate pravic za odpiranje %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="522"/>
+        <location filename="../src/widgets/window.cpp" line="619"/>
+        <location filename="../src/widgets/window.cpp" line="2359"/>
         <source>Invalid file: %1</source>
         <translation>Napačna datoteka: %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="602"/>
-        <location filename="../src/widgets/window.cpp" line="644"/>
+        <location filename="../src/widgets/window.cpp" line="733"/>
+        <location filename="../src/widgets/window.cpp" line="779"/>
         <source>Do you want to save this file?</source>
         <translation>Bi radi shranili to datoteko?</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="894"/>
+        <location filename="../src/widgets/window.cpp" line="1027"/>
         <source>You do not have permission to save %1</source>
         <translation>Nimate pravic za shranjevanje %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="918"/>
+        <location filename="../src/widgets/window.cpp" line="1051"/>
         <source>Saved successfully</source>
         <translation>Uspešno shranjeno</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="954"/>
-        <location filename="../src/widgets/window.cpp" line="1021"/>
-        <location filename="../src/widgets/window.cpp" line="1062"/>
+        <location filename="../src/widgets/window.cpp" line="1087"/>
+        <location filename="../src/widgets/window.cpp" line="1160"/>
+        <location filename="../src/widgets/window.cpp" line="1201"/>
         <source>Save File</source>
         <translation>Shrani datoteko</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1023"/>
+        <location filename="../src/widgets/window.cpp" line="1162"/>
         <source>Encoding</source>
         <translation>Kodiranje</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1211"/>
+        <location filename="../src/widgets/window.cpp" line="1350"/>
         <source>Read-Only mode is on</source>
         <translation>Vklopljeno je samo branje</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1441"/>
+        <location filename="../src/widgets/window.cpp" line="1770"/>
         <source>Current location remembered</source>
         <translation>Trenutni položaj je shranjen</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1492"/>
+        <location filename="../src/widgets/window.cpp" line="1821"/>
         <source>Ctrl+&apos;=&apos;</source>
         <translation>Ctrl+&apos;=&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1495"/>
+        <location filename="../src/widgets/window.cpp" line="1824"/>
         <source>Ctrl+&apos;-&apos;</source>
         <translation>Ctrl+&apos;-&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1524"/>
+        <location filename="../src/widgets/window.cpp" line="1853"/>
         <source>Editor</source>
         <translation>Urejevalnik</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1890"/>
+        <location filename="../src/widgets/window.cpp" line="2451"/>
         <source>Untitled %1</source>
         <translation>Neimenovano %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2215"/>
+        <location filename="../src/widgets/window.cpp" line="2794"/>
         <source>Cancel</source>
         <translation>Prekini</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2216"/>
+        <location filename="../src/widgets/window.cpp" line="2795"/>
         <source>Discard</source>
         <translation>Opusti</translation>
     </message>

--- a/translations/deepin-editor_sq.ts
+++ b/translations/deepin-editor_sq.ts
@@ -2,17 +2,17 @@
 <context>
     <name>BottomBar</name>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="39"/>
+        <location filename="../src/widgets/bottombar.cpp" line="24"/>
         <source>Row</source>
         <translation>Rresht</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="40"/>
+        <location filename="../src/widgets/bottombar.cpp" line="25"/>
         <source>Column</source>
         <translation>Shtyllë</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="41"/>
+        <location filename="../src/widgets/bottombar.cpp" line="26"/>
         <source>Characters %1</source>
         <translation>Shenja %1</translation>
     </message>
@@ -20,9 +20,9 @@
 <context>
     <name>DDropdownMenu</name>
     <message>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="300"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="344"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="349"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="290"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="341"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="346"/>
         <source>None</source>
         <translation>Asnjë</translation>
     </message>
@@ -30,80 +30,85 @@
 <context>
     <name>EditWrapper</name>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="201"/>
-        <location filename="../src/editor/editwrapper.cpp" line="264"/>
-        <location filename="../src/editor/editwrapper.cpp" line="321"/>
-        <location filename="../src/editor/editwrapper.cpp" line="536"/>
+        <location filename="../src/editor/editwrapper.cpp" line="246"/>
+        <location filename="../src/editor/editwrapper.cpp" line="314"/>
+        <location filename="../src/editor/editwrapper.cpp" line="439"/>
+        <location filename="../src/editor/editwrapper.cpp" line="702"/>
         <source>Save</source>
         <translation>Ruaje</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="316"/>
+        <location filename="../src/editor/editwrapper.cpp" line="434"/>
         <source>Do you want to save this file?</source>
         <translation>Doni të ruhet kjo kartelë?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="262"/>
-        <location filename="../src/editor/editwrapper.cpp" line="319"/>
+        <location filename="../src/editor/editwrapper.cpp" line="312"/>
+        <location filename="../src/editor/editwrapper.cpp" line="437"/>
         <source>Cancel</source>
         <translation>Anuloje</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="259"/>
+        <location filename="../src/editor/editwrapper.cpp" line="309"/>
         <source>Encoding changed. Do you want to save the file now?</source>
         <translation>Kodimi ndryshoi. Doni të ruhet kartela tani?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="320"/>
+        <location filename="../src/editor/editwrapper.cpp" line="438"/>
         <source>Discard</source>
         <translation>Hidhe Tej</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="445"/>
+        <location filename="../src/editor/editwrapper.cpp" line="564"/>
         <source>You do not have permission to save %1</source>
         <translation>S’keni leje të ruani %1</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="607"/>
+        <location filename="../src/editor/editwrapper.cpp" line="774"/>
         <source>File removed on the disk. Save it now?</source>
         <translation>Kartela u hoq nga disku. Të ruhet tani?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="612"/>
+        <location filename="../src/editor/editwrapper.cpp" line="779"/>
         <source>File has changed on disk. Reload?</source>
         <translation>Kartela ka ndryshuar në disk. Të ringarkohet?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="634"/>
-        <location filename="../src/widgets/bottombar.cpp" line="60"/>
+        <location filename="../src/editor/editwrapper.cpp" line="801"/>
+        <location filename="../src/widgets/bottombar.cpp" line="45"/>
         <source>INSERT</source>
         <translation>FUTE</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="637"/>
+        <location filename="../src/editor/editwrapper.cpp" line="804"/>
         <source>OVERWRITE</source>
         <translation>MBISHKRUAJE</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="640"/>
+        <location filename="../src/editor/editwrapper.cpp" line="807"/>
         <source>R/O</source>
         <translation>V/L</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="945"/>
+        <source>The file cannot be read, which may be too large or has been damaged!</source>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
     <name>FindBar</name>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="40"/>
+        <location filename="../src/controls/findbar.cpp" line="22"/>
         <source>Find</source>
         <translation>Gjej</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="44"/>
+        <location filename="../src/controls/findbar.cpp" line="26"/>
         <source>Previous</source>
         <translation>E mëparshmja</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="46"/>
+        <location filename="../src/controls/findbar.cpp" line="28"/>
         <source>Next</source>
         <translation>Pasuesja</translation>
     </message>
@@ -111,7 +116,7 @@
 <context>
     <name>JumpLineBar</name>
     <message>
-        <location filename="../src/controls/jumplinebar.cpp" line="40"/>
+        <location filename="../src/controls/jumplinebar.cpp" line="28"/>
         <source>Go to Line: </source>
         <translation>Shko te Rreshti: </translation>
     </message>
@@ -119,12 +124,12 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/editorapplication.cpp" line="27"/>
+        <location filename="../src/editorapplication.cpp" line="11"/>
         <source>Text Editor is a powerful tool for viewing and editing text files.</source>
         <translation>Përpunuesi i Teksteve është një mjet i fuqishëm për parje dhe përpunim kartelash tekst.</translation>
     </message>
     <message>
-        <location filename="../src/editorapplication.cpp" line="38"/>
+        <location filename="../src/editorapplication.cpp" line="22"/>
         <source>Text Editor</source>
         <translation>Përpunues Tekstesh</translation>
     </message>
@@ -132,572 +137,572 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/editorapplication.cpp" line="35"/>
+        <location filename="../src/editorapplication.cpp" line="19"/>
         <source>Text Editor</source>
         <translation>Përpunues Tekstesh</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="203"/>
-        <location filename="../src/editor/editwrapper.cpp" line="538"/>
-        <location filename="../src/widgets/window.cpp" line="956"/>
-        <location filename="../src/widgets/window.cpp" line="973"/>
-        <location filename="../src/widgets/window.cpp" line="1064"/>
-        <location filename="../src/widgets/window.cpp" line="1079"/>
+        <location filename="../src/editor/editwrapper.cpp" line="248"/>
+        <location filename="../src/editor/editwrapper.cpp" line="704"/>
+        <location filename="../src/widgets/window.cpp" line="1089"/>
+        <location filename="../src/widgets/window.cpp" line="1111"/>
+        <location filename="../src/widgets/window.cpp" line="1203"/>
+        <location filename="../src/widgets/window.cpp" line="1218"/>
         <source>Encoding</source>
         <translation>Kodim</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="24"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="9"/>
         <source>Basic</source>
         <translation>Elementare</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="25"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="10"/>
         <source>Font Style</source>
         <translation>Stil Shkronjash</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="26"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="11"/>
         <source>Font</source>
         <translation>Shkronja</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="27"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="12"/>
         <source>Font Size</source>
         <translation>Madhësi Shkronjash</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="28"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="13"/>
         <source>Shortcuts</source>
         <translation>Shkurtore</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="29"/>
-        <location filename="../src/controls/settingsdialog.cpp" line="30"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="14"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="15"/>
         <source>Keymap</source>
         <translation>Skemë tastiere</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="31"/>
-        <location filename="../src/controls/settingsdialog.cpp" line="107"/>
-        <location filename="../src/widgets/window.cpp" line="1482"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="16"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="92"/>
+        <location filename="../src/widgets/window.cpp" line="1811"/>
         <source>Window</source>
         <translation>Dritare</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="32"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="17"/>
         <source>New tab</source>
         <translation>Skedë e re</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="33"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="18"/>
         <source>New window</source>
         <translation>Dritare e re</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="34"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="19"/>
         <source>Save</source>
         <translation>Ruaje</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="35"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="20"/>
         <source>Save as</source>
         <translation>Ruaje si</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="36"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="21"/>
         <source>Next tab</source>
         <translation>Skeda pasuese</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="37"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="22"/>
         <source>Previous tab</source>
         <translation>Skeda e mëparshme</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="38"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="23"/>
         <source>Close tab</source>
         <translation>Mbylle skedën</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="39"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="24"/>
         <source>Close other tabs</source>
         <translation>Mbylli skedat e tjera</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="40"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="25"/>
         <source>Restore tab</source>
         <translation>Riktheje skedën</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="41"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="26"/>
         <source>Open file</source>
         <translation>Hap kartelë</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="42"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="27"/>
         <source>Increment font size</source>
         <translation>Rritje madhësie shkronjash</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="43"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="28"/>
         <source>Decrement font size</source>
         <translation>Zvogëlim madhësie shkronjash</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="44"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="29"/>
         <source>Reset font size</source>
         <translation>Ktheje madhësinë e shkronjave te parazgjedhja</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="45"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="30"/>
         <source>Help</source>
         <translation>Ndihmë</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="46"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="31"/>
         <source>Toggle fullscreen</source>
         <translation>Aktivizo/Çaktivizo mënyrën “sa krejt ekrani”</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="47"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="32"/>
         <source>Find</source>
         <translation>Gjej</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="48"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="33"/>
         <source>Replace</source>
         <translation>Zëvendësoje</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="49"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="34"/>
         <source>Go to line</source>
         <translation>Shko te rreshti</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="50"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="35"/>
         <source>Save cursor position</source>
         <translation>Ruaj pozicionin e kursorit</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="51"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="36"/>
         <source>Reset cursor position</source>
         <translation>Zero pozicionin e kursorit</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="52"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="37"/>
         <source>Exit</source>
         <translation>Dil</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="53"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="38"/>
         <source>Display shortcuts</source>
         <translation>Shfaq shkurtore</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="54"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="39"/>
         <source>Print</source>
         <translation>Shtype</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="55"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="40"/>
         <source>Editor</source>
         <translation>Përpunues</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="56"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="41"/>
         <source>Increase indent</source>
         <translation>Rrit hapësirë kryeradhe</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="57"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="42"/>
         <source>Decrease indent</source>
         <translation>Zvogëlo hapësirë kryeradhe</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="58"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="43"/>
         <source>Forward character</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="59"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="44"/>
         <source>Backward character</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="60"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="45"/>
         <source>Forward word</source>
         <translation>Fjala përpara</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="61"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="46"/>
         <source>Backward word</source>
         <translation>Fjala prapa</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="62"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="47"/>
         <source>Next line</source>
         <translation>Rreshti pasues</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="63"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="48"/>
         <source>Previous line</source>
         <translation>Rreshti i mëparshëm</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="64"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="49"/>
         <source>New line</source>
         <translation>Rresht i ri</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="65"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="50"/>
         <source>New line above</source>
         <translation>Rresht i ri sipër</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="66"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="51"/>
         <source>New line below</source>
         <translation>Rresht i ri poshtë</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="67"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="52"/>
         <source>Duplicate line</source>
         <translation>Përsëdyte rreshtin</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="68"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="53"/>
         <source>Delete to end of line</source>
         <translation>Fshije deri në fund të rreshtit</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="69"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="54"/>
         <source>Delete current line</source>
         <translation>Fshi rreshtin e tanishëm</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="70"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="55"/>
         <source>Swap line up</source>
         <translation>Këmbeje me rreshtin sipër</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="71"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="56"/>
         <source>Swap line down</source>
         <translation>Këmbeje me rreshtin poshtë</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="72"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="57"/>
         <source>Scroll up one line</source>
         <translation>Ngjitu një rresht më sipër</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="73"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="58"/>
         <source>Scroll down one line</source>
         <translation>Zbrit një rresht më poshtë</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="74"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="59"/>
         <source>Page up</source>
         <translation>Page Up</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="75"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="60"/>
         <source>Page down</source>
         <translation>Page Down</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="76"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="61"/>
         <source>Move to end of line</source>
         <translation>Kalo te fund rreshti</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="77"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="62"/>
         <source>Move to start of line</source>
         <translation>Kalo në fillim rreshti</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="78"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="63"/>
         <source>Move to end of text</source>
         <translation>Kalo në fund të tekstit</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="79"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="64"/>
         <source>Move to start of text</source>
         <translation>Kalo në fillim të tekstit</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="80"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="65"/>
         <source>Move to line indentation</source>
         <translation>Kalo te kryeradhë rreshti</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="81"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="66"/>
         <source>Upper case</source>
         <translation>Shkronja të mëdha</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="82"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="67"/>
         <source>Lower case</source>
         <translation>Shkronja të vogla</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="83"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="68"/>
         <source>Capitalize</source>
         <translation>Kaloje Në Shkronjë të Madhe</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="84"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="69"/>
         <source>Delete backward word</source>
         <translation>Fshi fjalën prapa</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="85"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="70"/>
         <source>Delete forward word</source>
         <translation>Fshi fjalën përpara</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="86"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="71"/>
         <source>Forward over a pair</source>
         <translation>Përpara tej një dysheje</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="87"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="72"/>
         <source>Backward over a pair</source>
         <translation>Mbrapsht tej një dysheje</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="88"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="73"/>
         <source>Select all</source>
         <translation>Përzgjidhe krejt</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="89"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="74"/>
         <source>Copy</source>
         <translation>Kopjoje</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="90"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="75"/>
         <source>Cut</source>
         <translation>Prije</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="91"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="76"/>
         <source>Paste</source>
         <translation>Ngjite</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="92"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="77"/>
         <source>Transpose character</source>
         <translation>Ndërkëmbe shenjën</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="93"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="78"/>
         <source>Mark</source>
         <translation>Vëri shenjë</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="94"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="79"/>
         <source>Unmark</source>
         <translation>Hiqja shenjën</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="95"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="80"/>
         <source>Copy line</source>
         <translation>Kopjo rreshtin</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="96"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="81"/>
         <source>Cut line</source>
         <translation>Prije rreshtin</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="97"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="82"/>
         <source>Merge lines</source>
         <translation>Përzie rreshta</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="98"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="83"/>
         <source>Read-Only mode</source>
         <translation>Mënyrë “Vetëm Për Lexim”</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="99"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="84"/>
         <source>Add comment</source>
         <translation>Shtoni koment</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="100"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="85"/>
         <source>Remove comment</source>
         <translation>Hiqe komentin</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="101"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="86"/>
         <source>Undo</source>
         <translation>Zhbëje</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="102"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="87"/>
         <source>Redo</source>
         <translation>Ribëje</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="103"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="88"/>
         <source>Add/Remove bookmark</source>
         <translation>Shtoni/Hiqni faqerojtës</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="104"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="89"/>
         <source>Move to previous bookmark</source>
         <translation>Kalo te faqerojtësi i mëparshëm</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="105"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="90"/>
         <source>Move to next bookmark</source>
         <translation>Kalo te faqerojtësi pasues</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="106"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="91"/>
         <source>Advanced</source>
         <translation>Të mëtejshme</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="108"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="93"/>
         <source>Window size</source>
         <translation>Madhësi dritareje</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="109"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="94"/>
         <source>Tab width</source>
         <translation>Gjerësi Tabulacioni</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="111"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="96"/>
         <source>Word wrap</source>
         <translation>Mbështjellje fjale</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="112"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="97"/>
         <source>Code folding flag</source>
         <translation>Shenjë për mbështjellje kodi</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="113"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="98"/>
         <source>Show line numbers</source>
         <translation>Shfaq numra rreshtash</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="114"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="99"/>
         <source>Show bookmarks icon</source>
         <translation>Shfaq ikonë faqerojtësish</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="115"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="100"/>
         <source>Show whitespaces and tabs</source>
         <translation>Shfaq hapësira të zbrazëta dhe tabulacione</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="116"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="101"/>
         <source>Highlight current line</source>
         <translation>Thekso rreshtin e tanishëm</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="117"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="102"/>
         <source>Color mark</source>
         <translation>Shenjë ngjyre</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="120"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="105"/>
         <source>Unicode</source>
         <translation>Unikod</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="121"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="106"/>
         <source>WesternEuropean</source>
         <translation>Europiane Perëndimore</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="122"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="107"/>
         <source>CentralEuropean</source>
         <translation>Europiane Qendrore</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="123"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="108"/>
         <source>Baltic</source>
         <translation>Baltike</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="124"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="109"/>
         <source>Cyrillic</source>
         <translation>Cirilike</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="125"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="110"/>
         <source>Arabic</source>
         <translation>Arabe</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="130"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="115"/>
         <source>Celtic</source>
         <translation>Kelte</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="131"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="116"/>
         <source>SouthEasternEuropean</source>
         <translation>Europiane Juglindore</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="126"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="111"/>
         <source>Greek</source>
         <translation>Greke</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="127"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="112"/>
         <source>Hebrew</source>
         <translation>Hebraishte</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="132"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="117"/>
         <source>ChineseSimplified</source>
         <translation>Kineze të Thjeshtuara</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="133"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="118"/>
         <source>ChineseTraditional</source>
         <translation>Kineze Tradicionale</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="134"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="119"/>
         <source>Japanese</source>
         <translation>Japoneze</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="135"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="120"/>
         <source>Korean</source>
         <translation>Koreane</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="129"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="114"/>
         <source>Thai</source>
         <translation>Tajlandeze</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="128"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="113"/>
         <source>Turkish</source>
         <translation>Turke</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="136"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="121"/>
         <source>Vietnamese</source>
         <translation>Vietnameze</translation>
     </message>
     <message>
-        <location filename="../src/startmanager.cpp" line="762"/>
+        <location filename="../src/startmanager.cpp" line="832"/>
         <source>File not saved</source>
         <translation>Kartela s’u ruajt</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="974"/>
-        <location filename="../src/widgets/window.cpp" line="1065"/>
-        <location filename="../src/widgets/window.cpp" line="1080"/>
+        <location filename="../src/widgets/window.cpp" line="1112"/>
+        <location filename="../src/widgets/window.cpp" line="1204"/>
+        <location filename="../src/widgets/window.cpp" line="1219"/>
         <source>Line Endings</source>
         <translation>Funde Rreshtash</translation>
     </message>
@@ -705,32 +710,32 @@
 <context>
     <name>ReplaceBar</name>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="39"/>
+        <location filename="../src/controls/replacebar.cpp" line="21"/>
         <source>Find</source>
         <translation>Gjej</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="43"/>
+        <location filename="../src/controls/replacebar.cpp" line="25"/>
         <source>Replace With</source>
         <translation>Zëvendësoje Me</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="47"/>
+        <location filename="../src/controls/replacebar.cpp" line="29"/>
         <source>Replace</source>
         <translation>Zëvendësoje</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="50"/>
+        <location filename="../src/controls/replacebar.cpp" line="32"/>
         <source>Skip</source>
         <translation>Anashkaloje</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="53"/>
+        <location filename="../src/controls/replacebar.cpp" line="35"/>
         <source>Replace Rest</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="56"/>
+        <location filename="../src/controls/replacebar.cpp" line="38"/>
         <source>Replace All</source>
         <translation>Zëvendësoji Krejt</translation>
     </message>
@@ -747,58 +752,58 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../src/common/settings.cpp" line="91"/>
+        <location filename="../src/common/settings.cpp" line="115"/>
         <source>Standard</source>
         <translation>Standarde</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="91"/>
+        <location filename="../src/common/settings.cpp" line="115"/>
         <source>Customize</source>
         <translation>Përshtateni</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="104"/>
+        <location filename="../src/common/settings.cpp" line="128"/>
         <source>Normal</source>
         <translation>Normale</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="104"/>
+        <location filename="../src/common/settings.cpp" line="128"/>
         <source>Maximum</source>
         <translation>Maksimum</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="104"/>
+        <location filename="../src/common/settings.cpp" line="128"/>
         <source>Fullscreen</source>
         <translation>Sa krejt ekrani</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="292"/>
+        <location filename="../src/common/settings.cpp" line="316"/>
         <source>This shortcut conflicts with system shortcut %1</source>
         <translation>Kjo shkurtore përplaset me shkurtoren e sistemit %1</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="294"/>
+        <location filename="../src/common/settings.cpp" line="318"/>
         <source>This shortcut conflicts with %1, click on Replace to make this shortcut effective immediately</source>
         <translation>Kjo shkurtore përplaset me %1, klikoni mbi Zëvendësoje për ta bërë këtë shkurtore të hyjë në fuqi menjëherë</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="410"/>
-        <location filename="../src/common/settings.cpp" line="418"/>
+        <location filename="../src/common/settings.cpp" line="464"/>
+        <location filename="../src/common/settings.cpp" line="472"/>
         <source>The shortcut %1 is invalid, please set another one.</source>
         <translation>Shkurtorja %1 është e pavlefshme, ju lutemi, caktoni një tjetër.</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="445"/>
+        <location filename="../src/common/settings.cpp" line="507"/>
         <source>Cancel</source>
         <translation>Anuloje</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="446"/>
+        <location filename="../src/common/settings.cpp" line="508"/>
         <source>Replace</source>
         <translation>Zëvendësoje</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="448"/>
+        <location filename="../src/common/settings.cpp" line="510"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
@@ -806,7 +811,7 @@
 <context>
     <name>StartManager</name>
     <message>
-        <location filename="../src/startmanager.cpp" line="340"/>
+        <location filename="../src/startmanager.cpp" line="350"/>
         <source>Untitled %1</source>
         <translation>%1 pa titull</translation>
     </message>
@@ -814,32 +819,32 @@
 <context>
     <name>Tabbar</name>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="515"/>
+        <location filename="../src/controls/tabbar.cpp" line="540"/>
         <source>Close tab</source>
         <translation>Mbylle skedën</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="516"/>
+        <location filename="../src/controls/tabbar.cpp" line="541"/>
         <source>Close other tabs</source>
         <translation>Mbylli skedat e tjera</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="517"/>
+        <location filename="../src/controls/tabbar.cpp" line="542"/>
         <source>More options</source>
         <translation>Më tepër mundësi</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="518"/>
+        <location filename="../src/controls/tabbar.cpp" line="543"/>
         <source>Close tabs to the left</source>
         <translation>Mbylli skedat në të majtë</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="519"/>
+        <location filename="../src/controls/tabbar.cpp" line="544"/>
         <source>Close tabs to the right</source>
         <translation>Mbylli skedat në të djathtë</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="520"/>
+        <location filename="../src/controls/tabbar.cpp" line="545"/>
         <source>Close unmodified tabs</source>
         <translation>Mbylli skedat e paprekura</translation>
     </message>
@@ -847,261 +852,259 @@
 <context>
     <name>TextEdit</name>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="235"/>
+        <location filename="../src/editor/dtextedit.cpp" line="259"/>
         <source>Undo</source>
         <translation>Zhbëje</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="236"/>
+        <location filename="../src/editor/dtextedit.cpp" line="260"/>
         <source>Redo</source>
         <translation>Ribëje</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="237"/>
+        <location filename="../src/editor/dtextedit.cpp" line="261"/>
         <source>Cut</source>
         <translation>Prije</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="238"/>
+        <location filename="../src/editor/dtextedit.cpp" line="262"/>
         <source>Copy</source>
         <translation>Kopjoje</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="239"/>
+        <location filename="../src/editor/dtextedit.cpp" line="263"/>
         <source>Paste</source>
         <translation>Ngjite</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="240"/>
+        <location filename="../src/editor/dtextedit.cpp" line="264"/>
         <source>Delete</source>
         <translation>Fshije</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="241"/>
+        <location filename="../src/editor/dtextedit.cpp" line="265"/>
         <source>Select All</source>
         <translation>Përzgjidhi Krejt</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="242"/>
-        <location filename="../src/widgets/window.cpp" line="361"/>
+        <location filename="../src/editor/dtextedit.cpp" line="266"/>
+        <location filename="../src/widgets/window.cpp" line="450"/>
         <source>Find</source>
         <translation>Gjej</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="243"/>
-        <location filename="../src/widgets/window.cpp" line="362"/>
+        <location filename="../src/editor/dtextedit.cpp" line="267"/>
+        <location filename="../src/widgets/window.cpp" line="451"/>
         <source>Replace</source>
         <translation>Zëvendësoje</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="244"/>
+        <location filename="../src/editor/dtextedit.cpp" line="268"/>
         <source>Go to Line</source>
         <translation>Shko te Rreshti</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="245"/>
+        <location filename="../src/editor/dtextedit.cpp" line="269"/>
         <source>Turn on Read-Only mode</source>
         <translation>Aktivizo mënyrën “Vetëm Për Lexim”</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="246"/>
+        <location filename="../src/editor/dtextedit.cpp" line="270"/>
         <source>Turn off Read-Only mode</source>
         <translation>Çaktivizo mënyrën “Vetëm Për Lexim”</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="247"/>
+        <location filename="../src/editor/dtextedit.cpp" line="271"/>
         <source>Fullscreen</source>
         <translation>Sa krejt ekrani</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="248"/>
+        <location filename="../src/editor/dtextedit.cpp" line="272"/>
         <source>Exit fullscreen</source>
         <translation>Dil nga mënyra sa krejt ekrani</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="249"/>
+        <location filename="../src/editor/dtextedit.cpp" line="273"/>
         <source>Display in file manager</source>
         <translation>Shfaqe në përgjegjës kartelash</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="250"/>
-        <location filename="../src/editor/dtextedit.cpp" line="302"/>
+        <location filename="../src/editor/dtextedit.cpp" line="274"/>
+        <location filename="../src/editor/dtextedit.cpp" line="326"/>
         <source>Add Comment</source>
         <translation>Shtoni Koment</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="251"/>
+        <location filename="../src/editor/dtextedit.cpp" line="275"/>
         <source>Text to Speech</source>
         <translation>Nga Tekst Në të Folur</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="252"/>
+        <location filename="../src/editor/dtextedit.cpp" line="276"/>
         <source>Stop reading</source>
         <translation>Ndale leximin</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="253"/>
+        <location filename="../src/editor/dtextedit.cpp" line="277"/>
         <source>Speech to Text</source>
         <translation>Nga e Folur Në Tekst</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="254"/>
+        <location filename="../src/editor/dtextedit.cpp" line="278"/>
         <source>Translate</source>
         <translation>Përkthejeni</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="255"/>
+        <location filename="../src/editor/dtextedit.cpp" line="279"/>
         <source>Column Mode</source>
         <translation>Mënyrë Shtylla</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="256"/>
+        <location filename="../src/editor/dtextedit.cpp" line="280"/>
         <source>Add bookmark</source>
         <translation>Shtoni faqerojtës</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="257"/>
+        <location filename="../src/editor/dtextedit.cpp" line="281"/>
         <source>Remove Bookmark</source>
         <translation>Hiqe Faqerojtësin</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="258"/>
+        <location filename="../src/editor/dtextedit.cpp" line="282"/>
         <source>Previous bookmark</source>
         <translation>Faqerojtësi i mëparshëm</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="259"/>
+        <location filename="../src/editor/dtextedit.cpp" line="283"/>
         <source>Next bookmark</source>
         <translation>Faqerojtësi pasues</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="260"/>
+        <location filename="../src/editor/dtextedit.cpp" line="284"/>
         <source>Remove All Bookmarks</source>
         <translation>Hiqi Krejt Faqerojtësit</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="261"/>
+        <location filename="../src/editor/dtextedit.cpp" line="285"/>
         <source>Fold All</source>
         <translation>Palosi Krejt</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="262"/>
+        <location filename="../src/editor/dtextedit.cpp" line="286"/>
         <source>Fold Current Level</source>
         <translation>Palos Nivelin e Tanishëm</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="263"/>
+        <location filename="../src/editor/dtextedit.cpp" line="287"/>
         <source>Unfold All</source>
         <translation>Shpalosi Krejt</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="264"/>
+        <location filename="../src/editor/dtextedit.cpp" line="288"/>
         <source>Unfold Current Level</source>
         <translation>Shpalos Nivelin e Tanishëm</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="269"/>
+        <location filename="../src/editor/dtextedit.cpp" line="293"/>
         <source>Color Mark</source>
         <translation>Shenjë Ngjyre</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="273"/>
+        <location filename="../src/editor/dtextedit.cpp" line="297"/>
         <source>Clear All Marks</source>
         <translation>Hiqi Krejt Shenjat</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="274"/>
+        <location filename="../src/editor/dtextedit.cpp" line="298"/>
         <source>Clear Last Mark</source>
         <translation>Spastro Shenjën e Fundit</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="283"/>
+        <location filename="../src/editor/dtextedit.cpp" line="307"/>
         <source>Mark</source>
         <translation>Vëri shenjë</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="295"/>
+        <location filename="../src/editor/dtextedit.cpp" line="319"/>
         <source>Mark All</source>
         <translation>Vëru Shenjë të Tërëve</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="303"/>
+        <location filename="../src/editor/dtextedit.cpp" line="327"/>
         <source>Remove Comment</source>
         <translation>Hiqe Komentin</translation>
     </message>
     <message>
-        <source>Failed to paste text: it is too large</source>
-        <translation type="vanished">S’u arrit të ngjitet tekst: është shumë i madh</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="2581"/>
+        <location filename="../src/editor/dtextedit.cpp" line="2672"/>
         <source>Copy failed: not enough memory</source>
         <translation>Kopjimi dështoi: s’ka kujtesë të mjaftueshme</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="2665"/>
+        <location filename="../src/editor/dtextedit.cpp" line="2756"/>
         <source>Press ALT and click lines to edit in column mode</source>
         <translation>Shtypni tastin ALT dhe klikoni mbi rreshtat që të përpunohen nën mënyrën shtyllë</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="346"/>
+        <location filename="../src/editor/dtextedit.cpp" line="370"/>
         <source>Change Case</source>
         <translation>Këmbe Shkronja</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="347"/>
+        <location filename="../src/editor/dtextedit.cpp" line="371"/>
         <source>Upper Case</source>
         <translation>Kaloje në Shkronja të Mëdha</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="348"/>
+        <location filename="../src/editor/dtextedit.cpp" line="372"/>
         <source>Lower Case</source>
         <translation>Kaloje në Shkronja të Vogla</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="349"/>
+        <location filename="../src/editor/dtextedit.cpp" line="373"/>
         <source>Capitalize</source>
         <translation>Kaloje Në Shkronjë të Madhe</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="64"/>
+        <location filename="../src/widgets/bottombar.cpp" line="49"/>
         <source>None</source>
         <translation>Asnjë</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1184"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1222"/>
         <source>Selected line(s) copied</source>
         <translation>U kopjua rreshti(at) i përzgjedhur</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1190"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1228"/>
         <source>Current line copied</source>
         <translation>U kopjua rreshti i tanishëm</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1210"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1248"/>
         <source>Selected line(s) clipped</source>
         <translation>Rreshti(at) i përzgjedhur u qeth</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1222"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1259"/>
         <source>Current line clipped</source>
         <translation>Rreshti i tanishëm u qeth</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="2591"/>
+        <location filename="../src/editor/dtextedit.cpp" line="2682"/>
         <source>Paste failed: not enough memory</source>
-        <translation type="unfinished"/>
+        <translation>Ngjitja dështoi: kujtesë e pamjaftueshme</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3439"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3617"/>
         <source>Read-Only mode is off</source>
         <translation>Mënyra “Vetëm Për Lexim” është off</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3446"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3465"/>
-        <location filename="../src/editor/dtextedit.cpp" line="6150"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3624"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3643"/>
+        <location filename="../src/editor/dtextedit.cpp" line="6656"/>
+        <location filename="../src/editor/dtextedit.cpp" line="6664"/>
+        <location filename="../src/editor/dtextedit.cpp" line="6675"/>
         <source>Read-Only mode is on</source>
         <translation>Mënyra “Vetëm Për Lexim” është on</translation>
     </message>
@@ -1109,7 +1112,7 @@
 <context>
     <name>WarningNotices</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="36"/>
+        <location filename="../src/controls/warningnotices.cpp" line="19"/>
         <source>Reload</source>
         <translation>Ringarkoje</translation>
     </message>
@@ -1117,129 +1120,130 @@
 <context>
     <name>Window</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="38"/>
-        <location filename="../src/widgets/window.cpp" line="357"/>
+        <location filename="../src/controls/warningnotices.cpp" line="21"/>
+        <location filename="../src/widgets/window.cpp" line="446"/>
         <source>Save as</source>
         <translation>Ruaje si</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="353"/>
+        <location filename="../src/widgets/window.cpp" line="442"/>
         <source>New window</source>
         <translation>Dritare e re</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="354"/>
+        <location filename="../src/widgets/window.cpp" line="443"/>
         <source>New tab</source>
         <translation>Skedë e re</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="355"/>
+        <location filename="../src/widgets/window.cpp" line="444"/>
         <source>Open file</source>
         <translation>Hap kartelë</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="356"/>
-        <location filename="../src/widgets/window.cpp" line="2217"/>
+        <location filename="../src/widgets/window.cpp" line="445"/>
+        <location filename="../src/widgets/window.cpp" line="2796"/>
         <source>Save</source>
         <translation>Ruaje</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="358"/>
+        <location filename="../src/widgets/window.cpp" line="447"/>
         <source>Print</source>
         <translation>Shtype</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="359"/>
+        <location filename="../src/widgets/window.cpp" line="448"/>
         <source>Switch theme</source>
         <translation>Këmbeni temë</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="360"/>
-        <location filename="../src/widgets/window.cpp" line="1542"/>
+        <location filename="../src/widgets/window.cpp" line="449"/>
+        <location filename="../src/widgets/window.cpp" line="1871"/>
         <source>Settings</source>
         <translation>Rregullime</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="471"/>
-        <location filename="../src/widgets/window.cpp" line="2468"/>
+        <location filename="../src/widgets/window.cpp" line="563"/>
+        <location filename="../src/widgets/window.cpp" line="3047"/>
         <source>Read-Only</source>
         <translation>Vetëm-Lexim</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="487"/>
+        <location filename="../src/widgets/window.cpp" line="579"/>
         <source>You do not have permission to open %1</source>
         <translation>S’keni leje të hapni %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="522"/>
+        <location filename="../src/widgets/window.cpp" line="619"/>
+        <location filename="../src/widgets/window.cpp" line="2359"/>
         <source>Invalid file: %1</source>
         <translation>Kartelë e pavlefshme: %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="602"/>
-        <location filename="../src/widgets/window.cpp" line="644"/>
+        <location filename="../src/widgets/window.cpp" line="733"/>
+        <location filename="../src/widgets/window.cpp" line="779"/>
         <source>Do you want to save this file?</source>
         <translation>Doni të ruhet kjo kartelë?</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="894"/>
+        <location filename="../src/widgets/window.cpp" line="1027"/>
         <source>You do not have permission to save %1</source>
         <translation>S’keni leje të ruani %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="918"/>
+        <location filename="../src/widgets/window.cpp" line="1051"/>
         <source>Saved successfully</source>
         <translation>U ruajt me sukses</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="954"/>
-        <location filename="../src/widgets/window.cpp" line="1021"/>
-        <location filename="../src/widgets/window.cpp" line="1062"/>
+        <location filename="../src/widgets/window.cpp" line="1087"/>
+        <location filename="../src/widgets/window.cpp" line="1160"/>
+        <location filename="../src/widgets/window.cpp" line="1201"/>
         <source>Save File</source>
         <translation>Ruaje Kartelën</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1023"/>
+        <location filename="../src/widgets/window.cpp" line="1162"/>
         <source>Encoding</source>
         <translation>Kodim</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1211"/>
+        <location filename="../src/widgets/window.cpp" line="1350"/>
         <source>Read-Only mode is on</source>
         <translation>Mënyra “Vetëm Për Lexim” është on</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1441"/>
+        <location filename="../src/widgets/window.cpp" line="1770"/>
         <source>Current location remembered</source>
         <translation>Vendi i tanishëm u mbajt mend</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1492"/>
+        <location filename="../src/widgets/window.cpp" line="1821"/>
         <source>Ctrl+&apos;=&apos;</source>
         <translation>Ctrl+&apos;=&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1495"/>
+        <location filename="../src/widgets/window.cpp" line="1824"/>
         <source>Ctrl+&apos;-&apos;</source>
         <translation>Ctrl+&apos;-&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1524"/>
+        <location filename="../src/widgets/window.cpp" line="1853"/>
         <source>Editor</source>
         <translation>Përpunues</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1890"/>
+        <location filename="../src/widgets/window.cpp" line="2451"/>
         <source>Untitled %1</source>
         <translation>%1 pa titull</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2215"/>
+        <location filename="../src/widgets/window.cpp" line="2794"/>
         <source>Cancel</source>
         <translation>Anuloje</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2216"/>
+        <location filename="../src/widgets/window.cpp" line="2795"/>
         <source>Discard</source>
         <translation>Hidhe Tej</translation>
     </message>

--- a/translations/deepin-editor_tr.ts
+++ b/translations/deepin-editor_tr.ts
@@ -2,17 +2,17 @@
 <context>
     <name>BottomBar</name>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="39"/>
+        <location filename="../src/widgets/bottombar.cpp" line="24"/>
         <source>Row</source>
         <translation>Satır</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="40"/>
+        <location filename="../src/widgets/bottombar.cpp" line="25"/>
         <source>Column</source>
         <translation>Sütun</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="41"/>
+        <location filename="../src/widgets/bottombar.cpp" line="26"/>
         <source>Characters %1</source>
         <translation>%1 Karakter</translation>
     </message>
@@ -20,9 +20,9 @@
 <context>
     <name>DDropdownMenu</name>
     <message>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="300"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="344"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="349"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="290"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="341"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="346"/>
         <source>None</source>
         <translation>Yok</translation>
     </message>
@@ -30,80 +30,85 @@
 <context>
     <name>EditWrapper</name>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="201"/>
-        <location filename="../src/editor/editwrapper.cpp" line="264"/>
-        <location filename="../src/editor/editwrapper.cpp" line="321"/>
-        <location filename="../src/editor/editwrapper.cpp" line="536"/>
+        <location filename="../src/editor/editwrapper.cpp" line="246"/>
+        <location filename="../src/editor/editwrapper.cpp" line="314"/>
+        <location filename="../src/editor/editwrapper.cpp" line="439"/>
+        <location filename="../src/editor/editwrapper.cpp" line="702"/>
         <source>Save</source>
         <translation>Kaydet</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="316"/>
+        <location filename="../src/editor/editwrapper.cpp" line="434"/>
         <source>Do you want to save this file?</source>
         <translation>Bu dosyayı kaydetmek ister misiniz?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="262"/>
-        <location filename="../src/editor/editwrapper.cpp" line="319"/>
+        <location filename="../src/editor/editwrapper.cpp" line="312"/>
+        <location filename="../src/editor/editwrapper.cpp" line="437"/>
         <source>Cancel</source>
         <translation>İptal</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="259"/>
+        <location filename="../src/editor/editwrapper.cpp" line="309"/>
         <source>Encoding changed. Do you want to save the file now?</source>
         <translation>Kodlama değişti. Dosyayı şimdi kaydetmek istiyor musunuz?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="320"/>
+        <location filename="../src/editor/editwrapper.cpp" line="438"/>
         <source>Discard</source>
         <translation>Yoksay</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="445"/>
+        <location filename="../src/editor/editwrapper.cpp" line="564"/>
         <source>You do not have permission to save %1</source>
         <translation>%1 dosyasını kaydetme izniniz yok</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="607"/>
+        <location filename="../src/editor/editwrapper.cpp" line="774"/>
         <source>File removed on the disk. Save it now?</source>
         <translation>Dosya diskten silinmiş. Şimdi kaydetmek ister misiniz?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="612"/>
+        <location filename="../src/editor/editwrapper.cpp" line="779"/>
         <source>File has changed on disk. Reload?</source>
         <translation>Disk üzerindeki dosya değişmiş. Yeniden yüklensin mi?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="634"/>
-        <location filename="../src/widgets/bottombar.cpp" line="60"/>
+        <location filename="../src/editor/editwrapper.cpp" line="801"/>
+        <location filename="../src/widgets/bottombar.cpp" line="45"/>
         <source>INSERT</source>
         <translation>EKLE</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="637"/>
+        <location filename="../src/editor/editwrapper.cpp" line="804"/>
         <source>OVERWRITE</source>
         <translation>ÜZERİNE YAZ</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="640"/>
+        <location filename="../src/editor/editwrapper.cpp" line="807"/>
         <source>R/O</source>
         <translation>S/O</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="945"/>
+        <source>The file cannot be read, which may be too large or has been damaged!</source>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
     <name>FindBar</name>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="40"/>
+        <location filename="../src/controls/findbar.cpp" line="22"/>
         <source>Find</source>
         <translation>Bul</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="44"/>
+        <location filename="../src/controls/findbar.cpp" line="26"/>
         <source>Previous</source>
         <translation>Önceki</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="46"/>
+        <location filename="../src/controls/findbar.cpp" line="28"/>
         <source>Next</source>
         <translation>Sonraki</translation>
     </message>
@@ -111,7 +116,7 @@
 <context>
     <name>JumpLineBar</name>
     <message>
-        <location filename="../src/controls/jumplinebar.cpp" line="40"/>
+        <location filename="../src/controls/jumplinebar.cpp" line="28"/>
         <source>Go to Line: </source>
         <translation>Şu Satıra Git:</translation>
     </message>
@@ -119,12 +124,12 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/editorapplication.cpp" line="27"/>
+        <location filename="../src/editorapplication.cpp" line="11"/>
         <source>Text Editor is a powerful tool for viewing and editing text files.</source>
         <translation>Metin Düzenleyici, metni görüntülemek ve düzenlemek için güçlü bir araçtır.</translation>
     </message>
     <message>
-        <location filename="../src/editorapplication.cpp" line="38"/>
+        <location filename="../src/editorapplication.cpp" line="22"/>
         <source>Text Editor</source>
         <translation>Metin Düzenleyici</translation>
     </message>
@@ -132,572 +137,572 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/editorapplication.cpp" line="35"/>
+        <location filename="../src/editorapplication.cpp" line="19"/>
         <source>Text Editor</source>
         <translation>Metin Düzenleyici</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="203"/>
-        <location filename="../src/editor/editwrapper.cpp" line="538"/>
-        <location filename="../src/widgets/window.cpp" line="956"/>
-        <location filename="../src/widgets/window.cpp" line="973"/>
-        <location filename="../src/widgets/window.cpp" line="1064"/>
-        <location filename="../src/widgets/window.cpp" line="1079"/>
+        <location filename="../src/editor/editwrapper.cpp" line="248"/>
+        <location filename="../src/editor/editwrapper.cpp" line="704"/>
+        <location filename="../src/widgets/window.cpp" line="1089"/>
+        <location filename="../src/widgets/window.cpp" line="1111"/>
+        <location filename="../src/widgets/window.cpp" line="1203"/>
+        <location filename="../src/widgets/window.cpp" line="1218"/>
         <source>Encoding</source>
         <translation>Kodlama</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="24"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="9"/>
         <source>Basic</source>
         <translation>Temel</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="25"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="10"/>
         <source>Font Style</source>
         <translation>Yazı Tipi Biçimi</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="26"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="11"/>
         <source>Font</source>
         <translation>Yazı Tipi</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="27"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="12"/>
         <source>Font Size</source>
         <translation>Yazı Tipi Boyutu</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="28"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="13"/>
         <source>Shortcuts</source>
         <translation>Kısayollar</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="29"/>
-        <location filename="../src/controls/settingsdialog.cpp" line="30"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="14"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="15"/>
         <source>Keymap</source>
         <translation>Tuş Eşleşmesi</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="31"/>
-        <location filename="../src/controls/settingsdialog.cpp" line="107"/>
-        <location filename="../src/widgets/window.cpp" line="1482"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="16"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="92"/>
+        <location filename="../src/widgets/window.cpp" line="1811"/>
         <source>Window</source>
         <translation>Pencere</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="32"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="17"/>
         <source>New tab</source>
         <translation>Yeni sekme</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="33"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="18"/>
         <source>New window</source>
         <translation>Yeni pencere</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="34"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="19"/>
         <source>Save</source>
         <translation>Kaydet</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="35"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="20"/>
         <source>Save as</source>
         <translation>Farklı kaydet</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="36"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="21"/>
         <source>Next tab</source>
         <translation>Sonraki sekme</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="37"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="22"/>
         <source>Previous tab</source>
         <translation>Önceki sekme</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="38"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="23"/>
         <source>Close tab</source>
         <translation>Sekmeyi kapat</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="39"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="24"/>
         <source>Close other tabs</source>
         <translation>Diğer sekmeleri kapat</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="40"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="25"/>
         <source>Restore tab</source>
         <translation>Sekmeyi geri yükle</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="41"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="26"/>
         <source>Open file</source>
         <translation>Dosya aç</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="42"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="27"/>
         <source>Increment font size</source>
         <translation>Yazı boyutunu büyüt</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="43"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="28"/>
         <source>Decrement font size</source>
         <translation>Yazı boyutunu küçült</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="44"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="29"/>
         <source>Reset font size</source>
         <translation>Yazı tipi boyutunu sıfırla</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="45"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="30"/>
         <source>Help</source>
         <translation>Yardım</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="46"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="31"/>
         <source>Toggle fullscreen</source>
         <translation>Tam ekranı aç/kapat</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="47"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="32"/>
         <source>Find</source>
         <translation>Bul</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="48"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="33"/>
         <source>Replace</source>
         <translation>Değiştir</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="49"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="34"/>
         <source>Go to line</source>
         <translation>Şu satıra git</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="50"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="35"/>
         <source>Save cursor position</source>
         <translation>İmleç konumunu kaydet</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="51"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="36"/>
         <source>Reset cursor position</source>
         <translation>İmleç konumunu sıfırla</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="52"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="37"/>
         <source>Exit</source>
         <translation>Çıkış</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="53"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="38"/>
         <source>Display shortcuts</source>
         <translation>Kısayolları görüntüle</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="54"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="39"/>
         <source>Print</source>
         <translation>Yazdır</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="55"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="40"/>
         <source>Editor</source>
         <translation>Düzenleyici</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="56"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="41"/>
         <source>Increase indent</source>
         <translation>Girinti düzeyini arttır</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="57"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="42"/>
         <source>Decrease indent</source>
         <translation>Girinti düzeyini azalt</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="58"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="43"/>
         <source>Forward character</source>
         <translation>Sonraki karakter</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="59"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="44"/>
         <source>Backward character</source>
         <translation>Önceki karakter</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="60"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="45"/>
         <source>Forward word</source>
         <translation>Sonraki sözcük</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="61"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="46"/>
         <source>Backward word</source>
         <translation>Önceki sözcük</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="62"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="47"/>
         <source>Next line</source>
         <translation>Sonraki satır</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="63"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="48"/>
         <source>Previous line</source>
         <translation>Önceki satır</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="64"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="49"/>
         <source>New line</source>
         <translation>Yeni satır</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="65"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="50"/>
         <source>New line above</source>
         <translation>Üste yeni satır</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="66"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="51"/>
         <source>New line below</source>
         <translation>Alta yeni satır</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="67"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="52"/>
         <source>Duplicate line</source>
         <translation>Yinelenen satır</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="68"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="53"/>
         <source>Delete to end of line</source>
         <translation>Satır sonuna kadar sil</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="69"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="54"/>
         <source>Delete current line</source>
         <translation>Mevcut satırı sil</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="70"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="55"/>
         <source>Swap line up</source>
         <translation>Üstteki satır ile değiştir</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="71"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="56"/>
         <source>Swap line down</source>
         <translation>Alttaki satır ile değiştir</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="72"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="57"/>
         <source>Scroll up one line</source>
         <translation>Bir satır yukarı kaydır</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="73"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="58"/>
         <source>Scroll down one line</source>
         <translation>Bir satır aşağı kaydır</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="74"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="59"/>
         <source>Page up</source>
         <translation>Sayfa üstü</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="75"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="60"/>
         <source>Page down</source>
         <translation>Sayfa altı</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="76"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="61"/>
         <source>Move to end of line</source>
         <translation>Satır sonuna git</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="77"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="62"/>
         <source>Move to start of line</source>
         <translation>Satır başına git</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="78"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="63"/>
         <source>Move to end of text</source>
         <translation>Metnin sonuna git</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="79"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="64"/>
         <source>Move to start of text</source>
         <translation>Metnin başına git</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="80"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="65"/>
         <source>Move to line indentation</source>
         <translation>Satır girintisine git</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="81"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="66"/>
         <source>Upper case</source>
         <translation>Büyük harf</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="82"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="67"/>
         <source>Lower case</source>
         <translation>Küçük harf</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="83"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="68"/>
         <source>Capitalize</source>
         <translation>İlk harfleri büyüt</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="84"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="69"/>
         <source>Delete backward word</source>
         <translation>Önceki sözcüğü sil</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="85"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="70"/>
         <source>Delete forward word</source>
         <translation>Sonraki sözcüğü sil</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="86"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="71"/>
         <source>Forward over a pair</source>
         <translation>Sonraki çift</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="87"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="72"/>
         <source>Backward over a pair</source>
         <translation>Önceki çift</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="88"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="73"/>
         <source>Select all</source>
         <translation>Tümünü seç</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="89"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="74"/>
         <source>Copy</source>
         <translation>Kopyala</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="90"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="75"/>
         <source>Cut</source>
         <translation>Kes</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="91"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="76"/>
         <source>Paste</source>
         <translation>Yapıştır</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="92"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="77"/>
         <source>Transpose character</source>
         <translation>Karakteri dönüştür</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="93"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="78"/>
         <source>Mark</source>
         <translation>İşaretle</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="94"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="79"/>
         <source>Unmark</source>
         <translation>İşareti kaldır</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="95"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="80"/>
         <source>Copy line</source>
         <translation>Satırı kopyala</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="96"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="81"/>
         <source>Cut line</source>
         <translation>Satırı kes</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="97"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="82"/>
         <source>Merge lines</source>
         <translation>Satırları birleştir</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="98"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="83"/>
         <source>Read-Only mode</source>
         <translation>Salt okunur kip</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="99"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="84"/>
         <source>Add comment</source>
         <translation>Yorum ekle</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="100"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="85"/>
         <source>Remove comment</source>
         <translation>Yorumu kaldır</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="101"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="86"/>
         <source>Undo</source>
         <translation>Geri al</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="102"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="87"/>
         <source>Redo</source>
         <translation>Yinele</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="103"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="88"/>
         <source>Add/Remove bookmark</source>
         <translation>Yer imi Ekle/Kaldır</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="104"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="89"/>
         <source>Move to previous bookmark</source>
         <translation>Önceki yer imine git</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="105"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="90"/>
         <source>Move to next bookmark</source>
         <translation>Sonraki yer imine git</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="106"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="91"/>
         <source>Advanced</source>
         <translation>Gelişmiş</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="108"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="93"/>
         <source>Window size</source>
         <translation>Pencere boyutu</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="109"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="94"/>
         <source>Tab width</source>
         <translation>Sekme genişliği</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="111"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="96"/>
         <source>Word wrap</source>
         <translation>Sözcük kaydır</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="112"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="97"/>
         <source>Code folding flag</source>
         <translation>Kod katlama bayrağı</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="113"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="98"/>
         <source>Show line numbers</source>
         <translation>Satır numaralarını göster</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="114"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="99"/>
         <source>Show bookmarks icon</source>
         <translation>Yer imi simgesini göster</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="115"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="100"/>
         <source>Show whitespaces and tabs</source>
         <translation>Boşluk ve sekmeleri göster</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="116"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="101"/>
         <source>Highlight current line</source>
         <translation>Mevcut satırı vurgula</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="117"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="102"/>
         <source>Color mark</source>
         <translation>Renk işareti</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="120"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="105"/>
         <source>Unicode</source>
         <translation>Unicode</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="121"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="106"/>
         <source>WesternEuropean</source>
         <translation>WesternEuropean</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="122"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="107"/>
         <source>CentralEuropean</source>
         <translation>CentralEuropean</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="123"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="108"/>
         <source>Baltic</source>
         <translation>Baltic</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="124"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="109"/>
         <source>Cyrillic</source>
         <translation>Cyrillic</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="125"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="110"/>
         <source>Arabic</source>
         <translation>Arabic</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="130"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="115"/>
         <source>Celtic</source>
         <translation>Celtic</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="131"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="116"/>
         <source>SouthEasternEuropean</source>
         <translation>SouthEasternEuropean</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="126"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="111"/>
         <source>Greek</source>
         <translation>Greek</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="127"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="112"/>
         <source>Hebrew</source>
         <translation>Hebrew</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="132"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="117"/>
         <source>ChineseSimplified</source>
         <translation>ChineseSimplified</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="133"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="118"/>
         <source>ChineseTraditional</source>
         <translation>ChineseTraditional</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="134"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="119"/>
         <source>Japanese</source>
         <translation>Japonca</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="135"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="120"/>
         <source>Korean</source>
         <translation>Korece</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="129"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="114"/>
         <source>Thai</source>
         <translation>Tayca</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="128"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="113"/>
         <source>Turkish</source>
         <translation>Türkçe</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="136"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="121"/>
         <source>Vietnamese</source>
         <translation>Vietnamca</translation>
     </message>
     <message>
-        <location filename="../src/startmanager.cpp" line="762"/>
+        <location filename="../src/startmanager.cpp" line="832"/>
         <source>File not saved</source>
         <translation>Dosya kaydedilmedi</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="974"/>
-        <location filename="../src/widgets/window.cpp" line="1065"/>
-        <location filename="../src/widgets/window.cpp" line="1080"/>
+        <location filename="../src/widgets/window.cpp" line="1112"/>
+        <location filename="../src/widgets/window.cpp" line="1204"/>
+        <location filename="../src/widgets/window.cpp" line="1219"/>
         <source>Line Endings</source>
         <translation>Satır Sonları</translation>
     </message>
@@ -705,32 +710,32 @@
 <context>
     <name>ReplaceBar</name>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="39"/>
+        <location filename="../src/controls/replacebar.cpp" line="21"/>
         <source>Find</source>
         <translation>Bul</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="43"/>
+        <location filename="../src/controls/replacebar.cpp" line="25"/>
         <source>Replace With</source>
         <translation>Şununla Değiştir</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="47"/>
+        <location filename="../src/controls/replacebar.cpp" line="29"/>
         <source>Replace</source>
         <translation>Değiştir</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="50"/>
+        <location filename="../src/controls/replacebar.cpp" line="32"/>
         <source>Skip</source>
         <translation>Atla</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="53"/>
+        <location filename="../src/controls/replacebar.cpp" line="35"/>
         <source>Replace Rest</source>
         <translation>Kalanları Değiştir</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="56"/>
+        <location filename="../src/controls/replacebar.cpp" line="38"/>
         <source>Replace All</source>
         <translation>Tümünü Değiştir</translation>
     </message>
@@ -747,58 +752,58 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../src/common/settings.cpp" line="91"/>
+        <location filename="../src/common/settings.cpp" line="115"/>
         <source>Standard</source>
         <translation>Standart</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="91"/>
+        <location filename="../src/common/settings.cpp" line="115"/>
         <source>Customize</source>
         <translation>Özelleştir</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="104"/>
+        <location filename="../src/common/settings.cpp" line="128"/>
         <source>Normal</source>
         <translation>Normal</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="104"/>
+        <location filename="../src/common/settings.cpp" line="128"/>
         <source>Maximum</source>
         <translation>En fazla</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="104"/>
+        <location filename="../src/common/settings.cpp" line="128"/>
         <source>Fullscreen</source>
         <translation>Tam ekran</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="292"/>
+        <location filename="../src/common/settings.cpp" line="316"/>
         <source>This shortcut conflicts with system shortcut %1</source>
         <translation>Bu kısayol, %1 sistem kısayolu ile çakışıyor</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="294"/>
+        <location filename="../src/common/settings.cpp" line="318"/>
         <source>This shortcut conflicts with %1, click on Replace to make this shortcut effective immediately</source>
         <translation>Bu kısayol %1 ile çakışıyor, bu kısayolu hemen etkin hale getirmek için Değiştire tıklayın</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="410"/>
-        <location filename="../src/common/settings.cpp" line="418"/>
+        <location filename="../src/common/settings.cpp" line="464"/>
+        <location filename="../src/common/settings.cpp" line="472"/>
         <source>The shortcut %1 is invalid, please set another one.</source>
         <translation>%1 kısayolu geçersiz, lütfen başka bir tane ayarlayın.</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="445"/>
+        <location filename="../src/common/settings.cpp" line="507"/>
         <source>Cancel</source>
         <translation>İptal</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="446"/>
+        <location filename="../src/common/settings.cpp" line="508"/>
         <source>Replace</source>
         <translation>Değiştir</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="448"/>
+        <location filename="../src/common/settings.cpp" line="510"/>
         <source>OK</source>
         <translation>Tamam</translation>
     </message>
@@ -806,7 +811,7 @@
 <context>
     <name>StartManager</name>
     <message>
-        <location filename="../src/startmanager.cpp" line="340"/>
+        <location filename="../src/startmanager.cpp" line="350"/>
         <source>Untitled %1</source>
         <translation>Başlıksız %1</translation>
     </message>
@@ -814,32 +819,32 @@
 <context>
     <name>Tabbar</name>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="515"/>
+        <location filename="../src/controls/tabbar.cpp" line="540"/>
         <source>Close tab</source>
         <translation>Sekmeyi kapat</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="516"/>
+        <location filename="../src/controls/tabbar.cpp" line="541"/>
         <source>Close other tabs</source>
         <translation>Diğer sekmeleri kapat</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="517"/>
+        <location filename="../src/controls/tabbar.cpp" line="542"/>
         <source>More options</source>
         <translation>Daha fazla seçenek</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="518"/>
+        <location filename="../src/controls/tabbar.cpp" line="543"/>
         <source>Close tabs to the left</source>
         <translation>Soldaki sekmeleri kapat</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="519"/>
+        <location filename="../src/controls/tabbar.cpp" line="544"/>
         <source>Close tabs to the right</source>
         <translation>Sağdaki sekmeleri kapat</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="520"/>
+        <location filename="../src/controls/tabbar.cpp" line="545"/>
         <source>Close unmodified tabs</source>
         <translation>Değiştirilmemiş sekmeleri kapat</translation>
     </message>
@@ -847,261 +852,259 @@
 <context>
     <name>TextEdit</name>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="235"/>
+        <location filename="../src/editor/dtextedit.cpp" line="259"/>
         <source>Undo</source>
         <translation>Geri al</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="236"/>
+        <location filename="../src/editor/dtextedit.cpp" line="260"/>
         <source>Redo</source>
         <translation>Yinele</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="237"/>
+        <location filename="../src/editor/dtextedit.cpp" line="261"/>
         <source>Cut</source>
         <translation>Kes</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="238"/>
+        <location filename="../src/editor/dtextedit.cpp" line="262"/>
         <source>Copy</source>
         <translation>Kopyala</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="239"/>
+        <location filename="../src/editor/dtextedit.cpp" line="263"/>
         <source>Paste</source>
         <translation>Yapıştır</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="240"/>
+        <location filename="../src/editor/dtextedit.cpp" line="264"/>
         <source>Delete</source>
         <translation>Sil</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="241"/>
+        <location filename="../src/editor/dtextedit.cpp" line="265"/>
         <source>Select All</source>
         <translation>Tümünü Seç</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="242"/>
-        <location filename="../src/widgets/window.cpp" line="361"/>
+        <location filename="../src/editor/dtextedit.cpp" line="266"/>
+        <location filename="../src/widgets/window.cpp" line="450"/>
         <source>Find</source>
         <translation>Bul</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="243"/>
-        <location filename="../src/widgets/window.cpp" line="362"/>
+        <location filename="../src/editor/dtextedit.cpp" line="267"/>
+        <location filename="../src/widgets/window.cpp" line="451"/>
         <source>Replace</source>
         <translation>Değiştir</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="244"/>
+        <location filename="../src/editor/dtextedit.cpp" line="268"/>
         <source>Go to Line</source>
         <translation>Şu Satıra Git</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="245"/>
+        <location filename="../src/editor/dtextedit.cpp" line="269"/>
         <source>Turn on Read-Only mode</source>
         <translation>Salt Okunur Kipi Aç</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="246"/>
+        <location filename="../src/editor/dtextedit.cpp" line="270"/>
         <source>Turn off Read-Only mode</source>
         <translation>Salt Okunur Kipi Kapat</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="247"/>
+        <location filename="../src/editor/dtextedit.cpp" line="271"/>
         <source>Fullscreen</source>
         <translation>Tam ekran</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="248"/>
+        <location filename="../src/editor/dtextedit.cpp" line="272"/>
         <source>Exit fullscreen</source>
         <translation>Tam ekrandan çık</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="249"/>
+        <location filename="../src/editor/dtextedit.cpp" line="273"/>
         <source>Display in file manager</source>
         <translation>Dosya yöneticisinde görüntüle</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="250"/>
-        <location filename="../src/editor/dtextedit.cpp" line="302"/>
+        <location filename="../src/editor/dtextedit.cpp" line="274"/>
+        <location filename="../src/editor/dtextedit.cpp" line="326"/>
         <source>Add Comment</source>
         <translation>Yorum Ekle</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="251"/>
+        <location filename="../src/editor/dtextedit.cpp" line="275"/>
         <source>Text to Speech</source>
         <translation>Yazıdan Konuşmaya</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="252"/>
+        <location filename="../src/editor/dtextedit.cpp" line="276"/>
         <source>Stop reading</source>
         <translation>Okumayı durdur</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="253"/>
+        <location filename="../src/editor/dtextedit.cpp" line="277"/>
         <source>Speech to Text</source>
         <translation>Konuşmadan Yazıya</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="254"/>
+        <location filename="../src/editor/dtextedit.cpp" line="278"/>
         <source>Translate</source>
         <translation>Çeviri</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="255"/>
+        <location filename="../src/editor/dtextedit.cpp" line="279"/>
         <source>Column Mode</source>
         <translation>Sütun Kipi</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="256"/>
+        <location filename="../src/editor/dtextedit.cpp" line="280"/>
         <source>Add bookmark</source>
         <translation>Yer imlerine ekle</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="257"/>
+        <location filename="../src/editor/dtextedit.cpp" line="281"/>
         <source>Remove Bookmark</source>
         <translation>Yer İmini Kaldır</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="258"/>
+        <location filename="../src/editor/dtextedit.cpp" line="282"/>
         <source>Previous bookmark</source>
         <translation>Önceki yer imi</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="259"/>
+        <location filename="../src/editor/dtextedit.cpp" line="283"/>
         <source>Next bookmark</source>
         <translation>Sonraki yer imi</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="260"/>
+        <location filename="../src/editor/dtextedit.cpp" line="284"/>
         <source>Remove All Bookmarks</source>
         <translation>Tüm Yer İmlerini Kaldır</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="261"/>
+        <location filename="../src/editor/dtextedit.cpp" line="285"/>
         <source>Fold All</source>
         <translation>Tümünü Katla</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="262"/>
+        <location filename="../src/editor/dtextedit.cpp" line="286"/>
         <source>Fold Current Level</source>
         <translation>Mevcut Seviyeyi Katla</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="263"/>
+        <location filename="../src/editor/dtextedit.cpp" line="287"/>
         <source>Unfold All</source>
         <translation>Tümünü Katlama</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="264"/>
+        <location filename="../src/editor/dtextedit.cpp" line="288"/>
         <source>Unfold Current Level</source>
         <translation>Mevcut Seviyeyi Katlama</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="269"/>
+        <location filename="../src/editor/dtextedit.cpp" line="293"/>
         <source>Color Mark</source>
         <translation>Renk İşareti</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="273"/>
+        <location filename="../src/editor/dtextedit.cpp" line="297"/>
         <source>Clear All Marks</source>
         <translation>Tüm İşaretleri Temizle</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="274"/>
+        <location filename="../src/editor/dtextedit.cpp" line="298"/>
         <source>Clear Last Mark</source>
         <translation>Son İşareti Temizle</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="283"/>
+        <location filename="../src/editor/dtextedit.cpp" line="307"/>
         <source>Mark</source>
         <translation>İşaretle</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="295"/>
+        <location filename="../src/editor/dtextedit.cpp" line="319"/>
         <source>Mark All</source>
         <translation>Tümünü İşaretle</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="303"/>
+        <location filename="../src/editor/dtextedit.cpp" line="327"/>
         <source>Remove Comment</source>
         <translation>Yorumu Kaldır</translation>
     </message>
     <message>
-        <source>Failed to paste text: it is too large</source>
-        <translation type="vanished">Metin yapıştırılamadı: çok büyük</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="2581"/>
+        <location filename="../src/editor/dtextedit.cpp" line="2672"/>
         <source>Copy failed: not enough memory</source>
         <translation>Kopyalama başarısız: yeterli bellek yok</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="2665"/>
+        <location filename="../src/editor/dtextedit.cpp" line="2756"/>
         <source>Press ALT and click lines to edit in column mode</source>
         <translation>Sütun kipinde düzenlemek için ALT tuşuna bas ve satırları tıkla</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="346"/>
+        <location filename="../src/editor/dtextedit.cpp" line="370"/>
         <source>Change Case</source>
         <translation>Büyük Küçük Harfi Değiştir</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="347"/>
+        <location filename="../src/editor/dtextedit.cpp" line="371"/>
         <source>Upper Case</source>
         <translation>Büyük Harf</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="348"/>
+        <location filename="../src/editor/dtextedit.cpp" line="372"/>
         <source>Lower Case</source>
         <translation>Küçük Harf</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="349"/>
+        <location filename="../src/editor/dtextedit.cpp" line="373"/>
         <source>Capitalize</source>
         <translation>İlk Harfleri Büyüt</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="64"/>
+        <location filename="../src/widgets/bottombar.cpp" line="49"/>
         <source>None</source>
         <translation>Yok</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1184"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1222"/>
         <source>Selected line(s) copied</source>
         <translation>Seçilen satır(lar) kopyalandı</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1190"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1228"/>
         <source>Current line copied</source>
         <translation>Mevcut satır kopyalandı</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1210"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1248"/>
         <source>Selected line(s) clipped</source>
         <translation>Seçilen satır(lar) kırpıldı</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1222"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1259"/>
         <source>Current line clipped</source>
         <translation>Mevcut satır kopyalandı</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="2591"/>
+        <location filename="../src/editor/dtextedit.cpp" line="2682"/>
         <source>Paste failed: not enough memory</source>
         <translation>Yapıştırılamadı: yeterli bellek yok</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3439"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3617"/>
         <source>Read-Only mode is off</source>
         <translation>Salt okunur kip kapalı</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3446"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3465"/>
-        <location filename="../src/editor/dtextedit.cpp" line="6150"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3624"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3643"/>
+        <location filename="../src/editor/dtextedit.cpp" line="6656"/>
+        <location filename="../src/editor/dtextedit.cpp" line="6664"/>
+        <location filename="../src/editor/dtextedit.cpp" line="6675"/>
         <source>Read-Only mode is on</source>
         <translation>Salt okunur kip açık</translation>
     </message>
@@ -1109,7 +1112,7 @@
 <context>
     <name>WarningNotices</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="36"/>
+        <location filename="../src/controls/warningnotices.cpp" line="19"/>
         <source>Reload</source>
         <translation>Yeniden yükle</translation>
     </message>
@@ -1117,129 +1120,130 @@
 <context>
     <name>Window</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="38"/>
-        <location filename="../src/widgets/window.cpp" line="357"/>
+        <location filename="../src/controls/warningnotices.cpp" line="21"/>
+        <location filename="../src/widgets/window.cpp" line="446"/>
         <source>Save as</source>
         <translation>Farklı kaydet</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="353"/>
+        <location filename="../src/widgets/window.cpp" line="442"/>
         <source>New window</source>
         <translation>Yeni pencere</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="354"/>
+        <location filename="../src/widgets/window.cpp" line="443"/>
         <source>New tab</source>
         <translation>Yeni sekme</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="355"/>
+        <location filename="../src/widgets/window.cpp" line="444"/>
         <source>Open file</source>
         <translation>Dosya aç</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="356"/>
-        <location filename="../src/widgets/window.cpp" line="2217"/>
+        <location filename="../src/widgets/window.cpp" line="445"/>
+        <location filename="../src/widgets/window.cpp" line="2796"/>
         <source>Save</source>
         <translation>Kaydet</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="358"/>
+        <location filename="../src/widgets/window.cpp" line="447"/>
         <source>Print</source>
         <translation>Yazdır</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="359"/>
+        <location filename="../src/widgets/window.cpp" line="448"/>
         <source>Switch theme</source>
         <translation>Temayı değiştir</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="360"/>
-        <location filename="../src/widgets/window.cpp" line="1542"/>
+        <location filename="../src/widgets/window.cpp" line="449"/>
+        <location filename="../src/widgets/window.cpp" line="1871"/>
         <source>Settings</source>
         <translation>Ayarlar</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="471"/>
-        <location filename="../src/widgets/window.cpp" line="2468"/>
+        <location filename="../src/widgets/window.cpp" line="563"/>
+        <location filename="../src/widgets/window.cpp" line="3047"/>
         <source>Read-Only</source>
         <translation>Salt Okunur</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="487"/>
+        <location filename="../src/widgets/window.cpp" line="579"/>
         <source>You do not have permission to open %1</source>
         <translation>%1 dosyasını açma izniniz yok</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="522"/>
+        <location filename="../src/widgets/window.cpp" line="619"/>
+        <location filename="../src/widgets/window.cpp" line="2359"/>
         <source>Invalid file: %1</source>
         <translation>Geçersiz dosya: %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="602"/>
-        <location filename="../src/widgets/window.cpp" line="644"/>
+        <location filename="../src/widgets/window.cpp" line="733"/>
+        <location filename="../src/widgets/window.cpp" line="779"/>
         <source>Do you want to save this file?</source>
         <translation>Bu dosyayı kaydetmek ister misiniz?</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="894"/>
+        <location filename="../src/widgets/window.cpp" line="1027"/>
         <source>You do not have permission to save %1</source>
         <translation>%1 dosyasını kaydetme izniniz yok</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="918"/>
+        <location filename="../src/widgets/window.cpp" line="1051"/>
         <source>Saved successfully</source>
         <translation>Başarıyla kaydedildi</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="954"/>
-        <location filename="../src/widgets/window.cpp" line="1021"/>
-        <location filename="../src/widgets/window.cpp" line="1062"/>
+        <location filename="../src/widgets/window.cpp" line="1087"/>
+        <location filename="../src/widgets/window.cpp" line="1160"/>
+        <location filename="../src/widgets/window.cpp" line="1201"/>
         <source>Save File</source>
         <translation>Dosyayı Kaydet</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1023"/>
+        <location filename="../src/widgets/window.cpp" line="1162"/>
         <source>Encoding</source>
         <translation>Kodlama</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1211"/>
+        <location filename="../src/widgets/window.cpp" line="1350"/>
         <source>Read-Only mode is on</source>
         <translation>Salt okunur kip açık</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1441"/>
+        <location filename="../src/widgets/window.cpp" line="1770"/>
         <source>Current location remembered</source>
         <translation>Mevcut konum hatırlandı</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1492"/>
+        <location filename="../src/widgets/window.cpp" line="1821"/>
         <source>Ctrl+&apos;=&apos;</source>
         <translation>Ctrl+&apos;=&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1495"/>
+        <location filename="../src/widgets/window.cpp" line="1824"/>
         <source>Ctrl+&apos;-&apos;</source>
         <translation>Ctrl+&apos;-&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1524"/>
+        <location filename="../src/widgets/window.cpp" line="1853"/>
         <source>Editor</source>
         <translation>Düzenleyici</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1890"/>
+        <location filename="../src/widgets/window.cpp" line="2451"/>
         <source>Untitled %1</source>
         <translation>Başlıksız %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2215"/>
+        <location filename="../src/widgets/window.cpp" line="2794"/>
         <source>Cancel</source>
         <translation>İptal</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2216"/>
+        <location filename="../src/widgets/window.cpp" line="2795"/>
         <source>Discard</source>
         <translation>Yoksay</translation>
     </message>

--- a/translations/deepin-editor_ug.ts
+++ b/translations/deepin-editor_ug.ts
@@ -2,17 +2,17 @@
 <context>
     <name>BottomBar</name>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="39"/>
+        <location filename="../src/widgets/bottombar.cpp" line="24"/>
         <source>Row</source>
         <translation>قۇر</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="40"/>
+        <location filename="../src/widgets/bottombar.cpp" line="25"/>
         <source>Column</source>
         <translation>قاتار</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="41"/>
+        <location filename="../src/widgets/bottombar.cpp" line="26"/>
         <source>Characters %1</source>
         <translation>ھەرپ-بەلگە سانى %1</translation>
     </message>
@@ -20,9 +20,9 @@
 <context>
     <name>DDropdownMenu</name>
     <message>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="300"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="344"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="349"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="290"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="341"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="346"/>
         <source>None</source>
         <translation>يوق</translation>
     </message>
@@ -30,80 +30,85 @@
 <context>
     <name>EditWrapper</name>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="201"/>
-        <location filename="../src/editor/editwrapper.cpp" line="264"/>
-        <location filename="../src/editor/editwrapper.cpp" line="321"/>
-        <location filename="../src/editor/editwrapper.cpp" line="536"/>
+        <location filename="../src/editor/editwrapper.cpp" line="246"/>
+        <location filename="../src/editor/editwrapper.cpp" line="314"/>
+        <location filename="../src/editor/editwrapper.cpp" line="439"/>
+        <location filename="../src/editor/editwrapper.cpp" line="702"/>
         <source>Save</source>
         <translation>ساقلاش</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="316"/>
+        <location filename="../src/editor/editwrapper.cpp" line="434"/>
         <source>Do you want to save this file?</source>
         <translation>بۇ ھۆججەتنى ساقلامسىز؟</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="262"/>
-        <location filename="../src/editor/editwrapper.cpp" line="319"/>
+        <location filename="../src/editor/editwrapper.cpp" line="312"/>
+        <location filename="../src/editor/editwrapper.cpp" line="437"/>
         <source>Cancel</source>
         <translation>بىكار قىلىش</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="259"/>
+        <location filename="../src/editor/editwrapper.cpp" line="309"/>
         <source>Encoding changed. Do you want to save the file now?</source>
         <translation>ھۆججەت كودلاش ئۇسۇلى ئۆزگەرتىلدى، ئۇنى ئاۋۋال ساقلىماقچىمۇ؟</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="320"/>
+        <location filename="../src/editor/editwrapper.cpp" line="438"/>
         <source>Discard</source>
         <translation>ساقلىمايمەن</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="445"/>
+        <location filename="../src/editor/editwrapper.cpp" line="564"/>
         <source>You do not have permission to save %1</source>
         <translation>%1نى ساقلاش ھوقۇقىڭىز يوق</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="607"/>
+        <location filename="../src/editor/editwrapper.cpp" line="774"/>
         <source>File removed on the disk. Save it now?</source>
         <translation>دىسكىدىكى ئەسلى ھۆججەت ئۆچۈرۈلدى، قايتا ساقلىماقچىمۇ؟</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="612"/>
+        <location filename="../src/editor/editwrapper.cpp" line="779"/>
         <source>File has changed on disk. Reload?</source>
         <translation>دىسكىدىكى ئەسلى ھۆججەت ئۆزگەرتىلدى، قايتا يۈكلىمەكچىمۇ؟</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="634"/>
-        <location filename="../src/widgets/bottombar.cpp" line="60"/>
+        <location filename="../src/editor/editwrapper.cpp" line="801"/>
+        <location filename="../src/widgets/bottombar.cpp" line="45"/>
         <source>INSERT</source>
         <translation>كىرگۈزۈش</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="637"/>
+        <location filename="../src/editor/editwrapper.cpp" line="804"/>
         <source>OVERWRITE</source>
         <translation>باستۇرۇش</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="640"/>
+        <location filename="../src/editor/editwrapper.cpp" line="807"/>
         <source>R/O</source>
         <translation>پەقەت ئوقۇش</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="945"/>
+        <source>The file cannot be read, which may be too large or has been damaged!</source>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
     <name>FindBar</name>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="40"/>
+        <location filename="../src/controls/findbar.cpp" line="22"/>
         <source>Find</source>
         <translation>ئىزدەش</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="44"/>
+        <location filename="../src/controls/findbar.cpp" line="26"/>
         <source>Previous</source>
         <translation>ئالدىنقىسى</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="46"/>
+        <location filename="../src/controls/findbar.cpp" line="28"/>
         <source>Next</source>
         <translation>كېيىنكىسى</translation>
     </message>
@@ -111,7 +116,7 @@
 <context>
     <name>JumpLineBar</name>
     <message>
-        <location filename="../src/controls/jumplinebar.cpp" line="40"/>
+        <location filename="../src/controls/jumplinebar.cpp" line="28"/>
         <source>Go to Line: </source>
         <translation>سەكرەش:</translation>
     </message>
@@ -119,12 +124,12 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/editorapplication.cpp" line="27"/>
+        <location filename="../src/editorapplication.cpp" line="11"/>
         <source>Text Editor is a powerful tool for viewing and editing text files.</source>
         <translation>تېكىست تەھرىرلىگۈچ تېكىست ھۆججەتلىرىنى كۆرۈش ۋە تەھرىرلەش قورالىدۇر.</translation>
     </message>
     <message>
-        <location filename="../src/editorapplication.cpp" line="38"/>
+        <location filename="../src/editorapplication.cpp" line="22"/>
         <source>Text Editor</source>
         <translation>تېكىست تەھرىرلىگۈچ</translation>
     </message>
@@ -132,572 +137,572 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/editorapplication.cpp" line="35"/>
+        <location filename="../src/editorapplication.cpp" line="19"/>
         <source>Text Editor</source>
         <translation>تېكىست تەھرىرلىگۈچ</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="203"/>
-        <location filename="../src/editor/editwrapper.cpp" line="538"/>
-        <location filename="../src/widgets/window.cpp" line="956"/>
-        <location filename="../src/widgets/window.cpp" line="973"/>
-        <location filename="../src/widgets/window.cpp" line="1064"/>
-        <location filename="../src/widgets/window.cpp" line="1079"/>
+        <location filename="../src/editor/editwrapper.cpp" line="248"/>
+        <location filename="../src/editor/editwrapper.cpp" line="704"/>
+        <location filename="../src/widgets/window.cpp" line="1089"/>
+        <location filename="../src/widgets/window.cpp" line="1111"/>
+        <location filename="../src/widgets/window.cpp" line="1203"/>
+        <location filename="../src/widgets/window.cpp" line="1218"/>
         <source>Encoding</source>
         <translation>كودلاش</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="24"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="9"/>
         <source>Basic</source>
         <translation>ئاساسىي تەڭشەكلەر</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="25"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="10"/>
         <source>Font Style</source>
         <translation>خەت شەكلى ھالىتى</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="26"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="11"/>
         <source>Font</source>
         <translation>خەت شەكلى</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="27"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="12"/>
         <source>Font Size</source>
         <translation>خەت نومۇرى</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="28"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="13"/>
         <source>Shortcuts</source>
         <translation>تېزلەتمە</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="29"/>
-        <location filename="../src/controls/settingsdialog.cpp" line="30"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="14"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="15"/>
         <source>Keymap</source>
         <translation>تېزلەتمە كۆرۈنسۇن</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="31"/>
-        <location filename="../src/controls/settingsdialog.cpp" line="107"/>
-        <location filename="../src/widgets/window.cpp" line="1482"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="16"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="92"/>
+        <location filename="../src/widgets/window.cpp" line="1811"/>
         <source>Window</source>
         <translation>كۆزنەك</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="32"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="17"/>
         <source>New tab</source>
         <translation>يېڭى خەتكۈچ</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="33"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="18"/>
         <source>New window</source>
         <translation>يېڭى كۆزنەك</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="34"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="19"/>
         <source>Save</source>
         <translation>ساقلاش</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="35"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="20"/>
         <source>Save as</source>
         <translation>باشقا ساقلاش</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="36"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="21"/>
         <source>Next tab</source>
         <translation>كېيىنكى خەتكۈچ</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="37"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="22"/>
         <source>Previous tab</source>
         <translation>ئالدىنقى خەتكۈچ</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="38"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="23"/>
         <source>Close tab</source>
         <translation>خەتكۈچنى تاقاش</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="39"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="24"/>
         <source>Close other tabs</source>
         <translation>باشقا خەتكۈچنى تاقاش</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="40"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="25"/>
         <source>Restore tab</source>
         <translation>خەتكۈچنى ئەسلگە كەلتۈرۈش</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="41"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="26"/>
         <source>Open file</source>
         <translation>ئېچىش</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="42"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="27"/>
         <source>Increment font size</source>
         <translation>خەت نومۇرىنى چوڭايتىش</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="43"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="28"/>
         <source>Decrement font size</source>
         <translation>خەت نومۇرىنى كىچىكلىتىش</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="44"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="29"/>
         <source>Reset font size</source>
         <translation>خەت نومۇرىنى ئەسلىگە قايتۇرۇش</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="45"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="30"/>
         <source>Help</source>
         <translation>ياردەم</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="46"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="31"/>
         <source>Toggle fullscreen</source>
         <translation>پۈتۈن ئېكرانغا ئالماشتۇرۇش</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="47"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="32"/>
         <source>Find</source>
         <translation>ئىزدەش</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="48"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="33"/>
         <source>Replace</source>
         <translation>ئالماشتۇرۇش</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="49"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="34"/>
         <source>Go to line</source>
         <translation>سەكرەش</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="50"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="35"/>
         <source>Save cursor position</source>
         <translation>نۇر بەلگىسىنىڭ ئورنىنى ساقلاش</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="51"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="36"/>
         <source>Reset cursor position</source>
         <translation>نۇر بەلگىسى ساقلانغان ئورۇنغا سەكرىسۇن</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="52"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="37"/>
         <source>Exit</source>
         <translation>چېكىنىش</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="53"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="38"/>
         <source>Display shortcuts</source>
         <translation>تېزلەتمە كۆرۈنسۇن</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="54"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="39"/>
         <source>Print</source>
         <translation>بېسىش</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="55"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="40"/>
         <source>Editor</source>
         <translation>تەھرىرلەش</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="56"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="41"/>
         <source>Increase indent</source>
         <translation>قۇر بېشىنى قىسقارتىش</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="57"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="42"/>
         <source>Decrease indent</source>
         <translation>قۇر بېسىنى كېڭەيتىش</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="58"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="43"/>
         <source>Forward character</source>
         <translation>ئوڭغا بىر ھەرپ-بەلگە سۈرۈلسۇن</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="59"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="44"/>
         <source>Backward character</source>
         <translation>سولغا بىر ھەرپ-بەلگە سۈرۈلسۇن</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="60"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="45"/>
         <source>Forward word</source>
         <translation>ئوڭغا بىر سۆز يۆتكەلسۇن</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="61"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="46"/>
         <source>Backward word</source>
         <translation>سولغا بىر سۆز يۆتكەلسۇن</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="62"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="47"/>
         <source>Next line</source>
         <translation>كېيىنكى قۇر</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="63"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="48"/>
         <source>Previous line</source>
         <translation>ئالدىنقى قۇر</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="64"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="49"/>
         <source>New line</source>
         <translation>قۇر ئالمىشىش</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="65"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="50"/>
         <source>New line above</source>
         <translation>ئۈستىگە بىر قۇر قوشۇش</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="66"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="51"/>
         <source>New line below</source>
         <translation>ئاستىغا بىر قۇر قوشۇش</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="67"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="52"/>
         <source>Duplicate line</source>
         <translation>ھازىرقى ئورۇنغا كۆچۈرۈش ۋە چاپلاش</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="68"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="53"/>
         <source>Delete to end of line</source>
         <translation>قۇر ئاخىرىغىچە ئۆچۈرۈش</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="69"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="54"/>
         <source>Delete current line</source>
         <translation>بۇ قۇرنى ئۆچۈرۈش</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="70"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="55"/>
         <source>Swap line up</source>
         <translation>ئۈستىگە بىر قۇر يۆتكەش</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="71"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="56"/>
         <source>Swap line down</source>
         <translation>ئاستىغا بىر قۇر يۆتكەش</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="72"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="57"/>
         <source>Scroll up one line</source>
         <translation>ئۈستىگە بىر قۇر سىيرىش</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="73"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="58"/>
         <source>Scroll down one line</source>
         <translation>ئاستىغا بىر قۇر سىيرىش</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="74"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="59"/>
         <source>Page up</source>
         <translation>ئۈستىگە بىر بەت سىيرىش</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="75"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="60"/>
         <source>Page down</source>
         <translation>ئاستىغا بىر بەت سىيرىش</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="76"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="61"/>
         <source>Move to end of line</source>
         <translation>قۇر ئاخىرىغا يۆتكەش</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="77"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="62"/>
         <source>Move to start of line</source>
         <translation>قۇر بېشىغا يۆتكەش</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="78"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="63"/>
         <source>Move to end of text</source>
         <translation>تېكىست ئاخىرىغا يۆتكەش</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="79"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="64"/>
         <source>Move to start of text</source>
         <translation>تېكىست بېشىغا يۆتكەش</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="80"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="65"/>
         <source>Move to line indentation</source>
         <translation>قۇر قىسقارغۇچە يۆتكەش</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="81"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="66"/>
         <source>Upper case</source>
         <translation>چوڭ يېزىلىشقا ئالماشتۇرۇش</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="82"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="67"/>
         <source>Lower case</source>
         <translation>كىچىك يېزىلىشقا ئالماشتۇرۇش</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="83"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="68"/>
         <source>Capitalize</source>
         <translation>1-ھەرپ چوڭ يېزىلسۇن</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="84"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="69"/>
         <source>Delete backward word</source>
         <translation>سولغا بىر خەت ئۆچۈرسۇن</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="85"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="70"/>
         <source>Delete forward word</source>
         <translation>ئوڭغا بىر خەت ئۆچۈرسۇن</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="86"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="71"/>
         <source>Forward over a pair</source>
         <translation>ئوڭغا ماسلاشسۇن</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="87"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="72"/>
         <source>Backward over a pair</source>
         <translation>سولغا ماسلاشسۇن</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="88"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="73"/>
         <source>Select all</source>
         <translation>ھەممىسى</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="89"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="74"/>
         <source>Copy</source>
         <translation>كۆچۈرۈش</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="90"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="75"/>
         <source>Cut</source>
         <translation>كېسىش</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="91"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="76"/>
         <source>Paste</source>
         <translation>چاپلاش</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="92"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="77"/>
         <source>Transpose character</source>
         <translation>ھەرپ-بەلگە ئالماشتۇرۇش</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="93"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="78"/>
         <source>Mark</source>
         <translation>بەلگە قويۇش</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="94"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="79"/>
         <source>Unmark</source>
         <translation>بەلگىنى ئېلىۋېتىش</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="95"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="80"/>
         <source>Copy line</source>
         <translation>قۇرنى كۆچۈرۈش</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="96"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="81"/>
         <source>Cut line</source>
         <translation>قۇرنى كېسىۋېلىش</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="97"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="82"/>
         <source>Merge lines</source>
         <translation>قۇرنى قوشۇۋېتىش</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="98"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="83"/>
         <source>Read-Only mode</source>
         <translation>پەقەت ئوقۇيدىغان قىلىش</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="99"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="84"/>
         <source>Add comment</source>
         <translation>ئىزاھات قوشۇش</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="100"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="85"/>
         <source>Remove comment</source>
         <translation>ئىزاھاتنى بىكار قىلىش</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="101"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="86"/>
         <source>Undo</source>
         <translation>ئەمەلدىن قالدۇرۇش</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="102"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="87"/>
         <source>Redo</source>
         <translation>قايتا</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="103"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="88"/>
         <source>Add/Remove bookmark</source>
         <translation>خەتكۈچ قوشۇش/چىقىرىۋېتىش</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="104"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="89"/>
         <source>Move to previous bookmark</source>
         <translation>ئالدىنقى خەتكۈچ</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="105"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="90"/>
         <source>Move to next bookmark</source>
         <translation>كېيىنكى خەتكۈچ</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="106"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="91"/>
         <source>Advanced</source>
         <translation>ئالىي تەڭشەك</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="108"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="93"/>
         <source>Window size</source>
         <translation>كۆزنەك ھالىتى</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="109"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="94"/>
         <source>Tab width</source>
         <translation>Tab ھەرپ-بەلگىسىنىڭ كەڭلىكى</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="111"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="96"/>
         <source>Word wrap</source>
         <translation>قۇر ئاپتوماتىك ئالماشسۇن</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="112"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="97"/>
         <source>Code folding flag</source>
         <translation>كود قاتلىۋەتكەن بەلگىلەرنى كۆرسىتىش</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="113"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="98"/>
         <source>Show line numbers</source>
         <translation>قۇر نومۇرى كۆرۈنسۇن</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="114"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="99"/>
         <source>Show bookmarks icon</source>
         <translation>خەتكۈچ سىنبەلگىسى كۆرۈنسۇن</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="115"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="100"/>
         <source>Show whitespaces and tabs</source>
         <translation>قۇرۇق ھەرپ/بەتكۈچلەر كۆرۈنسۇن</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="116"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="101"/>
         <source>Highlight current line</source>
         <translation>نۆۋەتتىكى قۇر ئىگىزلىكى يورۇقلۇقى</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="117"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="102"/>
         <source>Color mark</source>
         <translation>رەڭ بەلگىسى</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="120"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="105"/>
         <source>Unicode</source>
         <translation>يۇنىكود</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="121"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="106"/>
         <source>WesternEuropean</source>
         <translation>غەربىي ياۋروپا تىل سىستېمىسى</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="122"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="107"/>
         <source>CentralEuropean</source>
         <translation>ئوتتۇرا ياۋروپا تىل سىستېمىسى</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="123"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="108"/>
         <source>Baltic</source>
         <translation>بالتىق دىڭىزى تىللىرى</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="124"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="109"/>
         <source>Cyrillic</source>
         <translation>سىرىل يېزىقى</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="125"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="110"/>
         <source>Arabic</source>
         <translation>ئەرەب تىلى</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="130"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="115"/>
         <source>Celtic</source>
         <translation>كېلتىك تىلى</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="131"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="116"/>
         <source>SouthEasternEuropean</source>
         <translation>شەرقىي جەنۇبىي ياۋروپا تىل سىستېمىسى</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="126"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="111"/>
         <source>Greek</source>
         <translation>گرېك تىلى</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="127"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="112"/>
         <source>Hebrew</source>
         <translation>ئىبرانى تىلى</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="132"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="117"/>
         <source>ChineseSimplified</source>
         <translation>ئاددىي خەنزۇ يېزىقى</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="133"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="118"/>
         <source>ChineseTraditional</source>
         <translation>مۇرەككەپ خەنزۇ يېزىقى</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="134"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="119"/>
         <source>Japanese</source>
         <translation>ياپونچە</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="135"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="120"/>
         <source>Korean</source>
         <translation>كورىيەچە</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="129"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="114"/>
         <source>Thai</source>
         <translation>تەي</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="128"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="113"/>
         <source>Turkish</source>
         <translation>تۈرك تىلى</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="136"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="121"/>
         <source>Vietnamese</source>
         <translation>ۋېيتنامچە</translation>
     </message>
     <message>
-        <location filename="../src/startmanager.cpp" line="762"/>
+        <location filename="../src/startmanager.cpp" line="832"/>
         <source>File not saved</source>
         <translation>ھۆججەت ساقلانمىغان</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="974"/>
-        <location filename="../src/widgets/window.cpp" line="1065"/>
-        <location filename="../src/widgets/window.cpp" line="1080"/>
+        <location filename="../src/widgets/window.cpp" line="1112"/>
+        <location filename="../src/widgets/window.cpp" line="1204"/>
+        <location filename="../src/widgets/window.cpp" line="1219"/>
         <source>Line Endings</source>
         <translation>قۇر تاشلاش بەلگىسى</translation>
     </message>
@@ -705,32 +710,32 @@
 <context>
     <name>ReplaceBar</name>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="39"/>
+        <location filename="../src/controls/replacebar.cpp" line="21"/>
         <source>Find</source>
         <translation>ئىزدەش</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="43"/>
+        <location filename="../src/controls/replacebar.cpp" line="25"/>
         <source>Replace With</source>
         <translation>غا ئالماشتۇرۇش</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="47"/>
+        <location filename="../src/controls/replacebar.cpp" line="29"/>
         <source>Replace</source>
         <translation>ئالماشتۇرۇش</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="50"/>
+        <location filename="../src/controls/replacebar.cpp" line="32"/>
         <source>Skip</source>
         <translation>ئاتلاش</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="53"/>
+        <location filename="../src/controls/replacebar.cpp" line="35"/>
         <source>Replace Rest</source>
         <translation>قالغانلىرىنى ئالماشتۇرۇش</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="56"/>
+        <location filename="../src/controls/replacebar.cpp" line="38"/>
         <source>Replace All</source>
         <translation>ھەممىنى ئالماشتۇرۇش</translation>
     </message>
@@ -747,58 +752,58 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../src/common/settings.cpp" line="91"/>
+        <location filename="../src/common/settings.cpp" line="115"/>
         <source>Standard</source>
         <translation>ئۆلچەملىك</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="91"/>
+        <location filename="../src/common/settings.cpp" line="115"/>
         <source>Customize</source>
         <translation>بەلگىلەش</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="104"/>
+        <location filename="../src/common/settings.cpp" line="128"/>
         <source>Normal</source>
         <translation>نورمال كۆزنەك</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="104"/>
+        <location filename="../src/common/settings.cpp" line="128"/>
         <source>Maximum</source>
         <translation>كىچىكلىتىش</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="104"/>
+        <location filename="../src/common/settings.cpp" line="128"/>
         <source>Fullscreen</source>
         <translation>پۈتۈن ئېكران</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="292"/>
+        <location filename="../src/common/settings.cpp" line="316"/>
         <source>This shortcut conflicts with system shortcut %1</source>
         <translation>بۇ تېزلەتمە سىستېما تېزلەتمىسى %1 بىلەن توقۇنۇشىدۇ</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="294"/>
+        <location filename="../src/common/settings.cpp" line="318"/>
         <source>This shortcut conflicts with %1, click on Replace to make this shortcut effective immediately</source>
         <translation>بۇ تېزلەتمە %1 بىلەن توقۇنۇشىدۇ، ئالماشتۇرۇشنى بېسىپ بۇ تېزلەتمنى ئۈنۈملۈك قىلىڭ</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="410"/>
-        <location filename="../src/common/settings.cpp" line="418"/>
+        <location filename="../src/common/settings.cpp" line="464"/>
+        <location filename="../src/common/settings.cpp" line="472"/>
         <source>The shortcut %1 is invalid, please set another one.</source>
         <translation>%1 ئۈنۈمسىز، قايتا بەلگىلەڭ</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="445"/>
+        <location filename="../src/common/settings.cpp" line="507"/>
         <source>Cancel</source>
         <translation>بىكار قىلىش</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="446"/>
+        <location filename="../src/common/settings.cpp" line="508"/>
         <source>Replace</source>
         <translation>ئالماشتۇرۇش</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="448"/>
+        <location filename="../src/common/settings.cpp" line="510"/>
         <source>OK</source>
         <translation>ھەئە</translation>
     </message>
@@ -806,7 +811,7 @@
 <context>
     <name>StartManager</name>
     <message>
-        <location filename="../src/startmanager.cpp" line="340"/>
+        <location filename="../src/startmanager.cpp" line="350"/>
         <source>Untitled %1</source>
         <translation>%1نىڭ نامىنى ئۆزگەتىش</translation>
     </message>
@@ -814,32 +819,32 @@
 <context>
     <name>Tabbar</name>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="515"/>
+        <location filename="../src/controls/tabbar.cpp" line="540"/>
         <source>Close tab</source>
         <translation>خەتكۈچنى تاقاش</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="516"/>
+        <location filename="../src/controls/tabbar.cpp" line="541"/>
         <source>Close other tabs</source>
         <translation>باشقا خەتكۈچنى تاقاش</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="517"/>
+        <location filename="../src/controls/tabbar.cpp" line="542"/>
         <source>More options</source>
         <translation>تېخىمۇ كۆپ تاقاش ئۇسۇلى</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="518"/>
+        <location filename="../src/controls/tabbar.cpp" line="543"/>
         <source>Close tabs to the left</source>
         <translation>سولدىكى بارلىق خەتكۈچنى تاقاش</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="519"/>
+        <location filename="../src/controls/tabbar.cpp" line="544"/>
         <source>Close tabs to the right</source>
         <translation>ئوڭدىكى بارلىق خەتكۈچنى تاقاش</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="520"/>
+        <location filename="../src/controls/tabbar.cpp" line="545"/>
         <source>Close unmodified tabs</source>
         <translation>ئۆزگەرتىلمىگەن بارلىق خەتكۈچنى تاقاش</translation>
     </message>
@@ -847,261 +852,259 @@
 <context>
     <name>TextEdit</name>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="235"/>
+        <location filename="../src/editor/dtextedit.cpp" line="259"/>
         <source>Undo</source>
         <translation>ئەمەلدىن قالدۇرۇش</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="236"/>
+        <location filename="../src/editor/dtextedit.cpp" line="260"/>
         <source>Redo</source>
         <translation>قايتا</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="237"/>
+        <location filename="../src/editor/dtextedit.cpp" line="261"/>
         <source>Cut</source>
         <translation>چاپلاش</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="238"/>
+        <location filename="../src/editor/dtextedit.cpp" line="262"/>
         <source>Copy</source>
         <translation>كۆچۈرۈش</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="239"/>
+        <location filename="../src/editor/dtextedit.cpp" line="263"/>
         <source>Paste</source>
         <translation>چاپلاش</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="240"/>
+        <location filename="../src/editor/dtextedit.cpp" line="264"/>
         <source>Delete</source>
         <translation>ئۆچۈرۈش</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="241"/>
+        <location filename="../src/editor/dtextedit.cpp" line="265"/>
         <source>Select All</source>
         <translation>ھەممىنى</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="242"/>
-        <location filename="../src/widgets/window.cpp" line="361"/>
+        <location filename="../src/editor/dtextedit.cpp" line="266"/>
+        <location filename="../src/widgets/window.cpp" line="450"/>
         <source>Find</source>
         <translation>ئىزدەش</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="243"/>
-        <location filename="../src/widgets/window.cpp" line="362"/>
+        <location filename="../src/editor/dtextedit.cpp" line="267"/>
+        <location filename="../src/widgets/window.cpp" line="451"/>
         <source>Replace</source>
         <translation>ئالماشتۇرۇش</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="244"/>
+        <location filename="../src/editor/dtextedit.cpp" line="268"/>
         <source>Go to Line</source>
         <translation>سەكرەش</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="245"/>
+        <location filename="../src/editor/dtextedit.cpp" line="269"/>
         <source>Turn on Read-Only mode</source>
         <translation>پەقەت ئوقۇيدىغان ھالەتنى ئېچىش</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="246"/>
+        <location filename="../src/editor/dtextedit.cpp" line="270"/>
         <source>Turn off Read-Only mode</source>
         <translation>پەقەت ئوقۇيدىغان ھالەتنى تاقاش</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="247"/>
+        <location filename="../src/editor/dtextedit.cpp" line="271"/>
         <source>Fullscreen</source>
         <translation>پۈتۈن ئېكران</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="248"/>
+        <location filename="../src/editor/dtextedit.cpp" line="272"/>
         <source>Exit fullscreen</source>
         <translation>پۈتۈن ئېكراندىن چېكىنىش</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="249"/>
+        <location filename="../src/editor/dtextedit.cpp" line="273"/>
         <source>Display in file manager</source>
         <translation>ھۆججەت باشقۇرغۇچتا كۆرسىتىش</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="250"/>
-        <location filename="../src/editor/dtextedit.cpp" line="302"/>
+        <location filename="../src/editor/dtextedit.cpp" line="274"/>
+        <location filename="../src/editor/dtextedit.cpp" line="326"/>
         <source>Add Comment</source>
         <translation>ئىزاھات قوشۇش</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="251"/>
+        <location filename="../src/editor/dtextedit.cpp" line="275"/>
         <source>Text to Speech</source>
         <translation>تېكىستنى ئاۋازغا ئايلاندۇرۇش</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="252"/>
+        <location filename="../src/editor/dtextedit.cpp" line="276"/>
         <source>Stop reading</source>
         <translation>ئوقۇشنى توختىتىش</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="253"/>
+        <location filename="../src/editor/dtextedit.cpp" line="277"/>
         <source>Speech to Text</source>
         <translation>ئاۋازنى تېكىستكە ئايلاندۇرۇش</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="254"/>
+        <location filename="../src/editor/dtextedit.cpp" line="278"/>
         <source>Translate</source>
         <translation>تەرجىمان</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="255"/>
+        <location filename="../src/editor/dtextedit.cpp" line="279"/>
         <source>Column Mode</source>
         <translation>ئىستون تەھرىرلەش ھالىتى</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="256"/>
+        <location filename="../src/editor/dtextedit.cpp" line="280"/>
         <source>Add bookmark</source>
         <translation>خەتكۈچ قوشۇش</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="257"/>
+        <location filename="../src/editor/dtextedit.cpp" line="281"/>
         <source>Remove Bookmark</source>
         <translation>خەتكۈچ چىقىرىۋېتىش</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="258"/>
+        <location filename="../src/editor/dtextedit.cpp" line="282"/>
         <source>Previous bookmark</source>
         <translation>ئالدىنقى خەتكۈچ</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="259"/>
+        <location filename="../src/editor/dtextedit.cpp" line="283"/>
         <source>Next bookmark</source>
         <translation>كېيىنكى خەتكۈچ</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="260"/>
+        <location filename="../src/editor/dtextedit.cpp" line="284"/>
         <source>Remove All Bookmarks</source>
         <translation>بارلىق خەتكۈچنى چىقىرىۋېتىش</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="261"/>
+        <location filename="../src/editor/dtextedit.cpp" line="285"/>
         <source>Fold All</source>
         <translation>بارلىق قاتلامنى قاتلاش</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="262"/>
+        <location filename="../src/editor/dtextedit.cpp" line="286"/>
         <source>Fold Current Level</source>
         <translation>ھازىرقى قاتلامنى قاتلاش</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="263"/>
+        <location filename="../src/editor/dtextedit.cpp" line="287"/>
         <source>Unfold All</source>
         <translation>بارلىق قاتلامنى ئېچىش</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="264"/>
+        <location filename="../src/editor/dtextedit.cpp" line="288"/>
         <source>Unfold Current Level</source>
         <translation>ھازىرقى قاتلامنى ئېچىش</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="269"/>
+        <location filename="../src/editor/dtextedit.cpp" line="293"/>
         <source>Color Mark</source>
         <translation>رەڭ بەلگىسى</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="273"/>
+        <location filename="../src/editor/dtextedit.cpp" line="297"/>
         <source>Clear All Marks</source>
         <translation>بارلىق بەلگىلەرنى چىقىرىۋېتىش</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="274"/>
+        <location filename="../src/editor/dtextedit.cpp" line="298"/>
         <source>Clear Last Mark</source>
         <translation>ئالدىنقى بەلگىنى چىقىرىۋېتىش</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="283"/>
+        <location filename="../src/editor/dtextedit.cpp" line="307"/>
         <source>Mark</source>
         <translation>بەلگە قويۇش</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="295"/>
+        <location filename="../src/editor/dtextedit.cpp" line="319"/>
         <source>Mark All</source>
         <translation>ھەممىسىگە بەلگە قويۇش</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="303"/>
+        <location filename="../src/editor/dtextedit.cpp" line="327"/>
         <source>Remove Comment</source>
         <translation>ئىزاھاتنى بىكار قىلىش</translation>
     </message>
     <message>
-        <source>Failed to paste text: it is too large</source>
-        <translation type="vanished">تېكىست مەزمۇنى كۆپ، چاپلانمىدى</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="2581"/>
+        <location filename="../src/editor/dtextedit.cpp" line="2672"/>
         <source>Copy failed: not enough memory</source>
         <translation>ئىچكى ساقلىغۇچ يېتىشمىدى، كۆچۈرەلمىدى</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="2665"/>
+        <location filename="../src/editor/dtextedit.cpp" line="2756"/>
         <source>Press ALT and click lines to edit in column mode</source>
         <translation>ئىستون تەھرىرلەش ھالىتىنى ئالماشتۇرۇش ئۈچۈن ALT   بىلەن مائۇسنى ئىشلىتىڭ</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="346"/>
+        <location filename="../src/editor/dtextedit.cpp" line="370"/>
         <source>Change Case</source>
         <translation>چوڭ-كىچىك يېزىلىشىنى ئالماشتۇرۇش</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="347"/>
+        <location filename="../src/editor/dtextedit.cpp" line="371"/>
         <source>Upper Case</source>
         <translation>چوڭ يېزىلىش</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="348"/>
+        <location filename="../src/editor/dtextedit.cpp" line="372"/>
         <source>Lower Case</source>
         <translation>كىچىك يېزىلىش</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="349"/>
+        <location filename="../src/editor/dtextedit.cpp" line="373"/>
         <source>Capitalize</source>
         <translation>1-ھەرپ چوڭ يېزىلسۇن</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="64"/>
+        <location filename="../src/widgets/bottombar.cpp" line="49"/>
         <source>None</source>
         <translation>يوق</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1184"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1222"/>
         <source>Selected line(s) copied</source>
         <translation>تاللانغان قۇر چاپلاش تاختىسىغا كۆچۈرۈلدى</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1190"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1228"/>
         <source>Current line copied</source>
         <translation>نۆۋەتتىكى قۇر چاپلاش تاختىسىغا كۆچۈرۈلدى</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1210"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1248"/>
         <source>Selected line(s) clipped</source>
         <translation>تاللانغان قۇر چاپلاش تاختىسىغا كېسىلدى</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1222"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1259"/>
         <source>Current line clipped</source>
         <translation>نۆۋەتتىكى قۇر چاپلاش تاختىسىغا كېسىلدى</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="2591"/>
+        <location filename="../src/editor/dtextedit.cpp" line="2682"/>
         <source>Paste failed: not enough memory</source>
         <translation>ئىچكى ساقلىغۇچ يېتىشمىدى، چاپلانمىدى</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3439"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3617"/>
         <source>Read-Only mode is off</source>
         <translation>پەقەت ئوقۇيدىغان ھالەت تاقالدى</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3446"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3465"/>
-        <location filename="../src/editor/dtextedit.cpp" line="6150"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3624"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3643"/>
+        <location filename="../src/editor/dtextedit.cpp" line="6656"/>
+        <location filename="../src/editor/dtextedit.cpp" line="6664"/>
+        <location filename="../src/editor/dtextedit.cpp" line="6675"/>
         <source>Read-Only mode is on</source>
         <translation>پەقەت ئوقۇيدىغان ھالەتنى ئېچىلدى</translation>
     </message>
@@ -1109,7 +1112,7 @@
 <context>
     <name>WarningNotices</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="36"/>
+        <location filename="../src/controls/warningnotices.cpp" line="19"/>
         <source>Reload</source>
         <translation>قايتا كىرگۈزۈڭ</translation>
     </message>
@@ -1117,129 +1120,130 @@
 <context>
     <name>Window</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="38"/>
-        <location filename="../src/widgets/window.cpp" line="357"/>
+        <location filename="../src/controls/warningnotices.cpp" line="21"/>
+        <location filename="../src/widgets/window.cpp" line="446"/>
         <source>Save as</source>
         <translation>باشقا ساقلاش</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="353"/>
+        <location filename="../src/widgets/window.cpp" line="442"/>
         <source>New window</source>
         <translation>يېڭى كۆزنەك</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="354"/>
+        <location filename="../src/widgets/window.cpp" line="443"/>
         <source>New tab</source>
         <translation>يېڭى خەتكۈچ</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="355"/>
+        <location filename="../src/widgets/window.cpp" line="444"/>
         <source>Open file</source>
         <translation>ئېچىش</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="356"/>
-        <location filename="../src/widgets/window.cpp" line="2217"/>
+        <location filename="../src/widgets/window.cpp" line="445"/>
+        <location filename="../src/widgets/window.cpp" line="2796"/>
         <source>Save</source>
         <translation>ساقلاش</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="358"/>
+        <location filename="../src/widgets/window.cpp" line="447"/>
         <source>Print</source>
         <translation>بېسىش</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="359"/>
+        <location filename="../src/widgets/window.cpp" line="448"/>
         <source>Switch theme</source>
         <translation>ئۇسلۇب ئالماشتۇرۇش</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="360"/>
-        <location filename="../src/widgets/window.cpp" line="1542"/>
+        <location filename="../src/widgets/window.cpp" line="449"/>
+        <location filename="../src/widgets/window.cpp" line="1871"/>
         <source>Settings</source>
         <translation>تەڭشەك</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="471"/>
-        <location filename="../src/widgets/window.cpp" line="2468"/>
+        <location filename="../src/widgets/window.cpp" line="563"/>
+        <location filename="../src/widgets/window.cpp" line="3047"/>
         <source>Read-Only</source>
         <translation>پەقەت ئوقۇيدىغان قىلىش</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="487"/>
+        <location filename="../src/widgets/window.cpp" line="579"/>
         <source>You do not have permission to open %1</source>
         <translation>%1نى ئېچىش ھوقۇقىڭىز يوق</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="522"/>
+        <location filename="../src/widgets/window.cpp" line="619"/>
+        <location filename="../src/widgets/window.cpp" line="2359"/>
         <source>Invalid file: %1</source>
         <translation>ئۈنۈمسىز ھۆججەت: %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="602"/>
-        <location filename="../src/widgets/window.cpp" line="644"/>
+        <location filename="../src/widgets/window.cpp" line="733"/>
+        <location filename="../src/widgets/window.cpp" line="779"/>
         <source>Do you want to save this file?</source>
         <translation>بۇ ھۆججەتنى ساقلامسىز؟</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="894"/>
+        <location filename="../src/widgets/window.cpp" line="1027"/>
         <source>You do not have permission to save %1</source>
         <translation>%1نى ساقلاش ھوقۇقىڭىز يوق</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="918"/>
+        <location filename="../src/widgets/window.cpp" line="1051"/>
         <source>Saved successfully</source>
         <translation>ھۆججەت ساقلاندى</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="954"/>
-        <location filename="../src/widgets/window.cpp" line="1021"/>
-        <location filename="../src/widgets/window.cpp" line="1062"/>
+        <location filename="../src/widgets/window.cpp" line="1087"/>
+        <location filename="../src/widgets/window.cpp" line="1160"/>
+        <location filename="../src/widgets/window.cpp" line="1201"/>
         <source>Save File</source>
         <translation>ساقلاش</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1023"/>
+        <location filename="../src/widgets/window.cpp" line="1162"/>
         <source>Encoding</source>
         <translation>كودلاش</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1211"/>
+        <location filename="../src/widgets/window.cpp" line="1350"/>
         <source>Read-Only mode is on</source>
         <translation>پەقەت ئوقۇيدىغان ھالەتنى ئېچىلدى</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1441"/>
+        <location filename="../src/widgets/window.cpp" line="1770"/>
         <source>Current location remembered</source>
         <translation>نۆۋەتتىكى ئورۇن ئەستە ساقلاندى</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1492"/>
+        <location filename="../src/widgets/window.cpp" line="1821"/>
         <source>Ctrl+&apos;=&apos;</source>
         <translation>Ctrl+&apos;=&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1495"/>
+        <location filename="../src/widgets/window.cpp" line="1824"/>
         <source>Ctrl+&apos;-&apos;</source>
         <translation>Ctrl+&apos;-&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1524"/>
+        <location filename="../src/widgets/window.cpp" line="1853"/>
         <source>Editor</source>
         <translation>تەھرىرلەش</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1890"/>
+        <location filename="../src/widgets/window.cpp" line="2451"/>
         <source>Untitled %1</source>
         <translation>%1نىڭ نامىنى ئۆزگەتىش</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2215"/>
+        <location filename="../src/widgets/window.cpp" line="2794"/>
         <source>Cancel</source>
         <translation>بىكار قىلىش</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2216"/>
+        <location filename="../src/widgets/window.cpp" line="2795"/>
         <source>Discard</source>
         <translation>ساقلىمايمەن</translation>
     </message>

--- a/translations/deepin-editor_uk.ts
+++ b/translations/deepin-editor_uk.ts
@@ -2,17 +2,17 @@
 <context>
     <name>BottomBar</name>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="39"/>
+        <location filename="../src/widgets/bottombar.cpp" line="24"/>
         <source>Row</source>
         <translation>Рядок</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="40"/>
+        <location filename="../src/widgets/bottombar.cpp" line="25"/>
         <source>Column</source>
         <translation>Стовпчик</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="41"/>
+        <location filename="../src/widgets/bottombar.cpp" line="26"/>
         <source>Characters %1</source>
         <translation>%1 символів</translation>
     </message>
@@ -20,9 +20,9 @@
 <context>
     <name>DDropdownMenu</name>
     <message>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="300"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="344"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="349"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="290"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="341"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="346"/>
         <source>None</source>
         <translation>Ніякий</translation>
     </message>
@@ -30,80 +30,85 @@
 <context>
     <name>EditWrapper</name>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="201"/>
-        <location filename="../src/editor/editwrapper.cpp" line="264"/>
-        <location filename="../src/editor/editwrapper.cpp" line="321"/>
-        <location filename="../src/editor/editwrapper.cpp" line="536"/>
+        <location filename="../src/editor/editwrapper.cpp" line="246"/>
+        <location filename="../src/editor/editwrapper.cpp" line="314"/>
+        <location filename="../src/editor/editwrapper.cpp" line="439"/>
+        <location filename="../src/editor/editwrapper.cpp" line="702"/>
         <source>Save</source>
         <translation>Зберегти</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="316"/>
+        <location filename="../src/editor/editwrapper.cpp" line="434"/>
         <source>Do you want to save this file?</source>
         <translation>Хочете зберегти цей файл?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="262"/>
-        <location filename="../src/editor/editwrapper.cpp" line="319"/>
+        <location filename="../src/editor/editwrapper.cpp" line="312"/>
+        <location filename="../src/editor/editwrapper.cpp" line="437"/>
         <source>Cancel</source>
         <translation>Скасувати</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="259"/>
+        <location filename="../src/editor/editwrapper.cpp" line="309"/>
         <source>Encoding changed. Do you want to save the file now?</source>
         <translation>Кодування змінено. Хочете зберегти файл зараз?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="320"/>
+        <location filename="../src/editor/editwrapper.cpp" line="438"/>
         <source>Discard</source>
         <translation>Відкинути</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="445"/>
+        <location filename="../src/editor/editwrapper.cpp" line="564"/>
         <source>You do not have permission to save %1</source>
         <translation>У вас немає прав на збереження %1</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="607"/>
+        <location filename="../src/editor/editwrapper.cpp" line="774"/>
         <source>File removed on the disk. Save it now?</source>
         <translation>Файл вилучено з диска. Зберегти його?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="612"/>
+        <location filename="../src/editor/editwrapper.cpp" line="779"/>
         <source>File has changed on disk. Reload?</source>
         <translation>Файл на диску був змінений. Перезавантажити?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="634"/>
-        <location filename="../src/widgets/bottombar.cpp" line="60"/>
+        <location filename="../src/editor/editwrapper.cpp" line="801"/>
+        <location filename="../src/widgets/bottombar.cpp" line="45"/>
         <source>INSERT</source>
         <translation>ВСТАВЛЯТИ</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="637"/>
+        <location filename="../src/editor/editwrapper.cpp" line="804"/>
         <source>OVERWRITE</source>
         <translation>ПЕРЕЗАПИСУВАТИ</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="640"/>
+        <location filename="../src/editor/editwrapper.cpp" line="807"/>
         <source>R/O</source>
         <translation>ЛИШЕ ЧИТАННЯ</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="945"/>
+        <source>The file cannot be read, which may be too large or has been damaged!</source>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
     <name>FindBar</name>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="40"/>
+        <location filename="../src/controls/findbar.cpp" line="22"/>
         <source>Find</source>
         <translation>Знайти</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="44"/>
+        <location filename="../src/controls/findbar.cpp" line="26"/>
         <source>Previous</source>
         <translation>Попереднє</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="46"/>
+        <location filename="../src/controls/findbar.cpp" line="28"/>
         <source>Next</source>
         <translation>Наступне</translation>
     </message>
@@ -111,7 +116,7 @@
 <context>
     <name>JumpLineBar</name>
     <message>
-        <location filename="../src/controls/jumplinebar.cpp" line="40"/>
+        <location filename="../src/controls/jumplinebar.cpp" line="28"/>
         <source>Go to Line: </source>
         <translation>Перейти до рядка:</translation>
     </message>
@@ -119,12 +124,12 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/editorapplication.cpp" line="27"/>
+        <location filename="../src/editorapplication.cpp" line="11"/>
         <source>Text Editor is a powerful tool for viewing and editing text files.</source>
         <translation>Текстовий редактор є потужним інструментом для перегляду та редагування текстових файлів.</translation>
     </message>
     <message>
-        <location filename="../src/editorapplication.cpp" line="38"/>
+        <location filename="../src/editorapplication.cpp" line="22"/>
         <source>Text Editor</source>
         <translation>Текстовий редактор</translation>
     </message>
@@ -132,572 +137,572 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/editorapplication.cpp" line="35"/>
+        <location filename="../src/editorapplication.cpp" line="19"/>
         <source>Text Editor</source>
         <translation>Текстовий редактор</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="203"/>
-        <location filename="../src/editor/editwrapper.cpp" line="538"/>
-        <location filename="../src/widgets/window.cpp" line="956"/>
-        <location filename="../src/widgets/window.cpp" line="973"/>
-        <location filename="../src/widgets/window.cpp" line="1064"/>
-        <location filename="../src/widgets/window.cpp" line="1079"/>
+        <location filename="../src/editor/editwrapper.cpp" line="248"/>
+        <location filename="../src/editor/editwrapper.cpp" line="704"/>
+        <location filename="../src/widgets/window.cpp" line="1089"/>
+        <location filename="../src/widgets/window.cpp" line="1111"/>
+        <location filename="../src/widgets/window.cpp" line="1203"/>
+        <location filename="../src/widgets/window.cpp" line="1218"/>
         <source>Encoding</source>
         <translation>Кодування</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="24"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="9"/>
         <source>Basic</source>
         <translation>Базові</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="25"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="10"/>
         <source>Font Style</source>
         <translation>Стиль шрифту</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="26"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="11"/>
         <source>Font</source>
         <translation>Шрифт</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="27"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="12"/>
         <source>Font Size</source>
         <translation>Розмір шрифту</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="28"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="13"/>
         <source>Shortcuts</source>
         <translation>Сполучення клавіш</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="29"/>
-        <location filename="../src/controls/settingsdialog.cpp" line="30"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="14"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="15"/>
         <source>Keymap</source>
         <translation>Розкладка</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="31"/>
-        <location filename="../src/controls/settingsdialog.cpp" line="107"/>
-        <location filename="../src/widgets/window.cpp" line="1482"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="16"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="92"/>
+        <location filename="../src/widgets/window.cpp" line="1811"/>
         <source>Window</source>
         <translation>Вікно</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="32"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="17"/>
         <source>New tab</source>
         <translation>Нова вкладка</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="33"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="18"/>
         <source>New window</source>
         <translation>Нове вікно</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="34"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="19"/>
         <source>Save</source>
         <translation>Зберегти</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="35"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="20"/>
         <source>Save as</source>
         <translation>Зберегти як</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="36"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="21"/>
         <source>Next tab</source>
         <translation>Наступна вкладка</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="37"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="22"/>
         <source>Previous tab</source>
         <translation>Попередня вкладка</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="38"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="23"/>
         <source>Close tab</source>
         <translation>Закрити вкладку</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="39"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="24"/>
         <source>Close other tabs</source>
         <translation>Закрити інші вкладки</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="40"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="25"/>
         <source>Restore tab</source>
         <translation>Відновити вкладку</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="41"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="26"/>
         <source>Open file</source>
         <translation>Відкрити файл</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="42"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="27"/>
         <source>Increment font size</source>
         <translation>Збільшити розмір шрифту</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="43"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="28"/>
         <source>Decrement font size</source>
         <translation>Зменшити розмір шрифту</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="44"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="29"/>
         <source>Reset font size</source>
         <translation>Відновити початковий розмір шрифту</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="45"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="30"/>
         <source>Help</source>
         <translation>Довідка</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="46"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="31"/>
         <source>Toggle fullscreen</source>
         <translation>Увімкнути/вимкнути повноекранний режим</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="47"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="32"/>
         <source>Find</source>
         <translation>Знайти</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="48"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="33"/>
         <source>Replace</source>
         <translation>Замінити</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="49"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="34"/>
         <source>Go to line</source>
         <translation>Перейти до рядка</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="50"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="35"/>
         <source>Save cursor position</source>
         <translation>Зберегти розташування курсора</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="51"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="36"/>
         <source>Reset cursor position</source>
         <translation>Скинути розташування курсора</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="52"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="37"/>
         <source>Exit</source>
         <translation>Вийти</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="53"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="38"/>
         <source>Display shortcuts</source>
         <translation>Показати сполучення клавіш</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="54"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="39"/>
         <source>Print</source>
         <translation>Друк</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="55"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="40"/>
         <source>Editor</source>
         <translation>Редактор</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="56"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="41"/>
         <source>Increase indent</source>
         <translation>Збільшити відступ</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="57"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="42"/>
         <source>Decrease indent</source>
         <translation>Зменшити відступ</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="58"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="43"/>
         <source>Forward character</source>
         <translation>Вперед на символ</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="59"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="44"/>
         <source>Backward character</source>
         <translation>Назад на символ</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="60"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="45"/>
         <source>Forward word</source>
         <translation>Вперед на слово</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="61"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="46"/>
         <source>Backward word</source>
         <translation>Назад на слово</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="62"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="47"/>
         <source>Next line</source>
         <translation>Наступний рядок</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="63"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="48"/>
         <source>Previous line</source>
         <translation>Попередній рядок</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="64"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="49"/>
         <source>New line</source>
         <translation>Новий рядок</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="65"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="50"/>
         <source>New line above</source>
         <translation>Новий рядок вище</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="66"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="51"/>
         <source>New line below</source>
         <translation>Новий рядок нижче</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="67"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="52"/>
         <source>Duplicate line</source>
         <translation>Дублювати рядок</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="68"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="53"/>
         <source>Delete to end of line</source>
         <translation>Видалити до кінця рядка</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="69"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="54"/>
         <source>Delete current line</source>
         <translation>Видалити поточний рядок</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="70"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="55"/>
         <source>Swap line up</source>
         <translation>Поміняти місцями з рядком вище</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="71"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="56"/>
         <source>Swap line down</source>
         <translation>Поміняти місцями з рядком нижче</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="72"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="57"/>
         <source>Scroll up one line</source>
         <translation>Прокрутити вище на рядок</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="73"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="58"/>
         <source>Scroll down one line</source>
         <translation>Прокрутити нижче на рядок</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="74"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="59"/>
         <source>Page up</source>
         <translation>На сторінку вгору</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="75"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="60"/>
         <source>Page down</source>
         <translation>На сторінку вниз</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="76"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="61"/>
         <source>Move to end of line</source>
         <translation>Перейти до кінця рядка</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="77"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="62"/>
         <source>Move to start of line</source>
         <translation>Перейти до початку рядка</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="78"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="63"/>
         <source>Move to end of text</source>
         <translation>Перейти до кінця тексту</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="79"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="64"/>
         <source>Move to start of text</source>
         <translation>Перейти до початку тексту</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="80"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="65"/>
         <source>Move to line indentation</source>
         <translation>Перейти до відступу рядка</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="81"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="66"/>
         <source>Upper case</source>
         <translation>Верхній регістр</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="82"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="67"/>
         <source>Lower case</source>
         <translation>Нижній регістр</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="83"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="68"/>
         <source>Capitalize</source>
         <translation>Великі перші літери</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="84"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="69"/>
         <source>Delete backward word</source>
         <translation>Вилучити слово назад</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="85"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="70"/>
         <source>Delete forward word</source>
         <translation>Вилучити слово вперед</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="86"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="71"/>
         <source>Forward over a pair</source>
         <translation>Вперед через пару</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="87"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="72"/>
         <source>Backward over a pair</source>
         <translation>Назад через пару</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="88"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="73"/>
         <source>Select all</source>
         <translation>Вибрати все</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="89"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="74"/>
         <source>Copy</source>
         <translation>Копіювати</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="90"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="75"/>
         <source>Cut</source>
         <translation>Вирізати</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="91"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="76"/>
         <source>Paste</source>
         <translation>Вставити</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="92"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="77"/>
         <source>Transpose character</source>
         <translation>Транспонувати символ</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="93"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="78"/>
         <source>Mark</source>
         <translation>Позначити</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="94"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="79"/>
         <source>Unmark</source>
         <translation>Зняти позначку</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="95"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="80"/>
         <source>Copy line</source>
         <translation>Копіювати рядок</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="96"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="81"/>
         <source>Cut line</source>
         <translation>Вирізати рядок</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="97"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="82"/>
         <source>Merge lines</source>
         <translation>Об&apos;єднати рядки</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="98"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="83"/>
         <source>Read-Only mode</source>
         <translation>Режим лише для читання</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="99"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="84"/>
         <source>Add comment</source>
         <translation>Додати коментування</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="100"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="85"/>
         <source>Remove comment</source>
         <translation>Вилучити коментар</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="101"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="86"/>
         <source>Undo</source>
         <translation>Скасувати</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="102"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="87"/>
         <source>Redo</source>
         <translation>Повторити</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="103"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="88"/>
         <source>Add/Remove bookmark</source>
         <translation>Додати або вилучити закладку</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="104"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="89"/>
         <source>Move to previous bookmark</source>
         <translation>Перейти до попередньої закладки</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="105"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="90"/>
         <source>Move to next bookmark</source>
         <translation>Перейти до наступної закладки</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="106"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="91"/>
         <source>Advanced</source>
         <translation>Розширені</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="108"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="93"/>
         <source>Window size</source>
         <translation>Розмір вікна</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="109"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="94"/>
         <source>Tab width</source>
         <translation>Ширина табуляції</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="111"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="96"/>
         <source>Word wrap</source>
         <translation>Перенесення рядків</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="112"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="97"/>
         <source>Code folding flag</source>
         <translation>Прапорець згортання коду</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="113"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="98"/>
         <source>Show line numbers</source>
         <translation>Показувати номери рядків</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="114"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="99"/>
         <source>Show bookmarks icon</source>
         <translation>Показувати піктограму закладок</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="115"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="100"/>
         <source>Show whitespaces and tabs</source>
         <translation>Показувати пробіли і табуляції</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="116"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="101"/>
         <source>Highlight current line</source>
         <translation>Підсвічувати поточний рядок</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="117"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="102"/>
         <source>Color mark</source>
         <translation>Кольорова позначка</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="120"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="105"/>
         <source>Unicode</source>
         <translation>Юнікод</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="121"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="106"/>
         <source>WesternEuropean</source>
         <translation>Західноевропейське</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="122"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="107"/>
         <source>CentralEuropean</source>
         <translation>Центральноєвропейське</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="123"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="108"/>
         <source>Baltic</source>
         <translation>Балтійське</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="124"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="109"/>
         <source>Cyrillic</source>
         <translation>Кириличне</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="125"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="110"/>
         <source>Arabic</source>
         <translation>Арабська</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="130"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="115"/>
         <source>Celtic</source>
         <translation>Кельтське</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="131"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="116"/>
         <source>SouthEasternEuropean</source>
         <translation>Південно-східноєвропейське</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="126"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="111"/>
         <source>Greek</source>
         <translation>Грецька</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="127"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="112"/>
         <source>Hebrew</source>
         <translation>Іврит</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="132"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="117"/>
         <source>ChineseSimplified</source>
         <translation>Китайське спрощене</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="133"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="118"/>
         <source>ChineseTraditional</source>
         <translation>Китайське традиційне</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="134"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="119"/>
         <source>Japanese</source>
         <translation>Японська</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="135"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="120"/>
         <source>Korean</source>
         <translation>Корейська</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="129"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="114"/>
         <source>Thai</source>
         <translation>Тайська</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="128"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="113"/>
         <source>Turkish</source>
         <translation>Турецька</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="136"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="121"/>
         <source>Vietnamese</source>
         <translation>В&apos;єтнамська</translation>
     </message>
     <message>
-        <location filename="../src/startmanager.cpp" line="762"/>
+        <location filename="../src/startmanager.cpp" line="832"/>
         <source>File not saved</source>
         <translation>Файл не збережено</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="974"/>
-        <location filename="../src/widgets/window.cpp" line="1065"/>
-        <location filename="../src/widgets/window.cpp" line="1080"/>
+        <location filename="../src/widgets/window.cpp" line="1112"/>
+        <location filename="../src/widgets/window.cpp" line="1204"/>
+        <location filename="../src/widgets/window.cpp" line="1219"/>
         <source>Line Endings</source>
         <translation>Символ закінчення рядка</translation>
     </message>
@@ -705,32 +710,32 @@
 <context>
     <name>ReplaceBar</name>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="39"/>
+        <location filename="../src/controls/replacebar.cpp" line="21"/>
         <source>Find</source>
         <translation>Знайти</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="43"/>
+        <location filename="../src/controls/replacebar.cpp" line="25"/>
         <source>Replace With</source>
         <translation>Замінити на</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="47"/>
+        <location filename="../src/controls/replacebar.cpp" line="29"/>
         <source>Replace</source>
         <translation>Замінити</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="50"/>
+        <location filename="../src/controls/replacebar.cpp" line="32"/>
         <source>Skip</source>
         <translation>Пропустити</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="53"/>
+        <location filename="../src/controls/replacebar.cpp" line="35"/>
         <source>Replace Rest</source>
         <translation>Замінити решту</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="56"/>
+        <location filename="../src/controls/replacebar.cpp" line="38"/>
         <source>Replace All</source>
         <translation>Замінити все</translation>
     </message>
@@ -747,58 +752,58 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../src/common/settings.cpp" line="91"/>
+        <location filename="../src/common/settings.cpp" line="115"/>
         <source>Standard</source>
         <translation>Стандартна</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="91"/>
+        <location filename="../src/common/settings.cpp" line="115"/>
         <source>Customize</source>
         <translation>Налаштувати</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="104"/>
+        <location filename="../src/common/settings.cpp" line="128"/>
         <source>Normal</source>
         <translation>Звичайний</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="104"/>
+        <location filename="../src/common/settings.cpp" line="128"/>
         <source>Maximum</source>
         <translation>Максимум</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="104"/>
+        <location filename="../src/common/settings.cpp" line="128"/>
         <source>Fullscreen</source>
         <translation>На весь екран</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="292"/>
+        <location filename="../src/common/settings.cpp" line="316"/>
         <source>This shortcut conflicts with system shortcut %1</source>
         <translation>Це клавіатурне скорочення конфліктує із загальносистемним скороченням %1</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="294"/>
+        <location filename="../src/common/settings.cpp" line="318"/>
         <source>This shortcut conflicts with %1, click on Replace to make this shortcut effective immediately</source>
         <translation>Це клавіатурне скорочення конфліктує з %1. Натисніть кнопку «Замінити», щоб це клавіатурне скорочення набуло чинності негайно.</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="410"/>
-        <location filename="../src/common/settings.cpp" line="418"/>
+        <location filename="../src/common/settings.cpp" line="464"/>
+        <location filename="../src/common/settings.cpp" line="472"/>
         <source>The shortcut %1 is invalid, please set another one.</source>
         <translation>Скорочення %1 є некоректним. Будь ласка, встановіть інше.</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="445"/>
+        <location filename="../src/common/settings.cpp" line="507"/>
         <source>Cancel</source>
         <translation>Скасувати</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="446"/>
+        <location filename="../src/common/settings.cpp" line="508"/>
         <source>Replace</source>
         <translation>Замінити</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="448"/>
+        <location filename="../src/common/settings.cpp" line="510"/>
         <source>OK</source>
         <translation>Гаразд</translation>
     </message>
@@ -806,7 +811,7 @@
 <context>
     <name>StartManager</name>
     <message>
-        <location filename="../src/startmanager.cpp" line="340"/>
+        <location filename="../src/startmanager.cpp" line="350"/>
         <source>Untitled %1</source>
         <translation>Без назви %1</translation>
     </message>
@@ -814,32 +819,32 @@
 <context>
     <name>Tabbar</name>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="515"/>
+        <location filename="../src/controls/tabbar.cpp" line="540"/>
         <source>Close tab</source>
         <translation>Закрити вкладку</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="516"/>
+        <location filename="../src/controls/tabbar.cpp" line="541"/>
         <source>Close other tabs</source>
         <translation>Закрити інші вкладки</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="517"/>
+        <location filename="../src/controls/tabbar.cpp" line="542"/>
         <source>More options</source>
         <translation>Додаткові параметри</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="518"/>
+        <location filename="../src/controls/tabbar.cpp" line="543"/>
         <source>Close tabs to the left</source>
         <translation>Закрити вкладки ліворуч</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="519"/>
+        <location filename="../src/controls/tabbar.cpp" line="544"/>
         <source>Close tabs to the right</source>
         <translation>Закрити вкладки праворуч</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="520"/>
+        <location filename="../src/controls/tabbar.cpp" line="545"/>
         <source>Close unmodified tabs</source>
         <translation>Закрити вкладки без змін</translation>
     </message>
@@ -847,261 +852,259 @@
 <context>
     <name>TextEdit</name>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="235"/>
+        <location filename="../src/editor/dtextedit.cpp" line="259"/>
         <source>Undo</source>
         <translation>Скасувати</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="236"/>
+        <location filename="../src/editor/dtextedit.cpp" line="260"/>
         <source>Redo</source>
         <translation>Повторити</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="237"/>
+        <location filename="../src/editor/dtextedit.cpp" line="261"/>
         <source>Cut</source>
         <translation>Вирізати</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="238"/>
+        <location filename="../src/editor/dtextedit.cpp" line="262"/>
         <source>Copy</source>
         <translation>Копіювати</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="239"/>
+        <location filename="../src/editor/dtextedit.cpp" line="263"/>
         <source>Paste</source>
         <translation>Вставити</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="240"/>
+        <location filename="../src/editor/dtextedit.cpp" line="264"/>
         <source>Delete</source>
         <translation>Видалити</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="241"/>
+        <location filename="../src/editor/dtextedit.cpp" line="265"/>
         <source>Select All</source>
         <translation>Вибрати все</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="242"/>
-        <location filename="../src/widgets/window.cpp" line="361"/>
+        <location filename="../src/editor/dtextedit.cpp" line="266"/>
+        <location filename="../src/widgets/window.cpp" line="450"/>
         <source>Find</source>
         <translation>Знайти</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="243"/>
-        <location filename="../src/widgets/window.cpp" line="362"/>
+        <location filename="../src/editor/dtextedit.cpp" line="267"/>
+        <location filename="../src/widgets/window.cpp" line="451"/>
         <source>Replace</source>
         <translation>Замінити</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="244"/>
+        <location filename="../src/editor/dtextedit.cpp" line="268"/>
         <source>Go to Line</source>
         <translation>Перейти до рядка</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="245"/>
+        <location filename="../src/editor/dtextedit.cpp" line="269"/>
         <source>Turn on Read-Only mode</source>
         <translation>Увімкнути режим лише для читання</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="246"/>
+        <location filename="../src/editor/dtextedit.cpp" line="270"/>
         <source>Turn off Read-Only mode</source>
         <translation>Вимкнути режим лише для читання</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="247"/>
+        <location filename="../src/editor/dtextedit.cpp" line="271"/>
         <source>Fullscreen</source>
         <translation>На весь екран</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="248"/>
+        <location filename="../src/editor/dtextedit.cpp" line="272"/>
         <source>Exit fullscreen</source>
         <translation>Вийти з повноекранного режиму</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="249"/>
+        <location filename="../src/editor/dtextedit.cpp" line="273"/>
         <source>Display in file manager</source>
         <translation>Показати у файловому менеджері</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="250"/>
-        <location filename="../src/editor/dtextedit.cpp" line="302"/>
+        <location filename="../src/editor/dtextedit.cpp" line="274"/>
+        <location filename="../src/editor/dtextedit.cpp" line="326"/>
         <source>Add Comment</source>
         <translation>Додати коментування</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="251"/>
+        <location filename="../src/editor/dtextedit.cpp" line="275"/>
         <source>Text to Speech</source>
         <translation>Озвучення тексту</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="252"/>
+        <location filename="../src/editor/dtextedit.cpp" line="276"/>
         <source>Stop reading</source>
         <translation>Припинити читання</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="253"/>
+        <location filename="../src/editor/dtextedit.cpp" line="277"/>
         <source>Speech to Text</source>
         <translation>Перетворення звуку на текст</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="254"/>
+        <location filename="../src/editor/dtextedit.cpp" line="278"/>
         <source>Translate</source>
         <translation>Перекласти</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="255"/>
+        <location filename="../src/editor/dtextedit.cpp" line="279"/>
         <source>Column Mode</source>
         <translation>Режим стовпчиків</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="256"/>
+        <location filename="../src/editor/dtextedit.cpp" line="280"/>
         <source>Add bookmark</source>
         <translation>Додати закладку</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="257"/>
+        <location filename="../src/editor/dtextedit.cpp" line="281"/>
         <source>Remove Bookmark</source>
         <translation>Вилучити закладку</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="258"/>
+        <location filename="../src/editor/dtextedit.cpp" line="282"/>
         <source>Previous bookmark</source>
         <translation>Попередня закладка</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="259"/>
+        <location filename="../src/editor/dtextedit.cpp" line="283"/>
         <source>Next bookmark</source>
         <translation>Наступна закладка</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="260"/>
+        <location filename="../src/editor/dtextedit.cpp" line="284"/>
         <source>Remove All Bookmarks</source>
         <translation>Вилучити усі закладки</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="261"/>
+        <location filename="../src/editor/dtextedit.cpp" line="285"/>
         <source>Fold All</source>
         <translation>Згорнути усе</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="262"/>
+        <location filename="../src/editor/dtextedit.cpp" line="286"/>
         <source>Fold Current Level</source>
         <translation>Згорнути поточний рівень</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="263"/>
+        <location filename="../src/editor/dtextedit.cpp" line="287"/>
         <source>Unfold All</source>
         <translation>Розгорнути усе</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="264"/>
+        <location filename="../src/editor/dtextedit.cpp" line="288"/>
         <source>Unfold Current Level</source>
         <translation>Розгорнути поточний рівень</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="269"/>
+        <location filename="../src/editor/dtextedit.cpp" line="293"/>
         <source>Color Mark</source>
         <translation>Кольорова позначка</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="273"/>
+        <location filename="../src/editor/dtextedit.cpp" line="297"/>
         <source>Clear All Marks</source>
         <translation>Вилучити усі позначки</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="274"/>
+        <location filename="../src/editor/dtextedit.cpp" line="298"/>
         <source>Clear Last Mark</source>
         <translation>Вилучити останню позначку</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="283"/>
+        <location filename="../src/editor/dtextedit.cpp" line="307"/>
         <source>Mark</source>
         <translation>Позначити</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="295"/>
+        <location filename="../src/editor/dtextedit.cpp" line="319"/>
         <source>Mark All</source>
         <translation>Позначити усе</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="303"/>
+        <location filename="../src/editor/dtextedit.cpp" line="327"/>
         <source>Remove Comment</source>
         <translation>Вилучити коментування</translation>
     </message>
     <message>
-        <source>Failed to paste text: it is too large</source>
-        <translation type="vanished">Не вдалося вставити текст: текст є надто великим</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="2581"/>
+        <location filename="../src/editor/dtextedit.cpp" line="2672"/>
         <source>Copy failed: not enough memory</source>
         <translation>Не вдалося скопіювати: недостатньо пам&apos;яті</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="2665"/>
+        <location filename="../src/editor/dtextedit.cpp" line="2756"/>
         <source>Press ALT and click lines to edit in column mode</source>
         <translation>Натисніть клавішу Alt і клацайте на рядках, щоб редагувати текст у режимі стовпчиків</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="346"/>
+        <location filename="../src/editor/dtextedit.cpp" line="370"/>
         <source>Change Case</source>
         <translation>Змінити регістр</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="347"/>
+        <location filename="../src/editor/dtextedit.cpp" line="371"/>
         <source>Upper Case</source>
         <translation>Верхній регістр</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="348"/>
+        <location filename="../src/editor/dtextedit.cpp" line="372"/>
         <source>Lower Case</source>
         <translation>Нижній регістр</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="349"/>
+        <location filename="../src/editor/dtextedit.cpp" line="373"/>
         <source>Capitalize</source>
         <translation>Починати з великої літери</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="64"/>
+        <location filename="../src/widgets/bottombar.cpp" line="49"/>
         <source>None</source>
         <translation>Ніякий</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1184"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1222"/>
         <source>Selected line(s) copied</source>
         <translation>Вибрані рядки(ок) скопійовано</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1190"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1228"/>
         <source>Current line copied</source>
         <translation>Поточний рядок скопійовано</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1210"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1248"/>
         <source>Selected line(s) clipped</source>
         <translation>Вибрані рядки(ок) вирізано</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1222"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1259"/>
         <source>Current line clipped</source>
         <translation>Поточний рядок вирізано</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="2591"/>
+        <location filename="../src/editor/dtextedit.cpp" line="2682"/>
         <source>Paste failed: not enough memory</source>
         <translation>Не вдалося вставити: недостатньо пам&apos;яті</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3439"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3617"/>
         <source>Read-Only mode is off</source>
         <translation>Режим лише для читання вимкнено</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3446"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3465"/>
-        <location filename="../src/editor/dtextedit.cpp" line="6150"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3624"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3643"/>
+        <location filename="../src/editor/dtextedit.cpp" line="6656"/>
+        <location filename="../src/editor/dtextedit.cpp" line="6664"/>
+        <location filename="../src/editor/dtextedit.cpp" line="6675"/>
         <source>Read-Only mode is on</source>
         <translation>Режим лише для читання увімкнено</translation>
     </message>
@@ -1109,7 +1112,7 @@
 <context>
     <name>WarningNotices</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="36"/>
+        <location filename="../src/controls/warningnotices.cpp" line="19"/>
         <source>Reload</source>
         <translation>Перезавантажити</translation>
     </message>
@@ -1117,129 +1120,130 @@
 <context>
     <name>Window</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="38"/>
-        <location filename="../src/widgets/window.cpp" line="357"/>
+        <location filename="../src/controls/warningnotices.cpp" line="21"/>
+        <location filename="../src/widgets/window.cpp" line="446"/>
         <source>Save as</source>
         <translation>Зберегти як</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="353"/>
+        <location filename="../src/widgets/window.cpp" line="442"/>
         <source>New window</source>
         <translation>Нове вікно</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="354"/>
+        <location filename="../src/widgets/window.cpp" line="443"/>
         <source>New tab</source>
         <translation>Нова вкладка</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="355"/>
+        <location filename="../src/widgets/window.cpp" line="444"/>
         <source>Open file</source>
         <translation>Відкрити файл</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="356"/>
-        <location filename="../src/widgets/window.cpp" line="2217"/>
+        <location filename="../src/widgets/window.cpp" line="445"/>
+        <location filename="../src/widgets/window.cpp" line="2796"/>
         <source>Save</source>
         <translation>Зберегти</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="358"/>
+        <location filename="../src/widgets/window.cpp" line="447"/>
         <source>Print</source>
         <translation>Друк</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="359"/>
+        <location filename="../src/widgets/window.cpp" line="448"/>
         <source>Switch theme</source>
         <translation>Змінити тему</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="360"/>
-        <location filename="../src/widgets/window.cpp" line="1542"/>
+        <location filename="../src/widgets/window.cpp" line="449"/>
+        <location filename="../src/widgets/window.cpp" line="1871"/>
         <source>Settings</source>
         <translation>Налаштування</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="471"/>
-        <location filename="../src/widgets/window.cpp" line="2468"/>
+        <location filename="../src/widgets/window.cpp" line="563"/>
+        <location filename="../src/widgets/window.cpp" line="3047"/>
         <source>Read-Only</source>
         <translation>Лише читання</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="487"/>
+        <location filename="../src/widgets/window.cpp" line="579"/>
         <source>You do not have permission to open %1</source>
         <translation>У вас немає прав на відкриття %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="522"/>
+        <location filename="../src/widgets/window.cpp" line="619"/>
+        <location filename="../src/widgets/window.cpp" line="2359"/>
         <source>Invalid file: %1</source>
         <translation>Некоректний файл: %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="602"/>
-        <location filename="../src/widgets/window.cpp" line="644"/>
+        <location filename="../src/widgets/window.cpp" line="733"/>
+        <location filename="../src/widgets/window.cpp" line="779"/>
         <source>Do you want to save this file?</source>
         <translation>Хочете зберегти цей файл?</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="894"/>
+        <location filename="../src/widgets/window.cpp" line="1027"/>
         <source>You do not have permission to save %1</source>
         <translation>У вас немає прав на збереження %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="918"/>
+        <location filename="../src/widgets/window.cpp" line="1051"/>
         <source>Saved successfully</source>
         <translation>Успішно збережено</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="954"/>
-        <location filename="../src/widgets/window.cpp" line="1021"/>
-        <location filename="../src/widgets/window.cpp" line="1062"/>
+        <location filename="../src/widgets/window.cpp" line="1087"/>
+        <location filename="../src/widgets/window.cpp" line="1160"/>
+        <location filename="../src/widgets/window.cpp" line="1201"/>
         <source>Save File</source>
         <translation>Зберегти файл</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1023"/>
+        <location filename="../src/widgets/window.cpp" line="1162"/>
         <source>Encoding</source>
         <translation>Кодування</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1211"/>
+        <location filename="../src/widgets/window.cpp" line="1350"/>
         <source>Read-Only mode is on</source>
         <translation>Режим лише для читання увімкнено</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1441"/>
+        <location filename="../src/widgets/window.cpp" line="1770"/>
         <source>Current location remembered</source>
         <translation>Програма запам&apos;ятала поточне місце</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1492"/>
+        <location filename="../src/widgets/window.cpp" line="1821"/>
         <source>Ctrl+&apos;=&apos;</source>
         <translation>Ctrl+&apos;=&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1495"/>
+        <location filename="../src/widgets/window.cpp" line="1824"/>
         <source>Ctrl+&apos;-&apos;</source>
         <translation>Ctrl+&apos;-&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1524"/>
+        <location filename="../src/widgets/window.cpp" line="1853"/>
         <source>Editor</source>
         <translation>Редактор</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1890"/>
+        <location filename="../src/widgets/window.cpp" line="2451"/>
         <source>Untitled %1</source>
         <translation>Без назви %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2215"/>
+        <location filename="../src/widgets/window.cpp" line="2794"/>
         <source>Cancel</source>
         <translation>Скасувати</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2216"/>
+        <location filename="../src/widgets/window.cpp" line="2795"/>
         <source>Discard</source>
         <translation>Відкинути</translation>
     </message>

--- a/translations/deepin-editor_zh_CN.ts
+++ b/translations/deepin-editor_zh_CN.ts
@@ -2,17 +2,17 @@
 <context>
     <name>BottomBar</name>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="39"/>
+        <location filename="../src/widgets/bottombar.cpp" line="24"/>
         <source>Row</source>
         <translation>行</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="40"/>
+        <location filename="../src/widgets/bottombar.cpp" line="25"/>
         <source>Column</source>
         <translation>列</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="41"/>
+        <location filename="../src/widgets/bottombar.cpp" line="26"/>
         <source>Characters %1</source>
         <translation>字数 %1</translation>
     </message>
@@ -20,9 +20,9 @@
 <context>
     <name>DDropdownMenu</name>
     <message>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="300"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="344"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="349"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="290"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="341"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="346"/>
         <source>None</source>
         <translation>无</translation>
     </message>
@@ -30,80 +30,85 @@
 <context>
     <name>EditWrapper</name>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="201"/>
-        <location filename="../src/editor/editwrapper.cpp" line="264"/>
-        <location filename="../src/editor/editwrapper.cpp" line="321"/>
-        <location filename="../src/editor/editwrapper.cpp" line="536"/>
+        <location filename="../src/editor/editwrapper.cpp" line="246"/>
+        <location filename="../src/editor/editwrapper.cpp" line="314"/>
+        <location filename="../src/editor/editwrapper.cpp" line="439"/>
+        <location filename="../src/editor/editwrapper.cpp" line="702"/>
         <source>Save</source>
         <translation>保存</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="316"/>
+        <location filename="../src/editor/editwrapper.cpp" line="434"/>
         <source>Do you want to save this file?</source>
         <translation>您是否要保存此文件？</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="262"/>
-        <location filename="../src/editor/editwrapper.cpp" line="319"/>
+        <location filename="../src/editor/editwrapper.cpp" line="312"/>
+        <location filename="../src/editor/editwrapper.cpp" line="437"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="259"/>
+        <location filename="../src/editor/editwrapper.cpp" line="309"/>
         <source>Encoding changed. Do you want to save the file now?</source>
         <translation>文件编码已更改，是否先进行保存？</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="320"/>
+        <location filename="../src/editor/editwrapper.cpp" line="438"/>
         <source>Discard</source>
         <translation>不保存</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="445"/>
+        <location filename="../src/editor/editwrapper.cpp" line="564"/>
         <source>You do not have permission to save %1</source>
         <translation>您没有权限保存%1</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="607"/>
+        <location filename="../src/editor/editwrapper.cpp" line="774"/>
         <source>File removed on the disk. Save it now?</source>
         <translation>磁盘中的原文件已被移除，是否另存？</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="612"/>
+        <location filename="../src/editor/editwrapper.cpp" line="779"/>
         <source>File has changed on disk. Reload?</source>
-        <translation>磁盘中的原文件已被修改，是否重新载入？ </translation>
+        <translation>磁盘中的原文件已被修改，是否重新载入？</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="634"/>
-        <location filename="../src/widgets/bottombar.cpp" line="60"/>
+        <location filename="../src/editor/editwrapper.cpp" line="801"/>
+        <location filename="../src/widgets/bottombar.cpp" line="45"/>
         <source>INSERT</source>
         <translation>插入</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="637"/>
+        <location filename="../src/editor/editwrapper.cpp" line="804"/>
         <source>OVERWRITE</source>
         <translation>覆盖</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="640"/>
+        <location filename="../src/editor/editwrapper.cpp" line="807"/>
         <source>R/O</source>
         <translation>只读</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="945"/>
+        <source>The file cannot be read, which may be too large or has been damaged!</source>
+        <translation>无法读取该文件，文件可能过大或损坏</translation>
     </message>
 </context>
 <context>
     <name>FindBar</name>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="40"/>
+        <location filename="../src/controls/findbar.cpp" line="22"/>
         <source>Find</source>
         <translation>查找</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="44"/>
+        <location filename="../src/controls/findbar.cpp" line="26"/>
         <source>Previous</source>
         <translation>上一个</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="46"/>
+        <location filename="../src/controls/findbar.cpp" line="28"/>
         <source>Next</source>
         <translation>下一个</translation>
     </message>
@@ -111,7 +116,7 @@
 <context>
     <name>JumpLineBar</name>
     <message>
-        <location filename="../src/controls/jumplinebar.cpp" line="40"/>
+        <location filename="../src/controls/jumplinebar.cpp" line="28"/>
         <source>Go to Line: </source>
         <translation>跳到行：</translation>
     </message>
@@ -119,12 +124,12 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/editorapplication.cpp" line="27"/>
+        <location filename="../src/editorapplication.cpp" line="11"/>
         <source>Text Editor is a powerful tool for viewing and editing text files.</source>
         <translation>文本编辑器是一款用来查看和编辑文本文件的工具。</translation>
     </message>
     <message>
-        <location filename="../src/editorapplication.cpp" line="38"/>
+        <location filename="../src/editorapplication.cpp" line="22"/>
         <source>Text Editor</source>
         <translation>文本编辑器</translation>
     </message>
@@ -132,572 +137,572 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/editorapplication.cpp" line="35"/>
+        <location filename="../src/editorapplication.cpp" line="19"/>
         <source>Text Editor</source>
         <translation>文本编辑器</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="203"/>
-        <location filename="../src/editor/editwrapper.cpp" line="538"/>
-        <location filename="../src/widgets/window.cpp" line="956"/>
-        <location filename="../src/widgets/window.cpp" line="973"/>
-        <location filename="../src/widgets/window.cpp" line="1064"/>
-        <location filename="../src/widgets/window.cpp" line="1079"/>
+        <location filename="../src/editor/editwrapper.cpp" line="248"/>
+        <location filename="../src/editor/editwrapper.cpp" line="704"/>
+        <location filename="../src/widgets/window.cpp" line="1089"/>
+        <location filename="../src/widgets/window.cpp" line="1111"/>
+        <location filename="../src/widgets/window.cpp" line="1203"/>
+        <location filename="../src/widgets/window.cpp" line="1218"/>
         <source>Encoding</source>
         <translation>编码</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="24"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="9"/>
         <source>Basic</source>
         <translation>基础设置</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="25"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="10"/>
         <source>Font Style</source>
         <translation>字体样式</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="26"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="11"/>
         <source>Font</source>
         <translation>字体</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="27"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="12"/>
         <source>Font Size</source>
         <translation>字号</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="28"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="13"/>
         <source>Shortcuts</source>
         <translation>快捷键</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="29"/>
-        <location filename="../src/controls/settingsdialog.cpp" line="30"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="14"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="15"/>
         <source>Keymap</source>
         <translation>快捷键映射</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="31"/>
-        <location filename="../src/controls/settingsdialog.cpp" line="107"/>
-        <location filename="../src/widgets/window.cpp" line="1482"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="16"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="92"/>
+        <location filename="../src/widgets/window.cpp" line="1811"/>
         <source>Window</source>
         <translation>窗口</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="32"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="17"/>
         <source>New tab</source>
         <translation>新标签页</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="33"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="18"/>
         <source>New window</source>
         <translation>新窗口</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="34"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="19"/>
         <source>Save</source>
         <translation>保存</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="35"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="20"/>
         <source>Save as</source>
         <translation>另存为</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="36"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="21"/>
         <source>Next tab</source>
         <translation>下一个标签页</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="37"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="22"/>
         <source>Previous tab</source>
         <translation>上一个标签页</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="38"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="23"/>
         <source>Close tab</source>
         <translation>关闭标签页</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="39"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="24"/>
         <source>Close other tabs</source>
         <translation>关闭其他标签页</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="40"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="25"/>
         <source>Restore tab</source>
         <translation>恢复标签页</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="41"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="26"/>
         <source>Open file</source>
         <translation>打开文件</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="42"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="27"/>
         <source>Increment font size</source>
         <translation>放大字号</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="43"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="28"/>
         <source>Decrement font size</source>
         <translation>缩小字号</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="44"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="29"/>
         <source>Reset font size</source>
         <translation>还原字号</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="45"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="30"/>
         <source>Help</source>
         <translation>帮助</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="46"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="31"/>
         <source>Toggle fullscreen</source>
         <translation>切换全屏</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="47"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="32"/>
         <source>Find</source>
         <translation>查找</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="48"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="33"/>
         <source>Replace</source>
         <translation>替换</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="49"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="34"/>
         <source>Go to line</source>
         <translation>跳到行</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="50"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="35"/>
         <source>Save cursor position</source>
         <translation>保存光标位置</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="51"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="36"/>
         <source>Reset cursor position</source>
         <translation>跳转到保存光标位置</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="52"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="37"/>
         <source>Exit</source>
         <translation>退出</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="53"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="38"/>
         <source>Display shortcuts</source>
         <translation>显示快捷键</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="54"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="39"/>
         <source>Print</source>
         <translation>打印</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="55"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="40"/>
         <source>Editor</source>
         <translation>编辑</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="56"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="41"/>
         <source>Increase indent</source>
         <translation>增加缩进</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="57"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="42"/>
         <source>Decrease indent</source>
         <translation>减少缩进</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="58"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="43"/>
         <source>Forward character</source>
         <translation>右移一个字符</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="59"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="44"/>
         <source>Backward character</source>
         <translation>左移一个字符</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="60"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="45"/>
         <source>Forward word</source>
         <translation>右移一个词</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="61"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="46"/>
         <source>Backward word</source>
         <translation>左移一个词</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="62"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="47"/>
         <source>Next line</source>
         <translation>下一行</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="63"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="48"/>
         <source>Previous line</source>
         <translation>上一行</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="64"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="49"/>
         <source>New line</source>
         <translation>换行</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="65"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="50"/>
         <source>New line above</source>
         <translation>向上插入一行</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="66"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="51"/>
         <source>New line below</source>
         <translation>向下插入一行</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="67"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="52"/>
         <source>Duplicate line</source>
         <translation>复制并粘贴当前行</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="68"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="53"/>
         <source>Delete to end of line</source>
         <translation>删除到行尾</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="69"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="54"/>
         <source>Delete current line</source>
         <translation>删除当前行</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="70"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="55"/>
         <source>Swap line up</source>
         <translation>上移一行</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="71"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="56"/>
         <source>Swap line down</source>
         <translation>下移一行</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="72"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="57"/>
         <source>Scroll up one line</source>
         <translation>向上滚动一行</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="73"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="58"/>
         <source>Scroll down one line</source>
         <translation>向下滚动一行</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="74"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="59"/>
         <source>Page up</source>
         <translation>向上滚动一页</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="75"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="60"/>
         <source>Page down</source>
         <translation>向下滚动一页</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="76"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="61"/>
         <source>Move to end of line</source>
         <translation>移动到行尾</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="77"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="62"/>
         <source>Move to start of line</source>
         <translation>移动到行头</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="78"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="63"/>
         <source>Move to end of text</source>
         <translation>移动到文本结尾</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="79"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="64"/>
         <source>Move to start of text</source>
         <translation>移动到文本开头</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="80"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="65"/>
         <source>Move to line indentation</source>
         <translation>移动到行缩进</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="81"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="66"/>
         <source>Upper case</source>
         <translation>转换为大写</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="82"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="67"/>
         <source>Lower case</source>
         <translation>转换为小写</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="83"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="68"/>
         <source>Capitalize</source>
         <translation>首字母大写</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="84"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="69"/>
         <source>Delete backward word</source>
         <translation>向左删除一个词</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="85"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="70"/>
         <source>Delete forward word</source>
         <translation>向右删除一个词</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="86"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="71"/>
         <source>Forward over a pair</source>
         <translation>向右匹配</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="87"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="72"/>
         <source>Backward over a pair</source>
         <translation>向左匹配</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="88"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="73"/>
         <source>Select all</source>
         <translation>全选</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="89"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="74"/>
         <source>Copy</source>
         <translation>复制</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="90"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="75"/>
         <source>Cut</source>
         <translation>剪切</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="91"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="76"/>
         <source>Paste</source>
         <translation>粘贴</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="92"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="77"/>
         <source>Transpose character</source>
         <translation>调换字符</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="93"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="78"/>
         <source>Mark</source>
         <translation>设置标记</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="94"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="79"/>
         <source>Unmark</source>
         <translation>取消标记</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="95"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="80"/>
         <source>Copy line</source>
         <translation>复制行</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="96"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="81"/>
         <source>Cut line</source>
         <translation>剪切行</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="97"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="82"/>
         <source>Merge lines</source>
         <translation>合并行</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="98"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="83"/>
         <source>Read-Only mode</source>
         <translation>切换到只读模式</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="99"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="84"/>
         <source>Add comment</source>
         <translation>添加注释</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="100"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="85"/>
         <source>Remove comment</source>
         <translation>取消注释</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="101"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="86"/>
         <source>Undo</source>
         <translation>撤销</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="102"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="87"/>
         <source>Redo</source>
         <translation>重做</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="103"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="88"/>
         <source>Add/Remove bookmark</source>
         <translation>添加/清除书签</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="104"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="89"/>
         <source>Move to previous bookmark</source>
         <translation>跳转到上一个书签</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="105"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="90"/>
         <source>Move to next bookmark</source>
         <translation>跳转到下一个书签</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="106"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="91"/>
         <source>Advanced</source>
         <translation>高级设置</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="108"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="93"/>
         <source>Window size</source>
         <translation>窗口状态</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="109"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="94"/>
         <source>Tab width</source>
         <translation>Tab字符宽度</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="111"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="96"/>
         <source>Word wrap</source>
         <translation>自动换行</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="112"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="97"/>
         <source>Code folding flag</source>
         <translation>显示代码折叠标志</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="113"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="98"/>
         <source>Show line numbers</source>
         <translation>显示行号</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="114"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="99"/>
         <source>Show bookmarks icon</source>
         <translation>显示书签图标</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="115"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="100"/>
         <source>Show whitespaces and tabs</source>
         <translation>显示空白字符/制表符</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="116"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="101"/>
         <source>Highlight current line</source>
         <translation>当前行高亮</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="117"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="102"/>
         <source>Color mark</source>
         <translation>颜色标记</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="120"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="105"/>
         <source>Unicode</source>
         <translation>Unicode</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="121"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="106"/>
         <source>WesternEuropean</source>
         <translation>西欧语系</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="122"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="107"/>
         <source>CentralEuropean</source>
         <translation>中欧语系</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="123"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="108"/>
         <source>Baltic</source>
         <translation>波罗的海语言</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="124"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="109"/>
         <source>Cyrillic</source>
         <translation>西里尔文</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="125"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="110"/>
         <source>Arabic</source>
         <translation>阿拉伯语</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="130"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="115"/>
         <source>Celtic</source>
         <translation>凯尔特语</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="131"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="116"/>
         <source>SouthEasternEuropean</source>
         <translation>东南欧语系</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="126"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="111"/>
         <source>Greek</source>
         <translation>希腊语</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="127"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="112"/>
         <source>Hebrew</source>
         <translation>希伯来语</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="132"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="117"/>
         <source>ChineseSimplified</source>
         <translation>简体中文</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="133"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="118"/>
         <source>ChineseTraditional</source>
         <translation>繁体中文</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="134"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="119"/>
         <source>Japanese</source>
         <translation>日语</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="135"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="120"/>
         <source>Korean</source>
         <translation>韩语</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="129"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="114"/>
         <source>Thai</source>
         <translation>泰语</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="128"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="113"/>
         <source>Turkish</source>
         <translation>土耳其语</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="136"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="121"/>
         <source>Vietnamese</source>
         <translation>越南语</translation>
     </message>
     <message>
-        <location filename="../src/startmanager.cpp" line="762"/>
+        <location filename="../src/startmanager.cpp" line="832"/>
         <source>File not saved</source>
         <translation>文件未保存</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="974"/>
-        <location filename="../src/widgets/window.cpp" line="1065"/>
-        <location filename="../src/widgets/window.cpp" line="1080"/>
+        <location filename="../src/widgets/window.cpp" line="1112"/>
+        <location filename="../src/widgets/window.cpp" line="1204"/>
+        <location filename="../src/widgets/window.cpp" line="1219"/>
         <source>Line Endings</source>
         <translation>换行符</translation>
     </message>
@@ -705,32 +710,32 @@
 <context>
     <name>ReplaceBar</name>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="39"/>
+        <location filename="../src/controls/replacebar.cpp" line="21"/>
         <source>Find</source>
         <translation>查找</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="43"/>
+        <location filename="../src/controls/replacebar.cpp" line="25"/>
         <source>Replace With</source>
         <translation>替换为</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="47"/>
+        <location filename="../src/controls/replacebar.cpp" line="29"/>
         <source>Replace</source>
         <translation>替换</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="50"/>
+        <location filename="../src/controls/replacebar.cpp" line="32"/>
         <source>Skip</source>
         <translation>跳过</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="53"/>
+        <location filename="../src/controls/replacebar.cpp" line="35"/>
         <source>Replace Rest</source>
         <translation>剩余替换</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="56"/>
+        <location filename="../src/controls/replacebar.cpp" line="38"/>
         <source>Replace All</source>
         <translation>全部替换</translation>
     </message>
@@ -747,58 +752,58 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../src/common/settings.cpp" line="91"/>
+        <location filename="../src/common/settings.cpp" line="115"/>
         <source>Standard</source>
         <translation>标准</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="91"/>
+        <location filename="../src/common/settings.cpp" line="115"/>
         <source>Customize</source>
         <translation>自定义</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="104"/>
+        <location filename="../src/common/settings.cpp" line="128"/>
         <source>Normal</source>
         <translation>正常窗口</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="104"/>
+        <location filename="../src/common/settings.cpp" line="128"/>
         <source>Maximum</source>
         <translation>最大化</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="104"/>
+        <location filename="../src/common/settings.cpp" line="128"/>
         <source>Fullscreen</source>
         <translation>全屏</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="292"/>
+        <location filename="../src/common/settings.cpp" line="316"/>
         <source>This shortcut conflicts with system shortcut %1</source>
         <translation>此快捷键与系统快捷键%1冲突</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="294"/>
+        <location filename="../src/common/settings.cpp" line="318"/>
         <source>This shortcut conflicts with %1, click on Replace to make this shortcut effective immediately</source>
         <translation>此快捷键与%1冲突，点击替换使这个快捷键立即生效</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="410"/>
-        <location filename="../src/common/settings.cpp" line="418"/>
+        <location filename="../src/common/settings.cpp" line="464"/>
+        <location filename="../src/common/settings.cpp" line="472"/>
         <source>The shortcut %1 is invalid, please set another one.</source>
         <translation>%1为无效快捷键，请重新设置</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="445"/>
+        <location filename="../src/common/settings.cpp" line="507"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="446"/>
+        <location filename="../src/common/settings.cpp" line="508"/>
         <source>Replace</source>
         <translation>替换</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="448"/>
+        <location filename="../src/common/settings.cpp" line="510"/>
         <source>OK</source>
         <translation>确定</translation>
     </message>
@@ -806,7 +811,7 @@
 <context>
     <name>StartManager</name>
     <message>
-        <location filename="../src/startmanager.cpp" line="340"/>
+        <location filename="../src/startmanager.cpp" line="350"/>
         <source>Untitled %1</source>
         <translation>未命名文档%1</translation>
     </message>
@@ -814,32 +819,32 @@
 <context>
     <name>Tabbar</name>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="515"/>
+        <location filename="../src/controls/tabbar.cpp" line="540"/>
         <source>Close tab</source>
         <translation>关闭标签页</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="516"/>
+        <location filename="../src/controls/tabbar.cpp" line="541"/>
         <source>Close other tabs</source>
         <translation>关闭其他标签页</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="517"/>
+        <location filename="../src/controls/tabbar.cpp" line="542"/>
         <source>More options</source>
         <translation>更多关闭方式</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="518"/>
+        <location filename="../src/controls/tabbar.cpp" line="543"/>
         <source>Close tabs to the left</source>
         <translation>关闭左侧所有标签页</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="519"/>
+        <location filename="../src/controls/tabbar.cpp" line="544"/>
         <source>Close tabs to the right</source>
         <translation>关闭右侧所有标签页</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="520"/>
+        <location filename="../src/controls/tabbar.cpp" line="545"/>
         <source>Close unmodified tabs</source>
         <translation>关闭所有未修改标签页</translation>
     </message>
@@ -847,261 +852,259 @@
 <context>
     <name>TextEdit</name>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="235"/>
+        <location filename="../src/editor/dtextedit.cpp" line="259"/>
         <source>Undo</source>
         <translation>撤销</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="236"/>
+        <location filename="../src/editor/dtextedit.cpp" line="260"/>
         <source>Redo</source>
         <translation>重做</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="237"/>
+        <location filename="../src/editor/dtextedit.cpp" line="261"/>
         <source>Cut</source>
         <translation>剪切</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="238"/>
+        <location filename="../src/editor/dtextedit.cpp" line="262"/>
         <source>Copy</source>
         <translation>复制</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="239"/>
+        <location filename="../src/editor/dtextedit.cpp" line="263"/>
         <source>Paste</source>
         <translation>粘贴</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="240"/>
+        <location filename="../src/editor/dtextedit.cpp" line="264"/>
         <source>Delete</source>
         <translation>删除</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="241"/>
+        <location filename="../src/editor/dtextedit.cpp" line="265"/>
         <source>Select All</source>
         <translation>全选</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="242"/>
-        <location filename="../src/widgets/window.cpp" line="361"/>
+        <location filename="../src/editor/dtextedit.cpp" line="266"/>
+        <location filename="../src/widgets/window.cpp" line="450"/>
         <source>Find</source>
         <translation>查找</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="243"/>
-        <location filename="../src/widgets/window.cpp" line="362"/>
+        <location filename="../src/editor/dtextedit.cpp" line="267"/>
+        <location filename="../src/widgets/window.cpp" line="451"/>
         <source>Replace</source>
         <translation>替换</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="244"/>
+        <location filename="../src/editor/dtextedit.cpp" line="268"/>
         <source>Go to Line</source>
         <translation>跳到行</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="245"/>
+        <location filename="../src/editor/dtextedit.cpp" line="269"/>
         <source>Turn on Read-Only mode</source>
         <translation>开启只读模式</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="246"/>
+        <location filename="../src/editor/dtextedit.cpp" line="270"/>
         <source>Turn off Read-Only mode</source>
         <translation>关闭只读模式</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="247"/>
+        <location filename="../src/editor/dtextedit.cpp" line="271"/>
         <source>Fullscreen</source>
         <translation>全屏</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="248"/>
+        <location filename="../src/editor/dtextedit.cpp" line="272"/>
         <source>Exit fullscreen</source>
         <translation>退出全屏</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="249"/>
+        <location filename="../src/editor/dtextedit.cpp" line="273"/>
         <source>Display in file manager</source>
         <translation>在文件管理器中显示</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="250"/>
-        <location filename="../src/editor/dtextedit.cpp" line="302"/>
+        <location filename="../src/editor/dtextedit.cpp" line="274"/>
+        <location filename="../src/editor/dtextedit.cpp" line="326"/>
         <source>Add Comment</source>
         <translation>添加注释</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="251"/>
+        <location filename="../src/editor/dtextedit.cpp" line="275"/>
         <source>Text to Speech</source>
         <translation>语音朗读</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="252"/>
+        <location filename="../src/editor/dtextedit.cpp" line="276"/>
         <source>Stop reading</source>
         <translation>停止朗读</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="253"/>
+        <location filename="../src/editor/dtextedit.cpp" line="277"/>
         <source>Speech to Text</source>
         <translation>语音听写</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="254"/>
+        <location filename="../src/editor/dtextedit.cpp" line="278"/>
         <source>Translate</source>
         <translation>文本翻译</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="255"/>
+        <location filename="../src/editor/dtextedit.cpp" line="279"/>
         <source>Column Mode</source>
         <translation>列编辑模式</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="256"/>
+        <location filename="../src/editor/dtextedit.cpp" line="280"/>
         <source>Add bookmark</source>
         <translation>添加书签</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="257"/>
+        <location filename="../src/editor/dtextedit.cpp" line="281"/>
         <source>Remove Bookmark</source>
         <translation>清除书签</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="258"/>
+        <location filename="../src/editor/dtextedit.cpp" line="282"/>
         <source>Previous bookmark</source>
         <translation>上一个书签</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="259"/>
+        <location filename="../src/editor/dtextedit.cpp" line="283"/>
         <source>Next bookmark</source>
         <translation>下一个书签</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="260"/>
+        <location filename="../src/editor/dtextedit.cpp" line="284"/>
         <source>Remove All Bookmarks</source>
         <translation>清除所有书签</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="261"/>
+        <location filename="../src/editor/dtextedit.cpp" line="285"/>
         <source>Fold All</source>
         <translation>折叠所有层次</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="262"/>
+        <location filename="../src/editor/dtextedit.cpp" line="286"/>
         <source>Fold Current Level</source>
         <translation>折叠当前层次</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="263"/>
+        <location filename="../src/editor/dtextedit.cpp" line="287"/>
         <source>Unfold All</source>
         <translation>展开所有层次</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="264"/>
+        <location filename="../src/editor/dtextedit.cpp" line="288"/>
         <source>Unfold Current Level</source>
         <translation>展开当前层次</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="269"/>
+        <location filename="../src/editor/dtextedit.cpp" line="293"/>
         <source>Color Mark</source>
         <translation>颜色标记</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="273"/>
+        <location filename="../src/editor/dtextedit.cpp" line="297"/>
         <source>Clear All Marks</source>
         <translation>清除所有标记</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="274"/>
+        <location filename="../src/editor/dtextedit.cpp" line="298"/>
         <source>Clear Last Mark</source>
         <translation>清除上次标记</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="283"/>
+        <location filename="../src/editor/dtextedit.cpp" line="307"/>
         <source>Mark</source>
         <translation>添加标记</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="295"/>
+        <location filename="../src/editor/dtextedit.cpp" line="319"/>
         <source>Mark All</source>
         <translation>标记所有</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="303"/>
+        <location filename="../src/editor/dtextedit.cpp" line="327"/>
         <source>Remove Comment</source>
         <translation>取消注释</translation>
     </message>
     <message>
-        <source>Failed to paste text: it is too large</source>
-        <translation type="vanished">文本内容过大，粘贴失败</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="2581"/>
+        <location filename="../src/editor/dtextedit.cpp" line="2672"/>
         <source>Copy failed: not enough memory</source>
         <translation>内存不足，复制失败</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="2665"/>
+        <location filename="../src/editor/dtextedit.cpp" line="2756"/>
         <source>Press ALT and click lines to edit in column mode</source>
         <translation>请使用ALT+鼠标点选切换列编辑模式</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="346"/>
+        <location filename="../src/editor/dtextedit.cpp" line="370"/>
         <source>Change Case</source>
         <translation>切换大小写</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="347"/>
+        <location filename="../src/editor/dtextedit.cpp" line="371"/>
         <source>Upper Case</source>
         <translation>大写</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="348"/>
+        <location filename="../src/editor/dtextedit.cpp" line="372"/>
         <source>Lower Case</source>
         <translation>小写</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="349"/>
+        <location filename="../src/editor/dtextedit.cpp" line="373"/>
         <source>Capitalize</source>
         <translation>首字母大写</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="64"/>
+        <location filename="../src/widgets/bottombar.cpp" line="49"/>
         <source>None</source>
         <translation>无</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1184"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1222"/>
         <source>Selected line(s) copied</source>
         <translation>已复制选中行到剪贴板</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1190"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1228"/>
         <source>Current line copied</source>
         <translation>已复制当前行到剪贴板</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1210"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1248"/>
         <source>Selected line(s) clipped</source>
         <translation>已剪切选中行到剪贴板</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1222"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1259"/>
         <source>Current line clipped</source>
         <translation>已剪切当前行到剪贴板</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="2591"/>
+        <location filename="../src/editor/dtextedit.cpp" line="2682"/>
         <source>Paste failed: not enough memory</source>
         <translation>内存不足，粘贴失败</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3439"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3617"/>
         <source>Read-Only mode is off</source>
         <translation>只读模式已关闭</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3446"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3465"/>
-        <location filename="../src/editor/dtextedit.cpp" line="6150"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3624"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3643"/>
+        <location filename="../src/editor/dtextedit.cpp" line="6656"/>
+        <location filename="../src/editor/dtextedit.cpp" line="6664"/>
+        <location filename="../src/editor/dtextedit.cpp" line="6675"/>
         <source>Read-Only mode is on</source>
         <translation>只读模式已开启</translation>
     </message>
@@ -1109,7 +1112,7 @@
 <context>
     <name>WarningNotices</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="36"/>
+        <location filename="../src/controls/warningnotices.cpp" line="19"/>
         <source>Reload</source>
         <translation>重新载入</translation>
     </message>
@@ -1117,129 +1120,130 @@
 <context>
     <name>Window</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="38"/>
-        <location filename="../src/widgets/window.cpp" line="357"/>
+        <location filename="../src/controls/warningnotices.cpp" line="21"/>
+        <location filename="../src/widgets/window.cpp" line="446"/>
         <source>Save as</source>
         <translation>另存为</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="353"/>
+        <location filename="../src/widgets/window.cpp" line="442"/>
         <source>New window</source>
         <translation>新窗口</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="354"/>
+        <location filename="../src/widgets/window.cpp" line="443"/>
         <source>New tab</source>
         <translation>新标签页</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="355"/>
+        <location filename="../src/widgets/window.cpp" line="444"/>
         <source>Open file</source>
         <translation>打开文件</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="356"/>
-        <location filename="../src/widgets/window.cpp" line="2217"/>
+        <location filename="../src/widgets/window.cpp" line="445"/>
+        <location filename="../src/widgets/window.cpp" line="2796"/>
         <source>Save</source>
         <translation>保存</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="358"/>
+        <location filename="../src/widgets/window.cpp" line="447"/>
         <source>Print</source>
         <translation>打印</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="359"/>
+        <location filename="../src/widgets/window.cpp" line="448"/>
         <source>Switch theme</source>
         <translation>切换主题</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="360"/>
-        <location filename="../src/widgets/window.cpp" line="1542"/>
+        <location filename="../src/widgets/window.cpp" line="449"/>
+        <location filename="../src/widgets/window.cpp" line="1871"/>
         <source>Settings</source>
         <translation>设置</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="471"/>
-        <location filename="../src/widgets/window.cpp" line="2468"/>
+        <location filename="../src/widgets/window.cpp" line="563"/>
+        <location filename="../src/widgets/window.cpp" line="3047"/>
         <source>Read-Only</source>
         <translation>只读</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="487"/>
+        <location filename="../src/widgets/window.cpp" line="579"/>
         <source>You do not have permission to open %1</source>
         <translation>您没有权限打开%1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="522"/>
+        <location filename="../src/widgets/window.cpp" line="619"/>
+        <location filename="../src/widgets/window.cpp" line="2359"/>
         <source>Invalid file: %1</source>
         <translation>无效文件：%1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="602"/>
-        <location filename="../src/widgets/window.cpp" line="644"/>
+        <location filename="../src/widgets/window.cpp" line="733"/>
+        <location filename="../src/widgets/window.cpp" line="779"/>
         <source>Do you want to save this file?</source>
         <translation>您是否要保存此文件？</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="894"/>
+        <location filename="../src/widgets/window.cpp" line="1027"/>
         <source>You do not have permission to save %1</source>
         <translation>您没有权限保存%1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="918"/>
+        <location filename="../src/widgets/window.cpp" line="1051"/>
         <source>Saved successfully</source>
         <translation>文件已保存</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="954"/>
-        <location filename="../src/widgets/window.cpp" line="1021"/>
-        <location filename="../src/widgets/window.cpp" line="1062"/>
+        <location filename="../src/widgets/window.cpp" line="1087"/>
+        <location filename="../src/widgets/window.cpp" line="1160"/>
+        <location filename="../src/widgets/window.cpp" line="1201"/>
         <source>Save File</source>
         <translation>保存</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1023"/>
+        <location filename="../src/widgets/window.cpp" line="1162"/>
         <source>Encoding</source>
         <translation>编码</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1211"/>
+        <location filename="../src/widgets/window.cpp" line="1350"/>
         <source>Read-Only mode is on</source>
         <translation>只读模式已开启</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1441"/>
+        <location filename="../src/widgets/window.cpp" line="1770"/>
         <source>Current location remembered</source>
         <translation>已记住当前位置</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1492"/>
+        <location filename="../src/widgets/window.cpp" line="1821"/>
         <source>Ctrl+&apos;=&apos;</source>
         <translation>Ctrl+&apos;=&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1495"/>
+        <location filename="../src/widgets/window.cpp" line="1824"/>
         <source>Ctrl+&apos;-&apos;</source>
         <translation>Ctrl+&apos;-&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1524"/>
+        <location filename="../src/widgets/window.cpp" line="1853"/>
         <source>Editor</source>
         <translation>编辑</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1890"/>
+        <location filename="../src/widgets/window.cpp" line="2451"/>
         <source>Untitled %1</source>
         <translation>未命名文档%1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2215"/>
+        <location filename="../src/widgets/window.cpp" line="2794"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2216"/>
+        <location filename="../src/widgets/window.cpp" line="2795"/>
         <source>Discard</source>
         <translation>不保存</translation>
     </message>

--- a/translations/deepin-editor_zh_HK.ts
+++ b/translations/deepin-editor_zh_HK.ts
@@ -2,17 +2,17 @@
 <context>
     <name>BottomBar</name>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="39"/>
+        <location filename="../src/widgets/bottombar.cpp" line="24"/>
         <source>Row</source>
         <translation>行</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="40"/>
+        <location filename="../src/widgets/bottombar.cpp" line="25"/>
         <source>Column</source>
         <translation>列</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="41"/>
+        <location filename="../src/widgets/bottombar.cpp" line="26"/>
         <source>Characters %1</source>
         <translation>字數 %1</translation>
     </message>
@@ -20,9 +20,9 @@
 <context>
     <name>DDropdownMenu</name>
     <message>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="300"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="344"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="349"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="290"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="341"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="346"/>
         <source>None</source>
         <translation>無</translation>
     </message>
@@ -30,80 +30,85 @@
 <context>
     <name>EditWrapper</name>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="201"/>
-        <location filename="../src/editor/editwrapper.cpp" line="264"/>
-        <location filename="../src/editor/editwrapper.cpp" line="321"/>
-        <location filename="../src/editor/editwrapper.cpp" line="536"/>
+        <location filename="../src/editor/editwrapper.cpp" line="246"/>
+        <location filename="../src/editor/editwrapper.cpp" line="314"/>
+        <location filename="../src/editor/editwrapper.cpp" line="439"/>
+        <location filename="../src/editor/editwrapper.cpp" line="702"/>
         <source>Save</source>
         <translation>保存</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="316"/>
+        <location filename="../src/editor/editwrapper.cpp" line="434"/>
         <source>Do you want to save this file?</source>
         <translation>您是否要保存此文件？</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="262"/>
-        <location filename="../src/editor/editwrapper.cpp" line="319"/>
+        <location filename="../src/editor/editwrapper.cpp" line="312"/>
+        <location filename="../src/editor/editwrapper.cpp" line="437"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="259"/>
+        <location filename="../src/editor/editwrapper.cpp" line="309"/>
         <source>Encoding changed. Do you want to save the file now?</source>
         <translation>文件編碼已更改，是否先進行保存？</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="320"/>
+        <location filename="../src/editor/editwrapper.cpp" line="438"/>
         <source>Discard</source>
         <translation>不保存</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="445"/>
+        <location filename="../src/editor/editwrapper.cpp" line="564"/>
         <source>You do not have permission to save %1</source>
         <translation>您沒有權限保存%1</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="607"/>
+        <location filename="../src/editor/editwrapper.cpp" line="774"/>
         <source>File removed on the disk. Save it now?</source>
         <translation>磁盤中的原文件已被移除，是否另存？</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="612"/>
+        <location filename="../src/editor/editwrapper.cpp" line="779"/>
         <source>File has changed on disk. Reload?</source>
         <translation>磁盤中的原文件已被修改，是否重新載入？</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="634"/>
-        <location filename="../src/widgets/bottombar.cpp" line="60"/>
+        <location filename="../src/editor/editwrapper.cpp" line="801"/>
+        <location filename="../src/widgets/bottombar.cpp" line="45"/>
         <source>INSERT</source>
         <translation>插入</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="637"/>
+        <location filename="../src/editor/editwrapper.cpp" line="804"/>
         <source>OVERWRITE</source>
         <translation>覆蓋</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="640"/>
+        <location filename="../src/editor/editwrapper.cpp" line="807"/>
         <source>R/O</source>
         <translation>只讀</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="945"/>
+        <source>The file cannot be read, which may be too large or has been damaged!</source>
+        <translation>無法讀取該文件，文件可能過大或損壞</translation>
     </message>
 </context>
 <context>
     <name>FindBar</name>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="40"/>
+        <location filename="../src/controls/findbar.cpp" line="22"/>
         <source>Find</source>
         <translation>查找</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="44"/>
+        <location filename="../src/controls/findbar.cpp" line="26"/>
         <source>Previous</source>
         <translation>上一個</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="46"/>
+        <location filename="../src/controls/findbar.cpp" line="28"/>
         <source>Next</source>
         <translation>下一個</translation>
     </message>
@@ -111,7 +116,7 @@
 <context>
     <name>JumpLineBar</name>
     <message>
-        <location filename="../src/controls/jumplinebar.cpp" line="40"/>
+        <location filename="../src/controls/jumplinebar.cpp" line="28"/>
         <source>Go to Line: </source>
         <translation>跳到行：</translation>
     </message>
@@ -119,12 +124,12 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/editorapplication.cpp" line="27"/>
+        <location filename="../src/editorapplication.cpp" line="11"/>
         <source>Text Editor is a powerful tool for viewing and editing text files.</source>
         <translation>文本編輯器是一款用來查看和編輯文本文件的工具。</translation>
     </message>
     <message>
-        <location filename="../src/editorapplication.cpp" line="38"/>
+        <location filename="../src/editorapplication.cpp" line="22"/>
         <source>Text Editor</source>
         <translation>文本編輯器</translation>
     </message>
@@ -132,572 +137,572 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/editorapplication.cpp" line="35"/>
+        <location filename="../src/editorapplication.cpp" line="19"/>
         <source>Text Editor</source>
         <translation>文本編輯器</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="203"/>
-        <location filename="../src/editor/editwrapper.cpp" line="538"/>
-        <location filename="../src/widgets/window.cpp" line="956"/>
-        <location filename="../src/widgets/window.cpp" line="973"/>
-        <location filename="../src/widgets/window.cpp" line="1064"/>
-        <location filename="../src/widgets/window.cpp" line="1079"/>
+        <location filename="../src/editor/editwrapper.cpp" line="248"/>
+        <location filename="../src/editor/editwrapper.cpp" line="704"/>
+        <location filename="../src/widgets/window.cpp" line="1089"/>
+        <location filename="../src/widgets/window.cpp" line="1111"/>
+        <location filename="../src/widgets/window.cpp" line="1203"/>
+        <location filename="../src/widgets/window.cpp" line="1218"/>
         <source>Encoding</source>
         <translation>編碼</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="24"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="9"/>
         <source>Basic</source>
         <translation>基礎設置</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="25"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="10"/>
         <source>Font Style</source>
         <translation>字體樣式</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="26"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="11"/>
         <source>Font</source>
         <translation>字體</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="27"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="12"/>
         <source>Font Size</source>
         <translation>字號</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="28"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="13"/>
         <source>Shortcuts</source>
         <translation>快捷鍵</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="29"/>
-        <location filename="../src/controls/settingsdialog.cpp" line="30"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="14"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="15"/>
         <source>Keymap</source>
         <translation>快捷鍵映射</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="31"/>
-        <location filename="../src/controls/settingsdialog.cpp" line="107"/>
-        <location filename="../src/widgets/window.cpp" line="1482"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="16"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="92"/>
+        <location filename="../src/widgets/window.cpp" line="1811"/>
         <source>Window</source>
         <translation>窗口</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="32"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="17"/>
         <source>New tab</source>
         <translation>新標籤頁</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="33"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="18"/>
         <source>New window</source>
         <translation>新窗口</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="34"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="19"/>
         <source>Save</source>
         <translation>保存</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="35"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="20"/>
         <source>Save as</source>
         <translation>另存為</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="36"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="21"/>
         <source>Next tab</source>
         <translation>下一個標籤頁</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="37"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="22"/>
         <source>Previous tab</source>
         <translation>上一個標籤頁</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="38"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="23"/>
         <source>Close tab</source>
         <translation>關閉標籤頁</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="39"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="24"/>
         <source>Close other tabs</source>
         <translation>關閉其他標籤頁</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="40"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="25"/>
         <source>Restore tab</source>
         <translation>恢復標籤頁</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="41"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="26"/>
         <source>Open file</source>
         <translation>打開文件</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="42"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="27"/>
         <source>Increment font size</source>
         <translation>放大字號</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="43"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="28"/>
         <source>Decrement font size</source>
         <translation>縮小字號</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="44"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="29"/>
         <source>Reset font size</source>
         <translation>還原字號</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="45"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="30"/>
         <source>Help</source>
         <translation>幫助</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="46"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="31"/>
         <source>Toggle fullscreen</source>
         <translation>切換全屏</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="47"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="32"/>
         <source>Find</source>
         <translation>查找</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="48"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="33"/>
         <source>Replace</source>
         <translation>替換</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="49"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="34"/>
         <source>Go to line</source>
         <translation>跳到行</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="50"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="35"/>
         <source>Save cursor position</source>
         <translation>保存光標位置</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="51"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="36"/>
         <source>Reset cursor position</source>
         <translation>跳轉到保存光標位置</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="52"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="37"/>
         <source>Exit</source>
         <translation>退出</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="53"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="38"/>
         <source>Display shortcuts</source>
         <translation>顯示快捷鍵</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="54"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="39"/>
         <source>Print</source>
         <translation>打印</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="55"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="40"/>
         <source>Editor</source>
         <translation>編輯</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="56"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="41"/>
         <source>Increase indent</source>
         <translation>增加縮進</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="57"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="42"/>
         <source>Decrease indent</source>
         <translation>減少縮進</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="58"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="43"/>
         <source>Forward character</source>
         <translation>右移一個字符</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="59"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="44"/>
         <source>Backward character</source>
         <translation>左移一個字符</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="60"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="45"/>
         <source>Forward word</source>
         <translation>右移一個詞</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="61"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="46"/>
         <source>Backward word</source>
         <translation>左移一個詞</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="62"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="47"/>
         <source>Next line</source>
         <translation>下一行</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="63"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="48"/>
         <source>Previous line</source>
         <translation>上一行</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="64"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="49"/>
         <source>New line</source>
         <translation>換行</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="65"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="50"/>
         <source>New line above</source>
         <translation>向上插入一行</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="66"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="51"/>
         <source>New line below</source>
         <translation>向下插入一行</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="67"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="52"/>
         <source>Duplicate line</source>
         <translation>複製並黏貼當前行</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="68"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="53"/>
         <source>Delete to end of line</source>
         <translation>刪除到行尾</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="69"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="54"/>
         <source>Delete current line</source>
         <translation>刪除當前行</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="70"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="55"/>
         <source>Swap line up</source>
         <translation>上移一行</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="71"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="56"/>
         <source>Swap line down</source>
         <translation>下移一行</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="72"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="57"/>
         <source>Scroll up one line</source>
         <translation>向上滾動一行</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="73"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="58"/>
         <source>Scroll down one line</source>
         <translation>向下滾動一行</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="74"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="59"/>
         <source>Page up</source>
         <translation>向上滾動一頁</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="75"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="60"/>
         <source>Page down</source>
         <translation>向下滾動一頁</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="76"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="61"/>
         <source>Move to end of line</source>
         <translation>移動到行尾</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="77"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="62"/>
         <source>Move to start of line</source>
         <translation>移動到行頭</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="78"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="63"/>
         <source>Move to end of text</source>
         <translation>移動到文本結尾</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="79"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="64"/>
         <source>Move to start of text</source>
         <translation>移動到文本開頭</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="80"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="65"/>
         <source>Move to line indentation</source>
         <translation>移動到行縮進</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="81"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="66"/>
         <source>Upper case</source>
         <translation>轉換為大寫</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="82"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="67"/>
         <source>Lower case</source>
         <translation>轉換為小寫</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="83"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="68"/>
         <source>Capitalize</source>
         <translation>首字母大寫</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="84"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="69"/>
         <source>Delete backward word</source>
         <translation>向左刪除一個詞</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="85"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="70"/>
         <source>Delete forward word</source>
         <translation>向右刪除一個詞</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="86"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="71"/>
         <source>Forward over a pair</source>
         <translation>向右匹配</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="87"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="72"/>
         <source>Backward over a pair</source>
         <translation>向左匹配</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="88"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="73"/>
         <source>Select all</source>
         <translation>全選</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="89"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="74"/>
         <source>Copy</source>
         <translation>複製</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="90"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="75"/>
         <source>Cut</source>
         <translation>剪切</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="91"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="76"/>
         <source>Paste</source>
         <translation>黏貼</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="92"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="77"/>
         <source>Transpose character</source>
         <translation>調換字符</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="93"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="78"/>
         <source>Mark</source>
         <translation>設置標記</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="94"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="79"/>
         <source>Unmark</source>
         <translation>取消標記</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="95"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="80"/>
         <source>Copy line</source>
         <translation>複製行</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="96"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="81"/>
         <source>Cut line</source>
         <translation>剪切行</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="97"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="82"/>
         <source>Merge lines</source>
         <translation>合併行</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="98"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="83"/>
         <source>Read-Only mode</source>
         <translation>切換到只讀模式</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="99"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="84"/>
         <source>Add comment</source>
         <translation>添加注釋</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="100"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="85"/>
         <source>Remove comment</source>
         <translation>取消注釋</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="101"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="86"/>
         <source>Undo</source>
         <translation>撤銷</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="102"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="87"/>
         <source>Redo</source>
         <translation>重做</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="103"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="88"/>
         <source>Add/Remove bookmark</source>
         <translation>添加/清除書籤</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="104"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="89"/>
         <source>Move to previous bookmark</source>
         <translation>跳轉到上一個書籤</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="105"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="90"/>
         <source>Move to next bookmark</source>
         <translation>跳轉到下一個書籤</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="106"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="91"/>
         <source>Advanced</source>
         <translation>高級設置</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="108"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="93"/>
         <source>Window size</source>
         <translation>窗口狀態</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="109"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="94"/>
         <source>Tab width</source>
         <translation>Tab字符寬度</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="111"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="96"/>
         <source>Word wrap</source>
         <translation>自動換行</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="112"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="97"/>
         <source>Code folding flag</source>
         <translation>顯示代碼摺疊標誌</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="113"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="98"/>
         <source>Show line numbers</source>
         <translation>顯示行號</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="114"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="99"/>
         <source>Show bookmarks icon</source>
         <translation>顯示書籤圖標</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="115"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="100"/>
         <source>Show whitespaces and tabs</source>
         <translation>顯示空白字符/制表符</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="116"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="101"/>
         <source>Highlight current line</source>
         <translation>當前行高亮</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="117"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="102"/>
         <source>Color mark</source>
         <translation>顏色標記</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="120"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="105"/>
         <source>Unicode</source>
         <translation>Unicode</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="121"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="106"/>
         <source>WesternEuropean</source>
         <translation>西歐語系</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="122"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="107"/>
         <source>CentralEuropean</source>
         <translation>中歐語系</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="123"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="108"/>
         <source>Baltic</source>
         <translation>波羅的海語言</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="124"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="109"/>
         <source>Cyrillic</source>
         <translation>西里爾文</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="125"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="110"/>
         <source>Arabic</source>
         <translation>阿拉伯語</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="130"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="115"/>
         <source>Celtic</source>
         <translation>凱爾特語</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="131"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="116"/>
         <source>SouthEasternEuropean</source>
         <translation>東南歐語系</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="126"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="111"/>
         <source>Greek</source>
         <translation>希臘語</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="127"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="112"/>
         <source>Hebrew</source>
         <translation>希伯來語</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="132"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="117"/>
         <source>ChineseSimplified</source>
         <translation>簡體中文</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="133"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="118"/>
         <source>ChineseTraditional</source>
         <translation>繁體中文</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="134"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="119"/>
         <source>Japanese</source>
         <translation>日語</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="135"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="120"/>
         <source>Korean</source>
         <translation>韓語</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="129"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="114"/>
         <source>Thai</source>
         <translation>泰語</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="128"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="113"/>
         <source>Turkish</source>
         <translation>土耳其語</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="136"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="121"/>
         <source>Vietnamese</source>
         <translation>越南語</translation>
     </message>
     <message>
-        <location filename="../src/startmanager.cpp" line="762"/>
+        <location filename="../src/startmanager.cpp" line="832"/>
         <source>File not saved</source>
         <translation>文件未保存</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="974"/>
-        <location filename="../src/widgets/window.cpp" line="1065"/>
-        <location filename="../src/widgets/window.cpp" line="1080"/>
+        <location filename="../src/widgets/window.cpp" line="1112"/>
+        <location filename="../src/widgets/window.cpp" line="1204"/>
+        <location filename="../src/widgets/window.cpp" line="1219"/>
         <source>Line Endings</source>
         <translation>換行符</translation>
     </message>
@@ -705,32 +710,32 @@
 <context>
     <name>ReplaceBar</name>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="39"/>
+        <location filename="../src/controls/replacebar.cpp" line="21"/>
         <source>Find</source>
         <translation>查找</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="43"/>
+        <location filename="../src/controls/replacebar.cpp" line="25"/>
         <source>Replace With</source>
         <translation>替換為</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="47"/>
+        <location filename="../src/controls/replacebar.cpp" line="29"/>
         <source>Replace</source>
         <translation>替換</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="50"/>
+        <location filename="../src/controls/replacebar.cpp" line="32"/>
         <source>Skip</source>
         <translation>跳過</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="53"/>
+        <location filename="../src/controls/replacebar.cpp" line="35"/>
         <source>Replace Rest</source>
         <translation>剩餘替換</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="56"/>
+        <location filename="../src/controls/replacebar.cpp" line="38"/>
         <source>Replace All</source>
         <translation>全部替換</translation>
     </message>
@@ -747,58 +752,58 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../src/common/settings.cpp" line="91"/>
+        <location filename="../src/common/settings.cpp" line="115"/>
         <source>Standard</source>
         <translation>標準</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="91"/>
+        <location filename="../src/common/settings.cpp" line="115"/>
         <source>Customize</source>
         <translation>自定義</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="104"/>
+        <location filename="../src/common/settings.cpp" line="128"/>
         <source>Normal</source>
         <translation>正常窗口</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="104"/>
+        <location filename="../src/common/settings.cpp" line="128"/>
         <source>Maximum</source>
         <translation>最大化</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="104"/>
+        <location filename="../src/common/settings.cpp" line="128"/>
         <source>Fullscreen</source>
         <translation>全屏</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="292"/>
+        <location filename="../src/common/settings.cpp" line="316"/>
         <source>This shortcut conflicts with system shortcut %1</source>
         <translation>此快捷鍵與系統快捷鍵%1衝突</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="294"/>
+        <location filename="../src/common/settings.cpp" line="318"/>
         <source>This shortcut conflicts with %1, click on Replace to make this shortcut effective immediately</source>
         <translation>此快捷鍵與%1衝突，點擊替換使這個快捷鍵立即生效</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="410"/>
-        <location filename="../src/common/settings.cpp" line="418"/>
+        <location filename="../src/common/settings.cpp" line="464"/>
+        <location filename="../src/common/settings.cpp" line="472"/>
         <source>The shortcut %1 is invalid, please set another one.</source>
         <translation>%1為無效快捷鍵，請重新設置</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="445"/>
+        <location filename="../src/common/settings.cpp" line="507"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="446"/>
+        <location filename="../src/common/settings.cpp" line="508"/>
         <source>Replace</source>
         <translation>替換</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="448"/>
+        <location filename="../src/common/settings.cpp" line="510"/>
         <source>OK</source>
         <translation>確定</translation>
     </message>
@@ -806,7 +811,7 @@
 <context>
     <name>StartManager</name>
     <message>
-        <location filename="../src/startmanager.cpp" line="340"/>
+        <location filename="../src/startmanager.cpp" line="350"/>
         <source>Untitled %1</source>
         <translation>未命名文檔%1</translation>
     </message>
@@ -814,32 +819,32 @@
 <context>
     <name>Tabbar</name>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="515"/>
+        <location filename="../src/controls/tabbar.cpp" line="540"/>
         <source>Close tab</source>
         <translation>關閉標籤頁</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="516"/>
+        <location filename="../src/controls/tabbar.cpp" line="541"/>
         <source>Close other tabs</source>
         <translation>關閉其他標籤頁</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="517"/>
+        <location filename="../src/controls/tabbar.cpp" line="542"/>
         <source>More options</source>
         <translation>更多關閉方式</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="518"/>
+        <location filename="../src/controls/tabbar.cpp" line="543"/>
         <source>Close tabs to the left</source>
         <translation>關閉左側所有標籤頁</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="519"/>
+        <location filename="../src/controls/tabbar.cpp" line="544"/>
         <source>Close tabs to the right</source>
         <translation>關閉右側所有標籤頁</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="520"/>
+        <location filename="../src/controls/tabbar.cpp" line="545"/>
         <source>Close unmodified tabs</source>
         <translation>關閉所有未修改標籤頁</translation>
     </message>
@@ -847,261 +852,259 @@
 <context>
     <name>TextEdit</name>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="235"/>
+        <location filename="../src/editor/dtextedit.cpp" line="259"/>
         <source>Undo</source>
         <translation>撤銷</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="236"/>
+        <location filename="../src/editor/dtextedit.cpp" line="260"/>
         <source>Redo</source>
         <translation>重做</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="237"/>
+        <location filename="../src/editor/dtextedit.cpp" line="261"/>
         <source>Cut</source>
         <translation>剪切</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="238"/>
+        <location filename="../src/editor/dtextedit.cpp" line="262"/>
         <source>Copy</source>
         <translation>複製</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="239"/>
+        <location filename="../src/editor/dtextedit.cpp" line="263"/>
         <source>Paste</source>
         <translation>黏貼</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="240"/>
+        <location filename="../src/editor/dtextedit.cpp" line="264"/>
         <source>Delete</source>
         <translation>刪除</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="241"/>
+        <location filename="../src/editor/dtextedit.cpp" line="265"/>
         <source>Select All</source>
         <translation>全選</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="242"/>
-        <location filename="../src/widgets/window.cpp" line="361"/>
+        <location filename="../src/editor/dtextedit.cpp" line="266"/>
+        <location filename="../src/widgets/window.cpp" line="450"/>
         <source>Find</source>
         <translation>查找</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="243"/>
-        <location filename="../src/widgets/window.cpp" line="362"/>
+        <location filename="../src/editor/dtextedit.cpp" line="267"/>
+        <location filename="../src/widgets/window.cpp" line="451"/>
         <source>Replace</source>
         <translation>替換</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="244"/>
+        <location filename="../src/editor/dtextedit.cpp" line="268"/>
         <source>Go to Line</source>
         <translation>跳到行</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="245"/>
+        <location filename="../src/editor/dtextedit.cpp" line="269"/>
         <source>Turn on Read-Only mode</source>
         <translation>開啟只讀模式</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="246"/>
+        <location filename="../src/editor/dtextedit.cpp" line="270"/>
         <source>Turn off Read-Only mode</source>
         <translation>關閉只讀模式</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="247"/>
+        <location filename="../src/editor/dtextedit.cpp" line="271"/>
         <source>Fullscreen</source>
         <translation>全屏</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="248"/>
+        <location filename="../src/editor/dtextedit.cpp" line="272"/>
         <source>Exit fullscreen</source>
         <translation>退出全屏</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="249"/>
+        <location filename="../src/editor/dtextedit.cpp" line="273"/>
         <source>Display in file manager</source>
         <translation>在檔案管理員中顯示</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="250"/>
-        <location filename="../src/editor/dtextedit.cpp" line="302"/>
+        <location filename="../src/editor/dtextedit.cpp" line="274"/>
+        <location filename="../src/editor/dtextedit.cpp" line="326"/>
         <source>Add Comment</source>
         <translation>添加注釋</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="251"/>
+        <location filename="../src/editor/dtextedit.cpp" line="275"/>
         <source>Text to Speech</source>
         <translation>語音朗讀</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="252"/>
+        <location filename="../src/editor/dtextedit.cpp" line="276"/>
         <source>Stop reading</source>
         <translation>停止朗讀</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="253"/>
+        <location filename="../src/editor/dtextedit.cpp" line="277"/>
         <source>Speech to Text</source>
         <translation>語音聽寫</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="254"/>
+        <location filename="../src/editor/dtextedit.cpp" line="278"/>
         <source>Translate</source>
         <translation>文本翻譯</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="255"/>
+        <location filename="../src/editor/dtextedit.cpp" line="279"/>
         <source>Column Mode</source>
         <translation>列編輯模式</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="256"/>
+        <location filename="../src/editor/dtextedit.cpp" line="280"/>
         <source>Add bookmark</source>
         <translation>添加書籤</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="257"/>
+        <location filename="../src/editor/dtextedit.cpp" line="281"/>
         <source>Remove Bookmark</source>
         <translation>清除書籤</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="258"/>
+        <location filename="../src/editor/dtextedit.cpp" line="282"/>
         <source>Previous bookmark</source>
         <translation>上一個書籤</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="259"/>
+        <location filename="../src/editor/dtextedit.cpp" line="283"/>
         <source>Next bookmark</source>
         <translation>下一個書籤</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="260"/>
+        <location filename="../src/editor/dtextedit.cpp" line="284"/>
         <source>Remove All Bookmarks</source>
         <translation>清除所有書籤</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="261"/>
+        <location filename="../src/editor/dtextedit.cpp" line="285"/>
         <source>Fold All</source>
         <translation>摺疊所有層次</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="262"/>
+        <location filename="../src/editor/dtextedit.cpp" line="286"/>
         <source>Fold Current Level</source>
         <translation>摺疊當前層次</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="263"/>
+        <location filename="../src/editor/dtextedit.cpp" line="287"/>
         <source>Unfold All</source>
         <translation>展開所有層次</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="264"/>
+        <location filename="../src/editor/dtextedit.cpp" line="288"/>
         <source>Unfold Current Level</source>
         <translation>展開當前層次</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="269"/>
+        <location filename="../src/editor/dtextedit.cpp" line="293"/>
         <source>Color Mark</source>
         <translation>顏色標記</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="273"/>
+        <location filename="../src/editor/dtextedit.cpp" line="297"/>
         <source>Clear All Marks</source>
         <translation>清除所有標記</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="274"/>
+        <location filename="../src/editor/dtextedit.cpp" line="298"/>
         <source>Clear Last Mark</source>
         <translation>清除上次標記</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="283"/>
+        <location filename="../src/editor/dtextedit.cpp" line="307"/>
         <source>Mark</source>
         <translation>設置標記</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="295"/>
+        <location filename="../src/editor/dtextedit.cpp" line="319"/>
         <source>Mark All</source>
         <translation>標記所有</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="303"/>
+        <location filename="../src/editor/dtextedit.cpp" line="327"/>
         <source>Remove Comment</source>
         <translation>取消注釋</translation>
     </message>
     <message>
-        <source>Failed to paste text: it is too large</source>
-        <translation type="vanished">文本內容過大，黏貼失敗</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="2581"/>
+        <location filename="../src/editor/dtextedit.cpp" line="2672"/>
         <source>Copy failed: not enough memory</source>
         <translation>內存不足，複製失敗</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="2665"/>
+        <location filename="../src/editor/dtextedit.cpp" line="2756"/>
         <source>Press ALT and click lines to edit in column mode</source>
         <translation>請使用ALT+鼠標點選切換列編輯模式</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="346"/>
+        <location filename="../src/editor/dtextedit.cpp" line="370"/>
         <source>Change Case</source>
         <translation>切換大小寫</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="347"/>
+        <location filename="../src/editor/dtextedit.cpp" line="371"/>
         <source>Upper Case</source>
         <translation>大寫</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="348"/>
+        <location filename="../src/editor/dtextedit.cpp" line="372"/>
         <source>Lower Case</source>
         <translation>小寫</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="349"/>
+        <location filename="../src/editor/dtextedit.cpp" line="373"/>
         <source>Capitalize</source>
         <translation>首字母大寫</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="64"/>
+        <location filename="../src/widgets/bottombar.cpp" line="49"/>
         <source>None</source>
         <translation>無</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1184"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1222"/>
         <source>Selected line(s) copied</source>
         <translation>已複製選中行到剪貼板</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1190"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1228"/>
         <source>Current line copied</source>
         <translation>已複製當前行到剪貼板</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1210"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1248"/>
         <source>Selected line(s) clipped</source>
         <translation>已剪切選中行到剪貼板</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1222"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1259"/>
         <source>Current line clipped</source>
         <translation>已剪切當前行到剪貼板</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="2591"/>
+        <location filename="../src/editor/dtextedit.cpp" line="2682"/>
         <source>Paste failed: not enough memory</source>
         <translation>內存不足，黏貼失敗</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3439"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3617"/>
         <source>Read-Only mode is off</source>
         <translation>只讀模式已關閉</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3446"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3465"/>
-        <location filename="../src/editor/dtextedit.cpp" line="6150"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3624"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3643"/>
+        <location filename="../src/editor/dtextedit.cpp" line="6656"/>
+        <location filename="../src/editor/dtextedit.cpp" line="6664"/>
+        <location filename="../src/editor/dtextedit.cpp" line="6675"/>
         <source>Read-Only mode is on</source>
         <translation>只讀模式已開啟</translation>
     </message>
@@ -1109,7 +1112,7 @@
 <context>
     <name>WarningNotices</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="36"/>
+        <location filename="../src/controls/warningnotices.cpp" line="19"/>
         <source>Reload</source>
         <translation>重新載入</translation>
     </message>
@@ -1117,129 +1120,130 @@
 <context>
     <name>Window</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="38"/>
-        <location filename="../src/widgets/window.cpp" line="357"/>
+        <location filename="../src/controls/warningnotices.cpp" line="21"/>
+        <location filename="../src/widgets/window.cpp" line="446"/>
         <source>Save as</source>
         <translation>另存為</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="353"/>
+        <location filename="../src/widgets/window.cpp" line="442"/>
         <source>New window</source>
         <translation>新窗口</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="354"/>
+        <location filename="../src/widgets/window.cpp" line="443"/>
         <source>New tab</source>
         <translation>新標籤頁</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="355"/>
+        <location filename="../src/widgets/window.cpp" line="444"/>
         <source>Open file</source>
         <translation>打開文件</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="356"/>
-        <location filename="../src/widgets/window.cpp" line="2217"/>
+        <location filename="../src/widgets/window.cpp" line="445"/>
+        <location filename="../src/widgets/window.cpp" line="2796"/>
         <source>Save</source>
         <translation>保存</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="358"/>
+        <location filename="../src/widgets/window.cpp" line="447"/>
         <source>Print</source>
         <translation>打印</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="359"/>
+        <location filename="../src/widgets/window.cpp" line="448"/>
         <source>Switch theme</source>
         <translation>切換主題</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="360"/>
-        <location filename="../src/widgets/window.cpp" line="1542"/>
+        <location filename="../src/widgets/window.cpp" line="449"/>
+        <location filename="../src/widgets/window.cpp" line="1871"/>
         <source>Settings</source>
         <translation>設置</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="471"/>
-        <location filename="../src/widgets/window.cpp" line="2468"/>
+        <location filename="../src/widgets/window.cpp" line="563"/>
+        <location filename="../src/widgets/window.cpp" line="3047"/>
         <source>Read-Only</source>
         <translation>只讀</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="487"/>
+        <location filename="../src/widgets/window.cpp" line="579"/>
         <source>You do not have permission to open %1</source>
         <translation>您沒有權限打開%1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="522"/>
+        <location filename="../src/widgets/window.cpp" line="619"/>
+        <location filename="../src/widgets/window.cpp" line="2359"/>
         <source>Invalid file: %1</source>
         <translation>無效文件：%1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="602"/>
-        <location filename="../src/widgets/window.cpp" line="644"/>
+        <location filename="../src/widgets/window.cpp" line="733"/>
+        <location filename="../src/widgets/window.cpp" line="779"/>
         <source>Do you want to save this file?</source>
         <translation>您是否要保存此文件？</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="894"/>
+        <location filename="../src/widgets/window.cpp" line="1027"/>
         <source>You do not have permission to save %1</source>
         <translation>您沒有權限保存%1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="918"/>
+        <location filename="../src/widgets/window.cpp" line="1051"/>
         <source>Saved successfully</source>
         <translation>文件已保存</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="954"/>
-        <location filename="../src/widgets/window.cpp" line="1021"/>
-        <location filename="../src/widgets/window.cpp" line="1062"/>
+        <location filename="../src/widgets/window.cpp" line="1087"/>
+        <location filename="../src/widgets/window.cpp" line="1160"/>
+        <location filename="../src/widgets/window.cpp" line="1201"/>
         <source>Save File</source>
         <translation>保存</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1023"/>
+        <location filename="../src/widgets/window.cpp" line="1162"/>
         <source>Encoding</source>
         <translation>編碼</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1211"/>
+        <location filename="../src/widgets/window.cpp" line="1350"/>
         <source>Read-Only mode is on</source>
         <translation>只讀模式已開啟</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1441"/>
+        <location filename="../src/widgets/window.cpp" line="1770"/>
         <source>Current location remembered</source>
         <translation>已記住當前位置</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1492"/>
+        <location filename="../src/widgets/window.cpp" line="1821"/>
         <source>Ctrl+&apos;=&apos;</source>
         <translation>Ctrl+&apos;=&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1495"/>
+        <location filename="../src/widgets/window.cpp" line="1824"/>
         <source>Ctrl+&apos;-&apos;</source>
         <translation>Ctrl+&apos;-&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1524"/>
+        <location filename="../src/widgets/window.cpp" line="1853"/>
         <source>Editor</source>
         <translation>編輯</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1890"/>
+        <location filename="../src/widgets/window.cpp" line="2451"/>
         <source>Untitled %1</source>
         <translation>未命名文檔%1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2215"/>
+        <location filename="../src/widgets/window.cpp" line="2794"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2216"/>
+        <location filename="../src/widgets/window.cpp" line="2795"/>
         <source>Discard</source>
         <translation>不保存</translation>
     </message>

--- a/translations/deepin-editor_zh_TW.ts
+++ b/translations/deepin-editor_zh_TW.ts
@@ -2,17 +2,17 @@
 <context>
     <name>BottomBar</name>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="39"/>
+        <location filename="../src/widgets/bottombar.cpp" line="24"/>
         <source>Row</source>
         <translation>行</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="40"/>
+        <location filename="../src/widgets/bottombar.cpp" line="25"/>
         <source>Column</source>
         <translation>欄</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="41"/>
+        <location filename="../src/widgets/bottombar.cpp" line="26"/>
         <source>Characters %1</source>
         <translation>字數 %1</translation>
     </message>
@@ -20,9 +20,9 @@
 <context>
     <name>DDropdownMenu</name>
     <message>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="300"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="344"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="349"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="290"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="341"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="346"/>
         <source>None</source>
         <translation>無</translation>
     </message>
@@ -30,80 +30,85 @@
 <context>
     <name>EditWrapper</name>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="201"/>
-        <location filename="../src/editor/editwrapper.cpp" line="264"/>
-        <location filename="../src/editor/editwrapper.cpp" line="321"/>
-        <location filename="../src/editor/editwrapper.cpp" line="536"/>
+        <location filename="../src/editor/editwrapper.cpp" line="246"/>
+        <location filename="../src/editor/editwrapper.cpp" line="314"/>
+        <location filename="../src/editor/editwrapper.cpp" line="439"/>
+        <location filename="../src/editor/editwrapper.cpp" line="702"/>
         <source>Save</source>
         <translation>儲存</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="316"/>
+        <location filename="../src/editor/editwrapper.cpp" line="434"/>
         <source>Do you want to save this file?</source>
         <translation>是否儲存此檔案？</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="262"/>
-        <location filename="../src/editor/editwrapper.cpp" line="319"/>
+        <location filename="../src/editor/editwrapper.cpp" line="312"/>
+        <location filename="../src/editor/editwrapper.cpp" line="437"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="259"/>
+        <location filename="../src/editor/editwrapper.cpp" line="309"/>
         <source>Encoding changed. Do you want to save the file now?</source>
         <translation>文件編碼已更改，是否先進行儲存？</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="320"/>
+        <location filename="../src/editor/editwrapper.cpp" line="438"/>
         <source>Discard</source>
         <translation>捨棄</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="445"/>
+        <location filename="../src/editor/editwrapper.cpp" line="564"/>
         <source>You do not have permission to save %1</source>
         <translation>您沒有權限儲存 %1</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="607"/>
+        <location filename="../src/editor/editwrapper.cpp" line="774"/>
         <source>File removed on the disk. Save it now?</source>
         <translation>磁碟上的檔案已被移除。是否現在儲存？</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="612"/>
+        <location filename="../src/editor/editwrapper.cpp" line="779"/>
         <source>File has changed on disk. Reload?</source>
         <translation>磁碟上的檔案已被更改。是否重新載入？</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="634"/>
-        <location filename="../src/widgets/bottombar.cpp" line="60"/>
+        <location filename="../src/editor/editwrapper.cpp" line="801"/>
+        <location filename="../src/widgets/bottombar.cpp" line="45"/>
         <source>INSERT</source>
         <translation>插入</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="637"/>
+        <location filename="../src/editor/editwrapper.cpp" line="804"/>
         <source>OVERWRITE</source>
         <translation>覆寫</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="640"/>
+        <location filename="../src/editor/editwrapper.cpp" line="807"/>
         <source>R/O</source>
         <translation>唯讀</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="945"/>
+        <source>The file cannot be read, which may be too large or has been damaged!</source>
+        <translation>無法讀取該文件，文件可能過大或損壞</translation>
     </message>
 </context>
 <context>
     <name>FindBar</name>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="40"/>
+        <location filename="../src/controls/findbar.cpp" line="22"/>
         <source>Find</source>
         <translation>尋找</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="44"/>
+        <location filename="../src/controls/findbar.cpp" line="26"/>
         <source>Previous</source>
         <translation>上一個</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="46"/>
+        <location filename="../src/controls/findbar.cpp" line="28"/>
         <source>Next</source>
         <translation>下一個</translation>
     </message>
@@ -111,7 +116,7 @@
 <context>
     <name>JumpLineBar</name>
     <message>
-        <location filename="../src/controls/jumplinebar.cpp" line="40"/>
+        <location filename="../src/controls/jumplinebar.cpp" line="28"/>
         <source>Go to Line: </source>
         <translation>前往該行：</translation>
     </message>
@@ -119,12 +124,12 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/editorapplication.cpp" line="27"/>
+        <location filename="../src/editorapplication.cpp" line="11"/>
         <source>Text Editor is a powerful tool for viewing and editing text files.</source>
         <translation>文字編輯器是一款用來查看和編輯文字文件的工具。</translation>
     </message>
     <message>
-        <location filename="../src/editorapplication.cpp" line="38"/>
+        <location filename="../src/editorapplication.cpp" line="22"/>
         <source>Text Editor</source>
         <translation>文字編輯器</translation>
     </message>
@@ -132,572 +137,572 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/editorapplication.cpp" line="35"/>
+        <location filename="../src/editorapplication.cpp" line="19"/>
         <source>Text Editor</source>
         <translation>文字編輯器</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="203"/>
-        <location filename="../src/editor/editwrapper.cpp" line="538"/>
-        <location filename="../src/widgets/window.cpp" line="956"/>
-        <location filename="../src/widgets/window.cpp" line="973"/>
-        <location filename="../src/widgets/window.cpp" line="1064"/>
-        <location filename="../src/widgets/window.cpp" line="1079"/>
+        <location filename="../src/editor/editwrapper.cpp" line="248"/>
+        <location filename="../src/editor/editwrapper.cpp" line="704"/>
+        <location filename="../src/widgets/window.cpp" line="1089"/>
+        <location filename="../src/widgets/window.cpp" line="1111"/>
+        <location filename="../src/widgets/window.cpp" line="1203"/>
+        <location filename="../src/widgets/window.cpp" line="1218"/>
         <source>Encoding</source>
         <translation>編碼方式</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="24"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="9"/>
         <source>Basic</source>
         <translation>基本</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="25"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="10"/>
         <source>Font Style</source>
         <translation>字體樣式</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="26"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="11"/>
         <source>Font</source>
         <translation>字體</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="27"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="12"/>
         <source>Font Size</source>
         <translation>字體大小</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="28"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="13"/>
         <source>Shortcuts</source>
         <translation>快捷鍵</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="29"/>
-        <location filename="../src/controls/settingsdialog.cpp" line="30"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="14"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="15"/>
         <source>Keymap</source>
         <translation>按鍵映射</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="31"/>
-        <location filename="../src/controls/settingsdialog.cpp" line="107"/>
-        <location filename="../src/widgets/window.cpp" line="1482"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="16"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="92"/>
+        <location filename="../src/widgets/window.cpp" line="1811"/>
         <source>Window</source>
         <translation>視窗</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="32"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="17"/>
         <source>New tab</source>
         <translation>建立新標籤頁</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="33"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="18"/>
         <source>New window</source>
         <translation>建立新視窗</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="34"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="19"/>
         <source>Save</source>
         <translation>儲存</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="35"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="20"/>
         <source>Save as</source>
         <translation>另存新檔</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="36"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="21"/>
         <source>Next tab</source>
         <translation>下一個標籤頁</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="37"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="22"/>
         <source>Previous tab</source>
         <translation>上一個標籤頁</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="38"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="23"/>
         <source>Close tab</source>
         <translation>關閉標籤頁</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="39"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="24"/>
         <source>Close other tabs</source>
         <translation>關閉其他標籤頁</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="40"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="25"/>
         <source>Restore tab</source>
         <translation>還原標籤頁</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="41"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="26"/>
         <source>Open file</source>
         <translation>開啟檔案</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="42"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="27"/>
         <source>Increment font size</source>
         <translation>放大字體</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="43"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="28"/>
         <source>Decrement font size</source>
         <translation>縮小字體</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="44"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="29"/>
         <source>Reset font size</source>
         <translation>重設字體大小</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="45"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="30"/>
         <source>Help</source>
         <translation>說明</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="46"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="31"/>
         <source>Toggle fullscreen</source>
         <translation>切換全螢幕</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="47"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="32"/>
         <source>Find</source>
         <translation>尋找</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="48"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="33"/>
         <source>Replace</source>
         <translation>取代</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="49"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="34"/>
         <source>Go to line</source>
         <translation>前往該行</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="50"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="35"/>
         <source>Save cursor position</source>
         <translation>儲存游標位置</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="51"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="36"/>
         <source>Reset cursor position</source>
         <translation>重設游標位置</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="52"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="37"/>
         <source>Exit</source>
         <translation>退出</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="53"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="38"/>
         <source>Display shortcuts</source>
         <translation>顯示快捷鍵</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="54"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="39"/>
         <source>Print</source>
         <translation>列印</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="55"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="40"/>
         <source>Editor</source>
         <translation>編輯器</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="56"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="41"/>
         <source>Increase indent</source>
         <translation>增加縮排</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="57"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="42"/>
         <source>Decrease indent</source>
         <translation>減少縮排</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="58"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="43"/>
         <source>Forward character</source>
         <translation>右移字元</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="59"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="44"/>
         <source>Backward character</source>
         <translation>左移字元</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="60"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="45"/>
         <source>Forward word</source>
         <translation>後一個字詞</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="61"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="46"/>
         <source>Backward word</source>
         <translation>前一個字詞</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="62"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="47"/>
         <source>Next line</source>
         <translation>下一行</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="63"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="48"/>
         <source>Previous line</source>
         <translation>上一行</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="64"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="49"/>
         <source>New line</source>
         <translation>換行</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="65"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="50"/>
         <source>New line above</source>
         <translation>於上方換行</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="66"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="51"/>
         <source>New line below</source>
         <translation>於下方換行</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="67"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="52"/>
         <source>Duplicate line</source>
         <translation>複製一行</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="68"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="53"/>
         <source>Delete to end of line</source>
         <translation>刪除至行結尾所有字元</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="69"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="54"/>
         <source>Delete current line</source>
         <translation>刪除目前整行</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="70"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="55"/>
         <source>Swap line up</source>
         <translation>切到上一行</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="71"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="56"/>
         <source>Swap line down</source>
         <translation>切到下一行</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="72"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="57"/>
         <source>Scroll up one line</source>
         <translation>捲到上一行</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="73"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="58"/>
         <source>Scroll down one line</source>
         <translation>捲到下一行</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="74"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="59"/>
         <source>Page up</source>
         <translation>往上一頁</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="75"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="60"/>
         <source>Page down</source>
         <translation>往下一頁</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="76"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="61"/>
         <source>Move to end of line</source>
         <translation>移動到行結尾</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="77"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="62"/>
         <source>Move to start of line</source>
         <translation>移動到行開頭</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="78"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="63"/>
         <source>Move to end of text</source>
         <translation>移動到文字結尾</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="79"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="64"/>
         <source>Move to start of text</source>
         <translation>移動到文字開頭</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="80"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="65"/>
         <source>Move to line indentation</source>
         <translation>移到行縮排區塊</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="81"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="66"/>
         <source>Upper case</source>
         <translation>大寫</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="82"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="67"/>
         <source>Lower case</source>
         <translation>小寫</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="83"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="68"/>
         <source>Capitalize</source>
         <translation>首字母大寫</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="84"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="69"/>
         <source>Delete backward word</source>
         <translation>刪除前一個字詞</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="85"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="70"/>
         <source>Delete forward word</source>
         <translation>刪除後一個字詞</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="86"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="71"/>
         <source>Forward over a pair</source>
         <translation>往後一對</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="87"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="72"/>
         <source>Backward over a pair</source>
         <translation>往前一對</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="88"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="73"/>
         <source>Select all</source>
         <translation>全部選取</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="89"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="74"/>
         <source>Copy</source>
         <translation>複製</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="90"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="75"/>
         <source>Cut</source>
         <translation>剪下</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="91"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="76"/>
         <source>Paste</source>
         <translation>貼上</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="92"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="77"/>
         <source>Transpose character</source>
         <translation>交換字元</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="93"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="78"/>
         <source>Mark</source>
         <translation>標記</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="94"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="79"/>
         <source>Unmark</source>
         <translation>取消標記</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="95"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="80"/>
         <source>Copy line</source>
         <translation>複製一行</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="96"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="81"/>
         <source>Cut line</source>
         <translation>剪下一行</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="97"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="82"/>
         <source>Merge lines</source>
         <translation>合併一行</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="98"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="83"/>
         <source>Read-Only mode</source>
         <translation>唯讀模式</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="99"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="84"/>
         <source>Add comment</source>
         <translation>添加注釋</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="100"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="85"/>
         <source>Remove comment</source>
         <translation>取消注釋</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="101"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="86"/>
         <source>Undo</source>
         <translation>復原</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="102"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="87"/>
         <source>Redo</source>
         <translation>重做</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="103"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="88"/>
         <source>Add/Remove bookmark</source>
         <translation>添加/清除書籤</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="104"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="89"/>
         <source>Move to previous bookmark</source>
         <translation>跳轉到上一個書籤</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="105"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="90"/>
         <source>Move to next bookmark</source>
         <translation>跳轉到下一個書籤</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="106"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="91"/>
         <source>Advanced</source>
         <translation>進階</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="108"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="93"/>
         <source>Window size</source>
         <translation>視窗大小</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="109"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="94"/>
         <source>Tab width</source>
         <translation>Tab 寬度</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="111"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="96"/>
         <source>Word wrap</source>
         <translation>文字換行</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="112"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="97"/>
         <source>Code folding flag</source>
         <translation>顯示代碼摺疊標誌</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="113"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="98"/>
         <source>Show line numbers</source>
         <translation>顯示行號</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="114"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="99"/>
         <source>Show bookmarks icon</source>
         <translation>顯示書籤圖標</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="115"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="100"/>
         <source>Show whitespaces and tabs</source>
         <translation>顯示空白字符/制表符</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="116"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="101"/>
         <source>Highlight current line</source>
         <translation>當前行高亮</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="117"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="102"/>
         <source>Color mark</source>
         <translation>顏色標記</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="120"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="105"/>
         <source>Unicode</source>
         <translation>Unicode</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="121"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="106"/>
         <source>WesternEuropean</source>
         <translation>西歐語系</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="122"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="107"/>
         <source>CentralEuropean</source>
         <translation>中歐語系</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="123"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="108"/>
         <source>Baltic</source>
         <translation>波羅的海語言</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="124"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="109"/>
         <source>Cyrillic</source>
         <translation>西里爾文</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="125"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="110"/>
         <source>Arabic</source>
         <translation>阿拉伯語</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="130"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="115"/>
         <source>Celtic</source>
         <translation>凱爾特語</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="131"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="116"/>
         <source>SouthEasternEuropean</source>
         <translation>東南歐語系</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="126"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="111"/>
         <source>Greek</source>
         <translation>希臘語</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="127"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="112"/>
         <source>Hebrew</source>
         <translation>希伯來語</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="132"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="117"/>
         <source>ChineseSimplified</source>
         <translation>簡體中文</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="133"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="118"/>
         <source>ChineseTraditional</source>
         <translation>繁體中文</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="134"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="119"/>
         <source>Japanese</source>
         <translation>日語</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="135"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="120"/>
         <source>Korean</source>
         <translation>韓語</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="129"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="114"/>
         <source>Thai</source>
         <translation>泰語</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="128"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="113"/>
         <source>Turkish</source>
         <translation>土耳其語</translation>
     </message>
     <message>
-        <location filename="../src/controls/settingsdialog.cpp" line="136"/>
+        <location filename="../src/controls/settingsdialog.cpp" line="121"/>
         <source>Vietnamese</source>
         <translation>越南語</translation>
     </message>
     <message>
-        <location filename="../src/startmanager.cpp" line="762"/>
+        <location filename="../src/startmanager.cpp" line="832"/>
         <source>File not saved</source>
         <translation>文件未儲存</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="974"/>
-        <location filename="../src/widgets/window.cpp" line="1065"/>
-        <location filename="../src/widgets/window.cpp" line="1080"/>
+        <location filename="../src/widgets/window.cpp" line="1112"/>
+        <location filename="../src/widgets/window.cpp" line="1204"/>
+        <location filename="../src/widgets/window.cpp" line="1219"/>
         <source>Line Endings</source>
         <translation>換行符</translation>
     </message>
@@ -705,32 +710,32 @@
 <context>
     <name>ReplaceBar</name>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="39"/>
+        <location filename="../src/controls/replacebar.cpp" line="21"/>
         <source>Find</source>
         <translation>尋找</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="43"/>
+        <location filename="../src/controls/replacebar.cpp" line="25"/>
         <source>Replace With</source>
         <translation>取代為</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="47"/>
+        <location filename="../src/controls/replacebar.cpp" line="29"/>
         <source>Replace</source>
         <translation>取代</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="50"/>
+        <location filename="../src/controls/replacebar.cpp" line="32"/>
         <source>Skip</source>
         <translation>跳過</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="53"/>
+        <location filename="../src/controls/replacebar.cpp" line="35"/>
         <source>Replace Rest</source>
         <translation>取代剩餘部份</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="56"/>
+        <location filename="../src/controls/replacebar.cpp" line="38"/>
         <source>Replace All</source>
         <translation>全部取代</translation>
     </message>
@@ -747,58 +752,58 @@
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../src/common/settings.cpp" line="91"/>
+        <location filename="../src/common/settings.cpp" line="115"/>
         <source>Standard</source>
         <translation>標準</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="91"/>
+        <location filename="../src/common/settings.cpp" line="115"/>
         <source>Customize</source>
         <translation>自訂</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="104"/>
+        <location filename="../src/common/settings.cpp" line="128"/>
         <source>Normal</source>
         <translation>一般</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="104"/>
+        <location filename="../src/common/settings.cpp" line="128"/>
         <source>Maximum</source>
         <translation>最大</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="104"/>
+        <location filename="../src/common/settings.cpp" line="128"/>
         <source>Fullscreen</source>
         <translation>全螢幕</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="292"/>
+        <location filename="../src/common/settings.cpp" line="316"/>
         <source>This shortcut conflicts with system shortcut %1</source>
         <translation>此快捷鍵與系統快捷鍵%1衝突</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="294"/>
+        <location filename="../src/common/settings.cpp" line="318"/>
         <source>This shortcut conflicts with %1, click on Replace to make this shortcut effective immediately</source>
         <translation>此快捷鍵與%1衝突，點擊替換使這個快捷鍵立即生效</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="410"/>
-        <location filename="../src/common/settings.cpp" line="418"/>
+        <location filename="../src/common/settings.cpp" line="464"/>
+        <location filename="../src/common/settings.cpp" line="472"/>
         <source>The shortcut %1 is invalid, please set another one.</source>
         <translation>%1為無效快捷鍵，請重新設定</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="445"/>
+        <location filename="../src/common/settings.cpp" line="507"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="446"/>
+        <location filename="../src/common/settings.cpp" line="508"/>
         <source>Replace</source>
         <translation>取代</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="448"/>
+        <location filename="../src/common/settings.cpp" line="510"/>
         <source>OK</source>
         <translation>確定</translation>
     </message>
@@ -806,7 +811,7 @@
 <context>
     <name>StartManager</name>
     <message>
-        <location filename="../src/startmanager.cpp" line="340"/>
+        <location filename="../src/startmanager.cpp" line="350"/>
         <source>Untitled %1</source>
         <translation>未命名文件%1</translation>
     </message>
@@ -814,32 +819,32 @@
 <context>
     <name>Tabbar</name>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="515"/>
+        <location filename="../src/controls/tabbar.cpp" line="540"/>
         <source>Close tab</source>
         <translation>關閉標籤頁</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="516"/>
+        <location filename="../src/controls/tabbar.cpp" line="541"/>
         <source>Close other tabs</source>
         <translation>關閉其他標籤頁</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="517"/>
+        <location filename="../src/controls/tabbar.cpp" line="542"/>
         <source>More options</source>
         <translation>更多關閉方式</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="518"/>
+        <location filename="../src/controls/tabbar.cpp" line="543"/>
         <source>Close tabs to the left</source>
         <translation>關閉左側所有標籤頁</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="519"/>
+        <location filename="../src/controls/tabbar.cpp" line="544"/>
         <source>Close tabs to the right</source>
         <translation>關閉右側所有標籤頁</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="520"/>
+        <location filename="../src/controls/tabbar.cpp" line="545"/>
         <source>Close unmodified tabs</source>
         <translation>關閉所有未修改標籤頁</translation>
     </message>
@@ -847,261 +852,259 @@
 <context>
     <name>TextEdit</name>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="235"/>
+        <location filename="../src/editor/dtextedit.cpp" line="259"/>
         <source>Undo</source>
         <translation>復原</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="236"/>
+        <location filename="../src/editor/dtextedit.cpp" line="260"/>
         <source>Redo</source>
         <translation>重做</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="237"/>
+        <location filename="../src/editor/dtextedit.cpp" line="261"/>
         <source>Cut</source>
         <translation>剪下</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="238"/>
+        <location filename="../src/editor/dtextedit.cpp" line="262"/>
         <source>Copy</source>
         <translation>複製</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="239"/>
+        <location filename="../src/editor/dtextedit.cpp" line="263"/>
         <source>Paste</source>
         <translation>貼上</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="240"/>
+        <location filename="../src/editor/dtextedit.cpp" line="264"/>
         <source>Delete</source>
         <translation>刪除</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="241"/>
+        <location filename="../src/editor/dtextedit.cpp" line="265"/>
         <source>Select All</source>
         <translation>全部選取</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="242"/>
-        <location filename="../src/widgets/window.cpp" line="361"/>
+        <location filename="../src/editor/dtextedit.cpp" line="266"/>
+        <location filename="../src/widgets/window.cpp" line="450"/>
         <source>Find</source>
         <translation>尋找</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="243"/>
-        <location filename="../src/widgets/window.cpp" line="362"/>
+        <location filename="../src/editor/dtextedit.cpp" line="267"/>
+        <location filename="../src/widgets/window.cpp" line="451"/>
         <source>Replace</source>
         <translation>取代</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="244"/>
+        <location filename="../src/editor/dtextedit.cpp" line="268"/>
         <source>Go to Line</source>
         <translation>前往該行</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="245"/>
+        <location filename="../src/editor/dtextedit.cpp" line="269"/>
         <source>Turn on Read-Only mode</source>
         <translation>開啟唯讀模式</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="246"/>
+        <location filename="../src/editor/dtextedit.cpp" line="270"/>
         <source>Turn off Read-Only mode</source>
         <translation>關閉唯讀模式</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="247"/>
+        <location filename="../src/editor/dtextedit.cpp" line="271"/>
         <source>Fullscreen</source>
         <translation>全螢幕</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="248"/>
+        <location filename="../src/editor/dtextedit.cpp" line="272"/>
         <source>Exit fullscreen</source>
         <translation>退出全螢幕</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="249"/>
+        <location filename="../src/editor/dtextedit.cpp" line="273"/>
         <source>Display in file manager</source>
         <translation>在檔案管理器中顯示</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="250"/>
-        <location filename="../src/editor/dtextedit.cpp" line="302"/>
+        <location filename="../src/editor/dtextedit.cpp" line="274"/>
+        <location filename="../src/editor/dtextedit.cpp" line="326"/>
         <source>Add Comment</source>
         <translation>添加注釋</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="251"/>
+        <location filename="../src/editor/dtextedit.cpp" line="275"/>
         <source>Text to Speech</source>
         <translation>語音朗讀</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="252"/>
+        <location filename="../src/editor/dtextedit.cpp" line="276"/>
         <source>Stop reading</source>
         <translation>停止朗讀</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="253"/>
+        <location filename="../src/editor/dtextedit.cpp" line="277"/>
         <source>Speech to Text</source>
         <translation>語音聽寫</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="254"/>
+        <location filename="../src/editor/dtextedit.cpp" line="278"/>
         <source>Translate</source>
         <translation>文字翻譯</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="255"/>
+        <location filename="../src/editor/dtextedit.cpp" line="279"/>
         <source>Column Mode</source>
         <translation>列編輯模式</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="256"/>
+        <location filename="../src/editor/dtextedit.cpp" line="280"/>
         <source>Add bookmark</source>
         <translation>添加書籤</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="257"/>
+        <location filename="../src/editor/dtextedit.cpp" line="281"/>
         <source>Remove Bookmark</source>
         <translation>清除書籤</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="258"/>
+        <location filename="../src/editor/dtextedit.cpp" line="282"/>
         <source>Previous bookmark</source>
         <translation>上一個書籤</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="259"/>
+        <location filename="../src/editor/dtextedit.cpp" line="283"/>
         <source>Next bookmark</source>
         <translation>下一個書籤</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="260"/>
+        <location filename="../src/editor/dtextedit.cpp" line="284"/>
         <source>Remove All Bookmarks</source>
         <translation>清除所有書籤</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="261"/>
+        <location filename="../src/editor/dtextedit.cpp" line="285"/>
         <source>Fold All</source>
         <translation>摺疊所有層次</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="262"/>
+        <location filename="../src/editor/dtextedit.cpp" line="286"/>
         <source>Fold Current Level</source>
         <translation>摺疊當前層次</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="263"/>
+        <location filename="../src/editor/dtextedit.cpp" line="287"/>
         <source>Unfold All</source>
         <translation>展開所有層次</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="264"/>
+        <location filename="../src/editor/dtextedit.cpp" line="288"/>
         <source>Unfold Current Level</source>
         <translation>展開當前層次</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="269"/>
+        <location filename="../src/editor/dtextedit.cpp" line="293"/>
         <source>Color Mark</source>
         <translation>顏色標記</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="273"/>
+        <location filename="../src/editor/dtextedit.cpp" line="297"/>
         <source>Clear All Marks</source>
         <translation>清除所有標記</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="274"/>
+        <location filename="../src/editor/dtextedit.cpp" line="298"/>
         <source>Clear Last Mark</source>
         <translation>清除上次標記</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="283"/>
+        <location filename="../src/editor/dtextedit.cpp" line="307"/>
         <source>Mark</source>
         <translation>標記</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="295"/>
+        <location filename="../src/editor/dtextedit.cpp" line="319"/>
         <source>Mark All</source>
         <translation>標記所有</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="303"/>
+        <location filename="../src/editor/dtextedit.cpp" line="327"/>
         <source>Remove Comment</source>
         <translation>取消注釋</translation>
     </message>
     <message>
-        <source>Failed to paste text: it is too large</source>
-        <translation type="vanished">文字內容過大，貼上失敗</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="2581"/>
+        <location filename="../src/editor/dtextedit.cpp" line="2672"/>
         <source>Copy failed: not enough memory</source>
         <translation>記憶體不足，複製失敗</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="2665"/>
+        <location filename="../src/editor/dtextedit.cpp" line="2756"/>
         <source>Press ALT and click lines to edit in column mode</source>
         <translation>請使用ALT+滑鼠點選切換列編輯模式</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="346"/>
+        <location filename="../src/editor/dtextedit.cpp" line="370"/>
         <source>Change Case</source>
         <translation>變更大小寫</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="347"/>
+        <location filename="../src/editor/dtextedit.cpp" line="371"/>
         <source>Upper Case</source>
         <translation>大寫</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="348"/>
+        <location filename="../src/editor/dtextedit.cpp" line="372"/>
         <source>Lower Case</source>
         <translation>小寫</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="349"/>
+        <location filename="../src/editor/dtextedit.cpp" line="373"/>
         <source>Capitalize</source>
         <translation>首字母大寫</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="64"/>
+        <location filename="../src/widgets/bottombar.cpp" line="49"/>
         <source>None</source>
         <translation>無</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1184"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1222"/>
         <source>Selected line(s) copied</source>
         <translation>已複製選中行到剪貼簿</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1190"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1228"/>
         <source>Current line copied</source>
         <translation>已複製目前行到剪貼簿</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1210"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1248"/>
         <source>Selected line(s) clipped</source>
         <translation>已剪下選中行到剪貼簿</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1222"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1259"/>
         <source>Current line clipped</source>
         <translation>已剪下目前行到剪貼簿</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="2591"/>
+        <location filename="../src/editor/dtextedit.cpp" line="2682"/>
         <source>Paste failed: not enough memory</source>
         <translation>記憶體不足，貼上失敗</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3439"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3617"/>
         <source>Read-Only mode is off</source>
         <translation>唯讀模式已關閉</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3446"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3465"/>
-        <location filename="../src/editor/dtextedit.cpp" line="6150"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3624"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3643"/>
+        <location filename="../src/editor/dtextedit.cpp" line="6656"/>
+        <location filename="../src/editor/dtextedit.cpp" line="6664"/>
+        <location filename="../src/editor/dtextedit.cpp" line="6675"/>
         <source>Read-Only mode is on</source>
         <translation>唯讀模式已開啟</translation>
     </message>
@@ -1109,7 +1112,7 @@
 <context>
     <name>WarningNotices</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="36"/>
+        <location filename="../src/controls/warningnotices.cpp" line="19"/>
         <source>Reload</source>
         <translation>重新載入</translation>
     </message>
@@ -1117,129 +1120,130 @@
 <context>
     <name>Window</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="38"/>
-        <location filename="../src/widgets/window.cpp" line="357"/>
+        <location filename="../src/controls/warningnotices.cpp" line="21"/>
+        <location filename="../src/widgets/window.cpp" line="446"/>
         <source>Save as</source>
         <translation>另存新檔</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="353"/>
+        <location filename="../src/widgets/window.cpp" line="442"/>
         <source>New window</source>
         <translation>建立新視窗</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="354"/>
+        <location filename="../src/widgets/window.cpp" line="443"/>
         <source>New tab</source>
         <translation>建立新標籤頁</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="355"/>
+        <location filename="../src/widgets/window.cpp" line="444"/>
         <source>Open file</source>
         <translation>開啟檔案</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="356"/>
-        <location filename="../src/widgets/window.cpp" line="2217"/>
+        <location filename="../src/widgets/window.cpp" line="445"/>
+        <location filename="../src/widgets/window.cpp" line="2796"/>
         <source>Save</source>
         <translation>儲存</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="358"/>
+        <location filename="../src/widgets/window.cpp" line="447"/>
         <source>Print</source>
         <translation>列印</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="359"/>
+        <location filename="../src/widgets/window.cpp" line="448"/>
         <source>Switch theme</source>
         <translation>切換主題</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="360"/>
-        <location filename="../src/widgets/window.cpp" line="1542"/>
+        <location filename="../src/widgets/window.cpp" line="449"/>
+        <location filename="../src/widgets/window.cpp" line="1871"/>
         <source>Settings</source>
         <translation>設定</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="471"/>
-        <location filename="../src/widgets/window.cpp" line="2468"/>
+        <location filename="../src/widgets/window.cpp" line="563"/>
+        <location filename="../src/widgets/window.cpp" line="3047"/>
         <source>Read-Only</source>
         <translation>唯讀</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="487"/>
+        <location filename="../src/widgets/window.cpp" line="579"/>
         <source>You do not have permission to open %1</source>
         <translation>您沒有權限開啟 %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="522"/>
+        <location filename="../src/widgets/window.cpp" line="619"/>
+        <location filename="../src/widgets/window.cpp" line="2359"/>
         <source>Invalid file: %1</source>
         <translation>無效檔案：%1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="602"/>
-        <location filename="../src/widgets/window.cpp" line="644"/>
+        <location filename="../src/widgets/window.cpp" line="733"/>
+        <location filename="../src/widgets/window.cpp" line="779"/>
         <source>Do you want to save this file?</source>
         <translation>是否儲存此檔案？</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="894"/>
+        <location filename="../src/widgets/window.cpp" line="1027"/>
         <source>You do not have permission to save %1</source>
         <translation>您沒有權限儲存 %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="918"/>
+        <location filename="../src/widgets/window.cpp" line="1051"/>
         <source>Saved successfully</source>
         <translation>儲存成功</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="954"/>
-        <location filename="../src/widgets/window.cpp" line="1021"/>
-        <location filename="../src/widgets/window.cpp" line="1062"/>
+        <location filename="../src/widgets/window.cpp" line="1087"/>
+        <location filename="../src/widgets/window.cpp" line="1160"/>
+        <location filename="../src/widgets/window.cpp" line="1201"/>
         <source>Save File</source>
         <translation>儲存檔案</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1023"/>
+        <location filename="../src/widgets/window.cpp" line="1162"/>
         <source>Encoding</source>
         <translation>編碼方式</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1211"/>
+        <location filename="../src/widgets/window.cpp" line="1350"/>
         <source>Read-Only mode is on</source>
         <translation>唯讀模式已開啟</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1441"/>
+        <location filename="../src/widgets/window.cpp" line="1770"/>
         <source>Current location remembered</source>
         <translation>已記住目前位置</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1492"/>
+        <location filename="../src/widgets/window.cpp" line="1821"/>
         <source>Ctrl+&apos;=&apos;</source>
         <translation>Ctrl+&apos;=&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1495"/>
+        <location filename="../src/widgets/window.cpp" line="1824"/>
         <source>Ctrl+&apos;-&apos;</source>
         <translation>Ctrl+&apos;-&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1524"/>
+        <location filename="../src/widgets/window.cpp" line="1853"/>
         <source>Editor</source>
         <translation>編輯器</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1890"/>
+        <location filename="../src/widgets/window.cpp" line="2451"/>
         <source>Untitled %1</source>
         <translation>未命名文件%1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2215"/>
+        <location filename="../src/widgets/window.cpp" line="2794"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2216"/>
+        <location filename="../src/widgets/window.cpp" line="2795"/>
         <source>Discard</source>
         <translation>捨棄</translation>
     </message>


### PR DESCRIPTION
Description: 文本编辑器采用直接加载文件的处理方式，打开超过系统
内存的文件会导致申请内存失败。
添加异常捕获处理，在出现文本读取错误时提示文件可能过大或损坏。
添加新增提示的翻译。

Log: 修复读取超大文件时软件闪退的问题
Bug: https://pms.uniontech.com/bug-view-184107.html
Influence: 文件读取 翻译