### PR TITLE
fix: 修复特定中文字体下，右下角显示字体不全的问题。

### DIFF
--- a/src/widgets/bottombar.cpp
+++ b/src/widgets/bottombar.cpp
@@ -29,7 +29,6 @@ BottomBar::BottomBar(QWidget *parent)
       m_progressBar(new DProgressBar)
 {
     QFont font;
-    font.setFamily("SourceHanSansSC-Normal");
     m_pPositionLabel->setFont(font);
     m_pCharCountLabel->setFont(font);
     m_pCursorStatus->setFont(font);

--- a/src/widgets/ddropdownmenu.cpp
+++ b/src/widgets/ddropdownmenu.cpp
@@ -47,7 +47,6 @@ DDropdownMenu::DDropdownMenu(QWidget *parent)
     //设置字体
     int fontsize =DFontSizeManager::instance()->fontPixelSize(DFontSizeManager::T9);
     m_font.setPixelSize(fontsize);
-    m_font.setFamily("SourceHanSansSC-Normal");
 
      //添加布局
     QHBoxLayout *layout = new QHBoxLayout();
@@ -360,10 +359,10 @@ QIcon DDropdownMenu::createIcon()
         arrowPixmap = m_arrowPixmap;
     }
 
-    //根据字体大小设置icon大小
-    //height 30    width QFontMetrics fm(font()) fm.width(text)+40;
-    int fontWidth = QFontMetrics(m_font).width(m_text)+20;
-    int fontHeight = QFontMetrics(m_font).height();
+    // 根据字体大小设置icon大小，按计算的字体高度，而非从字体文件中读取的高度(部分字体中英文高度不同)
+    QFontMetrics metrics(m_font);
+    int fontWidth = metrics.width(m_text) + 20;
+    int fontHeight = metrics.size(Qt::TextSingleLine, m_text).height();
     int iconW = 8;
     int iconH = 5;
 


### PR DESCRIPTION
右下角显示文本在 paintEvent 中手动绘制，使用字体默认的英文字符高度，
但中英文字符在不同字体高度不同，导致计算错误，显示异常。
修改字符高度计算方式，调整为完整字符串的高度。
同时移除底栏设置的默认字体，保存与系统字体一致。

Log: 修复特定中文字体下，右下角显示字体不全的问题。
Bug: https://pms.uniontech.com/bug-view-187763.html
Influence: 底栏文件编码显示 底栏显示字体