### PR TITLE
fix: 修复文本编辑器大文件打印预览为空的问题

### DIFF
--- a/src/widgets/window.h
+++ b/src/widgets/window.h
@@ -236,6 +236,8 @@ private:
     // 打印多文本数据
     void printPageWithMultiDoc(int index, QPainter *painter, const QVector<PrintInfo> &printInfo,
                                const QRectF &body, const QRectF &pageCountBox);
+    // 重新更新文本
+    void rehighlightPrintDoc(QTextDocument *doc, CSyntaxHighlighter *highlighter);
 
 protected:
     void resizeEvent(QResizeEvent *event) override;
@@ -299,6 +301,8 @@ private:
     bool m_bLargePrint = false;                     // 是否为大文件打印
     bool m_bPrintProcessing = false;                // 文件打印计算中
     EditWrapper *m_printWrapper = nullptr;          // 当前处理的编辑对象(关闭标签页时需要退出打印)
+    QTextDocument *printCopyDoc = nullptr;              // 用于大文本打印时的拷贝文档
+    CSyntaxHighlighter *printCopyHighlighter = nullptr; // 用于大文本打印时的高亮文档
     QVector<PrintInfo> m_printDocList;              // 打印文档列表，用于超大文档打印
     int m_multiDocPageCount = 0;                    // 用于超大文档打印时单独记录多文档的打印页数
 

--- a/tests/src/widgets/ut_window.cpp
+++ b/tests/src/widgets/ut_window.cpp
@@ -2177,25 +2177,25 @@ TEST(UT_Window_slot_setTitleFocus, UT_Window_slot_setTitleFocus_002)
     w->deleteLater();
 }
 
-TEST(UT_Window_keyPressEvent, UT_Window_keyPressEvent_007)
+TEST(UT_Window_rehighlightPrintDoc, rehighlightPrintDoc_HighlightCpp_pass)
 {
-//    QStringList aa;
-//    Window *window = new Window();
-//    window->m_settings = Settings::instance();
+    Window* w = new Window;
+    w->addBlankTab();
+    w->m_printWrapper = w->currentWrapper();
+    QTextDocument *doc = new QTextDocument;
+    doc->setPlainText("#include <iostream>;\n"
+                      "int main(int argc, char *argv[]) { }");
 
-//    utils_getkeyshortcut = Utils::getKeyshortcutFromKeymap(window->m_settings, "window", "togglefullscreen");
-//    editwrapper_texteditor = new TextEdit;
+    CSyntaxHighlighter *highlighter = new CSyntaxHighlighter(doc);
+    KSyntaxHighlighting::Repository repository;
+    highlighter->setDefinition(repository.definitionForName("C++"));
+    highlighter->setTheme(repository.defaultTheme(KSyntaxHighlighting::Repository::LightTheme));
 
-//    Stub s1;s1.set(ADDR(Utils,getKeyshortcut),Utils_getKeyshortcut_stub);
-//    Stub s2;s2.set(ADDR(EditWrapper,textEditor),EditWrapper_textEditor_stub);
-//    Stub s3;s3.set(ADDR(Utils,getKeyshortcutFromKeymap),Utils_getKeyshortcutFromKeymap_stub);
+    w->rehighlightPrintDoc(doc, highlighter);
+    EXPECT_FALSE(doc->firstBlock().textFormats().isEmpty());
 
-//    window->keyPressEvent(eve);
-
-//    EXPECT_NE(window,nullptr);
-//    window->deleteLater();
-//    window->m_settings->deleteLater();
-//    editwrapper_texteditor->deleteLater();
+    doc->deleteLater();
+    w->deleteLater();
 }
 
 


### PR DESCRIPTION
Qt内部文本布局计算存在越界，完整文档高度可能返回负数，导致预览为空。
bug143359已有部分修改，此提交更新大文本预览调整文本高亮计算方式，
延后高亮处理。

Log: 修复文本编辑器大文件打印预览为空的问题
Bug: https://pms.uniontech.com/bug-view-67209.html
Influence: 大文件打印预览