### PR TITLE
fix: 修复撤销删除后位置错误的问题

### DIFF
--- a/src/editor/deletetextundocommand.cpp
+++ b/src/editor/deletetextundocommand.cpp
@@ -11,7 +11,7 @@ DeleteTextUndoCommand::DeleteTextUndoCommand(QTextCursor textcursor, QPlainTextE
     : QUndoCommand(parent)
     , m_edit(edit)
     , m_textCursor(textcursor)
-    , m_beginPos(m_textCursor.position())
+    , m_beginPos(m_textCursor.selectionStart())
 {
     if (m_textCursor.hasSelection()) {
         m_sInsertText = m_textCursor.selectedText();
@@ -32,7 +32,7 @@ DeleteTextUndoCommand::DeleteTextUndoCommand(QList<QTextEdit::ExtraSelection> &s
     : QUndoCommand(parent)
     , m_edit(edit)
     , m_ColumnEditSelections(selections)
-    , m_beginPos(m_textCursor.position())
+    , m_beginPos(m_textCursor.selectionStart())
 {
     int cnt = m_ColumnEditSelections.size();
     for (int i = 0; i < cnt; i++) {

--- a/src/editor/dtextedit.cpp
+++ b/src/editor/dtextedit.cpp
@@ -6649,8 +6649,7 @@ void TextEdit::mouseMoveEvent(QMouseEvent *e)
             selection.format = format;
             m_altModSelections << selection;
         }
-        //清除撤销重做栈
-        m_pUndoStack->clear();
+
         renderAllSelections();
         update();
     }


### PR DESCRIPTION
删除撤销项使用 QTextCursor::position() 记录起始位置，
反向选取文本时 position() 记录的是尾部索引，
修改为 selectionStart() ， 以恢复准确光标位置。

Log: 修复撤销删除后位置错误的问题
Bug: https://pms.uniontech.com/bug-view-187773.html
Influence: 撤销删除