### PR TITLE
fix: 修复使用特殊字体时，序号显示不全

### DIFF
--- a/src/editor/dtextedit.cpp
+++ b/src/editor/dtextedit.cpp
@@ -3245,6 +3245,11 @@ void TextEdit::setLeftAreaUpdateState(TextEdit::UpdateOperationType statevalue)
 {
     if (statevalue != m_LeftAreaUpdateState) {
         m_LeftAreaUpdateState = statevalue;
+
+        // 当文件读取完成时，手动触发更新界面
+        if (TextEdit::FileOpenEnd == m_LeftAreaUpdateState) {
+            m_pLeftAreaWidget->updateAll();
+        }
     }
 }
 

--- a/src/editor/dtextedit.cpp
+++ b/src/editor/dtextedit.cpp
@@ -4421,7 +4421,9 @@ int TextEdit::lineNumberAreaWidth()
         max /= 10;
         ++digits;
     }
-    int w = fontMetrics().horizontalAdvance(QLatin1Char('9')) * digits;
+    // 行号使用单独字体
+    QFontMetrics fm(m_fontLineNumberArea);
+    int w = fm.horizontalAdvance(QLatin1Char('9')) * digits;
 
     return w > 15 ? w : 15;
 }


### PR DESCRIPTION
文本编辑器序号显示使用单独字体，但计算宽度时未使用此字体计算,
导致显示绘制补全。调整计算序号宽度时使用指定字体，以正常显示。

Log: 修复使用特殊字体时，序号显示不全
Bug: https://pms.uniontech.com/bug-view-188417.html
Influence: 序号显示