### PR TITLE
feat: 适配GB18030-2022规范兼容2005标准

### DIFF
--- a/src/encodes/detectcode.cpp
+++ b/src/encodes/detectcode.cpp
@@ -602,6 +602,8 @@ bool DetectCode::convertEncodingTextCodec(QByteArray &inputStr,
         }
 
         convertData = fromCodec->toUnicode(inputStr);
+    } else {
+        convertData = QString::fromUtf8(inputStr);
     }
 
     if (toCode != "UTF-8") {

--- a/src/encodes/detectcode.h
+++ b/src/encodes/detectcode.h
@@ -60,6 +60,11 @@ public:
                                          const QString &fromCode,
                                          const QString &toCode = QString("UTF-8"));
 
+    static bool convertEncodingTextCodec(QByteArray &inputStr,
+                                         QByteArray &outStr,
+                                         const QString &fromCode,
+                                         const QString &toCode = QString("UTF-8"));
+
 private:
     static QMap<QString, QByteArray> sm_LangsMap;
 };


### PR DESCRIPTION
根据GB18030-2022文档，调整自2005标准的变更字符。
还原为iconv（2022标准）加载，同时对部分UTF展示字符做映射表适配。

Log: 适配GB18030-2022规范兼容2005标准
Influence: 编码转换 GB18030显示 另存