### PR TITLE
fix: 修复最小化后，双击文件无法弹出编辑器窗口

### DIFF
--- a/src/common/utils.cpp
+++ b/src/common/utils.cpp
@@ -783,7 +783,7 @@ QString Utils::getStringMD5Hash(const QString &input)
 
 bool Utils::activeWindowFromDock(quintptr winId)
 {
-    bool bRet = true;
+    bool bRet = false;
     // 优先采用V23接口
     QDBusInterface dockDbusInterfaceV23("org.deepin.dde.daemon.Dock1",
                                         "/org/deepin/dde/daemon/Dock1",
@@ -792,9 +792,8 @@ bool Utils::activeWindowFromDock(quintptr winId)
         QDBusReply<void> reply = dockDbusInterfaceV23.call("ActivateWindow", winId);
         if (!reply.isValid()) {
             qDebug() << "call v23 org.deepin.dde.daemon.Dock1 failed" << reply.error();
-            bRet = false;
         } else {
-            return bRet;
+            return true;
         }
     }
 
@@ -806,6 +805,8 @@ bool Utils::activeWindowFromDock(quintptr winId)
         if (!reply.isValid()) {
             qDebug() << "call v20 com.deepin.dde.daemon.Dock failed" << reply.error();
             bRet = false;
+        } else {
+            return true;
         }
     }
 


### PR DESCRIPTION
判断标志初始化错误，导致在V20环境下无法进入DBus调用的分支，
无法唤起窗口。

Log: 修复最小化后，双击文件无法弹出编辑器窗口
Bug: https://pms.uniontech.com/bug-view-194029.html
Influence: 激活窗口