### PR TITLE
fix: 修复设置界面中字体和字号选项未对齐

### DIFF
--- a/src/common/settings.cpp
+++ b/src/common/settings.cpp
@@ -217,19 +217,17 @@ void Settings::dtkThemeWorkaround(QWidget *parent, const QString &theme)
     }
 }
 
-//QWidget *Settings::createFontComBoBoxHandle(QObject *obj)
 QPair<QWidget *, QWidget *> Settings::createFontComBoBoxHandle(QObject *obj)
 {
     auto option = qobject_cast<DTK_CORE_NAMESPACE::DSettingsOption *>(obj);
 
     QComboBox *comboBox = new QComboBox;
-    //QWidget *optionWidget = DSettingsWidgetFactory::createTwoColumWidget(option, comboBox);
     QPair<QWidget *, QWidget *> optionWidget = DSettingsWidgetFactory::createStandardItem(QByteArray(), option, comboBox);
 
     QFontDatabase fontDatabase;
     comboBox->addItems(fontDatabase.families());
-    //comboBox->setItemDelegate(new FontItemDelegate);
-    //comboBox->setFixedSize(240, 36);
+    // 设置最小宽度，以保持和下方 OptionDSpinBox 一样的长度
+    comboBox->setMinimumSize(240, 36);
 
     if (option->value().toString().isEmpty()) {
         option->setValue(QFontDatabase::systemFont(QFontDatabase::FixedFont).family());


### PR DESCRIPTION
设置界面中的字体选项和字号选项非同一布局，高分辨率下异常，
调整字体的 ComboBox 宽度设置，以保证在压缩对话框宽度时，
ComboBox 缩放和下方的 SpinBox 保持一致。

Log: https://pms.uniontech.com/bug-view-157559.html
Bug: 修复设置界面中字体和字号选项未对齐
Influence: 设置界面