### PR TITLE
chore: remove redundant code for linglong

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -17,5 +17,6 @@ export DH_VERBOSE=1
 override_dh_auto_configure:
 	dh_auto_configure -- \
 	  -DCMAKE_BUILD_TYPE=Release \
+	  -DCMAKE_INSTALL_PREFIX=/usr \
 	  -DCMAKE_SAFETYTEST_ARG="CMAKE_SAFETYTEST_ARG_OFF" \
 	  -DVERSION=$(PACK_VER)

--- a/debian/source/format
+++ b/debian/source/format
@@ -1,1 +1,1 @@
-3.0 (quilt)
+3.0 (native)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -60,11 +60,6 @@ target_link_libraries(deepin-editor
     chardet
 )
 
-if(DEFINED ENV{PREFIX})
-   set(CMAKE_INSTALL_PREFIX $ENV{PREFIX})
-else()
-   set(CMAKE_INSTALL_PREFIX /usr)
-endif()
 add_definitions(-DLINGLONG_PREFIX=\"${CMAKE_INSTALL_PREFIX}/\")
 
 # Install qm files
@@ -83,17 +78,9 @@ endif()
 #if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "loongarch64")
 #    install(DIRECTORY ${CMAKE_SOURCE_DIR}/src/assets/loongarch64/deepin-editor DESTINATION /usr/share/deepin-manual/manual-assets/application/)
 if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "sw_64")
-    if(DEFINED ENV{PREFIX})
-        install(DIRECTORY ${CMAKE_SOURCE_DIR}/src/assets/loongarch64/deepin-editor DESTINATION ${CMAKE_INSTALL_PREFIX}/share/deepin-manual/manual-assets/application/)
-    else()
-        install(DIRECTORY ${CMAKE_SOURCE_DIR}/src/assets/loongarch64/deepin-editor DESTINATION ${CMAKE_INSTALL_PREFIX}/share/deepin-manual/manual-assets/application/)
-    endif()
+    install(DIRECTORY ${CMAKE_SOURCE_DIR}/src/assets/loongarch64/deepin-editor DESTINATION ${CMAKE_INSTALL_PREFIX}/share/deepin-manual/manual-assets/application/)
 else()
-    if(DEFINED ENV{PREFIX})
-        install(DIRECTORY ${CMAKE_SOURCE_DIR}/src/assets/deepin-editor DESTINATION ${CMAKE_INSTALL_PREFIX}/share/deepin-manual/manual-assets/application/)
-    else()
-        install(DIRECTORY ${CMAKE_SOURCE_DIR}/src/assets/deepin-editor DESTINATION ${CMAKE_INSTALL_PREFIX}/share/deepin-manual/manual-assets/application/)
-    endif()
+    install(DIRECTORY ${CMAKE_SOURCE_DIR}/src/assets/deepin-editor DESTINATION ${CMAKE_INSTALL_PREFIX}/share/deepin-manual/manual-assets/application/)
 endif()
 
 install(TARGETS deepin-editor DESTINATION bin/)

--- a/src/common/utils.h
+++ b/src/common/utils.h
@@ -18,10 +18,6 @@
 #define SAFE_DELETE(p)      if((p)) { delete (p); (p) = nullptr;}
 #endif
 
-#ifndef LINGLONG_PREFIX
-#define LINGLONG_PREFIX "/usr/"
-#endif
-
 #define DEEPIN_THEME        QString("%1share/deepin-editor/themes/deepin.theme").arg(LINGLONG_PREFIX)
 #define DEEPIN_DARK_THEME   QString("%1share/deepin-editor/themes/deepin_dark.theme").arg(LINGLONG_PREFIX)
 #define DATA_SIZE_1024      1024

--- a/src/thememodule/themelistmodel.cpp
+++ b/src/thememodule/themelistmodel.cpp
@@ -10,10 +10,6 @@
 #include <QDebug>
 #include <QDir>
 
-#ifndef LINGLONG_PREFIX
-#define LINGLONG_PREFIX "/usr/"
-#endif
-
 ThemeListModel::ThemeListModel(QObject *parent)
     : QAbstractListModel(parent)
 {


### PR DESCRIPTION
Log: 优化玲珑适配代码

让 linglong 和 debian 都统一使用 CMAKE_INSTALL_PREFIX 设置安装前缀，并都设置 LINGLONG_PREFIX 宏（debian 下=/usr），避免不必要的分支

注意 CMAKE_INSTALL_PREFIX 默认值是 /usr/local， 如果需要修改默认值应该使用：
```
if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
    set(CMAKE_INSTALL_PREFIX /usr)
endif ()
```

而不应该使用现在的写法，这会忽略用户指定的 -DCMAKE_INSTALL_PREFIX 参数。

尽管可以将默认值设置为 /usr ，但仍然建议使用 `/usr/local`， 系统管理员通过 `make install` 应该使用的该路径而非/usr，只是系统仓库的包必须使用 /usr 而非 /usr/local，这应该在 debian/rules 设置
