### PR TITLE
chore: Update version to 6.0.10

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+deepin-editor (6.0.10) unstable; urgency=medium
+
+  * chore: 更新翻译配置和翻译文件(Influence: 翻译配置 翻译文件)
+  * chore: 更新藏文翻译文件 (#251)(Influence: 翻译文件)
+
+ -- Deepin Packages Builder <packages@deepin.org>  Wed, 24 May 2023 13:20:03 +0800
+
 deepin-editor (6.0.9) unstable; urgency=medium
 
   * fix: deepin-editor searching problem(Bug: 4203)


### PR DESCRIPTION
Update version to 6.0.10
更新文本编辑器翻译。
相关PR:
* https://github.com/linuxdeepin/deepin-editor/pull/249
* https://github.com/linuxdeepin/deepin-editor/pull/251

Log: Update version to 6.0.10