### PR TITLE
fix: Document in maximumized window is incomplete.

### DIFF
--- a/src/editor/dtextedit.cpp
+++ b/src/editor/dtextedit.cpp
@@ -7335,6 +7335,17 @@ void TextEdit::resizeEvent(QResizeEvent *e)
     // 显示区域变化时同时更新视图
     markAllKeywordInView();
 
+    // 当前处于文档页面尾部时，缩放后保持焦点在文档页面尾部
+    if (e->oldSize().width() < e->size().width() && verticalScrollBar()->maximum() == verticalScrollBar()->value()) {
+        QTimer::singleShot(0, [this]() {
+            // 宽度变大时文档布局大小变更信号未触发，手动通知
+            auto docLayout = this->document()->documentLayout();
+            Q_EMIT docLayout->documentSizeChanged(docLayout->documentSize());
+
+            verticalScrollBar()->setValue(verticalScrollBar()->maximum());
+        });
+    }
+
     QPlainTextEdit::resizeEvent(e);
 }
 


### PR DESCRIPTION
文本重新高亮处理时，会导致文本块重新布局，和窗口大小变更时
导致的全文档重新布局存在计算冲突。调整文本高亮处理方式，
降低计算频率，已高亮的文本不再重复高亮，规避计算冲突。

Log: 修复部分格式高亮文本在窗口最大化状态下，文档不能完全显示
Bug: https://pms.uniontech.com/bug-view-172681.html
Influence: SyntaxHighlight