### PR TITLE
fix: Redo drag text error.

### DIFF
--- a/src/editor/deletebackcommond.cpp
+++ b/src/editor/deletebackcommond.cpp
@@ -24,8 +24,10 @@ void DeleteBackCommand::undo()
     m_cursor.setPosition(m_insertPos);
     m_cursor.insertText(m_delText);
 
-    m_cursor.setPosition(m_delPos);
-    m_edit->setTextCursor(m_cursor);
+    QTextCursor cursor = m_edit->textCursor();
+    cursor.setPosition(m_insertPos);
+    cursor.setPosition(m_insertPos + m_delText.size(), QTextCursor::KeepAnchor);
+    m_edit->setTextCursor(cursor);
 }
 
 void DeleteBackCommand::redo()

--- a/src/editor/dtextedit.cpp
+++ b/src/editor/dtextedit.cpp
@@ -2937,7 +2937,7 @@ void TextEdit::moveText(int from, int to, const QString &text, bool copy)
     }
 
     cursor.setPosition(to);
-    auto insertCommand = new InsertTextUndoCommand(cursor, text, this);
+    auto insertCommand = new DragInsertTextUndoCommand(cursor, text, this);
 
     //the positon of 'from' is on the left of the position of 'to',
     //therefore,firstly do the insert operation.

--- a/src/editor/inserttextundocommand.h
+++ b/src/editor/inserttextundocommand.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2019 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2019 - 2023 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -14,16 +14,19 @@
 class InsertTextUndoCommand : public QUndoCommand
 {
 public:
-    explicit InsertTextUndoCommand(QTextCursor textcursor, QString text, QPlainTextEdit *edit, QUndoCommand *parent = nullptr);
-    explicit InsertTextUndoCommand(QList<QTextEdit::ExtraSelection> &selections, QString text, QPlainTextEdit *edit, QUndoCommand *parent = nullptr);
+    explicit InsertTextUndoCommand(const QTextCursor &textcursor, const QString &text, QPlainTextEdit *edit, QUndoCommand *parent = nullptr);
+    explicit InsertTextUndoCommand(QList<QTextEdit::ExtraSelection> &selections,
+                                   const QString &text,
+                                   QPlainTextEdit *edit,
+                                   QUndoCommand *parent = nullptr);
     virtual void undo();
     virtual void redo();
 
 private:
     QPlainTextEdit *m_pEdit = nullptr;
     QTextCursor m_textCursor;
-    int m_beginPostion {0};
-    int m_endPostion   {0};
+    int m_beginPostion{0};
+    int m_endPostion{0};
     QString m_sInsertText;
     QList<QTextEdit::ExtraSelection> m_ColumnEditSelections;
     QString m_selectText = QString();
@@ -35,17 +38,40 @@ private:
 class MidButtonInsertTextUndoCommand : public QUndoCommand
 {
 public:
-    explicit MidButtonInsertTextUndoCommand(QTextCursor textcursor, QString text, QPlainTextEdit *edit, QUndoCommand *parent = nullptr);
+    explicit MidButtonInsertTextUndoCommand(const QTextCursor &textcursor,
+                                            const QString &text,
+                                            QPlainTextEdit *edit,
+                                            QUndoCommand *parent = nullptr);
 
     virtual void undo();
     virtual void redo();
 
 private:
-    QPlainTextEdit  *m_pEdit = nullptr;     // 关联的文本编辑控件
-    QTextCursor     m_textCursor;           // 插入前的光标
-    QString         m_sInsertText;          // 插入文本
-    int             m_beginPostion = 0;     // 维护插入位置的标记
-    int             m_endPostion = 0;
+    QPlainTextEdit *m_pEdit = nullptr;  // 关联的文本编辑控件
+    QTextCursor m_textCursor;           // 插入前的光标
+    QString m_sInsertText;              // 插入文本
+    int m_beginPostion = 0;             // 维护插入位置的标记
+    int m_endPostion = 0;
 };
 
-#endif // INSERTTEXTUNDOCOMMAND_H
+/**
+   @brief 拖拽插入文本处理
+ */
+class DragInsertTextUndoCommand : public QUndoCommand
+{
+public:
+    explicit DragInsertTextUndoCommand(const QTextCursor &textcursor,
+                                       const QString &text,
+                                       QPlainTextEdit *edit,
+                                       QUndoCommand *parent = nullptr);
+    virtual void undo() override;
+    virtual void redo() override;
+
+private:
+    QPlainTextEdit *m_pEdit = nullptr;
+    QTextCursor m_textCursor;
+    QString m_sInsertText;
+    int m_beginPostion{0};
+};
+
+#endif  // INSERTTEXTUNDOCOMMAND_H

--- a/tests/src/editor/ut_textedit.cpp
+++ b/tests/src/editor/ut_textedit.cpp
@@ -9648,3 +9648,73 @@ TEST(UT_Textedit_onAppPaletteChanged, OnAppPaletteChanged_ChangeBackground_Pass)
     edit->deleteLater();
     wra->deleteLater();
 }
+
+TEST(UT_Textedit_MoveText, moveText_Move_Pass)
+{
+    TextEdit* edit = new TextEdit;
+    EditWrapper* wra = new EditWrapper;
+    edit->m_wrapper = wra;
+
+    QString sourceText("123456789\n");
+    edit->setPlainText(sourceText);
+
+    edit->moveText(0, 10, "12");
+    EXPECT_EQ(edit->toPlainText(), QString("3456789\n12"));
+    edit->undo_();
+    EXPECT_EQ(edit->toPlainText(), sourceText);
+    edit->redo_();
+    EXPECT_EQ(edit->toPlainText(), QString("3456789\n12"));
+
+    edit->deleteLater();
+    wra->deleteLater();
+}
+
+TEST(UT_Textedit_MoveText, moveText_Copy_Pass)
+{
+    TextEdit* edit = new TextEdit;
+    EditWrapper* wra = new EditWrapper;
+    edit->m_wrapper = wra;
+
+    QString sourceText("123456789\n");
+    edit->setPlainText(sourceText);
+
+    edit->moveText(0, 10, "12", true);
+    EXPECT_EQ(edit->toPlainText(), QString("123456789\n12"));
+    edit->undo_();
+    EXPECT_EQ(edit->toPlainText(), sourceText);
+    edit->redo_();
+    EXPECT_EQ(edit->toPlainText(), QString("123456789\n12"));
+
+    edit->deleteLater();
+    wra->deleteLater();
+}
+
+TEST(UT_Textedit_MoveText, moveText_Multi_Pass)
+{
+    TextEdit* edit = new TextEdit;
+    EditWrapper* wra = new EditWrapper;
+    edit->m_wrapper = wra;
+
+    edit->insertTextEx(edit->textCursor(), "1\n");
+    edit->insertTextEx(edit->textCursor(), "2\n");
+    EXPECT_EQ(edit->toPlainText(), QString("1\n2\n"));
+
+    edit->moveText(2, 1, "2");
+    EXPECT_EQ(edit->toPlainText(), QString("12\n\n"));
+    edit->moveText(0, 4, "12");
+    EXPECT_EQ(edit->toPlainText(), QString("\n\n12"));
+    edit->moveText(2, 0, "12", true);
+    EXPECT_EQ(edit->toPlainText(), QString("12\n\n12"));
+
+    while(edit->m_pUndoStack->canUndo()) {
+        edit->undo_();
+    }
+    EXPECT_TRUE(edit->toPlainText().isEmpty());
+    while(edit->m_pUndoStack->canRedo()) {
+        edit->redo_();
+    }
+    EXPECT_EQ(edit->toPlainText(), QString("12\n\n12"));
+
+    edit->deleteLater();
+    wra->deleteLater();
+}


### PR DESCRIPTION
拖拽文本包含删除及插入操作，顺序执行时操作的
文本偏移量会更新，修改为固定的偏移量。
更新拖拽插入部分UT，修复部分异常的UT。

Log: 修复重做拖拽文本操作时，操作的文本位置异常
Bug: https://pms.uniontech.com/bug-view-196349.html
Influence: DragText UnitTest