### PR TITLE
fix: Redo drag text from other app error.

### DIFF
--- a/src/editor/dtextedit.cpp
+++ b/src/editor/dtextedit.cpp
@@ -6414,7 +6414,7 @@ void TextEdit::dropEvent(QDropEvent *event)
             cursor.setPosition(dstpos);
             cursor.setPosition(dstpos + data->text().size(), QTextCursor::KeepAnchor);
             cursor.deleteChar();
-            auto com = new InsertTextUndoCommand(cursor, data->text(), this);
+            auto com = new DragInsertTextUndoCommand(cursor, data->text(), this);
             m_pUndoStack->push(com);
 
             //operations in the source editor.
@@ -6437,7 +6437,7 @@ void TextEdit::dropEvent(QDropEvent *event)
             cursor.setPosition(dstpos);
             cursor.setPosition(dstpos + data->text().size(), QTextCursor::KeepAnchor);
             cursor.deleteChar();
-            auto com = new InsertTextUndoCommand(cursor, data->text(), this);
+            auto com = new DragInsertTextUndoCommand(cursor, data->text(), this);
             m_pUndoStack->push(com);
         }
     } else {


### PR DESCRIPTION
修复重做从其它应用或标签页拖拽文本操作时，复位位置错误,
使用固定的偏移量计算复位位置。

Log: 修复重做从其它应用或标签页拖拽文本操作时，复位位置错误
Influence: DragText