### PR TITLE
fix: Roll back gb18030 midification.

### DIFF
--- a/misc/configs/org.deepin.editor.json
+++ b/misc/configs/org.deepin.editor.json
@@ -1,17 +1,39 @@
 {
-    "magic":"dsg.config.meta",
-    "version":"1.0",
-    "contents":{
-        "disableImproveGB18030":{
-            "value":false,
-            "serial":0,
-            "flags":[],
-            "name":"屏蔽提高GB18030编码识别率",
-            "name[zh_CN]":"屏蔽提高GB18030编码识别率",
-            "description[zh_CN]":"屏蔽提高中文环境下GB18030编码的识别率的策略，默认不屏蔽",
-            "description":"Block the strategy to improve the recognition rate of GB18030 encoding in the Chinese environment, the default is not blocked",
-            "permissions":"readwrite",
-            "visibility":"private"
-        }   
-    }   
-}  
+    "magic": "dsg.config.meta",
+    "version": "1.0",
+    "contents": {
+        "disableImproveGB18030": {
+            "value": false,
+            "serial": 0,
+            "flags": [],
+            "name": "Block improtve GB18030",
+            "name[zh_CN]": "屏蔽提高GB18030编码识别率",
+            "description[zh_CN]": "屏蔽提高中文环境下GB18030编码的识别率的策略，默认不屏蔽",
+            "description": "Block the strategy to improve the recognition rate of GB18030 encoding in the Chinese environment, the default is not blocked",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "enablePatchedIconv": {
+            "value": false,
+            "serial": 0,
+            "flags": [],
+            "name": "Use iconv patch",
+            "name[zh_CN]": "使用iconv补丁",
+            "description[zh_CN]": "使用上层应用适配2022标准的iconv设置补丁,2005标准下此选项无效",
+            "description": "Use the iconv settings patch that adapts to the 2022 standard，the default is false",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "defaultEncoding": {
+            "value": "UTF-8",
+            "serial": 0,
+            "flags": [],
+            "name": "Default text encoding",
+            "name[zh_CN]": "文件识别默认编码",
+            "description[zh_CN]": "文件识别默认编码，ASCII及未知编码将使用配置的默认编码，默认UTF-8",
+            "description": "Default text encoding, ASCII and unknown encoding will use the configured default encoding，the default is UTF-8",
+            "permissions": "readwrite",
+            "visibility": "private"
+        }
+    }
+}

--- a/src/common/config.cpp
+++ b/src/common/config.cpp
@@ -4,13 +4,54 @@
 
 #include "config.h"
 
+#include <iconv.h>
+
 #include <QDebug>
 
 #ifdef DTKCORE_CLASS_DConfigFile
 #include <QStandardPaths>
 
 const QString g_keyDisableImproveGB18030 = "disableImproveGB18030";
+const QString g_keyDefaultEncoding = "defaultEncoding";
+const QString g_keyEnablePatchedIconv = "enablePatchedIconv";
 #endif
+
+/**
+   @brief 检测当前iconv使用的GB18030编码是否为2005标准，2005标准强制使用上层补丁版本
+        通过检测2005和2022编码转的差异，以附录D中的编码为例验证
+        2005标准 0xFE51 --> \u20087
+        2022标准 0xFE51 --> \uE816
+   @return iconv使用GB18030编码是否为2005标准，默认返回true
+ */
+bool detectIconvUse2005Standard()
+{
+    iconv_t handle = iconv_open("UTF-8", "GB18030");
+    if (handle == reinterpret_cast<iconv_t>(-1)) {
+        return true;
+    }
+
+    QByteArray input("\xFE\x51");
+    QByteArray output(input.size() * 2, 0);
+    char *inputData = input.data();
+    char *outputData = output.data();
+    size_t inputLen = static_cast<size_t>(input.count());
+    size_t outputLen = static_cast<size_t>(output.count());
+
+    const size_t ret = iconv(handle, &inputData, &inputLen, &outputData, &outputLen);
+    iconv_close(handle);
+
+    if (ret == static_cast<size_t>(-1)) {
+        return true;
+    }
+
+    if (!output.contains("\uE816")) {
+        qInfo() << "Current iconv gb18030 standard is 2005.";
+        return true;
+    }
+
+    qInfo() << "Current iconv gb18030 standard is 2022.";
+    return false;
+}
 
 /**
    @class Config
@@ -21,26 +62,43 @@ const QString g_keyDisableImproveGB18030 = "disableImproveGB18030";
 
 Config::Config(QObject *parent)
     : QObject(parent)
+    , encoding("UTF-8")
 {
 #ifdef DTKCORE_CLASS_DConfigFile
     dconfig = DConfig::create("org.deepin.editor", "org.deepin.editor");
     if (dconfig->isValid()) {
         // 默认提高GB18030识别率
         improveGB18030 = !dconfig->value(g_keyDisableImproveGB18030).toBool();
-        qInfo() << "DConfig::ImproveGB18030:" << improveGB18030;
+        qInfo() << qPrintable("DConfig::ImproveGB18030:") << improveGB18030;
+
+        patchedIconv = dconfig->value(g_keyEnablePatchedIconv).toBool();
+        qInfo() << qPrintable("DConfig::enablePatchedIconv:") << patchedIconv;
+
+        encoding = dconfig->value(g_keyDefaultEncoding).toByteArray().toUpper();
+        qInfo() << qPrintable("DConfig::defaultEncoding") << encoding;
 
         connect(dconfig, &DConfig::valueChanged, this, [this](const QString &key) {
             if (key == g_keyDisableImproveGB18030) {
                 this->improveGB18030 = !this->dconfig->value(g_keyDisableImproveGB18030).toBool();
-                qInfo() << "DConfig::ImproveGB18030 Changed:" << improveGB18030;
+                qInfo() << qPrintable("DConfig::ImproveGB18030 changed:") << improveGB18030;
+            } else if (key == g_keyEnablePatchedIconv) {
+                this->patchedIconv = dconfig->value(g_keyEnablePatchedIconv).toBool();
+                qInfo() << qPrintable("DConfig::enablePatchedIconv changed:") << patchedIconv;
+            } else if (key == g_keyDefaultEncoding) {
+                this->encoding = dconfig->value(g_keyDefaultEncoding).toByteArray().toUpper();
+                qInfo() << qPrintable("DConfig::defaultEncoding changed:") << encoding;
             }
         });
+
     } else {
-        qWarning() << "org.deepin.editor DConfig not valid!";
+        qWarning() << qPrintable("org.deepin.editor DConfig not valid!");
     }
 #else
     qWarning() << "DConfig is not supported by DTK!";
 #endif
+
+    // 检测当前iconv使用的GB18030编码是否为2005标准(2005标准强制使用上层补丁版本)
+    iocnvUse2005Standard = detectIconvUse2005Standard();
 }
 
 Config::~Config()
@@ -58,7 +116,27 @@ Config *Config::instance()
     return &config;
 }
 
+/**
+   @return 返回是否提高GB18030编码识别率
+ */
 bool Config::enableImproveGB18030() const
 {
     return improveGB18030;
+}
+
+/**
+   @return 返回是否使用上层修改的适配2022标准的iconv设置，
+    2005标准强制使用上层补丁版本，以适配2022要求
+ */
+bool Config::enablePatchedIconv() const
+{
+    return patchedIconv || iocnvUse2005Standard;
+}
+
+/**
+   @return 返回配置的默认编码，默认UTF-8
+ */
+QByteArray Config::defaultEncoding() const
+{
+    return encoding.isEmpty() ? QByteArray("UTF-8") : encoding;
 }

--- a/src/common/config.h
+++ b/src/common/config.h
@@ -22,12 +22,17 @@ class Config : public QObject
 public:
     static Config *instance();
     bool enableImproveGB18030() const;
+    bool enablePatchedIconv() const;
+    QByteArray defaultEncoding() const;
 
 private:
 #ifdef DTKCORE_CLASS_DConfigFile
     DConfig *dconfig = nullptr;
 #endif
     bool improveGB18030 = true;  ///< 默认提高GB18030编码识别率
+    bool patchedIconv = false;   ///< 默认不再使用上层修改的iconv
+    bool iocnvUse2005Standard = false;  ///< 检测当前iconv使用的GB18030编码是否为2005标准(2005标准强制使用上层补丁版本)
+    QByteArray encoding;  ///< 缺省编码设置
 };
 
 #endif  // CONFIG_H


### PR DESCRIPTION
iconv底层适配GB18030-2022标准,回退上层应用GB18030修改。
添加DConfig配置是否使用上层修改补丁，当处于2005标准时
仍会强制使用上层修改补丁以适配2022标准。

Log: 回退GB18030修改
Influence: GB18030 Encoding