### PR TITLE
fix: onPressedLineNumber() may cause process hangs.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -57,14 +57,19 @@ int main(int argc, char *argv[])
     parser.addOption(newWindowOption);
     parser.process(app);
 
+    qInfo() << qPrintable(QString("App start, pid: %1, version: %2").arg(app.applicationPid()).arg(app.applicationVersion()));
+
     QStringList urls;
     QStringList arguments = parser.positionalArguments();
 
     for (const QString &path : arguments) {
         UrlInfo info(path);
         urls << info.url.toLocalFile();
+
+        QFileInfo fileInfo(path);
+        qInfo() << qPrintable(QString("Open file, isFile: %1, suffix: %2, size: %3, permssion: %4").arg(fileInfo.isFile())
+                   .arg(fileInfo.suffix()).arg(fileInfo.size()).arg(fileInfo.permissions()));
     }
-    qInfo() << Q_FUNC_INFO << "Open file urls" << urls;
 
     bool hasWindowFlag = parser.isSet(newWindowOption);
 


### PR DESCRIPTION
点击序号列空白处，可能导致程序阻塞，这是由于循环判断
没有检查 QTextBlock 是否有效。
1. 修改 onPressedLineNumber() 函数，改为使用 cursorForPosition() 接口取得块位置，而非循环比对块区域范围。
2. 补充 onPressedLineNumber() 的单元测试。

Log: 修复一次点击序号可能导致程序阻塞的问题
Bug: https://pms.uniontech.com/bug-view-215591.html
Influence: LineNumber