### PR TITLE
chore: [linglong] Update version to 6.0.13

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+deepin-editor (6.0.13) unstable; urgency=medium
+
+  * fix: Add support mimetype mod/toml.(Bug: 210815, 212273)(Influence: SupportFormat)
+  * fix: Add mimetype toml in .desktop(Bug: 210815)
+
+ -- Deepin Packages Builder <packages@deepin.org>  Fri, 08 Sep 2023 14:21:02 +0800
+
 deepin-editor (6.0.12) unstable; urgency=medium
 
   * fix: onPressedLineNumber() may cause process hangs.(Bug: 215591)(Influence: LineNumber)


### PR DESCRIPTION
[linglong] Update version to 6.0.13
PR:
* https://github.com/linuxdeepin/deepin-editor/pull/261
* https://github.com/linuxdeepin/deepin-editor/pull/262

Log: [linglong] Update version to 6.0.13