### PR TITLE
chore: Bump version to 6.0.14

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+deepin-editor (6.0.14) unstable; urgency=medium
+
+  * fix: Add support mimetype mod/toml.(Bug: 210815, 212273)(Influence: SupportFormat)
+  * fix: Add mimetype toml in .desktop(Bug: 210815)
+  * feat: adapt compact mode.(Task: 292061)(Influence: UI)
+  * fix: Adapt compact mode for findbar and replacebar.(Bug: 220159)
+
+ -- renbin <renbin@uniontech.com>  Thu, 19 Oct 2023 13:25:37 +0800
+
 deepin-editor (6.0.13) unstable; urgency=medium
 
   * fix: Add support mimetype mod/toml.(Bug: 210815, 212273)(Influence: SupportFormat)


### PR DESCRIPTION
Bump version to 6.0.14
PR:
* https://github.com/linuxdeepin/deepin-editor/pull/261
* https://github.com/linuxdeepin/deepin-editor/pull/262
* https://github.com/linuxdeepin/deepin-editor/pull/264

Log: Bump version to 6.0.14