### PR TITLE
chore: Bump version to 6.0.17

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-editor (6.0.17) unstable; urgency=medium
+
+  * feat: Change default shortcuts popup position(Task: 332267)(Influence: Shortcuts)
+
+ -- renbin <renbin@uniontech.com>  Wed, 27 Mar 2024 15:37:32 +0800
+
 deepin-editor (6.0.16) unstable; urgency=medium
 
   * feat: add new tab to the end


### PR DESCRIPTION
Bump verion to 6.0.17
PR:
* https://github.com/linuxdeepin/deepin-editor/pull/274

Log: Bump verion to 6.0.17