### PR TITLE
fix: Change default search to be case insensitive

### DIFF
--- a/src/editor/dtextedit.h
+++ b/src/editor/dtextedit.h
@@ -197,21 +197,22 @@ public:
     void setFontSize(qreal fontSize);
     void updateFont();
 
-    void replaceAll(const QString &replaceText, const QString &withText);
-    void replaceNext(const QString &replaceText, const QString &withText);
-    void replaceRest(const QString &replaceText, const QString &withText);
-    void beforeReplace(const QString &strReplaceText);
+    void replaceAll(const QString &replaceText, const QString &withText, Qt::CaseSensitivity caseFlag = Qt::CaseInsensitive);
+    void replaceNext(const QString &replaceText, const QString &withText, Qt::CaseSensitivity caseFlag = Qt::CaseInsensitive);
+    void replaceRest(const QString &replaceText, const QString &withText, Qt::CaseSensitivity caseFlag = Qt::CaseInsensitive);
+    void beforeReplace(const QString &strReplaceText, Qt::CaseSensitivity caseFlag = Qt::CaseInsensitive);
 
     bool findKeywordForward(const QString &keyword);
 
     void removeKeywords();
-    bool highlightKeyword(QString keyword, int position);
-    bool highlightKeywordInView(QString keyword);
+    bool highlightKeyword(const QString &keyword, int position, Qt::CaseSensitivity caseFlag = Qt::CaseInsensitive);
+    bool highlightKeywordInView(const QString &keyword, Qt::CaseSensitivity caseFlag = Qt::CaseInsensitive);
     void clearFindMatchSelections();
     void updateCursorKeywordSelection(QString keyword, bool findNext);
     void updateHighlightLineSelection();
     bool updateKeywordSelections(QString keyword, QTextCharFormat charFormat, QList<QTextEdit::ExtraSelection> &listSelection);
-    bool updateKeywordSelectionsInView(QString keyword, QTextCharFormat charFormat, QList<QTextEdit::ExtraSelection> *listSelection);
+    bool updateKeywordSelectionsInView(QString keyword, QTextCharFormat charFormat, QList<QTextEdit::ExtraSelection> *listSelection,
+                                       Qt::CaseSensitivity caseFlag = Qt::CaseInsensitive);
     bool searchKeywordSeletion(QString keyword, QTextCursor cursor, bool findNext);
     void renderAllSelections();
 
@@ -549,7 +550,8 @@ public slots:
     void undo_();
 
     void moveText(int from, int to, const QString& text, bool copy = false);
-    QTextCursor findCursor(const QString &substr, const QString &text, int from, bool backward = false, int cursorPos = 0);
+    QTextCursor findCursor(const QString &substr, const QString &text, int from, bool backward = false, int cursorPos = 0,
+                           Qt::CaseSensitivity caseFlag = Qt::CaseInsensitive);
     void onPressedLineNumber(const QPoint& point);
     QString selectedText(bool checkCRLF = false);
     void onEndlineFormatChanged(BottomBar::EndlineFormat from,BottomBar::EndlineFormat to);
@@ -603,7 +605,8 @@ private:
     bool isAbleOperation(int iOperationType);
     // 计算颜色标记替换信息列表
     void calcMarkReplaceList(QList<TextEdit::MarkReplaceInfo> &replaceList, const QString &oldText,
-                             const QString &replaceText, const QString &withText, int offset = 0) const;
+                             const QString &replaceText, const QString &withText, int offset = 0,
+                             Qt::CaseSensitivity caseFlag = Qt::CaseInsensitive) const;
     // 查找行号line起始的折叠区域
     bool findFoldBlock(int line, QTextBlock &beginBlock, QTextBlock &endBlock, QTextBlock &curBlock);
 
@@ -861,5 +864,7 @@ private:
     bool m_MidButtonPatse = false;      // 鼠标中键黏贴处理
     bool m_isPreeditBefore = false;     // 上一个输入法时间是否是 preedit
     int m_preeditLengthBefore = 0;
+
+    Qt::CaseSensitivity defaultCaseSensitive = Qt::CaseInsensitive; // 查找匹配时默认不区分
 };
 #endif

--- a/tests/src/editor/ut_textedit.cpp
+++ b/tests/src/editor/ut_textedit.cpp
@@ -1801,6 +1801,7 @@ TEST(UT_test_textedit_replaceAll, UT_test_textedit_replaceAll_002)
     QString strRetAfter(pWindow->currentWrapper()->textEditor()->toPlainText());
 
     ASSERT_TRUE(!strRetAfter.compare(strRetBefore));
+
     pWindow->deleteLater();
 }
 
@@ -1819,6 +1820,35 @@ TEST(UT_test_textedit_replaceAll, UT_test_textedit_replaceAll_003)
     QString strRetAfter(pWindow->currentWrapper()->textEditor()->toPlainText());
 
     ASSERT_TRUE(!strRetAfter.compare(QString("Holle Holle\nHolle Holle")));
+
+    pWindow->currentWrapper()->textEditor()->replaceAll(QString("holle"), QString("World"));
+    strRetAfter = QString(pWindow->currentWrapper()->textEditor()->toPlainText());
+    ASSERT_TRUE(!strRetAfter.compare(QString("World World\nWorld World")));
+
+    pWindow->deleteLater();
+}
+
+//replaceAll check case sensitive
+TEST(UT_test_textedit_replaceAll, UT_test_textedit_replaceAll_CaseSensitive)
+{
+    Window *pWindow = new Window();
+    pWindow->addBlankTab(QString());
+    QString strMsg("Hello world\nHello world");
+    QTextCursor textCursor = pWindow->currentWrapper()->textEditor()->textCursor();
+    pWindow->currentWrapper()->textEditor()->insertTextEx(textCursor, strMsg);
+
+    auto *textEdit = pWindow->currentWrapper()->textEditor();
+
+    // NotChange
+    textEdit->replaceAll(QString("hello"), QString("world"), Qt::CaseSensitive);
+    ASSERT_TRUE(!textEdit->toPlainText().compare(strMsg));
+
+    textEdit->replaceAll(QString("hello"), QString("World"), Qt::CaseInsensitive);
+    ASSERT_TRUE(!textEdit->toPlainText().compare(QString("World world\nWorld world")));
+
+    textEdit->replaceAll(QString("world"), QString("World"), Qt::CaseInsensitive);
+    ASSERT_TRUE(!textEdit->toPlainText().compare(QString("World World\nWorld World")));
+
     pWindow->deleteLater();
 }
 
@@ -1909,6 +1939,38 @@ TEST(UT_test_textedit_replaceNext, UT_test_textedit_replaceNext_004)
     pWindow->deleteLater();
 }
 
+//replaceNext check sensitive
+TEST(UT_test_textedit_replaceNext, UT_test_textedit_replaceNext_CaseSensitive)
+{
+    Window *pWindow = new Window();
+    pWindow->addBlankTab(QString());
+    QString strMsg("Hello world\nHello world");
+    auto *textEdit = pWindow->currentWrapper()->textEditor();
+    QTextCursor textCursor = textEdit->textCursor();
+    textEdit->insertTextEx(textCursor, strMsg);
+
+    textCursor = textEdit->textCursor();
+    textCursor.movePosition(QTextCursor::Start);
+    textCursor.movePosition(QTextCursor::EndOfWord, QTextCursor::KeepAnchor);
+    textEdit->setTextCursor(textCursor);
+    textEdit->m_findHighlightSelection.cursor = textCursor;
+
+    QString strReplaceText("hello");
+    QString strWithText("World");
+    QString strRetBefore(textEdit->textCursor().block().text());
+
+    textEdit->replaceNext(strReplaceText, strWithText, Qt::CaseSensitive);
+    QString strRetAfter(textEdit->textCursor().block().text());
+    ASSERT_TRUE(!strRetAfter.compare(strRetBefore));
+
+    textEdit->setTextCursor(textCursor);
+    textEdit->m_findHighlightSelection.cursor = textCursor;
+    textEdit->replaceNext(strReplaceText, strWithText, Qt::CaseInsensitive);
+    ASSERT_TRUE(!textEdit->toPlainText().compare("World world\nHello world"));
+
+    pWindow->deleteLater();
+}
+
 //replaceRest 001
 TEST(UT_test_textedit_replaceRest, UT_test_textedit_replaceRest_001)
 {
@@ -1969,6 +2031,33 @@ TEST(UT_test_textedit_replaceRest, UT_test_textedit_replaceRest_003)
     ASSERT_TRUE(!strRetAfter.compare(QString("Helle Helle Helle Helle")));
     pWindow->deleteLater();
 }
+
+//replaceRest check case sensitive
+TEST(UT_test_textedit_replaceRest, UT_test_textedit_replaceRest_CaseSensitive)
+{
+    Window *pWindow = new Window();
+    pWindow->addBlankTab(QString());
+    QString strMsg("Hello world\nHello world Hello world");
+    QTextCursor textCursor = pWindow->currentWrapper()->textEditor()->textCursor();
+    pWindow->currentWrapper()->textEditor()->insertTextEx(textCursor, strMsg);
+
+    textCursor = pWindow->currentWrapper()->textEditor()->textCursor();
+    textCursor.movePosition(QTextCursor::StartOfBlock, QTextCursor::MoveAnchor);
+    pWindow->currentWrapper()->textEditor()->setTextCursor(textCursor);
+    QString strReplaceText("World");
+    QString strWithText("Hello");
+    QString strRetBefore(pWindow->currentWrapper()->textEditor()->textCursor().block().text());
+    pWindow->currentWrapper()->textEditor()->replaceRest(strReplaceText, strWithText, Qt::CaseSensitive);
+    QString strRetAfter(pWindow->currentWrapper()->textEditor()->textCursor().block().text());
+    ASSERT_TRUE(!strRetAfter.compare(strRetBefore));
+
+    pWindow->currentWrapper()->textEditor()->replaceRest(strReplaceText, strWithText, Qt::CaseInsensitive);
+    strRetAfter = QString(pWindow->currentWrapper()->textEditor()->textCursor().block().text());
+    ASSERT_TRUE(!strRetAfter.compare("Hello Hello Hello Hello"));
+
+    pWindow->deleteLater();
+}
+
 
 //beforeReplace
 TEST(UT_test_textedit_beforeReplace, UT_test_textedit_beforeReplace_001)
@@ -2047,6 +2136,27 @@ TEST(UT_test_textedit_highlightKeyword, UT_test_textedit_highlightKeyword_001)
     bool bRet = pWindow->currentWrapper()->textEditor()->highlightKeyword(QString("world"), 0);
 
     ASSERT_TRUE(bRet == true);
+    pWindow->deleteLater();
+}
+
+//highlightKeyword case sensitive
+TEST(UT_test_textedit_highlightKeyword, UT_test_textedit_highlightKeyword_CaseSensitive)
+{
+    Window *pWindow = new Window();
+    pWindow->addBlankTab(QString());
+    QString strMsg("Hello world\nHello world");
+    QTextCursor textCursor = pWindow->currentWrapper()->textEditor()->textCursor();
+    pWindow->currentWrapper()->textEditor()->insertTextEx(textCursor, strMsg);
+
+    bool bRet = pWindow->currentWrapper()->textEditor()->highlightKeyword(QString("World"), 0);
+    ASSERT_TRUE(bRet);
+
+    bRet = pWindow->currentWrapper()->textEditor()->highlightKeyword(QString("hello"), 0);
+    ASSERT_TRUE(bRet);
+
+    bRet = pWindow->currentWrapper()->textEditor()->highlightKeyword(QString("World"), 0, Qt::CaseSensitive);
+    ASSERT_FALSE(bRet);
+
     pWindow->deleteLater();
 }
 
@@ -2130,8 +2240,12 @@ TEST(UT_test_textedit_updateKeywordSelections, UT_test_textedit_updateKeywordSel
     QList<QTextEdit::ExtraSelection> listExtraSelection;
     listExtraSelection.append(extraSelection);
     bool bRet = pWindow->currentWrapper()->textEditor()->updateKeywordSelections(QString("smile"), charFormat, listExtraSelection);
-
     ASSERT_TRUE(bRet == false);
+
+    pWindow->currentWrapper()->textEditor()->defaultCaseSensitive = Qt::CaseSensitive;
+    bRet = pWindow->currentWrapper()->textEditor()->updateKeywordSelections(QString("World"), charFormat, listExtraSelection);
+    ASSERT_TRUE(bRet == false);
+
     pWindow->deleteLater();
 }
 
@@ -2151,8 +2265,11 @@ TEST(UT_test_textedit_updateKeywordSelections, UT_test_textedit_updateKeywordSel
     QList<QTextEdit::ExtraSelection> listExtraSelection;
     listExtraSelection.append(extraSelection);
     bool bRet = pWindow->currentWrapper()->textEditor()->updateKeywordSelections(QString("world"), charFormat, listExtraSelection);
-
     ASSERT_TRUE(bRet == true);
+
+    bRet = pWindow->currentWrapper()->textEditor()->updateKeywordSelections(QString("World"), charFormat, listExtraSelection);
+    ASSERT_TRUE(bRet == true);
+
     pWindow->deleteLater();
 }
 


### PR DESCRIPTION
Change default search to be case insensitive,
affecting rind / replace / color mark.

变更默认字符查找不区分大小写, 影响查找/替换/颜色
标记功能.

Log: 变更默认字符查找不区分大小写
Bug: https://pms.uniontech.com/bug-view-262733.html