### PR TITLE
fix: Wrong case sensitive config

### DIFF
--- a/src/editor/dtextedit.cpp
+++ b/src/editor/dtextedit.cpp
@@ -1875,7 +1875,7 @@ bool TextEdit::findKeywordForward(const QString &keyword)
 
         QTextDocument::FindFlags options;
         if (Qt::CaseSensitive == defaultCaseSensitive) {
-            options &= QTextDocument::FindCaseSensitively;
+            options |= QTextDocument::FindCaseSensitively;
         }
         bool foundOne = find(keyword, options);
 
@@ -1893,7 +1893,7 @@ bool TextEdit::findKeywordForward(const QString &keyword)
 
         QTextDocument::FindFlags options;
         if (Qt::CaseSensitive == defaultCaseSensitive) {
-            options &= QTextDocument::FindCaseSensitively;
+            options |= QTextDocument::FindCaseSensitively;
         }
         bool foundOne = find(keyword, options);
 
@@ -2098,7 +2098,7 @@ bool TextEdit::searchKeywordSeletion(QString keyword, QTextCursor cursor, bool f
     if (findNext) {
         QTextDocument::FindFlags options;
         if (Qt::CaseSensitive == defaultCaseSensitive) {
-            options &= QTextDocument::FindCaseSensitively;
+            options |= QTextDocument::FindCaseSensitively;
         }
 
         QTextCursor next = document()->find(keyword, cursor, options);
@@ -2115,7 +2115,7 @@ bool TextEdit::searchKeywordSeletion(QString keyword, QTextCursor cursor, bool f
     } else {
         QTextDocument::FindFlags options = QTextDocument::FindBackward;
         if (Qt::CaseSensitive == defaultCaseSensitive) {
-            options &= QTextDocument::FindCaseSensitively;
+            options |= QTextDocument::FindCaseSensitively;
         }
 
         QTextCursor prev = document()->find(keyword, cursor, options);


### PR DESCRIPTION
Change the setting when case sensitive.
调整区分大小写配置时的设置

Log: 修复错误的匹配大小写判断设置
Bug: https://pms.uniontech.com/bug-view-262733.html