### PR TITLE
chore: Bump version to 6.0.18

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+deepin-editor (6.0.18) unstable; urgency=medium
+
+  * fix: Change default search to be case insensitive(Bug: 262733)
+  * fix: Wrong case sensitive config(Bug: 262733)
+
+ -- renbin <renbin@uniontech.com>  Wed, 03 Jul 2024 18:14:32 +0800
+
 deepin-editor (6.0.17) unstable; urgency=medium
 
   * feat: Change default shortcuts popup position(Task: 332267)(Influence: Shortcuts)


### PR DESCRIPTION
Bump version to 6.0.18
PR:
* https://github.com/linuxdeepin/deepin-editor/pull/280
* https://github.com/linuxdeepin/deepin-editor/pull/281

Log: Bump version to 6.0.18