### PR TITLE
fix: column editing and insert

### DIFF
--- a/src/common/utils.h
+++ b/src/common/utils.h
@@ -15,16 +15,20 @@
 #include <QDBusReply>
 
 #ifndef SAFE_DELETE
-#define SAFE_DELETE(p)      if((p)) { delete (p); (p) = nullptr;}
+#define SAFE_DELETE(p)                                                                                                           \
+    if ((p)) {                                                                                                                   \
+        delete (p);                                                                                                              \
+        (p) = nullptr;                                                                                                           \
+    }
 #endif
 
-#define DEEPIN_THEME        QString("%1share/deepin-editor/themes/deepin.theme").arg(LINGLONG_PREFIX)
-#define DEEPIN_DARK_THEME   QString("%1share/deepin-editor/themes/deepin_dark.theme").arg(LINGLONG_PREFIX)
-#define DATA_SIZE_1024      1024
-#define TEXT_EIDT_MARK_ALL  "MARK_ALL"
-#define PROC_MEMINFO_PATH   "/proc/meminfo"
-#define COPY_CONSUME_MEMORY_MULTIPLE 9      //复制文本时内存占用系数
-#define PASTE_CONSUME_MEMORY_MULTIPLE 7     //粘贴文本时内存占用系数
+#define DEEPIN_THEME QString("%1share/deepin-editor/themes/deepin.theme").arg(LINGLONG_PREFIX)
+#define DEEPIN_DARK_THEME QString("%1share/deepin-editor/themes/deepin_dark.theme").arg(LINGLONG_PREFIX)
+#define DATA_SIZE_1024 1024
+#define TEXT_EIDT_MARK_ALL "MARK_ALL"
+#define PROC_MEMINFO_PATH "/proc/meminfo"
+#define COPY_CONSUME_MEMORY_MULTIPLE 9   // 复制文本时内存占用系数
+#define PASTE_CONSUME_MEMORY_MULTIPLE 7  // 粘贴文本时内存占用系数
 
 class Utils
 {
@@ -33,13 +37,13 @@ public:
      * @brief 区间交叉类型
      */
     enum RegionIntersectType {
-        ELeft,              ///< 活动区间在固定区间左侧 例如 [0, 9] 和 [-5, -1]
-        ERight,             ///< 活动区间在固定区间右侧 例如 [0, 9] 和 [10, 15]
+        ELeft,   ///< 活动区间在固定区间左侧 例如 [0, 9] 和 [-5, -1]
+        ERight,  ///< 活动区间在固定区间右侧 例如 [0, 9] 和 [10, 15]
 
-        EIntersectLeft,     ///< 活动区间在固定区间左侧存在范围重叠 例如 [0, 9] 和 [-5, 5]
-        EIntersectRight,    ///< 活动区间在固定区间右侧存在范围重叠 例如 [0, 9] 和 [5, 15]
-        EIntersectOutter,   ///< 活动区间包含固定区间            例如 [0, 9] 和 [-10, 10]
-        EIntersectInner,    ///< 活动区间处于固定区间内部         例如 [0, 9] 和 [5, 6]
+        EIntersectLeft,    ///< 活动区间在固定区间左侧存在范围重叠 例如 [0, 9] 和 [-5, 5]
+        EIntersectRight,   ///< 活动区间在固定区间右侧存在范围重叠 例如 [0, 9] 和 [5, 15]
+        EIntersectOutter,  ///< 活动区间包含固定区间            例如 [0, 9] 和 [-10, 10]
+        EIntersectInner,   ///< 活动区间处于固定区间内部         例如 [0, 9] 和 [5, 6]
     };
 
     /**
@@ -48,6 +52,18 @@ public:
     enum SystemVersion {
         V20,
         V23,
+    };
+
+    // TODO: annother command type
+    enum UndoCommandId {
+        IdDefault = -1,     // default QUndoCommand::id() return
+        IdUnknown = 256,    // sa: QTextUndoCommand::Command::Custom
+        IdInsert,
+        IdDelete,
+
+        IdColumnEdit = 0x1000,  // column edit mark
+        IdColumnEditInsert = IdColumnEdit | IdInsert,
+        IdColumnEditDelete = IdColumnEdit | IdDelete,  // column editing delete command
     };
 
     static QString getQrcPath(const QString &imageName);
@@ -89,25 +105,25 @@ public:
             安全考虑，不要全局使用．仅在个别控件中使用
     *******************************************************************************/
     static void clearChildrenFocus(QObject *objParent);
-    //清除　控件及子控件所以焦点　梁卫东　２０２０－０９－１４　１０：３４：１９
+    // 清除　控件及子控件所以焦点　梁卫东　２０２０－０９－１４　１０：３４：１９
     static void clearChildrenFoucusEx(QWidget *pWidget);
-    //设置所有控件焦点 梁卫东　２０２０－０９－１５　１７：５５：１８
+    // 设置所有控件焦点 梁卫东　２０２０－０９－１５　１７：５５：１８
     static void setChildrenFocus(QWidget *pWidget, Qt::FocusPolicy policy = Qt::StrongFocus);
-    //根据指定名称获取进程数量 秦浩玲　2021-01-26
+    // 根据指定名称获取进程数量 秦浩玲　2021-01-26
     static int getProcessCountByName(const char *pstrName);
-    //批量结束指定名称的进程 秦浩玲　2021-01-26
+    // 批量结束指定名称的进程 秦浩玲　2021-01-26
     static void killProcessByName(const char *pstrName);
-    //计算字符串MD5哈希值 秦浩玲　2021-01-28
+    // 计算字符串MD5哈希值 秦浩玲　2021-01-28
     static QString getStringMD5Hash(const QString &input);
-    //通过dbus接口从任务栏激活窗口 add by guoshaoyu 2021-04-07
+    // 通过dbus接口从任务栏激活窗口 add by guoshaoyu 2021-04-07
     static bool activeWindowFromDock(quintptr winId);
 
-    //判断是否共享文件夹且只读
+    // 判断是否共享文件夹且只读
     static bool isShareDirAndReadOnly(const QString &filePath);
 
     static float codecConfidenceForData(const QTextCodec *codec, const QByteArray &data, const QLocale::Country &country);
 
-    //return system language
+    // return system language
     static QString getSystemLan();
     // 取得系统版本是否为 V23
     static SystemVersion getSystemVersion();
@@ -115,19 +131,20 @@ public:
     static bool isWayland();
     static bool isTreeland();
 
-    // 计算换行内容 text: 原始文本内容， nWidth: 一行最大宽度， font:字体大小, nElideRow: 最大显示行数，超出最大行时，中间内容加···省略号显示
+    // 计算换行内容 text: 原始文本内容， nWidth: 一行最大宽度， font:字体大小, nElideRow:
+    // 最大显示行数，超出最大行时，中间内容加···省略号显示
     static QString lineFeed(const QString &text, int nWidth, const QFont &font, int nElidedRow = 2);
 
     // 判断 [x1, y1] 和 [x2, y2] 区间是否存在交集，返回交集类型
     static RegionIntersectType checkRegionIntersect(int x1, int y1, int x2, int y2);
     // 取得当前文本编辑器支持的编码格式，从文件 :/encodes/encodes.ini 中读取
-    static QVector<QPair<QString,QStringList>> getSupportEncoding();
+    static QVector<QPair<QString, QStringList>> getSupportEncoding();
     static QStringList getSupportEncodingList();
 
     /**
-    * @brief libPath 动态库路径
-    * @param strlib 路径的字符串
-    */
+     * @brief libPath 动态库路径
+     * @param strlib 路径的字符串
+     */
     static QString libPath(const QString &strlib);
 
     // 加载外部定制库，如ZPD定制库的等

--- a/src/editor/deletebackcommond.h
+++ b/src/editor/deletebackcommond.h
@@ -8,30 +8,29 @@
 #include <QTextCursor>
 #include <QTextEdit>
 #include <qplaintextedit.h>
-//向后删除单一文字或选中文字的撤销重做
-class DeleteBackCommand:public QUndoCommand
+// 向后删除单一文字或选中文字的撤销重做
+class DeleteBackCommand : public QUndoCommand
 {
 public:
-    DeleteBackCommand(QTextCursor cursor,QPlainTextEdit* edit);
+    DeleteBackCommand(QTextCursor cursor, QPlainTextEdit *edit);
     virtual ~DeleteBackCommand();
     virtual void undo();
     virtual void redo();
 
 private:
     QTextCursor m_cursor;
-    QString m_delText {QString()};
-    int m_delPos {0};
-    int m_insertPos {0};
+    QString m_delText{QString()};
+    int m_delPos{0};
+    int m_insertPos{0};
 
-    QPlainTextEdit* m_edit;
-
+    QPlainTextEdit *m_edit;
 };
 
-//列模式下向后删除的撤销重做
-class DeleteBackAltCommand:public QUndoCommand
+// 列模式下向后删除的撤销重做
+class DeleteBackAltCommand : public QUndoCommand
 {
 public:
-    DeleteBackAltCommand(QList<QTextEdit::ExtraSelection> &selections,QPlainTextEdit* edit);
+    DeleteBackAltCommand(const QList<QTextEdit::ExtraSelection> &selections, QPlainTextEdit *edit);
     virtual ~DeleteBackAltCommand();
     virtual void undo();
     virtual void redo();
@@ -47,9 +46,9 @@ public:
     };
 
 private:
-    QList<QTextEdit::ExtraSelection>& m_ColumnEditSelections;
+    QList<QTextEdit::ExtraSelection> m_ColumnEditSelections;
     QList<DelNode> m_deletions;
-    QPlainTextEdit* m_edit;
+    QPlainTextEdit *m_edit;
 };
 
-#endif // DELETEBACKCOMMOND_H
+#endif  // DELETEBACKCOMMOND_H

--- a/src/editor/deletebackcommond.h
+++ b/src/editor/deletebackcommond.h
@@ -4,18 +4,22 @@
 
 #ifndef DELETEBACKCOMMOND_H
 #define DELETEBACKCOMMOND_H
+
 #include <QUndoCommand>
 #include <QTextCursor>
 #include <QTextEdit>
 #include <qplaintextedit.h>
-// 向后删除单一文字或选中文字的撤销重做
+
+class TextEdit;
+
+// Delete selected text or charactor (if not selected) backward
 class DeleteBackCommand : public QUndoCommand
 {
 public:
     DeleteBackCommand(QTextCursor cursor, QPlainTextEdit *edit);
-    virtual ~DeleteBackCommand();
-    virtual void undo();
-    virtual void redo();
+    ~DeleteBackCommand() override;
+    void undo() override;
+    void redo() override;
 
 private:
     QTextCursor m_cursor;
@@ -26,29 +30,32 @@ private:
     QPlainTextEdit *m_edit;
 };
 
-// 列模式下向后删除的撤销重做
+// Delete redo / undo on column editing
 class DeleteBackAltCommand : public QUndoCommand
 {
 public:
-    DeleteBackAltCommand(const QList<QTextEdit::ExtraSelection> &selections, QPlainTextEdit *edit);
-    virtual ~DeleteBackAltCommand();
-    virtual void undo();
-    virtual void redo();
+    DeleteBackAltCommand(const QList<QTextEdit::ExtraSelection> &selections, TextEdit *edit, bool backward = false);
+    ~DeleteBackAltCommand() override;
+    void undo() override;
+    void redo() override;
+
+    int id() const override;
 
 public:
     struct DelNode
     {
-        QString m_delText;
-        int m_delPos;
-        int m_insertPos;
-        int m_id_in_Column;
-        QTextCursor m_cursor;
+        QString delText;
+        int delPos;
+        int insertPos;
+        int idInColumn;
+        QTextCursor cursor;
+        bool leftToRight;  // select orientation
     };
 
 private:
-    QList<QTextEdit::ExtraSelection> m_ColumnEditSelections;
+    QList<QTextEdit::ExtraSelection> m_columnEditSelections;
     QList<DelNode> m_deletions;
-    QPlainTextEdit *m_edit;
+    TextEdit *m_edit;
 };
 
 #endif  // DELETEBACKCOMMOND_H

--- a/src/editor/deletetextundocommand.cpp
+++ b/src/editor/deletetextundocommand.cpp
@@ -7,7 +7,9 @@
 #include <QDebug>
 #include <QTextBlock>
 
-DeleteTextUndoCommand::DeleteTextUndoCommand(QTextCursor textcursor, QPlainTextEdit *edit, QUndoCommand *parent)
+#include "dtextedit.h"
+
+DeleteTextUndoCommand::DeleteTextUndoCommand(QTextCursor textcursor, TextEdit *edit, QUndoCommand *parent)
     : QUndoCommand(parent)
     , m_edit(edit)
     , m_textCursor(textcursor)
@@ -27,7 +29,7 @@ DeleteTextUndoCommand::DeleteTextUndoCommand(QTextCursor textcursor, QPlainTextE
 }
 
 DeleteTextUndoCommand::DeleteTextUndoCommand(QList<QTextEdit::ExtraSelection> &selections,
-                                             QPlainTextEdit *edit,
+                                             TextEdit *edit,
                                              QUndoCommand *parent)
     : QUndoCommand(parent)
     , m_edit(edit)
@@ -72,6 +74,7 @@ void DeleteTextUndoCommand::undo()
         }
 
         if (m_edit && !m_ColumnEditSelections.isEmpty()) {
+            m_edit->restoreColumnEditSelection(m_ColumnEditSelections);
             m_edit->setTextCursor(m_ColumnEditSelections.last().cursor);
         }
     }
@@ -93,9 +96,16 @@ void DeleteTextUndoCommand::redo()
         }
 
         if (m_edit && !m_ColumnEditSelections.isEmpty()) {
+            m_edit->restoreColumnEditSelection(m_ColumnEditSelections);
             m_edit->setTextCursor(m_ColumnEditSelections.last().cursor);
         }
     }
+}
+
+int DeleteTextUndoCommand::id() const
+{
+    return m_ColumnEditSelections.isEmpty() ? Utils::IdDelete
+                                            : Utils::IdColumnEditDelete;
 }
 
 DeleteTextUndoCommand2::DeleteTextUndoCommand2(QTextCursor textcursor, QString text, QPlainTextEdit *edit, bool currLine)

--- a/src/editor/deletetextundocommand.h
+++ b/src/editor/deletetextundocommand.h
@@ -11,16 +11,20 @@
 #include <QTextEdit>
 #include <qplaintextedit.h>
 
+class TextEdit;
+
 class DeleteTextUndoCommand : public QUndoCommand
 {
 public:
-    explicit DeleteTextUndoCommand(QTextCursor textcursor, QPlainTextEdit* edit, QUndoCommand *parent = nullptr);
-    explicit DeleteTextUndoCommand(QList<QTextEdit::ExtraSelection> &selections, QPlainTextEdit* edit, QUndoCommand *parent = nullptr);
-    virtual void undo();
-    virtual void redo();
+    explicit DeleteTextUndoCommand(QTextCursor textcursor, TextEdit* edit, QUndoCommand *parent = nullptr);
+    explicit DeleteTextUndoCommand(QList<QTextEdit::ExtraSelection> &selections, TextEdit* edit, QUndoCommand *parent = nullptr);
+    void undo() override;
+    void redo() override;
+
+    int id() const override;
 
 private:
-    QPlainTextEdit* m_edit;
+    TextEdit* m_edit;
     QTextCursor m_textCursor;
     QString m_sInsertText;
     QList<QString> m_selectTextList;

--- a/src/editor/dtextedit.h
+++ b/src/editor/dtextedit.h
@@ -466,6 +466,8 @@ public:
 
     static bool isComment(const QString &text, int index, const QString &commentType);
 
+    void restoreColumnEditSelection(const QList<QTextEdit::ExtraSelection> &selections);
+
 signals:
     void clickFindAction();
     void clickReplaceAction();
@@ -609,6 +611,8 @@ private:
                              Qt::CaseSensitivity caseFlag = Qt::CaseInsensitive) const;
     // 查找行号line起始的折叠区域
     bool findFoldBlock(int line, QTextBlock &beginBlock, QTextBlock &endBlock, QTextBlock &curBlock);
+
+    bool refreshUndoRedoColumnStatus();
 
 private slots:
     // 文档内容变更时触发

--- a/src/editor/inserttextundocommand.h
+++ b/src/editor/inserttextundocommand.h
@@ -11,24 +11,40 @@
 #include <QTextEdit>
 #include <QPlainTextEdit>
 
+class TextEdit;
+
 class InsertTextUndoCommand : public QUndoCommand
 {
 public:
-    explicit InsertTextUndoCommand(const QTextCursor &textcursor, const QString &text, QPlainTextEdit *edit, QUndoCommand *parent = nullptr);
+    explicit InsertTextUndoCommand(const QTextCursor &textcursor,
+                                   const QString &text,
+                                   TextEdit *edit,
+                                   QUndoCommand *parent = nullptr);
     explicit InsertTextUndoCommand(QList<QTextEdit::ExtraSelection> &selections,
                                    const QString &text,
-                                   QPlainTextEdit *edit,
+                                   TextEdit *edit,
                                    QUndoCommand *parent = nullptr);
-    virtual void undo();
-    virtual void redo();
+    void undo() override;
+    void redo() override;
+
+    int id() const override;
 
 private:
-    QPlainTextEdit *m_pEdit = nullptr;
+    struct ColumnReplaceNode
+    {
+        int startPos{false};
+        int endPos{false};
+        bool leftToRight{true};
+        QString originText;  // replaced text before insert.
+    };
+
+    TextEdit *m_pEdit = nullptr;
     QTextCursor m_textCursor;
     int m_beginPostion{0};
     int m_endPostion{0};
     QString m_sInsertText;
-    QList<QTextEdit::ExtraSelection> m_ColumnEditSelections;
+    QList<QTextEdit::ExtraSelection> m_columnEditSelections;
+    QList<ColumnReplaceNode> m_replaces;
     QString m_selectText = QString();
 };
 

--- a/tests/src/editor/ut_deletebackcommond.cpp
+++ b/tests/src/editor/ut_deletebackcommond.cpp
@@ -4,13 +4,10 @@
 
 #include "ut_deletebackcommond.h"
 #include "../src/editor/deletebackcommond.h"
-#include"../../src/widgets/window.h"
+#include "../../src/widgets/window.h"
 #include "qplaintextedit.h"
 #include "qtextcursor.h"
-UT_Deletebackcommond::UT_Deletebackcommond()
-{
-
-}
+UT_Deletebackcommond::UT_Deletebackcommond() {}
 
 TEST(UT_Deletebackcommond_DeleteBackCommand, UT_Deletebackcommond_DeleteBackCommand)
 {
@@ -64,10 +61,7 @@ TEST(UT_Deletebackcommond_undo, UT_Deletebackcommond_undo)
     pWindow->deleteLater();
 }
 
-UT_Deletebackaltcommond::UT_Deletebackaltcommond()
-{
-
-}
+UT_Deletebackaltcommond::UT_Deletebackaltcommond() {}
 
 TEST(UT_Deletebackaltcommond_DeleteBackAltCommand, UT_Deletebackaltcommond_DeleteBackAltCommand)
 {
@@ -81,8 +75,8 @@ TEST(UT_Deletebackaltcommond_DeleteBackAltCommand, UT_Deletebackaltcommond_Delet
     list.push_back(sel);
     list.push_back(sel);
 
-    QPlainTextEdit* edit = new QPlainTextEdit;
-    DeleteBackAltCommand* com = new DeleteBackAltCommand(list, edit);
+    QPlainTextEdit *edit = new QPlainTextEdit;
+    DeleteBackAltCommand *com = new DeleteBackAltCommand(list, edit);
 
     delete com;
     com = nullptr;
@@ -92,48 +86,47 @@ TEST(UT_Deletebackaltcommond_DeleteBackAltCommand, UT_Deletebackaltcommond_Delet
 
 TEST(UT_Deletebackaltcommond_redo, UT_Deletebackaltcommond_redo)
 {
-
-    Window* window = new Window;
+    Window *window = new Window;
     EditWrapper *wrapper = window->createEditor();
-    TextEdit * edit = wrapper->textEditor();
+    TextEdit *edit = wrapper->textEditor();
     QString text = "test";
     QList<QTextEdit::ExtraSelection> list;
     QTextEdit::ExtraSelection sel;
     QTextCursor cursor;
     cursor.insertText(text);
-    cursor.movePosition(QTextCursor::Start,QTextCursor::KeepAnchor);
+    cursor.movePosition(QTextCursor::Start, QTextCursor::KeepAnchor);
     sel.cursor = cursor;
     list.push_back(sel);
     list.push_back(sel);
-    DeleteBackAltCommand * commond = new DeleteBackAltCommand(list,edit);
-    commond->m_deletions = {{"123",1,1,1,cursor}};
+    DeleteBackAltCommand *commond = new DeleteBackAltCommand(list, edit);
+    commond->m_deletions = {{"123", 1, 1, 1, cursor}};
     commond->redo();
 
     window->deleteLater();
     wrapper->deleteLater();
     edit->deleteLater();
 
-    delete commond;commond=nullptr;
+    delete commond;
+    commond = nullptr;
 }
-
 
 TEST(UT_Deletebackaltcommond_undo, UT_Deletebackaltcommond_undo)
 {
-    Window* window = new Window;
+    Window *window = new Window;
     EditWrapper *wrapper = window->createEditor();
-    TextEdit * edit = wrapper->textEditor();
+    TextEdit *edit = wrapper->textEditor();
     QString text = "test";
     QList<QTextEdit::ExtraSelection> list;
     QTextEdit::ExtraSelection sel;
     QTextCursor cursor;
     cursor.insertText(text);
-    cursor.movePosition(QTextCursor::Start,QTextCursor::KeepAnchor);
+    cursor.movePosition(QTextCursor::Start, QTextCursor::KeepAnchor);
     sel.cursor = cursor;
     list.push_back(sel);
     list.push_back(sel);
 
-    DeleteBackAltCommand* com = new DeleteBackAltCommand(list,edit);
-    com->m_deletions = {{"123",1,1,1,cursor}};
+    DeleteBackAltCommand *com = new DeleteBackAltCommand(list, edit);
+    com->m_deletions = {{"123", 1, 1, 1, cursor}};
     com->undo();
 
     window->deleteLater();
@@ -141,5 +134,45 @@ TEST(UT_Deletebackaltcommond_undo, UT_Deletebackaltcommond_undo)
     edit->deleteLater();
     delete com;
     com = nullptr;
+}
 
+TEST(UT_Deletebackaltcommond_MoveCursor, UT_Deletebackaltcommond_MoveCursor)
+{
+    Window *window = new Window;
+    EditWrapper *wrapper = window->createEditor();
+    TextEdit *edit = wrapper->textEditor();
+    QString text = "123456\nabcdef";
+    edit->setPlainText(text);
+
+    QList<QTextEdit::ExtraSelection> list;
+    QTextEdit::ExtraSelection sel;
+    QTextCursor cursor = edit->textCursor();
+    // select the left 3 colums: 123|456
+    //                           abc|def
+    cursor.movePosition(QTextCursor::Start);
+    cursor.movePosition(QTextCursor::NextCharacter, QTextCursor::KeepAnchor, 3);
+    sel.cursor = cursor;
+    list.append(sel);
+
+    cursor.movePosition(QTextCursor::NextBlock);
+    cursor.movePosition(QTextCursor::NextCharacter, QTextCursor::KeepAnchor, 3);
+    sel.cursor = cursor;
+    list.append(sel);
+
+    DeleteBackAltCommand *com = new DeleteBackAltCommand(list, edit);
+    com->redo();
+    EXPECT_EQ(edit->toPlainText(), QString("456\ndef"));
+
+    list.clear();
+    cursor.movePosition(QTextCursor::End);
+    edit->setTextCursor(cursor);
+
+    com->undo();
+    EXPECT_EQ(edit->toPlainText(), text);
+
+    window->deleteLater();
+    wrapper->deleteLater();
+    edit->deleteLater();
+    delete com;
+    com = nullptr;
 }

--- a/tests/src/editor/ut_deletetextundocommand.cpp
+++ b/tests/src/editor/ut_deletetextundocommand.cpp
@@ -92,8 +92,8 @@ TEST(UT_Deletetextundocommond_undo, UT_Deletetextundocommond_undo)
 
 TEST(UT_Deletetextundocommond_undo, undo_withTextCursor_restoreCursor)
 {
-    // 撤销后恢复光标位置
-    QPlainTextEdit *edit = new QPlainTextEdit;
+    // Revert the cursor position after undo
+    TextEdit *edit = new TextEdit;
     edit->setPlainText("123456789");
 
     QTextCursor cursor = edit->textCursor();
@@ -156,8 +156,8 @@ TEST(UT_Deletetextundocommond_redo, UT_Deletetextundocommond_redo)
 
 TEST(UT_Deletetextundocommond_rddo, redo_withTextCursor_changeCursor)
 {
-    // 重做后恢复光标位置
-    QPlainTextEdit *edit = new QPlainTextEdit;
+    // Restore the cursor position after redo
+    TextEdit *edit = new TextEdit;
     edit->setPlainText("123456789");
 
     QTextCursor cursor = edit->textCursor();

--- a/tests/src/editor/ut_inserttextundocommand.cpp
+++ b/tests/src/editor/ut_inserttextundocommand.cpp
@@ -4,6 +4,8 @@
 
 #include "ut_inserttextundocommand.h"
 #include "../../src/editor/inserttextundocommand.h"
+#include "../../src/editor/dtextedit.h"
+#include "../../src/widgets/window.h"
 
 test_InsertTextUndoCommand::test_InsertTextUndoCommand()
 {
@@ -82,7 +84,9 @@ TEST_F(test_InsertTextUndoCommand, redo2)
 TEST_F(test_InsertTextUndoCommand, redo_withTextCursor_restoreCursor)
 {
     // 重做恢复光标位置
-    QPlainTextEdit *edit = new QPlainTextEdit;
+    Window *window = new Window;
+    EditWrapper *wrapper = window->createEditor();
+    TextEdit *edit = wrapper->textEditor();
     edit->setPlainText("123789");
 
     QTextCursor cursor = edit->textCursor();
@@ -108,15 +112,19 @@ TEST_F(test_InsertTextUndoCommand, redo_withTextCursor_restoreCursor)
     EXPECT_EQ(QString("123456789"), edit->toPlainText());
     EXPECT_EQ(6, edit->textCursor().position());
 
+    window->deleteLater();
+    wrapper->deleteLater();
+    edit->deleteLater();
     delete command;
     delete command2;
-    delete edit;
 }
 
 TEST_F(test_InsertTextUndoCommand, undo_withTextCursor_restoreCursor)
 {
     // 撤销后恢复光标位置
-    QPlainTextEdit *edit = new QPlainTextEdit;
+    Window *window = new Window;
+    EditWrapper *wrapper = window->createEditor();
+    TextEdit *edit = wrapper->textEditor();
     edit->setPlainText("123456789");
 
     QTextCursor cursor = edit->textCursor();
@@ -137,7 +145,6 @@ TEST_F(test_InsertTextUndoCommand, undo_withTextCursor_restoreCursor)
     selection.format.setProperty(QTextFormat::FullWidthSelection, true);
     selection.cursor = edit->textCursor();
     selection.cursor.setPosition(3);
-    selection.cursor.movePosition(QTextCursor::NextCharacter, QTextCursor::KeepAnchor, 3);
     extraSelections.append(selection);
     InsertTextUndoCommand *command2 = new InsertTextUndoCommand(extraSelections, QString("456"), edit);
     command2->undo();
@@ -145,9 +152,11 @@ TEST_F(test_InsertTextUndoCommand, undo_withTextCursor_restoreCursor)
     EXPECT_EQ(QString("123789"), edit->toPlainText());
     EXPECT_EQ(3, edit->textCursor().position());
 
+    window->deleteLater();
+    wrapper->deleteLater();
+    edit->deleteLater();
     delete command;
     delete command2;
-    delete edit;
 }
 
 TEST(test_MidButtonInsertTextUndoCommand, redo_withTextCursor_restoreCursor)

--- a/tests/src/editor/ut_textedit.cpp
+++ b/tests/src/editor/ut_textedit.cpp
@@ -9753,7 +9753,7 @@ TEST(UT_Textedit_onAppPaletteChanged, OnAppPaletteChanged_ChangeBackground_Pass)
     edit->m_wrapper = wra;
 
     Stub s;
-    s.set(ADDR(DGuiApplicationHelper, applicationPalette), stubApplicationPalette);
+    s.set((DPalette(DGuiApplicationHelper::*)() const)(&DGuiApplicationHelper::applicationPalette), stubApplicationPalette);
 
     QTextEdit::ExtraSelection selection;
     selection.format.setBackground(QBrush(Qt::white));


### PR DESCRIPTION
[fix: crash when undoing column edit](https://github.com/linuxdeepin/deepin-editor/commit/bef96515048d757f2596d84f3dd7f6b60c76a589) 

Delete command stores temporary reference variable,
which will be empty when changing cursor.
Change storage variable type to store data persistently.

Log: Fix crash when undoing column edit
Bug: https://pms.uniontech.com/bug-view-273663.html
Influence: column-editing

[fix: restore column selection after undo](https://github.com/linuxdeepin/deepin-editor/commit/09b8dc3de7ec54c0e284b2faac05aacc637785a9) 

As title.
update backward / forward delete;
update unit test.

Log: Restore column selection after undo.
Bug: https://pms.uniontech.com/bug-view-273663.html
Influence: column-editing

[fix: cursor pos wrong after column insertion.](https://github.com/linuxdeepin/deepin-editor/commit/9e9265af5cd5c1429d8c7bd8980f8ee9f3257d15) 

As title.

Log: Fix column insert text.