### PR TITLE
fix: can not paste after undo

### DIFF
--- a/src/editor/inserttextundocommand.cpp
+++ b/src/editor/inserttextundocommand.cpp
@@ -141,7 +141,7 @@ void InsertTextUndoCommand::redo()
 
 int InsertTextUndoCommand::id() const
 {
-    return m_columnEditSelections.isEmpty() ? Utils::IdColumnEditInsert : Utils::IdInsert;
+    return m_columnEditSelections.isEmpty() ? Utils::IdInsert : Utils::IdColumnEditInsert;
 }
 
 /**


### PR DESCRIPTION
The `alt` column flag return incorrect,
paste empty text.

Log: Fix can not paste after undo
Bug: https://pms.uniontech.com/bug-view-287523.html
Influence: undo-stack