### PR TITLE
fix: floating message cannot be closed

### DIFF
--- a/src/controls/warningnotices.cpp
+++ b/src/controls/warningnotices.cpp
@@ -42,6 +42,13 @@ WarningNotices::WarningNotices(MessageType notifyType, QWidget *parent)
         this->setFont(font);
     });
 #endif
+
+    // TODO: wait dtkwidget fixed, see dtkwidget PR-628
+    connect(this, &DFloatingMessage::closeButtonClicked, this, [this]() {
+        if (this->isVisible()) {
+            this->close();
+        }
+    });
 }
 
 WarningNotices::~WarningNotices() {}


### PR DESCRIPTION
See https://github.com/linuxdeepin/dtkwidget/pull/628 The DFloatingMessage not trigger close() now,
wait for DtkWidget integration.

Log: Toast cannot be closed.
Bug: https://pms.uniontech.com/bug-view-297669.html