### PR TITLE
fix: can not open crt file

### DIFF
--- a/src/common/utils.cpp
+++ b/src/common/utils.cpp
@@ -582,7 +582,9 @@ bool Utils::isMimeTypeSupport(const QString &filepath)
                   << "application/x-pak"
                   << "application/x-code-workspace"
                   << "application/toml"
-                  << "audio/x-mod";
+                  << "audio/x-mod"
+                  << "application/pkix-attr-cert"
+                  << "application/x-x509-ca-cert";
 
     if (textMimeTypes.contains(mimeType)) {
         return true;


### PR DESCRIPTION
Add support cert file mime type.

Log: Add support cert file mime type.
Bug: https://pms.uniontech.com/bug-view-297967.html