### PR TITLE
fix: enable mark on read-only mode

### DIFF
--- a/src/editor/dtextedit.cpp
+++ b/src/editor/dtextedit.cpp
@@ -6942,6 +6942,9 @@ void TextEdit::keyPressEvent(QKeyEvent *e)
         } else if (key == "Shift+:") {
             copyLines();
             return;
+        } else if (key == Utils::getKeyshortcutFromKeymap(m_settings, "editor", "mark")) {
+            toggleMarkSelections();
+            return;
         } else if ((key == Utils::getKeyshortcutFromKeymap(m_settings, "editor", "togglereadonlymode")/* || key=="Alt+Meta+L"*/)
                    && m_bReadOnlyPermission == false) {
 //            setReadOnly(false);


### PR DESCRIPTION
As title.

Log: enable mark on read-only mode.
Bug: https://pms.uniontech.com/bug-view-297981.htm!