### PR TITLE
fix: text color not change with theme change

### DIFF
--- a/src/controls/tabbar.cpp
+++ b/src/controls/tabbar.cpp
@@ -338,11 +338,17 @@ void Tabbar::setTabText(int index, const QString &text)
 
 void Tabbar::setTabPalette(const QString &activeColor, const QString &highlightColor)
 {
+    // Not recommend manually setPalette()
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    Q_UNUSED(activeColor)
+    Q_UNUSED(highlightColor)
+#else
     QPalette pa = this->palette();
     pa.setColor(QPalette::Inactive, QPalette::HighlightedText, QColor(highlightColor));
     pa.setColor(QPalette::Inactive, QPalette::WindowText, QColor(activeColor));
     pa.setColor(QPalette::Active, QPalette::WindowText, QColor(activeColor));
     setPalette(pa);
+#endif
 }
 
 void Tabbar::setBackground(const QString &startColor, const QString &endColor)

--- a/src/editor/dtextedit.cpp
+++ b/src/editor/dtextedit.cpp
@@ -4655,10 +4655,16 @@ void TextEdit::tellFindBarClose()
 
 void TextEdit::setEditPalette(const QString &activeColor, const QString &inactiveColor)
 {
+    // Not recommend manually setPalette()
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    Q_UNUSED(activeColor)
+    Q_UNUSED(inactiveColor)
+#else
     QPalette pa = this->palette();
     pa.setColor(QPalette::Inactive, QPalette::Text, QColor(inactiveColor));
     pa.setColor(QPalette::Active, QPalette::Text, QColor(activeColor));
     setPalette(pa);
+#endif
 }
 
 void TextEdit::setCodeFoldWidgetHide(bool isHidden)

--- a/src/widgets/ddropdownmenu.cpp
+++ b/src/widgets/ddropdownmenu.cpp
@@ -178,8 +178,14 @@ void DDropdownMenu::slotRequestMenu(bool request)
     m_menu->exec();
     //清除ｆｏｃｕｓ
     m_pToolButton->clearFocus();
+
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    QHoverEvent event(QEvent::HoverLeave, center, center, center);
+    QApplication::sendEvent(m_pToolButton, &event);
+#else
     QEvent event(QEvent::HoverLeave);
     QApplication::sendEvent(m_pToolButton, &event);
+#endif
     emit sigSetTextEditFocus();
 }
 

--- a/src/widgets/window.cpp
+++ b/src/widgets/window.cpp
@@ -2919,6 +2919,7 @@ void Window::loadTheme(const QString &path)
 {
     QFileInfo fileInfo(path);
     if (!fileInfo.exists()) {
+        qWarning() << "Theme file not exists!" << path;
         return;
     }
 


### PR DESCRIPTION
[fix: text color not change with theme change](https://github.com/linuxdeepin/deepin-editor/commit/e8c71e32e1af129d4bb9b15f7ae76bc549b98d41) 

Manual setPalette() is not recommended for DTK under Qt6.
Disable setPalette(), updated automatically.

Log: fix a theme color issue.
Bug: https://pms.uniontech.com/bug-view-305473.html

[fix: crash on hover leave statusbar menu](https://github.com/linuxdeepin/deepin-editor/commit/60e146ddc382baecdbd3c74713eda61ef9e1187a) 

In Qt6, ensure proper matching between
QEvent types and QEvent instances.

Log: fix a crash issue.