### PR TITLE
chore: Bump version to 6.5.19

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.editor
   name: "deepin-editor"
-  version: 6.5.18.1
+  version: 6.5.19.1
   kind: app
   description: |
     editor for deepin os.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+deepin-editor (6.5.19) unstable; urgency=medium
+
+  * fix: use canonical file path(Bug: 297679)
+  * refactor: remove DFrameworkdbus dependency and update Qt path handling
+  * refactor: remove DFrameworkdbus dependency and update Qt path handling
+
+ -- renbin <renbin@uniontech.com>  Thu, 27 Mar 2025 13:27:24 +0800
+
 deepin-editor (6.5.18) unstable; urgency=medium
 
   * Update version to 6.5.18

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.editor
   name: "deepin-editor"
-  version: 6.5.18.1
+  version: 6.5.19.1
   kind: app
   description: |
     editor for deepin os.

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -10,7 +10,7 @@ version: "1"
 package:
   id: org.deepin.editor
   name: "deepin-editor"
-  version: 6.5.18.1
+  version: 6.5.19.1
   kind: app
   description: |
     editor for deepin os.


### PR DESCRIPTION
Bump version to 6.5.19

Log: Bump version to 6.5.19

## Summary by Sourcery

Chores:
- Update version number in linglong.yaml configuration files for arm64, loong64, and main package configurations