### PR TITLE
chore: Bump version to 6.5.20

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.editor
   name: "deepin-editor"
-  version: 6.5.19.1
+  version: 6.5.20.1
   kind: app
   description: |
     editor for deepin os.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-editor (6.5.20) unstable; urgency=medium
+
+  * fix: update lrelease path in translation generation
+
+ -- renbin <renbin@uniontech.com>  Fri, 28 Mar 2025 10:02:21 +0800
+
 deepin-editor (6.5.19) unstable; urgency=medium
 
   * fix: use canonical file path(Bug: 297679)

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.editor
   name: "deepin-editor"
-  version: 6.5.19.1
+  version: 6.5.20.1
   kind: app
   description: |
     editor for deepin os.

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -10,7 +10,7 @@ version: "1"
 package:
   id: org.deepin.editor
   name: "deepin-editor"
-  version: 6.5.19.1
+  version: 6.5.20.1
   kind: app
   description: |
     editor for deepin os.


### PR DESCRIPTION
Bump version to 6.5.20

Log: Bump version to 6.5.20

## Summary by Sourcery

Chores:
- Update version number in linglong.yaml configuration files for arm64, loong64, and main package configurations