### PR TITLE
chore: Bump version to 6.5.21

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.editor
   name: "deepin-editor"
-  version: 6.5.20.1
+  version: 6.5.21.1
   kind: app
   description: |
     editor for deepin os.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+deepin-editor (6.5.21) unstable; urgency=medium
+
+  * chore: update desktop file
+  * fix: build with icu 75+ ICU 75+ requires C++17 to build.
+  * Fix configuration for Packit 1.0.0
+
+ -- renbin <renbin@uniontech.com>  Wed, 02 Apr 2025 15:53:16 +0800
+
 deepin-editor (6.5.20) unstable; urgency=medium
 
   * fix: update lrelease path in translation generation

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.editor
   name: "deepin-editor"
-  version: 6.5.20.1
+  version: 6.5.21.1
   kind: app
   description: |
     editor for deepin os.

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -10,7 +10,7 @@ version: "1"
 package:
   id: org.deepin.editor
   name: "deepin-editor"
-  version: 6.5.20.1
+  version: 6.5.21.1
   kind: app
   description: |
     editor for deepin os.


### PR DESCRIPTION
Bump version to 6.5.21

Log: Bump version to 6.5.21

## Summary by Sourcery

Chores:
- Update version number in linglong.yaml configuration files for arm64, loong64, and main package configuration