### PR TITLE
fix: Disable AI features on MIPS

### DIFF
--- a/src/editor/dtextedit.cpp
+++ b/src/editor/dtextedit.cpp
@@ -520,6 +520,11 @@ void TextEdit::popRightMenu(QPoint pos)
         m_rightMenu->addAction(m_fullscreenAction);
     }
 
+    // Block ai actions on mips by default.
+#ifdef __mips__
+    if (IflytekAiAssistant::instance()->valid()) {
+#endif // __mips__
+
     // 'UOS AI' actions
     m_rightMenu->addAction(m_voiceReadingAction);
     m_voiceReadingAction->setEnabled((textCursor().hasSelection() || m_hasColumnSelection));
@@ -532,6 +537,10 @@ void TextEdit::popRightMenu(QPoint pos)
     m_rightMenu->addAction(m_translateAction);
     m_translateAction->setEnabled((textCursor().hasSelection() || m_hasColumnSelection));
 #endif
+
+#ifdef __mips__
+    }
+#endif  // __mips__
 
     if (!this->document()->isEmpty()) {
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,14 +15,12 @@
 #include <DMainWindow>
 #include <DWidgetUtil>
 #include <DLog>
-// #include <DApplicationSettings>
 #include <DSettingsOption>
 
 #include <QApplication>
 #include <QCommandLineParser>
 #include <QDBusConnection>
 #include <QDBusInterface>
-// #include <QDesktopWidget>
 #include <QScreen>
 #include <QDebug>
 
@@ -39,7 +37,6 @@ int main(int argc, char *argv[])
     }
 
     QCoreApplication::setAttribute(Qt::AA_UseOpenGLES);
-    // QGuiApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
 
     EditorApplication app(argc, argv);
     // save theme


### PR DESCRIPTION
- Block AI on MIPS via #ifndef
- Remove unused code in main.cpp

Log: Disabled AI on MIPS
Bug: https://pms.uniontech.com/bug-view-309189.html

## Summary by Sourcery

Disable AI features on MIPS architecture by conditionally blocking AI-related actions and removing unused code

Bug Fixes:
- Prevent AI features from being accessible on MIPS platforms

Enhancements:
- Conditionally compile out AI-related code for MIPS architecture

Chores:
- Remove commented-out and unused import statements in main.cpp