### PR TITLE
chore: Bump version to 6.5.22

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.editor
   name: "deepin-editor"
-  version: 6.5.21.1
+  version: 6.5.22.1
   kind: app
   description: |
     editor for deepin os.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-editor (6.5.22) unstable; urgency=medium
+
+  * fix: Disable AI features on MIPS(Bug: 309189)
+
+ -- renbin <renbin@uniontech.com>  Thu, 10 Apr 2025 19:17:12 +0800
+
 deepin-editor (6.5.21) unstable; urgency=medium
 
   * chore: update desktop file

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.editor
   name: "deepin-editor"
-  version: 6.5.21.1
+  version: 6.5.22.1
   kind: app
   description: |
     editor for deepin os.

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -10,7 +10,7 @@ version: "1"
 package:
   id: org.deepin.editor
   name: "deepin-editor"
-  version: 6.5.21.1
+  version: 6.5.22.1
   kind: app
   description: |
     editor for deepin os.


### PR DESCRIPTION
Bump version to 6.5.22

Log: Bump version to 6.5.22

## Summary by Sourcery

Chores:
- Update version number in linglong.yaml configuration files for arm64, loong64, and main package configurations