### PR TITLE
fix: improve MIME type detection and add man page support

### DIFF
--- a/src/common/utils.cpp
+++ b/src/common/utils.cpp
@@ -525,7 +525,7 @@ QVariantMap Utils::getThemeMapFromPath(const QString &filepath)
 
 bool Utils::isMimeTypeSupport(const QString &filepath)
 {
-    QString mimeType = QMimeDatabase().mimeTypeForFile(filepath).name();
+    QString mimeType = QMimeDatabase().mimeTypeForFile(filepath, QMimeDatabase::MatchMode::MatchContent).name();
 
     if (mimeType.startsWith("text/")) {
         return true;


### PR DESCRIPTION
Change MIME type detection to use content-based matching for more accurate file type recognition
Add application/x-troff-man MIME type to supported file types list

This improves file type detection accuracy by examining file contents
rather than relying solely on file extensions.

Log: improve MIME type detection and add man page support
Bug: https://pms.uniontech.com//bug-view-314393.html
