### PR TITLE
chore: Bump version to 6.5.24

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.editor
   name: "deepin-editor"
-  version: 6.5.23.1
+  version: 6.5.24.1
   kind: app
   description: |
     editor for deepin os.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+deepin-editor (6.5.24) unstable; urgency=medium
+
+  * fix: Refactor file saving with TextFileSaver and add safety checks
+  * fix: Refactor file saving with memory validation
+  * fix: capture bad_alloc(Bug: 311693)
+
+ -- renbin <renbin@uniontech.com>  Thu, 24 Apr 2025 17:14:55 +0800
+
 deepin-editor (6.5.23) unstable; urgency=medium
 
   * Fix: Add Qt6 support while maintaining Qt5 compatibility

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.editor
   name: "deepin-editor"
-  version: 6.5.23.1
+  version: 6.5.24.1
   kind: app
   description: |
     editor for deepin os.

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -10,7 +10,7 @@ version: "1"
 package:
   id: org.deepin.editor
   name: "deepin-editor"
-  version: 6.5.23.1
+  version: 6.5.24.1
   kind: app
   description: |
     editor for deepin os.


### PR DESCRIPTION
Bump version to 6.5.24

Log: Bump version to 6.5.24

## Summary by Sourcery

Chores:
- Update version number in linglong.yaml configuration files for arm64, loong64, and main package configurations