### PR TITLE
chore: Bump version to 6.5.25

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.editor
   name: "deepin-editor"
-  version: 6.5.24.1
+  version: 6.5.25.1
   kind: app
   description: |
     editor for deepin os.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-editor (6.5.25) unstable; urgency=medium
+
+  * Update version to 6.5.25
+
+ -- dengzhongyuan <dengzhongyuan@uniontech.com>  Wed, 14 May 2025 11:10:19 +0800
+
 deepin-editor (6.5.24) unstable; urgency=medium
 
   * fix: Refactor file saving with TextFileSaver and add safety checks

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.editor
   name: "deepin-editor"
-  version: 6.5.24.1
+  version: 6.5.25.1
   kind: app
   description: |
     editor for deepin os.

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -10,7 +10,7 @@ version: "1"
 package:
   id: org.deepin.editor
   name: "deepin-editor"
-  version: 6.5.24.1
+  version: 6.5.25.1
   kind: app
   description: |
     editor for deepin os.


### PR DESCRIPTION
Update version to 6.5.25

Log: Bump version to 6.5.25

## Summary by Sourcery

Chores:
- Update package version to 6.5.25.1 in arm64, loong64, and root packaging YAML files and debian changelog