### PR TITLE
fix:(src/common)simplify Iflytek Aiassistant service check

### DIFF
--- a/src/common/iflytekaiassistantthread.cpp
+++ b/src/common/iflytekaiassistantthread.cpp
@@ -16,19 +16,19 @@ IflytekAiassistantThread::~IflytekAiassistantThread() {}
 void IflytekAiassistantThread::run()
 {
     QDBusConnection connection = QDBusConnection::sessionBus();
-    QDBusConnectionInterface *bus = connection.interface();
-    bool bIsRegistUosAiAssistant = bus->isServiceRegistered("com.iflytek.aiassistant");
-    if (!bIsRegistUosAiAssistant) {
-        qInfo() << "com.iflytek.aiassistant service no registered, try get introspect.";
+    bool bIsRegistUosAiAssistant = false;
 
-        QDBusInterface introspect("com.iflytek.aiassistant", "/aiassistant/deepinmain", "org.freedesktop.DBus.Introspectable");
-        QDBusReply<QString> version = introspect.call("Introspect");
-        if (version.isValid()) {
-            bIsRegistUosAiAssistant = true;
-            qInfo() << "com.iflytek.aiassistant Introspect success.";
-        } else {
-            qInfo() << "com.iflytek.aiassistant Introspect also failed. " << version.error().message();
-        }
+    // 直接尝试调用 DBus 接口
+    QDBusInterface aiInterface("com.iflytek.aiassistant",
+                             "/aiassistant/deepinmain",
+                             "org.freedesktop.DBus.Introspectable");
+
+    QDBusReply<QString> reply = aiInterface.call("Introspect");
+    if (reply.isValid()) {
+        bIsRegistUosAiAssistant = true;
+        qInfo() << "com.iflytek.aiassistant service is available.";
+    } else {
+        qInfo() << "Failed to connect to com.iflytek.aiassistant: " << reply.error().message();
     }
 
     emit sigIsRegisteredIflytekAiassistant(bIsRegistUosAiAssistant);


### PR DESCRIPTION
- Directly attempt to call the DBus interface to check service availability

Log: (src/common)simplify Iflytek Aiassistant service check
Bug: https://pms.uniontech.com//bug-view-316423.html

## Summary by Sourcery

Simplify Iflytek Aiassistant DBus service availability check by replacing the two-step registration logic with a single direct Introspect call

Enhancements:
- Replace isServiceRegistered check and fallback introspection with a single QDBusInterface::Introspect call to detect service availability
- Update logging to report Introspect success or failure directly