### PR TITLE
fix: add the toast info for audio device disabled

### DIFF
--- a/src/editor/dtextedit.h
+++ b/src/editor/dtextedit.h
@@ -529,6 +529,13 @@ public slots:
     void slotVoiceReadingAction(bool checked = false);
     bool slotStopReadingAction(bool checked = false);
     void slotdictationAction(bool checked = false);
+    
+    // 音频设备检测方法
+    bool checkAudioOutputDevice();
+    bool checkAudioInputDevice();
+    
+    // 音频设备状态监听槽函数
+    void onAudioPortEnabledChanged(quint32 cardId, const QString &portName, bool enabled);
     void slotColumnEditAction(bool checked = false);
     void slotPreBookMarkAction(bool checked = false);
     void slotNextBookMarkAction(bool checked = false);

--- a/translations/deepin-editor_zh_CN.ts
+++ b/translations/deepin-editor_zh_CN.ts
@@ -1005,6 +1005,28 @@
         <translation>语音听写</translation>
     </message>
     <message>
+        <location filename="../src/editor/dtextedit.cpp" line="2814"/>
+        <location filename="../src/editor/dtextedit.cpp" line="2816"/>
+        <source>No audio output device was detected. Please ensure your speakers or headphones are properly connected and try again.</source>
+        <translation>未检测到音频输出设备，请检查后重试</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="2838"/>
+        <location filename="../src/editor/dtextedit.cpp" line="2840"/>
+        <source>No audio input device was detected. Please ensure your speakers or headphones are properly connected and try again.</source>
+        <translation>未检测到音频输入设备，请检查后重试</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="2826"/>
+        <location filename="../src/editor/dtextedit.cpp" line="2828"/>
+        <location filename="../src/editor/dtextedit.cpp" line="2852"/>
+        <location filename="../src/editor/dtextedit.cpp" line="2854"/>
+        <location filename="../src/editor/dtextedit.cpp" line="2868"/>
+        <location filename="../src/editor/dtextedit.cpp" line="2870"/>
+        <source>Please install UOS AI from the app store first.</source>
+        <translation>请前往应用商店安装“UOS AI”后再使用</translation>
+    </message>
+    <message>
         <location filename="../src/editor/dtextedit.cpp" line="292"/>
         <source>Translate</source>
         <translation>文本翻译</translation>


### PR DESCRIPTION
add the toast info for audio device disabled

Log: add the toast info for audio device disabled
Task: https://pms.uniontech.com/task-view-378245.html

## Summary by Sourcery

Add real-time audio device checks and toast notifications to inform users when audio input/output devices are missing or disabled, and block AI assistant actions accordingly

New Features:
- Display toast warnings when audio output or input devices are not detected or become disabled
- Subscribe to D-Bus Audio daemon PortEnabledChanged signals to update device status in real time

Enhancements:
- Add checkAudioOutputDevice and checkAudioInputDevice helper methods
- Prevent AI assistant actions (voice reading, dictation) when audio devices are unavailable or AI app is not installed
- Refine context menu action enabling logic and error message handling

Documentation:
- Add Chinese translations for the new audio device warning and AI installation messages