### PR TITLE
chore: Update package URLs and digests in linglong.yaml files

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.editor
   name: "deepin-editor"
-  version: 6.5.29.1
+  version: 6.5.30.1
   kind: app
   description: |
     editor for deepin os.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-editor (6.5.30) unstable; urgency=medium
+
+  * chore: Update package URLs and digests in linglong.yaml files
+
+ -- dengzhongyuan <dengzhongyuan@uniontech.com>  Thu, 10 Jul 2025 17:09:16 +0800
+
 deepin-editor (6.5.29) unstable; urgency=medium
 
   * chore: Update deepin-manual resources

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.editor
   name: "deepin-editor"
-  version: 6.5.29.1
+  version: 6.5.30.1
   kind: app
   description: |
     editor for deepin os.

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -10,7 +10,7 @@ version: "1"
 package:
   id: org.deepin.editor
   name: "deepin-editor"
-  version: 6.5.29.1
+  version: 6.5.30.1
   kind: app
   description: |
     editor for deepin os.


### PR DESCRIPTION
chore: Update package URLs and digests in linglong.yaml files

- Updated coreutils and cryfs package URLs and digests across all architectures.

log: Update package URLs and digests in linglong.yaml files

## Summary by Sourcery

Update package definitions in linglong.yaml across architectures to bump Deepin Editor version, refresh source URLs and checksums, and include new dependency entries.

Enhancements:
- Bump org.deepin.editor version to 6.5.30.1 in all linglong.yaml files
- Refresh source package URLs and digests to reference deepin4 builds and newer upstream releases
- Add new file entries for additional dependencies (libcurl3-gnutls, nghttp2/nghttp3/ngtcp2, rtmpdump, libsasl2, openldap, libssh2)