### PR TITLE
   fix: Remove return statement in recoverFile function

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.editor
   name: "deepin-editor"
-  version: 6.5.30.1
+  version: 6.5.31.1
   kind: app
   description: |
     editor for deepin os.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-editor (6.5.31) unstable; urgency=medium
+
+  * fix: Remove return statement in recoverFile function
+
+ -- dengzhongyuan <dengzhongyuan@uniontech.com>  Wed, 16 Jul 2025 11:32:50 +0800
+
 deepin-editor (6.5.30) unstable; urgency=medium
 
   * chore: Update package URLs and digests in linglong.yaml files

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.editor
   name: "deepin-editor"
-  version: 6.5.30.1
+  version: 6.5.31.1
   kind: app
   description: |
     editor for deepin os.

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -10,7 +10,7 @@ version: "1"
 package:
   id: org.deepin.editor
   name: "deepin-editor"
-  version: 6.5.30.1
+  version: 6.5.31.1
   kind: app
   description: |
     editor for deepin os.

--- a/src/startmanager.cpp
+++ b/src/startmanager.cpp
@@ -449,7 +449,6 @@ int StartManager::recoverFile(Window *window)
                 }
                 qInfo() << "Recovered files count:" << recFilesSum;
                 qDebug() << "Exit recoverFile";
-                return recFilesSum;
             }
         }
     }


### PR DESCRIPTION
   fix: Remove return statement in recoverFile function
    
    - Removed the return statement for recovered files count in StartManager::recoverFile to prevent unintended behavior.
    
    log: Remove return statement in recoverFile function
    
    bug：https://pms.uniontech.com/bug-view-324727.html
