### PR TITLE
    fix: Update file path handling in saveAsFileToDisk function

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.editor
   name: "deepin-editor"
-  version: 6.5.31.1
+  version: 6.5.32.1
   kind: app
   description: |
     editor for deepin os.
@@ -45,1160 +45,1160 @@ build: |
   bash ./deploy_dep "${LDD_FILES[@]}"
 
 sources:
-  # linglong:gen_deb_source sources arm64 http://10.20.64.92:8080/testing25_daily stable main
+  # linglong:gen_deb_source sources arm64 http://10.20.64.92:8080/crimson_25.0 stable main
   # linglong:gen_deb_source install qt6-5compat-dev, qt6-base-dev, qt6-tools-dev-tools, qt6-tools-dev, qt6-base-private-dev, qt6-svg-dev, libdtk6widget-dev, libdtk6gui-dev, libdtk6core-dev, libdtk6declarative-dev, libpolkit-qt6-1-dev, libkf6syntaxhighlighting-dev, libkf6codecs-dev, libgtest-dev, libgmock-dev, libchardet-dev, libuchardet-dev, libicu-dev, deepin-event-log
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/assistant-qt6_6.8.0-0deepin3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-tools/assistant-qt6_6.8.0-0deepin3_arm64.deb
     digest: db24bc67c73659376f0a1eae6d7c536aaa53eb75790e6bf51916a0cb2a630fbd
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/b/binutils/binutils-aarch64-linux-gnu_2.41-6deepin7_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/b/binutils/binutils-aarch64-linux-gnu_2.41-6deepin7_arm64.deb
     digest: 6d594af95ee6ae34a14f687a619b97684e7e136ec2551a36157a456f1b718577
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/b/binutils/binutils-common_2.41-6deepin7_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/b/binutils/binutils-common_2.41-6deepin7_arm64.deb
     digest: 29236b493e68174e0f83488bb022fc38af4e865bcbd88967cecd90cbf13138e9
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/b/binutils/binutils_2.41-6deepin7_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/b/binutils/binutils_2.41-6deepin7_arm64.deb
     digest: 15363c40bc3eab055b05020a334149c727b0801eab7119ee689c4be62f8b4cda
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/b/bzip2/bzip2_1.0.8-deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/b/bzip2/bzip2_1.0.8-deepin1_arm64.deb
     digest: 5fc6a22a0ad720a1b8fc7f8ef83ddfbb0c59bfa43ad383c7052cf2adf9f3d0d7
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/debconf/debconf_1.5.79-deepin_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/debconf/debconf_1.5.79-deepin_all.deb
     digest: ded6aaa7927ae27337ceb23d49391b4c7ec460a00ba692020e8f4e28388f345f
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/deepin-event-log/deepin-event-log-daemon_2.1.2-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/deepin-event-log/deepin-event-log-daemon_2.1.2-1_arm64.deb
     digest: 06922785a98f97eb174d2f0c283bf757fc79fa0baef7a7e52c34abfc031e9d5e
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/deepin-event-log/deepin-event-log_2.1.2-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/deepin-event-log/deepin-event-log_2.1.2-1_arm64.deb
     digest: 9478253b373d2d0941240de667c80a3df544dc13fce57aec0885f655682530de
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/designer-qt6_6.8.0-0deepin3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-tools/designer-qt6_6.8.0-0deepin3_arm64.deb
     digest: 11a42f07b2feefb7669441c3a67176cc32dc857c7d21b3290c464795fc514448
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dpkg/dpkg-dev_1.22.6deepin4_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/dpkg/dpkg-dev_1.22.6deepin4_all.deb
     digest: 8b3ec535c58fd4041effcff798c688ab1f4a36b6c2ac5989412020686c7607f7
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dpkg/dpkg_1.22.6deepin4_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/dpkg/dpkg_1.22.6deepin4_arm64.deb
     digest: 395526d8605c5a34c3bea89d6c32781d3a5625eae82b77f598835c09524f51cb
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fontconfig/fontconfig-config_2.15.0-2.3deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/fontconfig/fontconfig-config_2.15.0-2.3deepin1_arm64.deb
     digest: bedadcad1a6b77ae2842cb308003cfae181d382ee416ccbd9c35e309f1991d19
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fontconfig/fontconfig_2.15.0-2.3deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/fontconfig/fontconfig_2.15.0-2.3deepin1_arm64.deb
     digest: 6d7e0dca9ca1599c9950826e6c25918a3b30e7a37222ef980ae64fff2db42535
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fonts-noto/fonts-croscore_20201225-deepin_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/fonts-noto/fonts-croscore_20201225-deepin_all.deb
     digest: afbaf120869a08aa7dd14da9ad014de48a751aa4330534b531410bb86c411b55
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fonts-dejavu/fonts-dejavu-core_2.37-deepin_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/fonts-dejavu/fonts-dejavu-core_2.37-deepin_all.deb
     digest: 5982963d05dbf4efa009c3ab6db3576a03f680199d75d7d5edda89c55def912c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fonts-freefont/fonts-freefont-otf_20120503-10_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/fonts-freefont/fonts-freefont-otf_20120503-10_all.deb
     digest: c66666da94b9a0477351ee9d6d7a247a0a3c842e428da770991b45f03be2ee72
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fonts-freefont/fonts-freefont-ttf_20120503-10_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/fonts-freefont/fonts-freefont-ttf_20120503-10_all.deb
     digest: 79b23c3945d4628463672a804a0e81bc4c262ef87cb6316afb40167a50bc3145
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fonts-liberation/fonts-liberation_2.1.5-3_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/fonts-liberation/fonts-liberation_2.1.5-3_all.deb
     digest: 9285213fd8d6515bc6c1be5b810bf39918a668a17024a9fd3541879ce7fb5344
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fonts-noto/fonts-noto-core_20201225-deepin_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/fonts-noto/fonts-noto-core_20201225-deepin_all.deb
     digest: fa09d95f516c498d55e516d549b8ee41d9a7b6f17cdf0bb4b43744d672ce1366
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tex-gyre/fonts-texgyre_20180621-3.1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/t/tex-gyre/fonts-texgyre_20180621-3.1_all.deb
     digest: f66d6f798c4b99d8490558cc8209c069b0fe5577c11378c0e01f9e87ddf10824
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fonts-urw-base35/fonts-urw-base35_20200910-7_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/fonts-urw-base35/fonts-urw-base35_20200910-7_all.deb
     digest: 4800c0b08fbeac0335f1e23df2d41528a242383324c256ebece00c8f438eefbd
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gcc-13/gcc-13-base_13.2.0-3deepin4_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/gcc-13/gcc-13-base_13.2.0-3deepin4_arm64.deb
     digest: 781c11f578b76d0702466e2ecd81225460d64e1d70cd5f849159b84603028dff
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/glib2.0/gir1.2-glib-2.0_2.80.1-1deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/glib2.0/gir1.2-glib-2.0_2.80.1-1deepin1_arm64.deb
     digest: 44c091f38ef3e76d0b4d249b584a05e88b8e24a754834ba0bcde925734229ce3
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libgudev/gir1.2-gudev-1.0_238-2deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libg/libgudev/gir1.2-gudev-1.0_238-2deepin1_arm64.deb
     digest: 1afc84a191b5f3819a8bc441315d4ab876409ec711acf1af3eda81659f9e3abb
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/googletest/googletest_1.12.1-0.2_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/googletest/googletest_1.12.1-0.2_all.deb
     digest: 2df57ce8c5c8fdc37e1dbbe302d276f1cb9a784df5dd3423208f87933cfa28a0
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/i/icu/icu-devtools_74.2-1deepin4_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/i/icu/icu-devtools_74.2-1deepin4_arm64.deb
     digest: 19dc116ae37865faeab88a4a8053c39990b50d8ee85a49d93086a263a69afe02
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/a/acl/libacl1_2.3.1-3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/a/acl/libacl1_2.3.1-3_arm64.deb
     digest: ea023a815c9257d7d4f2028037d8d2b19009d9e36d6ae7d6cd5b20ad38e90565
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/a/avahi/libavahi-client3_0.8-5_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/a/avahi/libavahi-client3_0.8-5_arm64.deb
     digest: caef7cbebe662623b30149c2a4301d2ffeb03071e545f030bb0cff9ba881d2da
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/a/avahi/libavahi-common-data_0.8-5_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/a/avahi/libavahi-common-data_0.8-5_arm64.deb
     digest: 5995162791c2d06696885bb9a0ba3f160071b28a810b0f0e68f13fcbb6e83fc8
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/a/avahi/libavahi-common3_0.8-5_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/a/avahi/libavahi-common3_0.8-5_arm64.deb
     digest: 811cd69fd19e3765e96a76121722a3ed06966590e529793cb311dd3c0e27ceaf
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libb/libb2/libb2-1_0.98.1-1.1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libb/libb2/libb2-1_0.98.1-1.1_arm64.deb
     digest: cac541f3cf746d006b71a08f88364b6743222b8956fda9a7cbd35ffb1cf32ed9
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/b/binutils/libbinutils_2.41-6deepin7_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/b/binutils/libbinutils_2.41-6deepin7_arm64.deb
     digest: f3a6cc55f4f51a453f361aa91f3da7497d15c27001d779937952f2aea946393d
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-linux/libblkid-dev_2.40.4-3deepin4_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/u/util-linux/libblkid-dev_2.40.4-3deepin4_arm64.deb
     digest: 70ce30db93ccf7870f384aee1946b51da113cf55c7b046c443e8627d35cf73c9
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-linux/libblkid1_2.40.4-3deepin4_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/u/util-linux/libblkid1_2.40.4-3deepin4_arm64.deb
     digest: 4bcb4a5b87eb5953643d6afbe829641df4d4f68a3fbecd978c6f5e3e61c6dc6c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/b/brotli/libbrotli-dev_1.1.0-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/b/brotli/libbrotli-dev_1.1.0-2_arm64.deb
     digest: 016574d411e89311351ae6117b766a6bfa1ef7c0f49a4e17601200a33c2a19b5
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/b/brotli/libbrotli1_1.1.0-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/b/brotli/libbrotli1_1.1.0-2_arm64.deb
     digest: 982215712f2faad9f502b5d82d60152aab99acbef30457c9839988264a7c9190
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libb/libbsd/libbsd0_0.11.7-4_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libb/libbsd/libbsd0_0.11.7-4_arm64.deb
     digest: cb575189104cacfa40cd228b6fb11f4a90e1c2f6b258e1627c843ebe5cb36f09
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/b/bzip2/libbz2-1.0_1.0.8-deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/b/bzip2/libbz2-1.0_1.0.8-deepin1_arm64.deb
     digest: 0728bcbf280531a397947cba90fe861f3fde48a5811736509e2075c1f832dee4
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/b/bzip2/libbz2-dev_1.0.8-deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/b/bzip2/libbz2-dev_1.0.8-deepin1_arm64.deb
     digest: 502bf30d0f5d2a06d33495526cb4f5f7929623e87ed3c716aafb91f29565c1c3
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/glibc/libc-dev-bin_2.38-6deepin13+rb1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/glibc/libc-dev-bin_2.38-6deepin13+rb1_arm64.deb
     digest: 6a0003821a9d50b196b9b9f38a5f1f60de910ac24d61208b457cdf3707e66f2c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/glibc/libc6-dev_2.38-6deepin13+rb1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/glibc/libc6-dev_2.38-6deepin13+rb1_arm64.deb
     digest: 4c44dbb55a5c867b1116eb01c650066512ccd958d2eab84fda139250c8c5f65d
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/glibc/libc6_2.38-6deepin13+rb1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/glibc/libc6_2.38-6deepin13+rb1_arm64.deb
     digest: 2421a632cc90d03e652d8cddf07b614505a981adf16e40dc177b832b3d3892ca
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libc/libcap2/libcap2_2.66-5_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libc/libcap2/libcap2_2.66-5_arm64.deb
     digest: 6f196062b90716256bf2a57e919d18c74eb6cc19d98f1cf88e603cbd8d68b188
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libc/libchardet/libchardet-dev_1.0.4-2deepin_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libc/libchardet/libchardet-dev_1.0.4-2deepin_arm64.deb
     digest: 8a1d68c58d1a3958669b5f10f86ee9b8a5ffdb8f9c73d384cdf8d9d0fbdc97b0
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libc/libchardet/libchardet1_1.0.4-2deepin_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libc/libchardet/libchardet1_1.0.4-2deepin_arm64.deb
     digest: 9556bb311bc90bfb0c3c7789a47b79125075fd2f82b680f93bdc0710053d367a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/l/llvm-toolchain-17/libclang-cpp17_17.0.6-5deepin5_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/l/llvm-toolchain-17/libclang-cpp17_17.0.6-5deepin5_arm64.deb
     digest: 544520612dc6697c5165126dab9ec2cabae88d42678aaa5a762674559a6ace92
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/l/llvm-toolchain-17/libclang1-17_17.0.6-5deepin5_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/l/llvm-toolchain-17/libclang1-17_17.0.6-5deepin5_arm64.deb
     digest: 167b974f0fc6e2547f68b5b2f7add39efb575f3f0e36a14806fd779216d7b62e
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/e/e2fsprogs/libcom-err2_1.47.0-2deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/e/e2fsprogs/libcom-err2_1.47.0-2deepin1_arm64.deb
     digest: 32582278847580e89bdab5abc948478e0dbe3c24959ff2b15d9af5a46cb111fe
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxcrypt/libcrypt-dev_4.4.36-5_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxcrypt/libcrypt-dev_4.4.36-5_arm64.deb
     digest: fbc8cb951f3a23a095dd6fc672832bb8dbfdde96725939bc3dc162584a9f2efc
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxcrypt/libcrypt1_4.4.36-5_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxcrypt/libcrypt1_4.4.36-5_arm64.deb
     digest: 037584e67001e5de6f78c0d3acabe70a7b2e7dc592252ae0d9397c263c41c9f4
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/b/binutils/libctf-nobfd0_2.41-6deepin7_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/b/binutils/libctf-nobfd0_2.41-6deepin7_arm64.deb
     digest: e34f53bdde8f49dddfcbd7daa63d613f5c71b92d0e79683b500c8bccd0866bb4
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/b/binutils/libctf0_2.41-6deepin7_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/b/binutils/libctf0_2.41-6deepin7_arm64.deb
     digest: bab638b4aed73a4a9420a17ec27f3120ff10404c3d3e6e1a66fe023fa8a44121
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cups/libcups2-dev_2.4.2-5deepin2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/c/cups/libcups2-dev_2.4.2-5deepin2_arm64.deb
     digest: a72f4563335d016cf4a0f8bbf5d26b0ed90f554a8ff2e6b9701967daa114569b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cups/libcups2_2.4.2-5deepin2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/c/cups/libcups2_2.4.2-5deepin2_arm64.deb
     digest: 534a9ba35f69f93d103edbe1736a7ffe7f2b84a8e3746889d78feadfaa507d22
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cups/libcupsimage2-dev_2.4.2-5deepin2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/c/cups/libcupsimage2-dev_2.4.2-5deepin2_arm64.deb
     digest: 01509b9730896972e09e937a3d27ae4c9cea9b536b0296db37af464314490934
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cups/libcupsimage2_2.4.2-5deepin2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/c/cups/libcupsimage2_2.4.2-5deepin2_arm64.deb
     digest: 24db7f1a3f57d436a532a215e32df71a9df3ff19731d81c7988c0d77df86b692
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/curl/libcurl3-gnutls_8.11.0-0deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/c/curl/libcurl3-gnutls_8.11.0-0deepin1_arm64.deb
     digest: 4fcab53e5e791e65cd9160e0e77eacec106bce0f5ea0567bcb1387b362101488
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/db5.3/libdb5.3_5.3.28+dfsg1-0.8deepin0_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/db5.3/libdb5.3_5.3.28+dfsg1-0.8deepin0_arm64.deb
     digest: ee20a140ab90ce9fa2ab045eab6195b426d5c441459a788e15966687a1d57221
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dbus/libdbus-1-3_1.14.10-3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/dbus/libdbus-1-3_1.14.10-3_arm64.deb
     digest: 7b736881f8730994a643683bec66e7105c23d0ecf5e407e21c427faf2428c237
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libd/libdeflate/libdeflate-dev_1.18-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libd/libdeflate/libdeflate-dev_1.18-1_arm64.deb
     digest: d5e52d889f15c80ffe7214c06605d831488c2650ec00d7c9eb9b50ebbc108133
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libd/libdeflate/libdeflate0_1.18-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libd/libdeflate/libdeflate0_1.18-1_arm64.deb
     digest: 044cb710b30d6019492308216ead89b7a7357e4e63a2574929a85a167967f515
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/double-conversion/libdouble-conversion3_3.3.0-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/double-conversion/libdouble-conversion3_3.3.0-1_arm64.deb
     digest: 78e9245e377c8f61009cc60d2b55001aaddd7b656fceb916b3ba8f07344251b7
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dpkg/libdpkg-perl_1.22.6deepin4_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/dpkg/libdpkg-perl_1.22.6deepin4_all.deb
     digest: 569373a35267f9cf2e8d0ee6d42c9047f50fa2174a0ac72fa77f494a0f0a9d1b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libd/libdrm/libdrm-amdgpu1_2.4.123-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libd/libdrm/libdrm-amdgpu1_2.4.123-1_arm64.deb
     digest: ea011d2a1b77d97ea5d538786dc3aece9a24e317489827cf5e4dfc6032cb61f4
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libd/libdrm/libdrm-common_2.4.123-1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libd/libdrm/libdrm-common_2.4.123-1_all.deb
     digest: b8289eaa6341a8493f4c191a45165fe944248da69f675d09005a29058e7ae5a6
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libd/libdrm/libdrm-radeon1_2.4.123-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libd/libdrm/libdrm-radeon1_2.4.123-1_arm64.deb
     digest: e1b45eb0e3b7599cb1010679fa97507f0c3a814d00ed37d7912fc2bb95270e35
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libd/libdrm/libdrm2_2.4.123-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libd/libdrm/libdrm2_2.4.123-1_arm64.deb
     digest: 6c900feb79b1e5f847a5b9f53c6bda3f6aa12a9abfcf106f872a3812ef78bbc4
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6core/libdtk6core-dev_6.0.38_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/dtk6core/libdtk6core-dev_6.0.38_arm64.deb
     digest: c9472936e80c216fd09a2e9c5123ca1cedea9432294261178883d8a952c7f99b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6core/libdtk6core_6.0.38_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/dtk6core/libdtk6core_6.0.38_arm64.deb
     digest: e8a717160caa08f795f1f567ec57d2b661814e8084fe8d860d94f56a3e05ea47
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6declarative/libdtk6declarative-dev_6.0.38_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/dtk6declarative/libdtk6declarative-dev_6.0.38_arm64.deb
     digest: ab639306ed1a5d686a808aec6cee3eaaf5414cc52425e1a6561ea39b90e2dcfd
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6declarative/libdtk6declarative_6.0.38_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/dtk6declarative/libdtk6declarative_6.0.38_arm64.deb
     digest: 2a6d2a663d84e65e199b76e6a164808edc1c84f75d6021eed277a955eb6df437
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6gui/libdtk6gui-dev_6.0.38_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/dtk6gui/libdtk6gui-dev_6.0.38_arm64.deb
     digest: a80d44bf31660feda6ed1208ff5521335b7fb201da93956945359b0549a8f7b8
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6gui/libdtk6gui_6.0.38_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/dtk6gui/libdtk6gui_6.0.38_arm64.deb
     digest: 1594a4003d6dfee6d91d2ed7a0af502f4ea38504631401f3a1baa5860c70cbb6
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6log/libdtk6log-dev_0.0.4_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/dtk6log/libdtk6log-dev_0.0.4_arm64.deb
     digest: 0d2a9910f59a67a92ae67c644d2a78df0476a710a1bd4284869a3e3a993d9734
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6log/libdtk6log_0.0.4_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/dtk6log/libdtk6log_0.0.4_arm64.deb
     digest: 01a779e198b225da4069a480677d4e7c816f04309c3ce70829411b4bbe8b3a96
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6widget/libdtk6widget-dev_6.0.38_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/dtk6widget/libdtk6widget-dev_6.0.38_arm64.deb
     digest: f1743536d71c1610937a548699d0bd40692b3ce34ce5ea591c4ad919d6ae1b6b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6widget/libdtk6widget_6.0.38_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/dtk6widget/libdtk6widget_6.0.38_arm64.deb
     digest: 85c4766d67def86998b406625bc1a22eacf910a131bf1006735af2897efe3e1b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtkcommon/libdtkcommon-dev_5.7.18_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/dtkcommon/libdtkcommon-dev_5.7.18_arm64.deb
     digest: 766177ea4c8c2a5cfdeb1b3eee5b31b62b72be9aa06744dd7a6542cc888c494c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtkcommon/libdtkdata_5.7.18_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/dtkcommon/libdtkdata_5.7.18_arm64.deb
     digest: a34538990a42f2be5b28b198b3b75d96ab6edfc9b850824c8ee222305f42c699
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/duktape/libduktape207_2.7.0-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/duktape/libduktape207_2.7.0-2_arm64.deb
     digest: 514955337167c41ebe2aec0cab0cf30ebf6f47cb7893b0ae1db20590c3d29ad9
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libe/libedit/libedit2_3.1-20230828-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libe/libedit/libedit2_3.1-20230828-1_arm64.deb
     digest: ba394c531b520e3ee365d29c127505bce3554df15885dd53dbe9a9deee191326
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mesa/libegl-mesa0_24.3.0-1deepin4_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/m/mesa/libegl-mesa0_24.3.0-1deepin4_arm64.deb
     digest: 426be89c01067a002f4d4873688297fa1444a5a3048baba3eba418febf47d143
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libegl1_1.7.0-1deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libg/libglvnd/libegl1_1.7.0-1deepin1_arm64.deb
     digest: 0b59eeb273489ae76f00c5192fac7d4fd7ca4db31b0f77b1424cbe6a70fa20f8
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/e/elfutils/libelf1_0.191-1deepin2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/e/elfutils/libelf1_0.191-1deepin2_arm64.deb
     digest: a3926debe22263846a70333372425e555a2ed796d44b8fe87eecd8116dedaf2c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libe/libevdev/libevdev-dev_1.12.0+dfsg-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libe/libevdev/libevdev-dev_1.12.0+dfsg-1_arm64.deb
     digest: d2e39d9eadc5fc955478dbe6f1a66627a770ffbe8f165f1f8700934f8263e576
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libe/libevdev/libevdev2_1.12.0+dfsg-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libe/libevdev/libevdev2_1.12.0+dfsg-1_arm64.deb
     digest: fbbe2a51d531e25bc6bd01b2a732ea480411f065940a2b581d47dcd98ec7fcc3
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/e/expat/libexpat1-dev_2.7.1-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/e/expat/libexpat1-dev_2.7.1-1_arm64.deb
     digest: c0b33ae628f9f7a2be567fc237b7c3f3c2ca1ef33360eff1718977c72d414a38
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/e/expat/libexpat1_2.7.1-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/e/expat/libexpat1_2.7.1-1_arm64.deb
     digest: 5cb7b15a898bfb29141bc121435c82871d5ac497035fae132c37df32e69eb388
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libf/libffi/libffi-dev_3.4.6-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libf/libffi/libffi-dev_3.4.6-1_arm64.deb
     digest: 44b6f1a9aceead0cac121cfd13cdd9a529eb2b60522f8482c7dc4f67432d1904
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libf/libffi/libffi8_3.4.6-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libf/libffi/libffi8_3.4.6-1_arm64.deb
     digest: dd69564a592502ee67ae166c13d6d6a0a62021a47c2f3154589ed3bc62fe6b52
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fmtlib/libfmt10_10.1.1+ds1-4_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/fmtlib/libfmt10_10.1.1+ds1-4_arm64.deb
     digest: 65fdd731df6fc44891d7c77da9d16717fd23df0d4251085dc0c43b4313e903eb
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fontconfig/libfontconfig-dev_2.15.0-2.3deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/fontconfig/libfontconfig-dev_2.15.0-2.3deepin1_arm64.deb
     digest: bbbc845e4a6ade7d6fe9d7147e9891f1bcb60c971ef8d0ab7c253d7089fc1f8b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fontconfig/libfontconfig1_2.15.0-2.3deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/fontconfig/libfontconfig1_2.15.0-2.3deepin1_arm64.deb
     digest: 82b4c63adda13ee062e7cac011f49859d31b911c5e64678d8d1404e5da3a92da
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libf/libfontenc/libfontenc1_1.1.4-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libf/libfontenc/libfontenc1_1.1.4-1_arm64.deb
     digest: 222148f71812a1026457b2d86edfe68eac087f0063ab5e8159439e3d11793425
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/freetype/libfreetype-dev_2.13.2+dfsg-1deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/freetype/libfreetype-dev_2.13.2+dfsg-1deepin1_arm64.deb
     digest: dc1cc27076ac172ffd75b7fe88d5889be20c84eb0dbbeeff2a29f24c84d965dd
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/freetype/libfreetype6_2.13.2+dfsg-1deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/freetype/libfreetype6_2.13.2+dfsg-1deepin1_arm64.deb
     digest: 5363e03d3eb944c73fbc75e303cca2814077607480b2e7f7c9015d70aee31a27
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mesa/libgbm1_24.3.0-1deepin4_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/m/mesa/libgbm1_24.3.0-1deepin4_arm64.deb
     digest: d16ede274574a5ede58f7f2318cf33f2b0074ca31845097ce633393b87b3caf0
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gcc-13/libgcc-s1_13.2.0-3deepin4_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/gcc-13/libgcc-s1_13.2.0-3deepin4_arm64.deb
     digest: 6ed2090f5c442f6dbccfc825cf0303e42954ee2db527d4605435c09862a43d57
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libgcrypt20/libgcrypt20_1.10.3-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libg/libgcrypt20/libgcrypt20_1.10.3-2_arm64.deb
     digest: 86a50d1b85ed82764e7f356b2e3e5543149cc778edca29dae9765ddbc3789d9a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gdbm/libgdbm-compat4_1.22-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/gdbm/libgdbm-compat4_1.22-1_arm64.deb
     digest: d7dc16662376708bef84fd84bb79a769c443cfb2ce69e608c16c98f85080848c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gdbm/libgdbm6_1.22-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/gdbm/libgdbm6_1.22-1_arm64.deb
     digest: ba32e543ec6296045f2680d23a890c315ab00c4a34201a7a55d3f72384518930
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/glib2.0/libgirepository-2.0-0_2.80.1-1deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/glib2.0/libgirepository-2.0-0_2.80.1-1deepin1_arm64.deb
     digest: 67fb7f1a7f5bf707a6dcead0b5b044c1704f454c2a51050fcb020ea9b1317913
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libgl-dev_1.7.0-1deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libg/libglvnd/libgl-dev_1.7.0-1deepin1_arm64.deb
     digest: ef605bf23fa580844d6a5faa61caf503f3825bc69acc9e30dab40689116a2627
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mesa/libgl1-mesa-dri_24.3.0-1deepin4_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/m/mesa/libgl1-mesa-dri_24.3.0-1deepin4_arm64.deb
     digest: 9a47b3a7b9568d735534ae7c949ef5bed2ff18975f0812d71acbd163c6f5030c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libgl1_1.7.0-1deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libg/libglvnd/libgl1_1.7.0-1deepin1_arm64.deb
     digest: fb58114fedbd3864291f2a6c3d7d5d1b62476a3532e98926774727988411b3e4
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mesa/libglapi-mesa_24.3.0-1deepin4_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/m/mesa/libglapi-mesa_24.3.0-1deepin4_arm64.deb
     digest: 82508b674b91518c3217f0d2f38ee78ed65a15fb6acb49420076d368e338af7e
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/glib2.0/libglib2.0-0_2.80.1-1deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/glib2.0/libglib2.0-0_2.80.1-1deepin1_arm64.deb
     digest: bcd728365b170a9b2598f2c3a13a7b4b27bcbcc5c966610496f7a66c13d93394
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/glib2.0/libglib2.0-bin_2.80.1-1deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/glib2.0/libglib2.0-bin_2.80.1-1deepin1_arm64.deb
     digest: 5306892a7f1ea756d7c63a92aa346da632b78072b44ce30cf5f0567e22d7d39b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/glib2.0/libglib2.0-data_2.80.1-1deepin1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/glib2.0/libglib2.0-data_2.80.1-1deepin1_all.deb
     digest: 4e75a1c9e56c81ed2c1737e3e6fe590163a77ff45179101a4fcfb90b4c0d135d
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/glib2.0/libglib2.0-dev-bin_2.80.1-1deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/glib2.0/libglib2.0-dev-bin_2.80.1-1deepin1_arm64.deb
     digest: 4a16ad0b756f1336f01999c1c55cd69bb576416f985bf0445c5f08cbc889ab96
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/glib2.0/libglib2.0-dev_2.80.1-1deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/glib2.0/libglib2.0-dev_2.80.1-1deepin1_arm64.deb
     digest: 894d0a7818c905544b7114e8c7268a3c8dded4395d3d859bdcb774e546e7ac98
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libglvnd0_1.7.0-1deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libg/libglvnd/libglvnd0_1.7.0-1deepin1_arm64.deb
     digest: d4371fcc299ddafc3230a139ecc4475dcd0b0dedb2746d46da1de9a951bf749a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libglx-dev_1.7.0-1deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libg/libglvnd/libglx-dev_1.7.0-1deepin1_arm64.deb
     digest: ff60370ae98f4515ea9eda99af3ab9d468b53b23bdd22f4b51abf8064655e810
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mesa/libglx-mesa0_24.3.0-1deepin4_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/m/mesa/libglx-mesa0_24.3.0-1deepin4_arm64.deb
     digest: 9388fddc0b068998f436342e6d562cc6f5553f34dbee9e86a51639a24d92dbaa
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libglx0_1.7.0-1deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libg/libglvnd/libglx0_1.7.0-1deepin1_arm64.deb
     digest: 0e206a1e5b7a0a16abefac96b5774e2740c0446d988488ba3ca3af616a4eb3f6
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/googletest/libgmock-dev_1.12.1-0.2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/googletest/libgmock-dev_1.12.1-0.2_arm64.deb
     digest: 8e50d1c881f679be9859f51037271c5ca9a963b13dec606b34e45deb84d22baf
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gmp/libgmp10_6.3.0+dfsg-2deepin0_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/gmp/libgmp10_6.3.0+dfsg-2deepin0_arm64.deb
     digest: ccfd8cc3ef27d1a32ddb9f3a57f05ee35576482f640532be70dddeb98395193f
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gnutls28/libgnutls30_3.7.9-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/gnutls28/libgnutls30_3.7.9-2_arm64.deb
     digest: 88703de5a0a7bc5c03730e2de61ae40894fa6f4d6d1f89def93ec44055c6771d
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gcc-13/libgomp1_13.2.0-3deepin4_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/gcc-13/libgomp1_13.2.0-3deepin4_arm64.deb
     digest: 5f619ecbd600ec16a9b65db818e1687594141a86fc843f971f4106ef3d12343d
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libgpg-error/libgpg-error0_1.47-3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libg/libgpg-error/libgpg-error0_1.47-3_arm64.deb
     digest: e67f481218dd4fc506bb97ebccacbbd39e5420caca6c71ba011b1efcc0f1f5a0
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/b/binutils/libgprofng0_2.41-6deepin7_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/b/binutils/libgprofng0_2.41-6deepin7_arm64.deb
     digest: 640d2c1b93bfece28cb70c1213450ace0864adb34d288b00c6108bb5bc5cfdeb
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/graphite2/libgraphite2-3_1.3.14-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/graphite2/libgraphite2-3_1.3.14-2_arm64.deb
     digest: bf8f6e987ba71ddd6161066f0828663b4ffc4af78acbdbff04b71e5c2b1e207f
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/k/krb5/libgssapi-krb5-2_1.20.1-5_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/k/krb5/libgssapi-krb5-2_1.20.1-5_arm64.deb
     digest: e09ffd8646be9798699b1324b7d6292382f7c8c3665fbd0a6aed4536561ff06c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/googletest/libgtest-dev_1.12.1-0.2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/googletest/libgtest-dev_1.12.1-0.2_arm64.deb
     digest: 1782a1ae89d81c14a53cdc7be83811cf3448ffe2f93a475820ff96042b5bb4c8
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libgudev/libgudev-1.0-0_238-2deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libg/libgudev/libgudev-1.0-0_238-2deepin1_arm64.deb
     digest: c952bbe64709d944821b367c5c211af4447ddb59f58f1c2b2fa264ab234890bd
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libgudev/libgudev-1.0-dev_238-2deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libg/libgudev/libgudev-1.0-dev_238-2deepin1_arm64.deb
     digest: 97b751c1e82af92962c3688f1bc9c0cdded3ea5bacc43d478f0780d22f8d6e6d
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gumbo-parser/libgumbo2_0.12.0+dfsg-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/gumbo-parser/libgumbo2_0.12.0+dfsg-2_arm64.deb
     digest: 1af178c5a43fc3f1a40d90a4890bf8a00372449495bc32e6ddd82165927b3591
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/h/harfbuzz/libharfbuzz0b_8.0.1-1+rb1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/h/harfbuzz/libharfbuzz0b_8.0.1-1+rb1_arm64.deb
     digest: b50ec89e04006c13764afac632d9fd4793c187d20fc54670018f76241fbe8495
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/n/nettle/libhogweed6_3.7.3-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/n/nettle/libhogweed6_3.7.3-1_arm64.deb
     digest: 0caf1aec7651bca8c8c0646eb87b064e522fbdc654edebc8c7e10e0a12f77c94
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libi/libice/libice6_1.0.10-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libi/libice/libice6_1.0.10-1_arm64.deb
     digest: a1910186258a924c4367673da786e7200f32e54ea54f65e2b885e3e451197e0e
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/i/icu/libicu-dev_74.2-1deepin4_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/i/icu/libicu-dev_74.2-1deepin4_arm64.deb
     digest: b7c8cb9211519ac308269e2d25796258b3ff7926e7ec33da839c199b565bfd86
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/i/icu/libicu74_74.2-1deepin4_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/i/icu/libicu74_74.2-1deepin4_arm64.deb
     digest: d5bc8f5eb78bf50444fec39a361f43c52b13d13a9c2ea45c272b05d1c8afbb5c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libi/libidn2/libidn2-0_2.3.2-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libi/libidn2/libidn2-0_2.3.2-2_arm64.deb
     digest: 66be80634fd2243b4741bc12bf02ae140d4af694da58e23415130322eb8e17cc
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libi/libinput/libinput-bin_1.26.0-1deepin3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libi/libinput/libinput-bin_1.26.0-1deepin3_arm64.deb
     digest: 0c312f699653f007733afd743554d7200cc43d9fa3d74ba23622165f75cf23f0
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libi/libinput/libinput-dev_1.26.0-1deepin3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libi/libinput/libinput-dev_1.26.0-1deepin3_arm64.deb
     digest: 18bc7373f096e8017e59bfdeb551589ca0fe341dbbba016b2d648914770fe3e7
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libi/libinput/libinput10_1.26.0-1deepin3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libi/libinput/libinput10_1.26.0-1deepin3_arm64.deb
     digest: 9a6aaef5f1bd4c34230d194a5d13354b0e614fe330d77bee0c293b9a627ca752
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/j/jansson/libjansson4_2.14-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/j/jansson/libjansson4_2.14-2_arm64.deb
     digest: ef540161f4618cca67a1e5c14ff7e1531f85b8066ced54f873e249bbd89287de
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/j/jbigkit/libjbig-dev_2.1-3.1-deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/j/jbigkit/libjbig-dev_2.1-3.1-deepin1_arm64.deb
     digest: d554b612e70c2416c6d831b575c1bc1c3f4c0143454ada80203e08f918143e77
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/j/jbigkit/libjbig0_2.1-3.1-deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/j/jbigkit/libjbig0_2.1-3.1-deepin1_arm64.deb
     digest: cce7a06a6c026ffde094ac6555c1feff1763121dd88bba0d2977bfa59cdf403b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libj/libjpeg-turbo/libjpeg-dev_2.1.5-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libj/libjpeg-turbo/libjpeg-dev_2.1.5-2_arm64.deb
     digest: 7eb0cf9914476bdf669f0087c7fcba1d0cfd49f9697804d72fd2869e6fc3ecf6
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libj/libjpeg-turbo/libjpeg62-turbo-dev_2.1.5-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libj/libjpeg-turbo/libjpeg62-turbo-dev_2.1.5-2_arm64.deb
     digest: 4355b250325f762945b8d68dbb1e39fd0847230f9bf56284c35d4a69aa819e5a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libj/libjpeg-turbo/libjpeg62-turbo_2.1.5-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libj/libjpeg-turbo/libjpeg62-turbo_2.1.5-2_arm64.deb
     digest: 127ab1d74ddbf0f1620b8a2b907d9160a359079c49fdef8e07ee6ef795b502ff
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/j/json-glib/libjson-glib-1.0-0_1.8.0-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/j/json-glib/libjson-glib-1.0-0_1.8.0-2_arm64.deb
     digest: 52265c84dfb5b0a9a38cd6e6acfdda4d180d610899b34bb93f62d14f76dc9201
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/j/json-glib/libjson-glib-1.0-common_1.8.0-2_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/j/json-glib/libjson-glib-1.0-common_1.8.0-2_all.deb
     digest: f4ffb8e62cabbb4b691413d38e3c8a03b430f4eba287bef4d8637dd3d708cab1
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/k/krb5/libk5crypto3_1.20.1-5_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/k/krb5/libk5crypto3_1.20.1-5_arm64.deb
     digest: b25339e6e18dbdd4ea57d508158d999a86e539045789a5885667c6d6ecb81c9d
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/k/keyutils/libkeyutils1_1.6.3-3.1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/k/keyutils/libkeyutils1_1.6.3-3.1_arm64.deb
     digest: 91223dc8480403e5770986e2fd73b8a92ce1e74b9f52b442616cc3ef0ff59dc7
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/k/kf6-kcodecs/libkf6codecs-data_6.6.0-1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/k/kf6-kcodecs/libkf6codecs-data_6.6.0-1_all.deb
     digest: 961c0272ce73f6d2f872d0dd077b3f1bdcae602bbe1c69ab391021f4e3243301
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/k/kf6-kcodecs/libkf6codecs-dev_6.6.0-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/k/kf6-kcodecs/libkf6codecs-dev_6.6.0-1_arm64.deb
     digest: e95078875e22fc504199e505724358c4fba4e98f8546219e5dd915a097ac0f06
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/k/kf6-kcodecs/libkf6codecs6_6.6.0-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/k/kf6-kcodecs/libkf6codecs6_6.6.0-1_arm64.deb
     digest: 03786da078662b368f864b566c1db4525c1703a24911f7dec1e7b69875961dbe
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/k/kf6-syntax-highlighting/libkf6syntaxhighlighting-data_6.10.0-1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/k/kf6-syntax-highlighting/libkf6syntaxhighlighting-data_6.10.0-1_all.deb
     digest: 50c8a8aedc9c68416b28cdc5205172e42a8702bb64176ebb1a893e7460ee3c98
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/k/kf6-syntax-highlighting/libkf6syntaxhighlighting-dev_6.10.0-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/k/kf6-syntax-highlighting/libkf6syntaxhighlighting-dev_6.10.0-1_arm64.deb
     digest: 0e72818263cc55e899a7cb9a69ca10ee4ecfccc8dac734599098b5e062348cd4
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/k/kf6-syntax-highlighting/libkf6syntaxhighlighting6_6.10.0-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/k/kf6-syntax-highlighting/libkf6syntaxhighlighting6_6.10.0-1_arm64.deb
     digest: c050ac68b2552cffd02e57462b6b76ab10729f21cbab18077858f31be0b3c06a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/k/krb5/libkrb5-3_1.20.1-5_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/k/krb5/libkrb5-3_1.20.1-5_arm64.deb
     digest: 32e10af6aefa67b71ea312c55b8f9a3f7c016d1edc6bd30907ed38ec27aef8d8
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/k/krb5/libkrb5support0_1.20.1-5_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/k/krb5/libkrb5support0_1.20.1-5_arm64.deb
     digest: 50aefca2b75fd2478e62ac9c7c5571e7e510ffa697207e78e29bfa6d40f3271d
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/l/lcms2/liblcms2-2_2.14-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/l/lcms2/liblcms2-2_2.14-2_arm64.deb
     digest: ce6ca7ecc06a131d36a0cf01b7e0a2774bc0b75abc8c29aa432a6c6ed2d2ba3f
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/o/openldap/libldap-2.5-0_2.5.13+dfsg-5_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/o/openldap/libldap-2.5-0_2.5.13+dfsg-5_arm64.deb
     digest: d055aef7a24526618a27b82b62d9a220e1fdb93f5cb0e49bc1b083693a43b607
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/l/lerc/liblerc-dev_4.0.0+ds-3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/l/lerc/liblerc-dev_4.0.0+ds-3_arm64.deb
     digest: 1084fe140088878214dd72f6c8ebf4f4835b83f542ed443ce79cc2f43821d6d9
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/l/lerc/liblerc4_4.0.0+ds-3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/l/lerc/liblerc4_4.0.0+ds-3_arm64.deb
     digest: b2510d375b08fc5b324dcc39a234971675c787d7b9a5cdfcbd8fbb414f9549e7
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/l/litehtml/liblitehtml0_0.9-0deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/l/litehtml/liblitehtml0_0.9-0deepin1_arm64.deb
     digest: 82d472f20711c3b0eee4afb2b8bc8a0971f6fb7ced7612317f07597768e6ddad
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/l/llvm-toolchain-17/libllvm17_17.0.6-5deepin5_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/l/llvm-toolchain-17/libllvm17_17.0.6-5deepin5_arm64.deb
     digest: 7faa4f0b4e3c95e4f0fa1ef4bc52329dbed095bdf87d495d0f8c21b934c78319
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/l/llvm-toolchain-19/libllvm19_19.1.4-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/l/llvm-toolchain-19/libllvm19_19.1.4-1_arm64.deb
     digest: c31aea104e1ce9b782ae8525506c3fb4fc8e9a2f0f19ceebc00d28fd69214fa4
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/l/lz4/liblz4-1_1.9.3-deepin_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/l/lz4/liblz4-1_1.9.3-deepin_arm64.deb
     digest: 9de94343c0eaf87ec1b298d8f5dbfe42f06316f8dc608968e0718437035c1ee9
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/x/xz-utils/liblzma-dev_5.4.5-0.3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xz-utils/liblzma-dev_5.4.5-0.3_arm64.deb
     digest: 0e91a2383f5ab980fb06cb347c66dc6b6480a7b76cb67ded44bb4b183f295d21
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/x/xz-utils/liblzma5_5.4.5-0.3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xz-utils/liblzma5_5.4.5-0.3_arm64.deb
     digest: 89bd6cb9e9f756b25b0e973012a88d2df0c273c0dc44ab0cbc2a0bb6b773ba55
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libm/libmd/libmd0_1.0.4-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libm/libmd/libmd0_1.0.4-1_arm64.deb
     digest: a1f7a672a07a62b85c2651bdba09552498db565da6ecf5748be618812124acc2
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/md4c/libmd4c0_0.4.8-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/m/md4c/libmd4c0_0.4.8-1_arm64.deb
     digest: 8b58cf124cb0a435765f6cbc7bc8a59d431a8f84babbc2956beb1a46b53b99f5
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libm/libmng/libmng1_1.0.10+dfsg-3.1-deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libm/libmng/libmng1_1.0.10+dfsg-3.1-deepin1_arm64.deb
     digest: 15763cf880b4073ba036e05f2a3b9b46aa43802f9d2c49848fd315a9229d9be8
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-linux/libmount-dev_2.40.4-3deepin4_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/u/util-linux/libmount-dev_2.40.4-3deepin4_arm64.deb
     digest: 62f3c994934747f7cb43813a34b1090787d0f7471d4c1f0607b2ad476f5f7105
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-linux/libmount1_2.40.4-3deepin4_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/u/util-linux/libmount1_2.40.4-3deepin4_arm64.deb
     digest: ef3494fcc16550aa223cffc70e189fa2355dd5bcebc8b78dc303250063cd7dae
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mtdev/libmtdev-dev_1.1.6-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/m/mtdev/libmtdev-dev_1.1.6-1_arm64.deb
     digest: 17fc6b739d5d25e6139f8786daa9ac90b81315dfde9df401d7a8896831bc1828
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mtdev/libmtdev1_1.1.6-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/m/mtdev/libmtdev1_1.1.6-1_arm64.deb
     digest: 646172dd88b260728ef1da45a78d41c78161a8341d0ce43de738c63f2e4089ca
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/n/ncurses/libncursesw6_6.4-4deepin2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/n/ncurses/libncursesw6_6.4-4deepin2_arm64.deb
     digest: d13327f9f92ee7c7b2784dddd987a3cd1380f176f7b3dc2c0ba8022cbafc8743
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/n/nettle/libnettle8_3.7.3-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/n/nettle/libnettle8_3.7.3-1_arm64.deb
     digest: 94f6240b06e89b83e43b85f3ac482f57468f7b78b3a356f692a9a2508b4b62f2
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/n/nghttp2/libnghttp2-14_1.59.0-1deepin0_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/n/nghttp2/libnghttp2-14_1.59.0-1deepin0_arm64.deb
     digest: a4a4ad6f2f5e0bf234331c7e22f12e13b7b5f52f6ee93188517427f88cda3b8f
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/n/nghttp3/libnghttp3-9_1.4.0-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/n/nghttp3/libnghttp3-9_1.4.0-1_arm64.deb
     digest: d64740b68d9dafdb6c4cb6fbf944281d6e88036b8fb3bfc228c235b8f3ab25d7
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/n/ngtcp2/libngtcp2-16_1.6.0-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/n/ngtcp2/libngtcp2-16_1.6.0-1_arm64.deb
     digest: 510f2bd3d9d32bfcccbd68838d57698ec80337b5e2ca1ea1273d82733ff10c95
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/n/ngtcp2/libngtcp2-crypto-gnutls8_1.6.0-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/n/ngtcp2/libngtcp2-crypto-gnutls8_1.6.0-1_arm64.deb
     digest: 6bbbeeb6977d1080858dfa0fa2d179c1e351cfa01afd661b6b3094c8dea59d76
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libn/libnsl/libnsl-dev_1.3.0-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libn/libnsl/libnsl-dev_1.3.0-2_arm64.deb
     digest: f6267e06818bde69c32fcb07f15807e9c0240561de3c4bbe90e1cc4189a12d22
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libn/libnsl/libnsl2_1.3.0-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libn/libnsl/libnsl2_1.3.0-2_arm64.deb
     digest: 08c95ea4d7177490751748ac26160236580dd2351a4e8ffdb57774e7874a40a7
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libopengl-dev_1.7.0-1deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libg/libglvnd/libopengl-dev_1.7.0-1deepin1_arm64.deb
     digest: d52a6102a07d9cff9066f0e3ebd802ab14e119bd1f9a890999be8cfda4c2cdce
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libopengl0_1.7.0-1deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libg/libglvnd/libopengl0_1.7.0-1deepin1_arm64.deb
     digest: 74251d10b4940be8c9fe26be6c337af904a1f0494723882d50dd1bcb04189416
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/p11-kit/libp11-kit0_0.25.5-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/p11-kit/libp11-kit0_0.25.5-2_arm64.deb
     digest: a8cf0f0f9be1f016846baa4b2d2012fbef8b560dfc3cfa920b3d8ebb920038a4
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pcre2/libpcre2-16-0_10.39-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/pcre2/libpcre2-16-0_10.39-2_arm64.deb
     digest: b417f72e1d3895f3350645ac7f10859246808db988273031cecc41fbec6f567c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pcre2/libpcre2-32-0_10.39-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/pcre2/libpcre2-32-0_10.39-2_arm64.deb
     digest: c50abb1ce61a1a2d6a3ec98848f179da3b9e000672f7278f0f1c865cb998fb37
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pcre2/libpcre2-8-0_10.39-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/pcre2/libpcre2-8-0_10.39-2_arm64.deb
     digest: f721d2c4a9224b106c26b793af1f4a0c884184766e8e3d005369b4f265e0637e
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pcre2/libpcre2-dev_10.39-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/pcre2/libpcre2-dev_10.39-2_arm64.deb
     digest: ba71787ac1c892e4b8fe9aa1544ecd81a7d9436538c3bb28b0d710fc391143d3
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pcre2/libpcre2-posix3_10.39-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/pcre2/libpcre2-posix3_10.39-2_arm64.deb
     digest: 6bb5a3b25014a1b3d0daff71338861f704defc4a1d7d5a2896b58604716914f3
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/perl/libperl5.36_5.36.0-10deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/perl/libperl5.36_5.36.0-10deepin1_arm64.deb
     digest: 0845846b66b31eedd72c968130416fd011806d63c87506237ef08fa765edfc28
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pkgconf/libpkgconf3_1.8.1-4_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/pkgconf/libpkgconf3_1.8.1-4_arm64.deb
     digest: 225ac12d1f1dbf507b8b994fcd0e127f24287b2f5cef5a2b86d85677c8576ec9
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libp/libpng1.6/libpng-dev_1.6.45-1deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libp/libpng1.6/libpng-dev_1.6.45-1deepin1_arm64.deb
     digest: 36ef5b74e950afa328783b48852de9093f39a157287fcc5d407671a752de8212
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libp/libpng1.6/libpng16-16_1.6.45-1deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libp/libpng1.6/libpng16-16_1.6.45-1deepin1_arm64.deb
     digest: 6d1a2ce1e132e24abc4c04edab9f0c9a0d180ed01e1f49f19c9391f1e0c926d0
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/policykit-1/libpolkit-agent-1-0_123-3deepin7_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/policykit-1/libpolkit-agent-1-0_123-3deepin7_arm64.deb
     digest: b97403d9f18a9f81f3b2f39f8d7bf458e6667f228759ab104824be390dc7c291
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/policykit-1/libpolkit-gobject-1-0_123-3deepin7_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/policykit-1/libpolkit-gobject-1-0_123-3deepin7_arm64.deb
     digest: 925c8a5c655f77618d9b764053fc51eaf5cb61dbf499c2655be89e2da21654c4
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/polkit-qt-1/libpolkit-qt6-1-1_0.200.0-4deepin2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/polkit-qt-1/libpolkit-qt6-1-1_0.200.0-4deepin2_arm64.deb
     digest: 510509608df1e38739722d377529634263a0bf4c3c265bd6874dc89ab6bea2e5
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/polkit-qt-1/libpolkit-qt6-1-dev_0.200.0-4deepin2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/polkit-qt-1/libpolkit-qt6-1-dev_0.200.0-4deepin2_arm64.deb
     digest: 68b86d1919c3d0141af8acfec2f1944c6a205bc223ef2222b049ee99ce679d16
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libp/libproxy/libproxy1v5_0.5.9-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libp/libproxy/libproxy1v5_0.5.9-1_arm64.deb
     digest: c4961acabed64ea88a254ba89930110925ea89fb182f5d088e428503d9c531fe
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libp/libpsl/libpsl5_0.21.0-1.2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libp/libpsl/libpsl5_0.21.0-1.2_arm64.deb
     digest: 906e8192d44527cb25bcbfd2a90992b25acfc3698a6b0cc6536edc6e935d64e6
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libp/libpthread-stubs/libpthread-stubs0-dev_0.4-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libp/libpthread-stubs/libpthread-stubs0-dev_0.4-1_arm64.deb
     digest: 3c2fef66a85ca8d8219283c1402eb66500b8587fa4f4495d327515e12b71e710
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/python3-defaults/libpython3-stdlib_3.12.1-1deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/python3-defaults/libpython3-stdlib_3.12.1-1deepin1_arm64.deb
     digest: 94be53c10a1ed8538483d1dbd426700ff5a79ffffc7632c3a3eee0cd9ba2e869
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/python3.12/libpython3.12-minimal_3.12.11-0deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/python3.12/libpython3.12-minimal_3.12.11-0deepin1_arm64.deb
     digest: 6dc58f5d2bda46ed44cadb9a08729430975a9a4dc41eb28f6633c6be041f9085
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/python3.12/libpython3.12-stdlib_3.12.11-0deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/python3.12/libpython3.12-stdlib_3.12.11-0deepin1_arm64.deb
     digest: 73b9c0dcd766f4132d7aaff51f969d0ed8708f54355143d308aaa7033018d198
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6concurrent6_6.8.0+dfsg-0deepin8_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/libqt6concurrent6_6.8.0+dfsg-0deepin8_arm64.deb
     digest: 3ed642827043b354e44832524287cc3808804c996e5c9fcd18a3ed7b051f435c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-5compat/libqt6core5compat6_6.8.0-0deepin_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-5compat/libqt6core5compat6_6.8.0-0deepin_arm64.deb
     digest: 503f5c8e330d3b7cf0bf0ced200124c129b4157dce1f4f9ff2d9ee333e30ffa6
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6core6_6.8.0+dfsg-0deepin8_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/libqt6core6_6.8.0+dfsg-0deepin8_arm64.deb
     digest: b2ec9e16dd93f9fcc6db6a8213ada4c6a032263dc26ebaeaa518e1020587e33c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6dbus6_6.8.0+dfsg-0deepin8_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/libqt6dbus6_6.8.0+dfsg-0deepin8_arm64.deb
     digest: f23850190fc6dcfcb2e9552ad18a861690f1c9d3a5b2ea8d7c1726ccb3d7ccd0
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/libqt6designer6_6.8.0-0deepin3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-tools/libqt6designer6_6.8.0-0deepin3_arm64.deb
     digest: 82c28b84f82cbf7e3d9098c0f856b955e811a65b1fd42c8515711aecd05fb894
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/libqt6designercomponents6_6.8.0-0deepin3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-tools/libqt6designercomponents6_6.8.0-0deepin3_arm64.deb
     digest: c183e82838d5b340b4273253e90667078512862e1f8e9781b72b7ce048bf54d3
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6gui6_6.8.0+dfsg-0deepin8_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/libqt6gui6_6.8.0+dfsg-0deepin8_arm64.deb
     digest: 865f2bc49642dca8ed4b823a6cd6e286e0e38922b94b333b3d1c6a135b068a0a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/libqt6help6_6.8.0-0deepin3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-tools/libqt6help6_6.8.0-0deepin3_arm64.deb
     digest: d725d7423abfc45ea48abf3d9cc444b95af145636802254bb44565f31d4d4245
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6network6_6.8.0+dfsg-0deepin8_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/libqt6network6_6.8.0+dfsg-0deepin8_arm64.deb
     digest: b4adf25025b9ac22a52f68777b8b0e35acb2259b0c5dbb6d21d1e390bf272246
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6opengl6_6.8.0+dfsg-0deepin8_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/libqt6opengl6_6.8.0+dfsg-0deepin8_arm64.deb
     digest: 14b464d8f9c3c54bb8adf97c276cb3862e37403897250d96dc3cd2918d2c4ce0
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6openglwidgets6_6.8.0+dfsg-0deepin8_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/libqt6openglwidgets6_6.8.0+dfsg-0deepin8_arm64.deb
     digest: abc3d24f963cab39c953bb44b1f1d258a0cb06716345f71bebf7bb70deee3f17
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6printsupport6_6.8.0+dfsg-0deepin8_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/libqt6printsupport6_6.8.0+dfsg-0deepin8_arm64.deb
     digest: ded05e7b5416ee5139309098046f51d68eeea2f646c234113f0c4b754e7c362b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-declarative/libqt6qml6_6.8.0+dfsg-0deepin3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-declarative/libqt6qml6_6.8.0+dfsg-0deepin3_arm64.deb
     digest: 8c18da39ba69ceef945d4c64e3a0e62a1bdcbe2b41921ead0aa08f4cc52c459e
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-declarative/libqt6qmlcompiler6_6.8.0+dfsg-0deepin3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-declarative/libqt6qmlcompiler6_6.8.0+dfsg-0deepin3_arm64.deb
     digest: 0b1362b883a6eba427379a5b8563897b350f06e21199a5d413432cc38aa9cff5
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-declarative/libqt6qmlmodels6_6.8.0+dfsg-0deepin3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-declarative/libqt6qmlmodels6_6.8.0+dfsg-0deepin3_arm64.deb
     digest: 27a13b40585767a4e67f2aecfc130574be84c8f42b086c3479aa4aa178465dcb
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-declarative/libqt6quick6_6.8.0+dfsg-0deepin3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-declarative/libqt6quick6_6.8.0+dfsg-0deepin3_arm64.deb
     digest: 19c0e1c50056e4bffc43d46122f7661ebb8985750066dc772884cf1196ef1f44
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-declarative/libqt6quickcontrols2-6_6.8.0+dfsg-0deepin3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-declarative/libqt6quickcontrols2-6_6.8.0+dfsg-0deepin3_arm64.deb
     digest: a31cfa8da19d6c7ba7258bd8c9c5a1cab22e2ea68b8c4294b03b57816a1b49b8
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-declarative/libqt6quicktemplates2-6_6.8.0+dfsg-0deepin3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-declarative/libqt6quicktemplates2-6_6.8.0+dfsg-0deepin3_arm64.deb
     digest: 3f45dc7af58bb0aa3c7336c029063b4d0bcc6318612089451c467affe35794aa
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-declarative/libqt6quicktest6_6.8.0+dfsg-0deepin3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-declarative/libqt6quicktest6_6.8.0+dfsg-0deepin3_arm64.deb
     digest: 27dfa2d8acf855de465d500c8e4ff9e665d8b949f1ba9588bdf0d40c9777b514
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-declarative/libqt6quickvectorimagegenerator6_6.8.0+dfsg-0deepin3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-declarative/libqt6quickvectorimagegenerator6_6.8.0+dfsg-0deepin3_arm64.deb
     digest: 01b55d2f3f3771bf8b298db554ffc7a4e3812d32d0e1de99ce60ae44206423fc
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-declarative/libqt6quickwidgets6_6.8.0+dfsg-0deepin3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-declarative/libqt6quickwidgets6_6.8.0+dfsg-0deepin3_arm64.deb
     digest: 9e46187cdd05eae2b1113623f827e080aa663da7919c1d87b44dbb03792b4dbf
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-shadertools/libqt6shadertools6_6.8.0-0deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-shadertools/libqt6shadertools6_6.8.0-0deepin1_arm64.deb
     digest: 6580d46c45a2b2a72aead40acfe67184e7e15149ca0737d0a594c11f750daf2c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6sql6-sqlite_6.8.0+dfsg-0deepin8_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/libqt6sql6-sqlite_6.8.0+dfsg-0deepin8_arm64.deb
     digest: f7b98e59524a570d02433e2773cbac7cb14f1c2862bd5252b9decd75e8921489
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6sql6_6.8.0+dfsg-0deepin8_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/libqt6sql6_6.8.0+dfsg-0deepin8_arm64.deb
     digest: b9e0a5ee05c9c86e240c655e6e78b96ac25ab93b082f9ab04139be82dbe60327
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-svg/libqt6svg6_6.8.0-0deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-svg/libqt6svg6_6.8.0-0deepin1_arm64.deb
     digest: 9902fd043a3e62bba9f7d13edccd49a25d8d17ffa0ec5cdc761dd7a5c0d8b63a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-svg/libqt6svgwidgets6_6.8.0-0deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-svg/libqt6svgwidgets6_6.8.0-0deepin1_arm64.deb
     digest: 34f386ccca09b000fd6621ede73daa2fac0b94f8fd9af514767a94ed39a15bf7
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6test6_6.8.0+dfsg-0deepin8_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/libqt6test6_6.8.0+dfsg-0deepin8_arm64.deb
     digest: 2ac2f2f94233663607c1664831330558c716de3f588ad4658b82f45085d5bd7b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/libqt6uitools6_6.8.0-0deepin3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-tools/libqt6uitools6_6.8.0-0deepin3_arm64.deb
     digest: 75ef6edab7f429e473a3f73bed21049eaa774f3e6333cc583e55b1f6bda9f016
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-wayland/libqt6waylandclient6_6.8.0-0deepin7_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-wayland/libqt6waylandclient6_6.8.0-0deepin7_arm64.deb
     digest: f4b2cfd1d6b0a4573939eee7d9a48133e1068fb741d0b4ec8dc18889bc24fb8a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6widgets6_6.8.0+dfsg-0deepin8_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/libqt6widgets6_6.8.0+dfsg-0deepin8_arm64.deb
     digest: 3b09263af197ed4bb2ca92e54db9b7e14e141d78de8f143a578e01bf707f4094
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6xml6_6.8.0+dfsg-0deepin8_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/libqt6xml6_6.8.0+dfsg-0deepin8_arm64.deb
     digest: 5336d29dac452ff7e4f227f421dcb52bb6278488d4ed2833663d109e85126f49
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/r/readline/libreadline8_8.2-3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/r/readline/libreadline8_8.2-3_arm64.deb
     digest: 9bb27a75806c579d3ec78f6a455fccbd771b345a4b72014614392cf835a249df
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/r/rtmpdump/librtmp1_2.4+20151223.gitfa8646d.1-deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/r/rtmpdump/librtmp1_2.4+20151223.gitfa8646d.1-deepin1_arm64.deb
     digest: 06467b3c81e07336f2e7381ebde3b511f8a1d1dfa5c6ef8c74504589445a86fb
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cyrus-sasl2/libsasl2-2_2.1.28+dfsg1-4_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/c/cyrus-sasl2/libsasl2-2_2.1.28+dfsg1-4_arm64.deb
     digest: 15b8585dbd98a84d43b18797fb0619363087f91bff7ca70f042a9d0a63c9060b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cyrus-sasl2/libsasl2-modules-db_2.1.28+dfsg1-4_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/c/cyrus-sasl2/libsasl2-modules-db_2.1.28+dfsg1-4_arm64.deb
     digest: ff33028cb84a0712ccf76443ab69e9b52dfeeb33e2aa20a98c2f4a0a6ed97a4f
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libselinux/libselinux1-dev_3.5-1deepin5_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libs/libselinux/libselinux1-dev_3.5-1deepin5_arm64.deb
     digest: aa09e909d7f1ba4c18ed4aac21d5aac26637731dbc0580e01cd76ee3cb8103c0
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libselinux/libselinux1_3.5-1deepin5_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libs/libselinux/libselinux1_3.5-1deepin5_arm64.deb
     digest: cb9047fe72aeb8caaf8ffd6d7be6fb0f307df7d382d167aec933327ed83c87b8
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/l/lm-sensors/libsensors-config_3.6.0-7_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/l/lm-sensors/libsensors-config_3.6.0-7_all.deb
     digest: 164115506dfd335f26101e76cb49e2162b0440398ccf2d0c969ebc465dfd7867
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/l/lm-sensors/libsensors5_3.6.0-7_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/l/lm-sensors/libsensors5_3.6.0-7_arm64.deb
     digest: 1d958884723ef414ba8ac8c05701ec36cbf81ac586ea2b5a2a042b3efd0f2342
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libsepol/libsepol-dev_3.5-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libs/libsepol/libsepol-dev_3.5-2_arm64.deb
     digest: c55790b3f227a9f9b3736f40c03c8881adcf60732ce7be9a04c7b79fed7240e4
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libsepol/libsepol2_3.5-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libs/libsepol/libsepol2_3.5-2_arm64.deb
     digest: 2b1f781c87f8381b9cb83ae410f7607c56e42cc15c1c5d85cc2ef9c0364141c7
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/b/binutils/libsframe1_2.41-6deepin7_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/b/binutils/libsframe1_2.41-6deepin7_arm64.deb
     digest: cdddf20e77c1b89542721df1e13d34bfc4d38d1477b32f0370b21a6d6af2990b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libw/libwebp/libsharpyuv-dev_1.3.2-0.2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libw/libwebp/libsharpyuv-dev_1.3.2-0.2_arm64.deb
     digest: d989b877a836aa9d00d3d211dec9ecdbd06a1a18bd5683f154ad12c42f8b5bff
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libw/libwebp/libsharpyuv0_1.3.2-0.2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libw/libwebp/libsharpyuv0_1.3.2-0.2_arm64.deb
     digest: e3544fe81f21e00b53d6b9bf1be9efbc2aea360e5e074d726832f228db44cd82
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libsm/libsm6_1.2.3-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libs/libsm/libsm6_1.2.3-1_arm64.deb
     digest: 04dcd31830a75668f1114bff0dd08033af565b7f4f05cdb411d101ccff99d6e3
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/s/spdlog/libspdlog1.12_1.12.0+ds-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/s/spdlog/libspdlog1.12_1.12.0+ds-2_arm64.deb
     digest: ffeba610e1f0ffa299499d88562b65eece4f9865d8810d3a6194ff5d2cd02b38
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/s/sqlite3/libsqlite3-0_3.46.1-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/s/sqlite3/libsqlite3-0_3.46.1-1_arm64.deb
     digest: cae5a428e02558cdccde604a755eb1fb983a252597224050f4683437147e6af1
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libssh2/libssh2-1_1.11.1-1deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libs/libssh2/libssh2-1_1.11.1-1deepin1_arm64.deb
     digest: 08093eb78fa9240413e29c306f3af7f2ce9cd2599d0905cbbc48166518849895
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/o/openssl/libssl3_3.2.4-0deepin2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/o/openssl/libssl3_3.2.4-0deepin2_arm64.deb
     digest: 52f865e7d1f3a927ba35308dd28a7aa3856dbda643b4976595519e652c7bf850
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/s/startup-notification/libstartup-notification0_0.12-deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/s/startup-notification/libstartup-notification0_0.12-deepin1_arm64.deb
     digest: 6afa3a2ae947564d05b220d89298c7e6e1f875cb05b4ed1a9a450be99a3ba47d
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gcc-13/libstdc++6_13.2.0-3deepin4_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/gcc-13/libstdc++6_13.2.0-3deepin4_arm64.deb
     digest: a4c67085eb06e81f133feb7cd9309cb5582edcc256cbfe3a2a534f37d1a09da5
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/s/sysprof/libsysprof-capture-4-dev_46.0-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/s/sysprof/libsysprof-capture-4-dev_46.0-1_arm64.deb
     digest: 41ff44785effab7f081c3d4744d9e9cf25e374c13a00ab8ef93052a0a4d57114
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/s/systemd/libsystemd0_255.2-4deepin11_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/s/systemd/libsystemd0_255.2-4deepin11_arm64.deb
     digest: 694573210aea6173c54cc5084a8c29aa2001200e0a1e2144d6338463050f3979
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libt/libtasn1-6/libtasn1-6_4.18.0-4_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libt/libtasn1-6/libtasn1-6_4.18.0-4_arm64.deb
     digest: a193d7e19d36227ab39cc199ed2601bd6bbb91baddaa26dad3a2530288a57cab
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tiff/libtiff-dev_4.5.1+git230720-5_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/t/tiff/libtiff-dev_4.5.1+git230720-5_arm64.deb
     digest: fd7e6348b6fa6351d03f5bb80c2a64231ba0fb9379ccffd2effed33debdaebc1
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tiff/libtiff6_4.5.1+git230720-5_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/t/tiff/libtiff6_4.5.1+git230720-5_arm64.deb
     digest: 31c5f7d8398f83511d35d4357bcaf81f701d81ff300d6de741250d4fec1721a5
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tiff/libtiffxx6_4.5.1+git230720-5_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/t/tiff/libtiffxx6_4.5.1+git230720-5_arm64.deb
     digest: f5f19efd2db90b958cab21bcdf5be58393937b5c370e8e94d87798e5314d9b8e
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/n/ncurses/libtinfo6_6.4-4deepin2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/n/ncurses/libtinfo6_6.4-4deepin2_arm64.deb
     digest: 4fb5668afdea19caf1057ea0e2e4c1c27a7411f87c924e72055a29e7cc76a6e3
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libt/libtirpc/libtirpc-common_1.3.2-2_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libt/libtirpc/libtirpc-common_1.3.2-2_all.deb
     digest: 74bddc18e3289947b20653433e82025873f5679ccba52f258ca4912e435a09ee
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libt/libtirpc/libtirpc-dev_1.3.2-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libt/libtirpc/libtirpc-dev_1.3.2-2_arm64.deb
     digest: 02edc284e6a4be67f3bc1bdd8660f0a310ca8901c583cd18542450cdc947ebc3
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libt/libtirpc/libtirpc3_1.3.2-2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libt/libtirpc/libtirpc3_1.3.2-2_arm64.deb
     digest: 917ce3bf402df16ea74ccc1f67e1b1d97b09286609087461dd09c9c265f694c0
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tslib/libts0_1.22-1+rb3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/t/tslib/libts0_1.22-1+rb3_arm64.deb
     digest: 790a0e469c3b174d03eb0eb64f4a69ddddd95ddfd4b8daf930e4b4ac7cde179b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/uchardet/libuchardet-dev_0.0.7-1deepin0_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/u/uchardet/libuchardet-dev_0.0.7-1deepin0_arm64.deb
     digest: 666ae8e9fdea5153152511a85bd8566d9c9756288fd379a5fe8b60c204359718
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/uchardet/libuchardet0_0.0.7-1deepin0_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/u/uchardet/libuchardet0_0.0.7-1deepin0_arm64.deb
     digest: 08e6350a1fa2f96b99505d8421a1df75df69e8eef71e8d59b30eb0e778b8b4f9
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/s/systemd/libudev-dev_255.2-4deepin11_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/s/systemd/libudev-dev_255.2-4deepin11_arm64.deb
     digest: d1cad5842de92817d400e8fce7df7f7f1ea1d786356f7f9b9169509030030fad
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/s/systemd/libudev1_255.2-4deepin11_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/s/systemd/libudev1_255.2-4deepin11_arm64.deb
     digest: a6e7866b11d30f3c747d2b1a9cac9c4e9c8c233ff4c546946d75345fc3352aff
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libu/libunistring/libunistring2_0.9.10-6_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libu/libunistring/libunistring2_0.9.10-6_arm64.deb
     digest: 55c2f09476f2f0e2949afdab39939e5cb62cd99976bf36ee189011e34553b06f
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-linux/libuuid1_2.40.4-3deepin4_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/u/util-linux/libuuid1_2.40.4-3deepin4_arm64.deb
     digest: 35e273e250258aec0345b1fb3659e26fe1c31ca0516e749f5dc663435a993e5f
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/v/vulkan-loader/libvulkan-dev_1.3.268.0-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/v/vulkan-loader/libvulkan-dev_1.3.268.0-1_arm64.deb
     digest: 358dfa214cce0157b019b7f2016e7a112c6461a708e2e8d54af0d2b25c26feda
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/v/vulkan-loader/libvulkan1_1.3.268.0-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/v/vulkan-loader/libvulkan1_1.3.268.0-1_arm64.deb
     digest: 3f4142af12fb84600c5f5b9458f7fd06d28ff6f7f5bcafff4c507624d16e3126
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libw/libwacom/libwacom-common_1.12-1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libw/libwacom/libwacom-common_1.12-1_all.deb
     digest: ae18d0c6d1b68084756ae6a5ca4d4d680659ad6a9e5384bdbb49de48ffb75bd8
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libw/libwacom/libwacom-dev_1.12-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libw/libwacom/libwacom-dev_1.12-1_arm64.deb
     digest: 3d5a7ebd49f242956b1058290b1a909c4b5e687529d3b4e8530c1556f3d99b40
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libw/libwacom/libwacom2_1.12-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libw/libwacom/libwacom2_1.12-1_arm64.deb
     digest: c07692f2fda707855dbdd2f4586f8f1acf5b9cfc9618db7c08bf3442e4b7af3a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/w/wayland/libwayland-client0_1.23.0-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/w/wayland/libwayland-client0_1.23.0-1_arm64.deb
     digest: a4670daba8af6be69669976cad828b8e161c15f2707a4dfd2a67e7e1c56e775c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/w/wayland/libwayland-cursor0_1.23.0-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/w/wayland/libwayland-cursor0_1.23.0-1_arm64.deb
     digest: c055857df620bf9ae756fdb5f55c8aad8a74d32eb26fe4a7d8df5e97589cdefc
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/w/wayland/libwayland-server0_1.23.0-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/w/wayland/libwayland-server0_1.23.0-1_arm64.deb
     digest: 4f70d6062b322d7a3fd0a56c01399b5e24ea2dab26b1a5530392b26ac315d1a5
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libw/libwebp/libwebp-dev_1.3.2-0.2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libw/libwebp/libwebp-dev_1.3.2-0.2_arm64.deb
     digest: f783e2d15596e657a9077db7a3dd7e8de84360a27ab504644069df49922a9545
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libw/libwebp/libwebp7_1.3.2-0.2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libw/libwebp/libwebp7_1.3.2-0.2_arm64.deb
     digest: 72524d566f18c5461925b1bb5d352d312034f118bf5b039d76f248a682c64449
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libw/libwebp/libwebpdecoder3_1.3.2-0.2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libw/libwebp/libwebpdecoder3_1.3.2-0.2_arm64.deb
     digest: 9115ed02a3d0d9de956bc1474b608f922aa61feecfd27e267d88e2687caa19b1
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libw/libwebp/libwebpdemux2_1.3.2-0.2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libw/libwebp/libwebpdemux2_1.3.2-0.2_arm64.deb
     digest: 55519f654e68fcbcb5aecd7812a217b8ee836e7f6372487571a355b210f07224
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libw/libwebp/libwebpmux3_1.3.2-0.2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libw/libwebp/libwebpmux3_1.3.2-0.2_arm64.deb
     digest: 5473ae2903e00b0fa112a226da1db479e7ad8006ef170a650a4292704f5d9723
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libx11/libx11-6_1.8.7-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libx11/libx11-6_1.8.7-1_arm64.deb
     digest: ac2d623345cb425a3c38685f0b2d61022ac9c4092a141099dcf818d8361e7d7d
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libx11/libx11-data_1.8.7-1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libx11/libx11-data_1.8.7-1_all.deb
     digest: 400aaa7eaab268850d8c2c512474228204d47774f2aac79cef29d1c125e0c656
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libx11/libx11-dev_1.8.7-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libx11/libx11-dev_1.8.7-1_arm64.deb
     digest: 1c6d4a10271b55eaf39aa83f76851047669a842f2c15b18282f2851bf29644d0
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libx11/libx11-xcb1_1.8.7-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libx11/libx11-xcb1_1.8.7-1_arm64.deb
     digest: 6293185372418e4f14c17d5c4d14cb631ecb1474be1b3d81d00a61f984bef922
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxau/libxau-dev_1.0.9-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxau/libxau-dev_1.0.9-1_arm64.deb
     digest: 28ba4c91230a4d8e3caa43b0897bc56960e5b07eb6e8297ddfe3d57c3514457e
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxau/libxau6_1.0.9-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxau/libxau6_1.0.9-1_arm64.deb
     digest: 82a1fcfe359eeb57e4c0dedd434719360650ed2423d08af807a06d0a0ba91bae
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/x/xcb-util-cursor/libxcb-cursor0_0.1.1-4_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xcb-util-cursor/libxcb-cursor0_0.1.1-4_arm64.deb
     digest: 3e5079ca95b7a9f560cd332344e808d35a4cc1d90b57737abd43c8807fd9cd93
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxcb/libxcb-dri3-0_1.15-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxcb/libxcb-dri3-0_1.15-1_arm64.deb
     digest: 66f3b86e8de5a56edf32de02641ad515380cf3fa84d219523c2a04dd7d2bd602
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxcb/libxcb-glx0_1.15-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxcb/libxcb-glx0_1.15-1_arm64.deb
     digest: 8f251424b4a32ab7b0341578f3421c3eb15d25362117994350a6786f0b251f00
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/x/xcb-util-wm/libxcb-icccm4_0.4.1-1.1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xcb-util-wm/libxcb-icccm4_0.4.1-1.1_arm64.deb
     digest: 58945d6723d8d5b00b0524877f5dd8c4cd4292ff73c561d72feb68f46e1acc42
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/x/xcb-util-image/libxcb-image0_0.4.0-deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xcb-util-image/libxcb-image0_0.4.0-deepin1_arm64.deb
     digest: 15b4c9739300d22125e53ccd84636ed156d0df2b62b49519649aa2076cd0c343
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/x/xcb-util-keysyms/libxcb-keysyms1_0.4.0-deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xcb-util-keysyms/libxcb-keysyms1_0.4.0-deepin1_arm64.deb
     digest: 1044daab8cffa74f4c4dcbe8009ba2efa1cc9b5dd4dd615b0ef1207d3feed915
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxcb/libxcb-present0_1.15-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxcb/libxcb-present0_1.15-1_arm64.deb
     digest: 4eb85646303b49b352e71e9c83e41ab3d66bf6729728e6b0a5545e9383a10c7c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxcb/libxcb-randr0_1.15-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxcb/libxcb-randr0_1.15-1_arm64.deb
     digest: 57ae90f4b2a203258755300a18e6cdf3bdd30055b49f2b2931d76e4f39930691
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/x/xcb-util-renderutil/libxcb-render-util0_0.3.9-deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xcb-util-renderutil/libxcb-render-util0_0.3.9-deepin1_arm64.deb
     digest: 1cc4fbb689677ac40edd81fdf7fad185847826720e9b4a974b4de4fa505ba7a5
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxcb/libxcb-render0_1.15-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxcb/libxcb-render0_1.15-1_arm64.deb
     digest: a94a481050202abd6227bb5df04eebd5d41243c51ac611490f79bffc9210d56a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxcb/libxcb-shape0_1.15-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxcb/libxcb-shape0_1.15-1_arm64.deb
     digest: 02dec7d7fa38f1a3bcc8df6f3d3882fe660e5e84abaffd73055d495b558fae7d
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxcb/libxcb-shm0_1.15-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxcb/libxcb-shm0_1.15-1_arm64.deb
     digest: 8270f8631c37a5ce16edb733617bebfdaa4bfe0d9885a95b565ac39d76c7dba0
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxcb/libxcb-sync1_1.15-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxcb/libxcb-sync1_1.15-1_arm64.deb
     digest: c447e06e8318215b440f20992c69647cee90c31d9158cef9f16ec00424f7f509
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/x/xcb-util/libxcb-util1_0.4.0-deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xcb-util/libxcb-util1_0.4.0-deepin1_arm64.deb
     digest: 18e3bc7f50b606984f78dcd7f2a137f68a8fde96ef17da18c7195242f1313c84
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxcb/libxcb-xfixes0_1.15-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxcb/libxcb-xfixes0_1.15-1_arm64.deb
     digest: c3c442fc82728a145e47ff2ce37bf173cc96bd26dc3329f8eed3daec2d47c211
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxcb/libxcb-xkb1_1.15-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxcb/libxcb-xkb1_1.15-1_arm64.deb
     digest: 0386603371b588c01d5d5114b96c0a05c62b9107ee8033807a9c14e8e466da98
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxcb/libxcb1-dev_1.15-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxcb/libxcb1-dev_1.15-1_arm64.deb
     digest: f655f75fb5205cb90667bd2e1b1c08ccd93e0f937d1b4124b10afbab5bd4bc54
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxcb/libxcb1_1.15-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxcb/libxcb1_1.15-1_arm64.deb
     digest: 6a66b765b483884d4a8edb62dcbca87acae889488fba889b8e631982d0e35467
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxdmcp/libxdmcp-dev_1.1.2-3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxdmcp/libxdmcp-dev_1.1.2-3_arm64.deb
     digest: 26b4210ed6ce4e5d1dc2f766ae3b47dc36442294c8b7e8eaed61da9792f76130
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxdmcp/libxdmcp6_1.1.2-3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxdmcp/libxdmcp6_1.1.2-3_arm64.deb
     digest: 1ac4558b1438d14fbc93d8c969bafac2ac7cfe4f4ec609d6ef34a47d73eda2dc
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxext/libxext6_1.3.4-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxext/libxext6_1.3.4-1_arm64.deb
     digest: 1018afc359feea593e136caed0273075e2d92aa9848bbb63b70fd55730fc4046
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxi/libxi6_1.8.1-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxi/libxi6_1.8.1-1_arm64.deb
     digest: 7469379eee4164ad50e2d1369cff5f8394b1da88c92fac8f04fee521da5634b7
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxkbcommon/libxkbcommon-dev_1.6.0-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxkbcommon/libxkbcommon-dev_1.6.0-1_arm64.deb
     digest: 941544912030ac7a4ef2b1c3944932245be753179c8b83f93f2ecce2286ad833
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxkbcommon/libxkbcommon-x11-0_1.6.0-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxkbcommon/libxkbcommon-x11-0_1.6.0-1_arm64.deb
     digest: baaa366b8142ee3eac7bb178b46096caf39bcfb7b4772857af8b795d2dc6cd29
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxkbcommon/libxkbcommon0_1.6.0-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxkbcommon/libxkbcommon0_1.6.0-1_arm64.deb
     digest: f17db6332bf3598ce69a9e82ead1270c456976d1313365c0f4b2414a919338da
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxml2/libxml2_2.9.14+dfsg-1.3+rb2_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxml2/libxml2_2.9.14+dfsg-1.3+rb2_arm64.deb
     digest: 821afd2170d402ff5a6f4cf852f27b329dd267a2a3d8ef10a0dd84c034ba83df
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxshmfence/libxshmfence1_1.3-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxshmfence/libxshmfence1_1.3-1_arm64.deb
     digest: 60d857474c350e734ae71d52d2f178bb094040eee606ad3b492e7bad7d105e35
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxxf86vm/libxxf86vm1_1.1.4-deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxxf86vm/libxxf86vm1_1.1.4-deepin1_arm64.deb
     digest: 03c6008b099fcb1e65cb6616159d20db0bdb71c201ca864f7b88e54e82d8541d
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/z/z3/libz3-4_4.8.12-deepin2+rb1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/z/z3/libz3-4_4.8.12-deepin2+rb1_arm64.deb
     digest: 0ef6e252cc4bc0db0aa9ac30c918a210d8abcdcd059f4c5f7cc6d6cef7b10600
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libz/libzstd/libzstd-dev_1.5.6+dfsg-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libz/libzstd/libzstd-dev_1.5.6+dfsg-1_arm64.deb
     digest: ca9575f6503945c733c4dc2ce78dee09745bdb6eef34f631212d2311e1d635f1
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libz/libzstd/libzstd1_1.5.6+dfsg-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libz/libzstd/libzstd1_1.5.6+dfsg-1_arm64.deb
     digest: 36724ed79e7cc83e5357ab2f3e8c2ca75362b5352611bf5bc3c54289191f3e02
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/linguist-qt6_6.8.0-0deepin3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-tools/linguist-qt6_6.8.0-0deepin3_arm64.deb
     digest: 467675c0f4007bad669a8fefe0ec4ab45f1d356f947afd7aabba2f17b88401fb
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/l/linux-upstream/linux-libc-dev_25.01.01.01_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/l/linux-upstream/linux-libc-dev_25.01.01.01_arm64.deb
     digest: 7a770cbb690f79ec2702611e320d3eced7565598bd3db72ac9eb060c476979a2
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/l/lshw/lshw_02.19.git.2021.06.19.996aaad9c7-2deepin0_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/l/lshw/lshw_02.19.git.2021.06.19.996aaad9c7-2deepin0_arm64.deb
     digest: 0e32f0eef7e7f5effe89929ad9a1c14a2838e5033fa9142cf0b3e6bcb81f8573
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mailcap/mailcap_3.70_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/m/mailcap/mailcap_3.70_all.deb
     digest: 7ca67d118c03eaf58346eb1e676ff16f4d1aa5252a8cc6b5b3b1ed44556180f1
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/make-dfsg/make_4.4.1-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/m/make-dfsg/make_4.4.1-1_arm64.deb
     digest: fd601544bf60cf407d143282c4fb1296842e0cb583308339bde436df40c45b36
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/media-types/media-types_4.0.0_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/m/media-types/media-types_4.0.0_all.deb
     digest: cd124053950ab8b0373203bceb7eab841791017daf1d50db2ece09e4da52406a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mesa/mesa-libgallium_24.3.0-1deepin4_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/m/mesa/mesa-libgallium_24.3.0-1deepin4_arm64.deb
     digest: 60d8a9cf9d9fa0751184d40ff2771f8f832d3c27458af93be77c37f4e9c63b56
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mime-support/mime-support_3.66_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/m/mime-support/mime-support_3.66_all.deb
     digest: 20294deda4378616c2b48614ee226731ec09663c3497c35a467e8ea5fa03f16a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/n/netbase/netbase_6.4_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/n/netbase/netbase_6.4_all.deb
     digest: 5fd05a5d63864b96453ba55a4c5efa287b8e7e53fbd833e7a944e066d30e1eb1
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/patch/patch_2.7.6-7_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/patch/patch_2.7.6-7_arm64.deb
     digest: d69d6e60753f09647125fa0991f7bda438f75c33708a9ca01dd6f1b6b87a3bd7
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/perl/perl-base_5.36.0-10deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/perl/perl-base_5.36.0-10deepin1_arm64.deb
     digest: e98e08d6308dadcd156dfe5bb14d8f12ad9bef51804dc6caa6cce6f157dc0f1a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/perl/perl-modules-5.36_5.36.0-10deepin1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/perl/perl-modules-5.36_5.36.0-10deepin1_all.deb
     digest: b79ccae8397e919ee917cd187b8be2d3b10eb598f43cf72a9d9a50c3d81ec288
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/perl/perl_5.36.0-10deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/perl/perl_5.36.0-10deepin1_arm64.deb
     digest: f4769ff0d6a971a7fc77d5f80e5cf6333da1ad8e2589da461c26c3744e944888
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pkgconf/pkg-config_1.8.1-4_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/pkgconf/pkg-config_1.8.1-4_arm64.deb
     digest: 8b40ce5f7439c482fa8800f2a60160fb34fd46492d8ed397480ca0471b7fc9d8
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pkgconf/pkgconf-bin_1.8.1-4_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/pkgconf/pkgconf-bin_1.8.1-4_arm64.deb
     digest: fb3f32b7b567509b63afab51fdf5afbef9f9af569f10aac490b98d34feab8670
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pkgconf/pkgconf_1.8.1-4_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/pkgconf/pkgconf_1.8.1-4_arm64.deb
     digest: 141f5145e6adf2f9519d95a6e4ec3b1410e829621777b48c7c48bc02bc779c40
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/python3-defaults/python3-minimal_3.12.1-1deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/python3-defaults/python3-minimal_3.12.1-1deepin1_arm64.deb
     digest: 2456806adbaacfe2d195ee74a70141e692fbc364152c5f7a19d36697a518ed8d
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/python-packaging/python3-packaging_24.0-1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/python-packaging/python3-packaging_24.0-1_all.deb
     digest: acf9e0347764b07624b219b64fa7721705d6eeea5a98871f892aff3ab0293ae4
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/python3.12/python3.12-minimal_3.12.11-0deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/python3.12/python3.12-minimal_3.12.11-0deepin1_arm64.deb
     digest: f646ff8063d6635c9df51bf873deecfda699a61dc0db1f51745f770d4f9ae0bd
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/python3.12/python3.12_3.12.11-0deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/python3.12/python3.12_3.12.11-0deepin1_arm64.deb
     digest: 0d85d36c0e59a7b1986cfa894814256a7361d2ccb5818e623712faa65795fc44
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/python3-defaults/python3_3.12.1-1deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/python3-defaults/python3_3.12.1-1deepin1_arm64.deb
     digest: 18b254c8a2ea4801a79cab3d7946d9730e41360e251094765cf8c4928f448a23
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/qdbus-qt6_6.8.0-0deepin3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-tools/qdbus-qt6_6.8.0-0deepin3_arm64.deb
     digest: 2608678aef17e7c03c4b1fc3f3e8e10b91c7ec523471e4e4cd7790be50ef8a40
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qmake6-bin_6.8.0+dfsg-0deepin8_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/qmake6-bin_6.8.0+dfsg-0deepin8_arm64.deb
     digest: ce44156c4871fe1af1cf1c7113d623489f7789b0cca8ae63a3acba72ff176889
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qmake6_6.8.0+dfsg-0deepin8_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/qmake6_6.8.0+dfsg-0deepin8_arm64.deb
     digest: cc0a67ca33b3c44efeb4723a95d34b986eb989278c17e9d9c6dcfa21aeef9b73
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/k/kf6-syntax-highlighting/qml6-module-org-kde-syntaxhighlighting_6.10.0-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/k/kf6-syntax-highlighting/qml6-module-org-kde-syntaxhighlighting_6.10.0-1_arm64.deb
     digest: 5723de3763ef45d9ff3219f314a12caa31f74d25df85cba18577a976f1f096af
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-5compat/qml6-module-qt5compat-graphicaleffects_6.8.0-0deepin_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-5compat/qml6-module-qt5compat-graphicaleffects_6.8.0-0deepin_arm64.deb
     digest: 0a4a4e7f77ba792604bb9563b61689c8311a746bc4d5e2c1a10b80fbd9f91785
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-declarative/qml6-module-qtqml-workerscript_6.8.0+dfsg-0deepin3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-declarative/qml6-module-qtqml-workerscript_6.8.0+dfsg-0deepin3_arm64.deb
     digest: 3f2442b73e48918050635d141f1ea8112442ff9217e92bd998bc9155ad201411
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-declarative/qml6-module-qtqml_6.8.0+dfsg-0deepin3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-declarative/qml6-module-qtqml_6.8.0+dfsg-0deepin3_arm64.deb
     digest: 96f2f1d1953e3a48542911d7d13f179fc9e7766a462f5941a995f56455c9fc63
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6declarative/qml6-module-qtquick-controls2-styles-chameleon_6.0.38_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/dtk6declarative/qml6-module-qtquick-controls2-styles-chameleon_6.0.38_arm64.deb
     digest: 2d1a77295c50eefc4b0609629378e9f2c26164501b004ba1d018e6a634d5c93d
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-declarative/qml6-module-qtquick-controls_6.8.0+dfsg-0deepin3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-declarative/qml6-module-qtquick-controls_6.8.0+dfsg-0deepin3_arm64.deb
     digest: 6ebce1670e7a4ac7a1a854e8d874cc6a52a1ff5fe2240e692ebbc0640ac94b5a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-declarative/qml6-module-qtquick-effects_6.8.0+dfsg-0deepin3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-declarative/qml6-module-qtquick-effects_6.8.0+dfsg-0deepin3_arm64.deb
     digest: 057b065e255438aff8701c50d93ad4fcc1a41b8074a703ab6ba7618b9f4cd9ee
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-declarative/qml6-module-qtquick-shapes_6.8.0+dfsg-0deepin3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-declarative/qml6-module-qtquick-shapes_6.8.0+dfsg-0deepin3_arm64.deb
     digest: 0b4e44ed3ecddb764aa1c10864e03a5ff5ce734846d9c78ca2a83bafa11a88cc
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-declarative/qml6-module-qtquick-templates_6.8.0+dfsg-0deepin3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-declarative/qml6-module-qtquick-templates_6.8.0+dfsg-0deepin3_arm64.deb
     digest: 79053ecd79a1eb3d3ff47a57b81871d54831659aa1a94ac8289c525a256bc0d7
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-declarative/qml6-module-qtquick_6.8.0+dfsg-0deepin3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-declarative/qml6-module-qtquick_6.8.0+dfsg-0deepin3_arm64.deb
     digest: 429968f77078516eb9464fbe5224f3fc8bf3cf7831889c9677638ecfdefb905a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-5compat/qt6-5compat-dev_6.8.0-0deepin_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-5compat/qt6-5compat-dev_6.8.0-0deepin_arm64.deb
     digest: f16c25091859915e16ec9079cf2e640f789fd896b55aa43c4a2b00d7df88c864
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qt6-base-dev-tools_6.8.0+dfsg-0deepin8_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/qt6-base-dev-tools_6.8.0+dfsg-0deepin8_arm64.deb
     digest: 1789a73946e436fa2aaa758278d023c47ba8cc0cfe2547ac70c18f77058ba834
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qt6-base-dev_6.8.0+dfsg-0deepin8_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/qt6-base-dev_6.8.0+dfsg-0deepin8_arm64.deb
     digest: f86c153ce4628e34e8f59d66ecd3a001016cdc9cfa43e03756581a177be17e40
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qt6-base-private-dev_6.8.0+dfsg-0deepin8_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/qt6-base-private-dev_6.8.0+dfsg-0deepin8_arm64.deb
     digest: 651905afd63f5427e9b9a14d9a667709ef7449d7dcd140ec62aa1fe05ed13828
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-declarative/qt6-declarative-dev-tools_6.8.0+dfsg-0deepin3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-declarative/qt6-declarative-dev-tools_6.8.0+dfsg-0deepin3_arm64.deb
     digest: ea038341d9afa62f15a85b976ef6e3a12291092d403080520144b9ba98a46e08
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-declarative/qt6-declarative-dev_6.8.0+dfsg-0deepin3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-declarative/qt6-declarative-dev_6.8.0+dfsg-0deepin3_arm64.deb
     digest: b0dd5c46c4bc9c0207a21e342f472dc33856dc00d0305687c783044d73a01cc7
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/qt6-documentation-tools_6.8.0-0deepin3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-tools/qt6-documentation-tools_6.8.0-0deepin3_arm64.deb
     digest: 719086d3983481e4d78e4c7424a796831db3925c1ca6b3495513e9cde674565b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-imageformats/qt6-image-formats-plugins_6.8.0-0deepin_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-imageformats/qt6-image-formats-plugins_6.8.0-0deepin_arm64.deb
     digest: 4e4323c9a9a51342c64424187e92f7653a7aead8899f523561bc2bf8215ed513
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/qt6-l10n-tools_6.8.0-0deepin3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-tools/qt6-l10n-tools_6.8.0-0deepin3_arm64.deb
     digest: 9265848cc3a9da02d8de859a7705604e75d2baef2fc16cd243485e56f15ccf5a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-declarative/qt6-qmllint-plugins_6.8.0+dfsg-0deepin3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-declarative/qt6-qmllint-plugins_6.8.0+dfsg-0deepin3_arm64.deb
     digest: f47370f34de61952736e23307d07de7959bd61028c1274f18c5c6f1f83f91b49
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-declarative/qt6-qmltooling-plugins_6.8.0+dfsg-0deepin3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-declarative/qt6-qmltooling-plugins_6.8.0+dfsg-0deepin3_arm64.deb
     digest: 20a6ee2e72e310403594fff1a282b55c171db07f87407f87463d03a4955a2030
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qt6-qpa-plugins_6.8.0+dfsg-0deepin8_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/qt6-qpa-plugins_6.8.0+dfsg-0deepin8_arm64.deb
     digest: b5dc6687475a84e1aa544d8fa3cc1eb80c13ada54c0c3b10625fc96a605c6518
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-svg/qt6-svg-dev_6.8.0-0deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-svg/qt6-svg-dev_6.8.0-0deepin1_arm64.deb
     digest: e6732e7d1132d2a84254c8868b2c4cbf36e2afc4db8f82859bd8e5b9f40bbc7c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/qt6-tools-dev-tools_6.8.0-0deepin3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-tools/qt6-tools-dev-tools_6.8.0-0deepin3_arm64.deb
     digest: c45c4550873e94c31f4372e71b06dd80d8e634f532585d496dbfc60218fa49d4
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/qt6-tools-dev_6.8.0-0deepin3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-tools/qt6-tools-dev_6.8.0-0deepin3_arm64.deb
     digest: 03bb344dd34bd0076551e13b833b014c2c379d13213a0d0668af15544e509de4
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/r/readline/readline-common_8.2-3_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/r/readline/readline-common_8.2-3_all.deb
     digest: 35fe59faceb8d9def8b6aa664e091eac8444887bc1f33ba2cf22099c3646e7bd
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/r/rpcsvc-proto/rpcsvc-proto_1.4.2-4_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/r/rpcsvc-proto/rpcsvc-proto_1.4.2-4_arm64.deb
     digest: ae2f397b418bbed8a068fdc9223133120390dbe734734c72b8e152962a76da91
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/s/shared-mime-info/shared-mime-info_2.2-1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/s/shared-mime-info/shared-mime-info_2.2-1_arm64.deb
     digest: e026d478f271cdce55bcc623fea311ee9605e39bf17ee3919b2502221d0e86e0
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tar/tar_1.35+dfsg-3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/t/tar/tar_1.35+dfsg-3_arm64.deb
     digest: 9e736851d33ca49a6e7ae4b188c480ea0929cb8e322da77174570c64a1037175
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tzdata/tzdata_2023d-1deepin1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/t/tzdata/tzdata_2023d-1deepin1_all.deb
     digest: fe503c524801260208482a1dfc061e79c2a7450111dd90f88ed40d70ac935832
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-linux/uuid-dev_2.40.4-3deepin4_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/u/util-linux/uuid-dev_2.40.4-3deepin4_arm64.deb
     digest: 079ee6193e894d85bdb6c51b4318514bf0f788c12560b7bd05b46d6f12df388a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/x/xorg/x11-common_7.7+23-deepin1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xorg/x11-common_7.7+23-deepin1_all.deb
     digest: 9a7643db11023a8bec126312edec4b1b7357b93416bdfbaf9b0cb8bc04506d49
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/x/xorgproto/x11proto-core-dev_2024.1-1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xorgproto/x11proto-core-dev_2024.1-1_all.deb
     digest: 82bff9dab1d74e30bdbc6130f94d1bd361c3c1d3cdad660bd92e5b730c4cba7b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/x/xorgproto/x11proto-dev_2024.1-1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xorgproto/x11proto-dev_2024.1-1_all.deb
     digest: 39e14817ff2ab4eedade206fefebb7b2632e4dd7c358a9cfe36bcdd477554a04
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/x/xfonts-encodings/xfonts-encodings_1.0.4-2.1deepin1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xfonts-encodings/xfonts-encodings_1.0.4-2.1deepin1_all.deb
     digest: 07d68c68eeeca62cea0558b4f0bc25896bd82fddfa6c4b02693ee0adc4bde224
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/x/xfonts-utils/xfonts-utils_7.7+6-deepin_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xfonts-utils/xfonts-utils_7.7+6-deepin_arm64.deb
     digest: c92b2bd8b458619a6f6fdca530fe2b8d9faf3ed273cd867126898275078c1ec7
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/x/xkeyboard-config/xkb-data_2.38-2deepin1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xkeyboard-config/xkb-data_2.38-2deepin1_all.deb
     digest: 6fdc32f08737735128e20a10f9a8425bde19855e3917d8f26a62ea3a12a9a720
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/x/xorg-sgml-doctools/xorg-sgml-doctools_1.11-1.1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xorg-sgml-doctools/xorg-sgml-doctools_1.11-1.1_all.deb
     digest: c3ac4805a75219ecc8a92a79697d39fa9abf6a7fa16da540800a0d30bdcc2847
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/x/xtrans/xtrans-dev_1.4.0-1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xtrans/xtrans-dev_1.4.0-1_all.deb
     digest: ab37e512128e066d7225deb7f51f0c77f9b0c3913d75f2a7f9b1d708327a099d
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/x/xz-utils/xz-utils_5.4.5-0.3_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xz-utils/xz-utils_5.4.5-0.3_arm64.deb
     digest: 8df904affdf74d76f6a265ba072c57844c981ae39074c5526c763752cb03f100
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/z/zlib/zlib1g-dev_1.3.dfsg+really1.3.1-1deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/z/zlib/zlib1g-dev_1.3.dfsg+really1.3.1-1deepin1_arm64.deb
     digest: 29a1888f6b7be54992868b36050c68d6063820ae6c4a2e09ffa2317a7e0b6d6f
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/z/zlib/zlib1g_1.3.dfsg+really1.3.1-1deepin1_arm64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/z/zlib/zlib1g_1.3.dfsg+really1.3.1-1deepin1_arm64.deb
     digest: 2c38eb2adccdb6baf292a182b5963a7eee5895afd657917be10282bdb2b2139f

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-editor (6.5.32) unstable; urgency=medium
+
+  * fix: Update file path handling in saveAsFileToDisk function
+
+ -- dengzhongyuan <dengzhongyuan@uniontech.com>  Fri, 18 Jul 2025 13:16:52 +0800
+
 deepin-editor (6.5.31) unstable; urgency=medium
 
   * fix: Remove return statement in recoverFile function

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.editor
   name: "deepin-editor"
-  version: 6.5.31.1
+  version: 6.5.32.1
   kind: app
   description: |
     editor for deepin os.
@@ -45,1166 +45,1166 @@ build: |
   bash ./deploy_dep "${LDD_FILES[@]}"
 
 sources:
-  # linglong:gen_deb_source sources amd64 http://10.20.64.92:8080/testing25_daily stable main
+  # linglong:gen_deb_source sources amd64 http://10.20.64.92:8080/crimson_25.0 stable main
   # linglong:gen_deb_source install qt6-5compat-dev, qt6-base-dev, qt6-tools-dev-tools, qt6-tools-dev, qt6-base-private-dev, qt6-svg-dev, libdtk6widget-dev, libdtk6gui-dev, libdtk6core-dev, libdtk6declarative-dev, libpolkit-qt6-1-dev, libkf6syntaxhighlighting-dev, libkf6codecs-dev, libgtest-dev, libgmock-dev, libchardet-dev, libuchardet-dev, libicu-dev, deepin-event-log
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/assistant-qt6_6.8.0-0deepin3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-tools/assistant-qt6_6.8.0-0deepin3_amd64.deb
     digest: b6175963d3e4cf00d76fe431e75e52450bad93604945040d706d97b65cd8623d
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/b/binutils/binutils-common_2.41-6deepin7_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/b/binutils/binutils-common_2.41-6deepin7_amd64.deb
     digest: 479ecc732776fe043e2ee3c652f10258c5dac413324566c1bdb594b026d6bf5a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/b/binutils/binutils-x86-64-linux-gnu_2.41-6deepin7_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/b/binutils/binutils-x86-64-linux-gnu_2.41-6deepin7_amd64.deb
     digest: 59150923974958d8ca8e64d1e7bdfd983c03b44e83c28287cc57eb7fc8b612a6
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/b/binutils/binutils_2.41-6deepin7_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/b/binutils/binutils_2.41-6deepin7_amd64.deb
     digest: 676af766071e8edcf4e35a85a1a0eb3907ec6be6036c0dce3cdb0fa91700fc50
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/b/bzip2/bzip2_1.0.8-deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/b/bzip2/bzip2_1.0.8-deepin1_amd64.deb
     digest: a67b553f354a824475090fcd7a1b6fe237598a1445158526027f2970aa976def
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/debconf/debconf_1.5.79-deepin_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/debconf/debconf_1.5.79-deepin_all.deb
     digest: ded6aaa7927ae27337ceb23d49391b4c7ec460a00ba692020e8f4e28388f345f
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/deepin-event-log/deepin-event-log-daemon_2.1.2-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/deepin-event-log/deepin-event-log-daemon_2.1.2-1_amd64.deb
     digest: 30037f716885fe58a6f1c5f53533241d1aa8e77df91db24ca2dd5cf831d45eb3
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/deepin-event-log/deepin-event-log_2.1.2-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/deepin-event-log/deepin-event-log_2.1.2-1_amd64.deb
     digest: 0dd5471ec1a5bbf443cd0082bd72bbb800c423483f3789fc50595003987e2ab2
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/designer-qt6_6.8.0-0deepin3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-tools/designer-qt6_6.8.0-0deepin3_amd64.deb
     digest: f0e1fe7a35fc386fb5944eb9bc4325c4e2d8913f43639ab6791ed3ea6084f584
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dpkg/dpkg-dev_1.22.6deepin4_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/dpkg/dpkg-dev_1.22.6deepin4_all.deb
     digest: 8b3ec535c58fd4041effcff798c688ab1f4a36b6c2ac5989412020686c7607f7
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dpkg/dpkg_1.22.6deepin4_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/dpkg/dpkg_1.22.6deepin4_amd64.deb
     digest: 2837fb44598aa57a0fc7d2b477c6539b3c268a1312f2580d4fb227e83d023d9b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fontconfig/fontconfig-config_2.15.0-2.3deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/fontconfig/fontconfig-config_2.15.0-2.3deepin1_amd64.deb
     digest: 70df7073f2ddecf0ecce688b92939d7bf31268d37d299a416243dd6a114a96ab
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fontconfig/fontconfig_2.15.0-2.3deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/fontconfig/fontconfig_2.15.0-2.3deepin1_amd64.deb
     digest: c3c6ce170d17d875a72e644f67be87e47ae19feb7682517eab59259591348441
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fonts-noto/fonts-croscore_20201225-deepin_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/fonts-noto/fonts-croscore_20201225-deepin_all.deb
     digest: afbaf120869a08aa7dd14da9ad014de48a751aa4330534b531410bb86c411b55
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fonts-dejavu/fonts-dejavu-core_2.37-deepin_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/fonts-dejavu/fonts-dejavu-core_2.37-deepin_all.deb
     digest: 5982963d05dbf4efa009c3ab6db3576a03f680199d75d7d5edda89c55def912c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fonts-freefont/fonts-freefont-otf_20120503-10_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/fonts-freefont/fonts-freefont-otf_20120503-10_all.deb
     digest: c66666da94b9a0477351ee9d6d7a247a0a3c842e428da770991b45f03be2ee72
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fonts-freefont/fonts-freefont-ttf_20120503-10_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/fonts-freefont/fonts-freefont-ttf_20120503-10_all.deb
     digest: 79b23c3945d4628463672a804a0e81bc4c262ef87cb6316afb40167a50bc3145
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fonts-liberation/fonts-liberation_2.1.5-3_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/fonts-liberation/fonts-liberation_2.1.5-3_all.deb
     digest: 9285213fd8d6515bc6c1be5b810bf39918a668a17024a9fd3541879ce7fb5344
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fonts-noto/fonts-noto-core_20201225-deepin_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/fonts-noto/fonts-noto-core_20201225-deepin_all.deb
     digest: fa09d95f516c498d55e516d549b8ee41d9a7b6f17cdf0bb4b43744d672ce1366
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tex-gyre/fonts-texgyre_20180621-3.1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/t/tex-gyre/fonts-texgyre_20180621-3.1_all.deb
     digest: f66d6f798c4b99d8490558cc8209c069b0fe5577c11378c0e01f9e87ddf10824
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fonts-urw-base35/fonts-urw-base35_20200910-7_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/fonts-urw-base35/fonts-urw-base35_20200910-7_all.deb
     digest: 4800c0b08fbeac0335f1e23df2d41528a242383324c256ebece00c8f438eefbd
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gcc-13/gcc-13-base_13.2.0-3deepin4_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/gcc-13/gcc-13-base_13.2.0-3deepin4_amd64.deb
     digest: 67ac59a7c56a0c1ea647222bfa7830ac81d98895867a348fc30746e2176ec9bd
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/glib2.0/gir1.2-glib-2.0_2.80.1-1deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/glib2.0/gir1.2-glib-2.0_2.80.1-1deepin1_amd64.deb
     digest: 19242756d4cc8125e5b18e34319ba4f4445aeff9bc3c1560e9dc5a87fcacb0d2
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libgudev/gir1.2-gudev-1.0_238-2deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libg/libgudev/gir1.2-gudev-1.0_238-2deepin1_amd64.deb
     digest: 3cbcb69c6edaebc428fc9f7c19a4a4e7a057bb980ab6b6f754561e3aee3ea011
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/googletest/googletest_1.12.1-0.2_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/googletest/googletest_1.12.1-0.2_all.deb
     digest: 2df57ce8c5c8fdc37e1dbbe302d276f1cb9a784df5dd3423208f87933cfa28a0
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/i/icu/icu-devtools_74.2-1deepin4_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/i/icu/icu-devtools_74.2-1deepin4_amd64.deb
     digest: 8b92d6873155948ce1a7925c25c0de19aea2350f8da9dad804d392774da333d4
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/a/acl/libacl1_2.3.1-3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/a/acl/libacl1_2.3.1-3_amd64.deb
     digest: e7235d27da99795b0ca6c6bc5e8d6e84702335063fe9d08b19320c0bc965679c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/a/avahi/libavahi-client3_0.8-5_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/a/avahi/libavahi-client3_0.8-5_amd64.deb
     digest: 28bdf7a8c0529f6397921fe59358e8d94cf3d3f1e498f09e9b4035254ee15baf
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/a/avahi/libavahi-common-data_0.8-5_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/a/avahi/libavahi-common-data_0.8-5_amd64.deb
     digest: 5fdc5ef24ff229630b683db663cb26e108aa719fd288b808c4607c680de52c75
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/a/avahi/libavahi-common3_0.8-5_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/a/avahi/libavahi-common3_0.8-5_amd64.deb
     digest: a966db72e688d76b06a665dfe894c66faae8d2033cf5dd8776bf56f41912035f
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libb/libb2/libb2-1_0.98.1-1.1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libb/libb2/libb2-1_0.98.1-1.1_amd64.deb
     digest: ad82b2de93cc49cdf37c861b03275245318b1555255639e5e805cf612a40171e
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/b/binutils/libbinutils_2.41-6deepin7_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/b/binutils/libbinutils_2.41-6deepin7_amd64.deb
     digest: 10e86800f4da1db706020bdcf6642096be3c093759d41631cf6492237e26748b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-linux/libblkid-dev_2.40.4-3deepin4_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/u/util-linux/libblkid-dev_2.40.4-3deepin4_amd64.deb
     digest: a4d108ebdc3c5710be943be9fc8b480e7db0704da63fb2c041dc2865df4ce4f9
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-linux/libblkid1_2.40.4-3deepin4_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/u/util-linux/libblkid1_2.40.4-3deepin4_amd64.deb
     digest: 567b0f1dfc7844c74fcca08a18d6f0d527caf16278e205095522a0454ca23918
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/b/brotli/libbrotli-dev_1.1.0-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/b/brotli/libbrotli-dev_1.1.0-2_amd64.deb
     digest: 87226cff96c560b3ea8b15110f7f2b00047b0cc9dd29c9fdbc372b4d9154de80
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/b/brotli/libbrotli1_1.1.0-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/b/brotli/libbrotli1_1.1.0-2_amd64.deb
     digest: c90c041d2069cc78a80e07d62ce3e251306a81b23f9b95fa35a65ce7af87ad04
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libb/libbsd/libbsd0_0.11.7-4_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libb/libbsd/libbsd0_0.11.7-4_amd64.deb
     digest: 40e8755d2d6de7ee5c90483c74d586c6270f088eaf630acdc32bc848c09cedfe
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/b/bzip2/libbz2-1.0_1.0.8-deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/b/bzip2/libbz2-1.0_1.0.8-deepin1_amd64.deb
     digest: 42c04d805408bc1f10872e8394e26d3ff1bc6aa3477efac7e94612f9b7b2d972
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/b/bzip2/libbz2-dev_1.0.8-deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/b/bzip2/libbz2-dev_1.0.8-deepin1_amd64.deb
     digest: 60e1d9cbac4fafa4f7823e6495212ec02805997e64dead0f40de1d86ff138d41
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/glibc/libc-dev-bin_2.38-6deepin13+rb1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/glibc/libc-dev-bin_2.38-6deepin13+rb1_amd64.deb
     digest: 00d51bccb99085bb8b797d1da104893235789b72dc88f42f5d5d7b50d2139874
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/glibc/libc6-dev_2.38-6deepin13+rb1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/glibc/libc6-dev_2.38-6deepin13+rb1_amd64.deb
     digest: 4a8025393fce99a77e4428caee83481ffe9bee64c2b985d0ac96c2ab2ab86893
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/glibc/libc6_2.38-6deepin13+rb1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/glibc/libc6_2.38-6deepin13+rb1_amd64.deb
     digest: cdf2227d3d1614bb3c643012dddb2daa52abc647f90a820beb07f19b8ed6bdf3
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libc/libcap2/libcap2_2.66-5_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libc/libcap2/libcap2_2.66-5_amd64.deb
     digest: f4f581c5ed9c6576ff284117ee51ae8b4e47e6799d71fabc7c0aa2d3a260752a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libc/libchardet/libchardet-dev_1.0.4-2deepin_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libc/libchardet/libchardet-dev_1.0.4-2deepin_amd64.deb
     digest: 3a5cd3375c490bdde2e7204931ee279e3f6ab0f4b846bd8f2a46b727bdbb7ccc
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libc/libchardet/libchardet1_1.0.4-2deepin_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libc/libchardet/libchardet1_1.0.4-2deepin_amd64.deb
     digest: 80d9ff27c50cefc3cbcaa30902e44d63323841daa674eef85f5ebb2c8dc23117
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/l/llvm-toolchain-17/libclang-cpp17_17.0.6-5deepin5_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/l/llvm-toolchain-17/libclang-cpp17_17.0.6-5deepin5_amd64.deb
     digest: a34b10500cae17c2c122760901c453df850a968a32699978c2015cf355fd5580
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/l/llvm-toolchain-17/libclang1-17_17.0.6-5deepin5_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/l/llvm-toolchain-17/libclang1-17_17.0.6-5deepin5_amd64.deb
     digest: 7fd516db3504bc518b5c3911819880a8296964af7089e4c6d39753096a668fed
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/e/e2fsprogs/libcom-err2_1.47.0-2deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/e/e2fsprogs/libcom-err2_1.47.0-2deepin1_amd64.deb
     digest: 016e7e4d9ff3fa97f1631669aba86aebe7bd1d1c8d04fd8ec66b38c87cccab05
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxcrypt/libcrypt-dev_4.4.36-5_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxcrypt/libcrypt-dev_4.4.36-5_amd64.deb
     digest: 3505f9548808b3e2e06dac00d3c674a023815c011ab6ddad1bc85283e899adc6
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxcrypt/libcrypt1_4.4.36-5_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxcrypt/libcrypt1_4.4.36-5_amd64.deb
     digest: a7af8c9a2b767781d83f60fa32553f6a713569a0f7c4666e68dab41c46feaf1c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/b/binutils/libctf-nobfd0_2.41-6deepin7_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/b/binutils/libctf-nobfd0_2.41-6deepin7_amd64.deb
     digest: 44b5e0a887f8b8d84166ba81f4cf1d70b607914c8b59959c47bde1ce750645bb
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/b/binutils/libctf0_2.41-6deepin7_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/b/binutils/libctf0_2.41-6deepin7_amd64.deb
     digest: c58e37fce60c661d023d37f46d1af34772c40783b2be220f0d11eb8e2d8029b4
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cups/libcups2-dev_2.4.2-5deepin2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/c/cups/libcups2-dev_2.4.2-5deepin2_amd64.deb
     digest: 57726c5fbe502348eda3a0ba248978a0769eb7fd134d8998386e3216875e18d9
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cups/libcups2_2.4.2-5deepin2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/c/cups/libcups2_2.4.2-5deepin2_amd64.deb
     digest: c3677b705c3b3214cec20cc24f7a4e4a05c975e1de8834e4647f5f2575b114e5
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cups/libcupsimage2-dev_2.4.2-5deepin2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/c/cups/libcupsimage2-dev_2.4.2-5deepin2_amd64.deb
     digest: 94aabf445b3d15c635a2a1710066107e3f3860bcc15cdd982b3ae5581b132960
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cups/libcupsimage2_2.4.2-5deepin2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/c/cups/libcupsimage2_2.4.2-5deepin2_amd64.deb
     digest: 35286abdab600d5aede3a3e77030ad9f65535287d63be8140f0959fa9e0641f8
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/curl/libcurl3-gnutls_8.11.0-0deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/c/curl/libcurl3-gnutls_8.11.0-0deepin1_amd64.deb
     digest: c8fd9506ce9de38317bc40295bd9c673d332e444771e00c6bf249373e424b82d
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/db5.3/libdb5.3_5.3.28+dfsg1-0.8deepin0_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/db5.3/libdb5.3_5.3.28+dfsg1-0.8deepin0_amd64.deb
     digest: 98830ff429c7212767f0de4d239870f1936b37527ce365287de30eb8276a8330
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dbus/libdbus-1-3_1.14.10-3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/dbus/libdbus-1-3_1.14.10-3_amd64.deb
     digest: 1dff3a63259f14e7de7c4502e7083f7077b30a274f09d195176d566406b1b827
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libd/libdeflate/libdeflate-dev_1.18-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libd/libdeflate/libdeflate-dev_1.18-1_amd64.deb
     digest: 04a8d4c536a9f106a9f4b38fdc012fbe745b928e32ef3f05db4704d30c1023b5
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libd/libdeflate/libdeflate0_1.18-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libd/libdeflate/libdeflate0_1.18-1_amd64.deb
     digest: 1b411007d982c5f2f2a6d1e2d0af7a85cbc274770e533fbd895fc54956a995ba
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/double-conversion/libdouble-conversion3_3.3.0-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/double-conversion/libdouble-conversion3_3.3.0-1_amd64.deb
     digest: e6c6d028a74d0a752ae638ec19b8239f404c36d676c7569936f31000d25a75f4
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dpkg/libdpkg-perl_1.22.6deepin4_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/dpkg/libdpkg-perl_1.22.6deepin4_all.deb
     digest: 569373a35267f9cf2e8d0ee6d42c9047f50fa2174a0ac72fa77f494a0f0a9d1b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libd/libdrm/libdrm-amdgpu1_2.4.123-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libd/libdrm/libdrm-amdgpu1_2.4.123-1_amd64.deb
     digest: f58eaae37579b2a3964f84993a8893fe00a05447b23f5e937102c30f64fead50
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libd/libdrm/libdrm-common_2.4.123-1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libd/libdrm/libdrm-common_2.4.123-1_all.deb
     digest: b8289eaa6341a8493f4c191a45165fe944248da69f675d09005a29058e7ae5a6
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libd/libdrm/libdrm-intel1_2.4.123-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libd/libdrm/libdrm-intel1_2.4.123-1_amd64.deb
     digest: 9de0a6e4bea3c7244aa6c88ccb46c7297fac4b475756b4885b7eec53191eaa17
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libd/libdrm/libdrm-radeon1_2.4.123-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libd/libdrm/libdrm-radeon1_2.4.123-1_amd64.deb
     digest: 6c5a1a1849b24b6b02608d28fe9294c85f366f3bdf94f46cc622c4f2e980774e
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libd/libdrm/libdrm2_2.4.123-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libd/libdrm/libdrm2_2.4.123-1_amd64.deb
     digest: c2f1676c3335ab76ff829190951052abef661b735f2ddfefdb8d6c0698c41756
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6core/libdtk6core-dev_6.0.38_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/dtk6core/libdtk6core-dev_6.0.38_amd64.deb
     digest: dc0e1738af9ccdb458d217b3d2eecb2ffbb49092f6247b6021f786b0548d12b0
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6core/libdtk6core_6.0.38_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/dtk6core/libdtk6core_6.0.38_amd64.deb
     digest: 00964a07edce1826a9ca23dc820091f95c77da6950ff704aab34d59ace7bdc3b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6declarative/libdtk6declarative-dev_6.0.38_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/dtk6declarative/libdtk6declarative-dev_6.0.38_amd64.deb
     digest: 5496508c6c72a77b28d017c65a0308bf1ff783e19e888887f3816f0f228add07
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6declarative/libdtk6declarative_6.0.38_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/dtk6declarative/libdtk6declarative_6.0.38_amd64.deb
     digest: 3a2136b075943d98740221761647120e78fded87897cc12285ffe7414cbf8bed
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6gui/libdtk6gui-dev_6.0.38_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/dtk6gui/libdtk6gui-dev_6.0.38_amd64.deb
     digest: 242c7b48aac3fe35579fdd2f52cfa88e12a8f0df5ed29926d042441e4d449471
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6gui/libdtk6gui_6.0.38_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/dtk6gui/libdtk6gui_6.0.38_amd64.deb
     digest: 43302b4536ee242e84c461c32eff19e794a892636734c15ee2c8094ad77cd28d
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6log/libdtk6log-dev_0.0.4_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/dtk6log/libdtk6log-dev_0.0.4_amd64.deb
     digest: f9e6c1e18e5166aea09e13367e954c527f0d8b7f5cbdcbd9493d933a65ec7fd1
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6log/libdtk6log_0.0.4_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/dtk6log/libdtk6log_0.0.4_amd64.deb
     digest: 4fecfdb38533bc2e6b9a16e559cb70c56ec50fa061b92b1124b606d28d7b3887
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6widget/libdtk6widget-dev_6.0.38_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/dtk6widget/libdtk6widget-dev_6.0.38_amd64.deb
     digest: 4e0ae6248f9f3c03765a71c4cd4df02f2a7ff242c4e7bb45d1617c9d234084d0
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6widget/libdtk6widget_6.0.38_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/dtk6widget/libdtk6widget_6.0.38_amd64.deb
     digest: 649ec642a62e9ac7aef520a41b14f0d3b09bccee17b4676790ea45ec15a37c1e
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtkcommon/libdtkcommon-dev_5.7.18_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/dtkcommon/libdtkcommon-dev_5.7.18_amd64.deb
     digest: c490431f2dcecb0bc945f62ce139994ed039098c4c803a14c39b37c65e6d0698
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtkcommon/libdtkdata_5.7.18_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/dtkcommon/libdtkdata_5.7.18_amd64.deb
     digest: b68e4815cea197c703fe17fc8cd90206bd6cbd9a582edb909cf8f641ee1e313e
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/duktape/libduktape207_2.7.0-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/duktape/libduktape207_2.7.0-2_amd64.deb
     digest: 03743b861cdfa66aa9a94608574f3c6c784fa0ede3264e70d436c2fc8e902b95
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libe/libedit/libedit2_3.1-20230828-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libe/libedit/libedit2_3.1-20230828-1_amd64.deb
     digest: 72d015604676696e4e10e238f4795fbdc3d7c0e241147d55c9782ea8baf9a03c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mesa/libegl-mesa0_24.3.0-1deepin4_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/m/mesa/libegl-mesa0_24.3.0-1deepin4_amd64.deb
     digest: bb9a950bed0f7a14f62e0787bc8b650262a6094c5b244d7771ef9f4514a0dfc2
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libegl1_1.7.0-1deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libg/libglvnd/libegl1_1.7.0-1deepin1_amd64.deb
     digest: 1675190466ac26b2ae0f64131a83aef2663c42ee1c1775aafb2ab6878df3f235
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/e/elfutils/libelf1_0.191-1deepin2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/e/elfutils/libelf1_0.191-1deepin2_amd64.deb
     digest: 27dd39d5858cff9969ff58d01f7fe44a846dc9e9477898e250633c7b96c72757
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libe/libevdev/libevdev-dev_1.12.0+dfsg-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libe/libevdev/libevdev-dev_1.12.0+dfsg-1_amd64.deb
     digest: 7e338355abfb198b7fe4ff9d02f4b950f822965712d429e3a623e25509e41daf
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libe/libevdev/libevdev2_1.12.0+dfsg-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libe/libevdev/libevdev2_1.12.0+dfsg-1_amd64.deb
     digest: 48c0a7c73d835054b291645fa21fd597271e28a6eb98d8b22f2283e364e83893
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/e/expat/libexpat1-dev_2.7.1-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/e/expat/libexpat1-dev_2.7.1-1_amd64.deb
     digest: 8dcb891102e9f4dd8a9903bffde5576f017d651927538d613b664c92c6130ab2
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/e/expat/libexpat1_2.7.1-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/e/expat/libexpat1_2.7.1-1_amd64.deb
     digest: 5b7f0cea08bc334eb501726e90caa650c72fb86b2fdd09e653688ac0a184bbb3
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libf/libffi/libffi-dev_3.4.6-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libf/libffi/libffi-dev_3.4.6-1_amd64.deb
     digest: eadc61825e77bad028fd5eff398ac0e13da7a08870261058525d3f620d90cb7b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libf/libffi/libffi8_3.4.6-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libf/libffi/libffi8_3.4.6-1_amd64.deb
     digest: daa2aeb5a23c7dea09b2f16b94d15fa6f015ad5ff8c3db15bd0ab890fc920dd2
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fmtlib/libfmt10_10.1.1+ds1-4_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/fmtlib/libfmt10_10.1.1+ds1-4_amd64.deb
     digest: 63b2c4d61d1e41070896b399b52c4b38cd5cc529b66692394b4dbe7f5375dad4
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fontconfig/libfontconfig-dev_2.15.0-2.3deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/fontconfig/libfontconfig-dev_2.15.0-2.3deepin1_amd64.deb
     digest: f24f727e6c0976f6f7a728eadc4c887c847c6fa241f40c72b0db90d53441fe75
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fontconfig/libfontconfig1_2.15.0-2.3deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/fontconfig/libfontconfig1_2.15.0-2.3deepin1_amd64.deb
     digest: bda58c37ad85fd9f7d0498483b11cdcf250eda86fff6e399d13105594737857e
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libf/libfontenc/libfontenc1_1.1.4-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libf/libfontenc/libfontenc1_1.1.4-1_amd64.deb
     digest: 758a94a3acf10d671cc056981255d2bca91e42d74e46edb27f3c89b9c5d5d3cf
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/freetype/libfreetype-dev_2.13.2+dfsg-1deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/freetype/libfreetype-dev_2.13.2+dfsg-1deepin1_amd64.deb
     digest: 96d67a80be9adf8a9418e1dd33d2bf12d36bb12d4518297842fc8de29bf50763
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/freetype/libfreetype6_2.13.2+dfsg-1deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/freetype/libfreetype6_2.13.2+dfsg-1deepin1_amd64.deb
     digest: 362fcb4c7c381338fd78bfa018b17b25f00596afb9c7d99c28b075944b20eb2b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mesa/libgbm1_24.3.0-1deepin4_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/m/mesa/libgbm1_24.3.0-1deepin4_amd64.deb
     digest: 4022d612b88be490e20eea8ce8d3ee2862a2c3fd563e549a523eca14cee34639
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gcc-13/libgcc-s1_13.2.0-3deepin4_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/gcc-13/libgcc-s1_13.2.0-3deepin4_amd64.deb
     digest: e70f1a5d9e15b85cc026d9a816064453dfb05a78fc4891a3da8b595a67debd9a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libgcrypt20/libgcrypt20_1.10.3-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libg/libgcrypt20/libgcrypt20_1.10.3-2_amd64.deb
     digest: f377a741b54094b2b71a461878bf012c8d602d9af146be9826ce058767e396d5
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gdbm/libgdbm-compat4_1.22-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/gdbm/libgdbm-compat4_1.22-1_amd64.deb
     digest: 35bdaf12b3222875708f4f3967f4517897062a05730f38893695d6344e4f496e
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gdbm/libgdbm6_1.22-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/gdbm/libgdbm6_1.22-1_amd64.deb
     digest: af88f48a9978a03543cb1bb5170ef936fb80595c8621d73137ba47bfef0de0d3
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/glib2.0/libgirepository-2.0-0_2.80.1-1deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/glib2.0/libgirepository-2.0-0_2.80.1-1deepin1_amd64.deb
     digest: 6340c9628c7bcfda4c6826a49c52bc8bf28bfb8d12c163eb19ebde7b0ad61578
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libgl-dev_1.7.0-1deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libg/libglvnd/libgl-dev_1.7.0-1deepin1_amd64.deb
     digest: 9555387119d2c7118202da7424f3d95a358843cb6e3369135979bf3fb1e7586e
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mesa/libgl1-mesa-dri_24.3.0-1deepin4_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/m/mesa/libgl1-mesa-dri_24.3.0-1deepin4_amd64.deb
     digest: e98cff9eb0e1302ecc54f63bfedd21b9b1d96a9aa81f0c224363a26c7380755b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libgl1_1.7.0-1deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libg/libglvnd/libgl1_1.7.0-1deepin1_amd64.deb
     digest: a80285158761a0fb609a7a27676b6ba15f9e30b12985012de34ffd84a8d03e95
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mesa/libglapi-mesa_24.3.0-1deepin4_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/m/mesa/libglapi-mesa_24.3.0-1deepin4_amd64.deb
     digest: 90ec3a2e108d28d421cb65fe9245dbeeb0cc923d81f1da45a1af6ec6be5d4024
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/glib2.0/libglib2.0-0_2.80.1-1deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/glib2.0/libglib2.0-0_2.80.1-1deepin1_amd64.deb
     digest: 33857078b63370d9edfbceec5a4f8d159db6f75da9f486dd12c97711598f43de
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/glib2.0/libglib2.0-bin_2.80.1-1deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/glib2.0/libglib2.0-bin_2.80.1-1deepin1_amd64.deb
     digest: a90fbe965ef03785f21e55dc04d550243495e96ba47107ddf0874bd0bde8a416
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/glib2.0/libglib2.0-data_2.80.1-1deepin1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/glib2.0/libglib2.0-data_2.80.1-1deepin1_all.deb
     digest: 4e75a1c9e56c81ed2c1737e3e6fe590163a77ff45179101a4fcfb90b4c0d135d
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/glib2.0/libglib2.0-dev-bin_2.80.1-1deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/glib2.0/libglib2.0-dev-bin_2.80.1-1deepin1_amd64.deb
     digest: 47e6ec3f082c09540ec0ce8ec0358e9d0d28ea7822e9e7cd5000672f6fd35adb
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/glib2.0/libglib2.0-dev_2.80.1-1deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/glib2.0/libglib2.0-dev_2.80.1-1deepin1_amd64.deb
     digest: f6e2df667c442e8ad0305ec62c85227aead61ff85d591ef32ec9de31d086a74e
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libglvnd0_1.7.0-1deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libg/libglvnd/libglvnd0_1.7.0-1deepin1_amd64.deb
     digest: 58699e543f5a5135c84153224efd63d61c3312201debeb93430014dbd28f313b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libglx-dev_1.7.0-1deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libg/libglvnd/libglx-dev_1.7.0-1deepin1_amd64.deb
     digest: 5b8281d799f1b3844524c1baa475e4876665b4d6062800655e180586dc0015bf
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mesa/libglx-mesa0_24.3.0-1deepin4_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/m/mesa/libglx-mesa0_24.3.0-1deepin4_amd64.deb
     digest: ff5c14a729458868c87b7eaeca9e9dab4c06f2f5eec59d71382d36e36f79f3f3
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libglx0_1.7.0-1deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libg/libglvnd/libglx0_1.7.0-1deepin1_amd64.deb
     digest: c7571d6a7a90722d85f06bda863fbae2a42ab73f0b4162ce89b5b6c87382dc59
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/googletest/libgmock-dev_1.12.1-0.2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/googletest/libgmock-dev_1.12.1-0.2_amd64.deb
     digest: 4179e4554c662d6c18d5b31f9273804d0450bc43822f527dd21ce328059ee603
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gmp/libgmp10_6.3.0+dfsg-2deepin0_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/gmp/libgmp10_6.3.0+dfsg-2deepin0_amd64.deb
     digest: a809596d1ce3a18f2965759b2443fdcb83edd50ae143d61c60cd26862b57850b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gnutls28/libgnutls30_3.7.9-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/gnutls28/libgnutls30_3.7.9-2_amd64.deb
     digest: d56ddf6802b16bc9c2ba21d8c5d6312e0620c9b96dfc11f8345d42c8233e9e74
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gcc-13/libgomp1_13.2.0-3deepin4_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/gcc-13/libgomp1_13.2.0-3deepin4_amd64.deb
     digest: bb63b95d0f3cd0b62509318e31af201db37434c93337268db2b366214f85ad71
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libgpg-error/libgpg-error0_1.47-3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libg/libgpg-error/libgpg-error0_1.47-3_amd64.deb
     digest: c7c00dbad22e7c549a25c147e3d471fae76d0c22d479c0de61aac4cf60e97f36
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/b/binutils/libgprofng0_2.41-6deepin7_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/b/binutils/libgprofng0_2.41-6deepin7_amd64.deb
     digest: bb74544850bc21a47d09919728769c419233639c8d9e8b1f07679d652b1549bf
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/graphite2/libgraphite2-3_1.3.14-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/graphite2/libgraphite2-3_1.3.14-2_amd64.deb
     digest: b4697179666eb012313127a7ff04d286f427b49523f50ada6d593694030c0b51
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/k/krb5/libgssapi-krb5-2_1.20.1-5_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/k/krb5/libgssapi-krb5-2_1.20.1-5_amd64.deb
     digest: dfa250b0e4ecb5b3c359f49161b460b0139c38b1592b6d6538395855f6c952f1
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/googletest/libgtest-dev_1.12.1-0.2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/googletest/libgtest-dev_1.12.1-0.2_amd64.deb
     digest: 6d6ad81fe698a56f8b31aa7776e0526347b83c344651d7a0b4f8ec0625fcff45
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libgudev/libgudev-1.0-0_238-2deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libg/libgudev/libgudev-1.0-0_238-2deepin1_amd64.deb
     digest: fb9f1c72e40fd7fece5eab37c9eb473bf3d19c84fb808512d60af3bc909a8c5f
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libgudev/libgudev-1.0-dev_238-2deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libg/libgudev/libgudev-1.0-dev_238-2deepin1_amd64.deb
     digest: b0b603d7732573aed035c0ab43d92a054eb4351a7098fe6f37e4c736c1b5bd12
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gumbo-parser/libgumbo2_0.12.0+dfsg-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/gumbo-parser/libgumbo2_0.12.0+dfsg-2_amd64.deb
     digest: b4036cefbbc4f6a5f73f6ac19d3065c52dc6b923691268c5b3032971465c35ac
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/h/harfbuzz/libharfbuzz0b_8.0.1-1+rb1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/h/harfbuzz/libharfbuzz0b_8.0.1-1+rb1_amd64.deb
     digest: 29f8f51877821f22adc742cab010c0f627ff4db8ffb03a1479441c5f2061f9e3
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/n/nettle/libhogweed6_3.7.3-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/n/nettle/libhogweed6_3.7.3-1_amd64.deb
     digest: 0557f0e34a15444b6792c2726b5d1eb48f9ea8cd42bc7f4d697081e804ced558
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libi/libice/libice6_1.0.10-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libi/libice/libice6_1.0.10-1_amd64.deb
     digest: 03da9ec604f5bd9ba6526c4e6cf90c5b4266818b2c9a34110d74c42b9be87646
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/i/icu/libicu-dev_74.2-1deepin4_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/i/icu/libicu-dev_74.2-1deepin4_amd64.deb
     digest: 494d22bb9439e7f7e3ee3d71061916fe3f645ce8cc8e4411d191c47bf6c10302
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/i/icu/libicu74_74.2-1deepin4_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/i/icu/libicu74_74.2-1deepin4_amd64.deb
     digest: a1afb2975773d7ee675f61ea12720c79002d6bcb6b586a5e6975a997b60775fb
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libi/libidn2/libidn2-0_2.3.2-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libi/libidn2/libidn2-0_2.3.2-2_amd64.deb
     digest: 0ac47209fe66a5906497d6fb1c76a2addaa8daa2becaa434b17d32b98dd057cc
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libi/libinput/libinput-bin_1.26.0-1deepin3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libi/libinput/libinput-bin_1.26.0-1deepin3_amd64.deb
     digest: eb9aca98fdaf66cc394f87b65799ae177c2f97ca300e0c55a34ac736525c9733
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libi/libinput/libinput-dev_1.26.0-1deepin3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libi/libinput/libinput-dev_1.26.0-1deepin3_amd64.deb
     digest: 9153a6287da744a308744636d0e39ed6a92c25f51d00d50e0376203a48e300c3
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libi/libinput/libinput10_1.26.0-1deepin3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libi/libinput/libinput10_1.26.0-1deepin3_amd64.deb
     digest: 52cbd20e0fc0708991bf66a0af9f5ad9a18d88a7552a8a1b46e209a2f54d25f0
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/j/jansson/libjansson4_2.14-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/j/jansson/libjansson4_2.14-2_amd64.deb
     digest: bbf5325c3ccfd468e1d8fdafb68c3ffaa89db1e0043e8e757b9f240452c67c26
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/j/jbigkit/libjbig-dev_2.1-3.1-deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/j/jbigkit/libjbig-dev_2.1-3.1-deepin1_amd64.deb
     digest: 7ce8d535aa0768ca1cf24178b956b3bbbc82cca19ce4bbe91ab32c36038ae336
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/j/jbigkit/libjbig0_2.1-3.1-deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/j/jbigkit/libjbig0_2.1-3.1-deepin1_amd64.deb
     digest: 98eb75afc9dd66ec83f782a46aad59b0add9aad5ac521e91e35d606bb6313147
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libj/libjpeg-turbo/libjpeg-dev_2.1.5-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libj/libjpeg-turbo/libjpeg-dev_2.1.5-2_amd64.deb
     digest: fbc596effd2b0a596b71e306d120e5b660bd478c8c9d24e47c61b4ce2db33d27
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libj/libjpeg-turbo/libjpeg62-turbo-dev_2.1.5-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libj/libjpeg-turbo/libjpeg62-turbo-dev_2.1.5-2_amd64.deb
     digest: 126fa110768ecfbb4569ddb66d53621f7007dcefa1234e0ba4f37e364903a607
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libj/libjpeg-turbo/libjpeg62-turbo_2.1.5-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libj/libjpeg-turbo/libjpeg62-turbo_2.1.5-2_amd64.deb
     digest: 664abd1a931622f6d14cced9ea87f3b4f201adf9616e6ef2daf1b044903f699f
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/j/json-glib/libjson-glib-1.0-0_1.8.0-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/j/json-glib/libjson-glib-1.0-0_1.8.0-2_amd64.deb
     digest: ad1c305d40313e0fa758c9d3336e78b2ca5aa6dd2e41523d54df50f9115891b7
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/j/json-glib/libjson-glib-1.0-common_1.8.0-2_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/j/json-glib/libjson-glib-1.0-common_1.8.0-2_all.deb
     digest: f4ffb8e62cabbb4b691413d38e3c8a03b430f4eba287bef4d8637dd3d708cab1
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/k/krb5/libk5crypto3_1.20.1-5_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/k/krb5/libk5crypto3_1.20.1-5_amd64.deb
     digest: 203bda60f112a6eb51bfb431c1c9287ff1dbfd4f8bacb931b8ab5aacf52ed4e3
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/k/keyutils/libkeyutils1_1.6.3-3.1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/k/keyutils/libkeyutils1_1.6.3-3.1_amd64.deb
     digest: 784e45679941a3e3de3d747f94f215a6fd4b3767aa0b92c4e66a43cc5d628d33
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/k/kf6-kcodecs/libkf6codecs-data_6.6.0-1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/k/kf6-kcodecs/libkf6codecs-data_6.6.0-1_all.deb
     digest: 961c0272ce73f6d2f872d0dd077b3f1bdcae602bbe1c69ab391021f4e3243301
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/k/kf6-kcodecs/libkf6codecs-dev_6.6.0-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/k/kf6-kcodecs/libkf6codecs-dev_6.6.0-1_amd64.deb
     digest: 32a5f7ddc3cc5a5ec0930576df4aab1e62de90aa2d120fb9adc03585b3ff1777
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/k/kf6-kcodecs/libkf6codecs6_6.6.0-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/k/kf6-kcodecs/libkf6codecs6_6.6.0-1_amd64.deb
     digest: 162c610cae594616ae4598bcc4fadf9630675776ca3d510a471d83dbcce0f2e2
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/k/kf6-syntax-highlighting/libkf6syntaxhighlighting-data_6.10.0-1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/k/kf6-syntax-highlighting/libkf6syntaxhighlighting-data_6.10.0-1_all.deb
     digest: 50c8a8aedc9c68416b28cdc5205172e42a8702bb64176ebb1a893e7460ee3c98
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/k/kf6-syntax-highlighting/libkf6syntaxhighlighting-dev_6.10.0-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/k/kf6-syntax-highlighting/libkf6syntaxhighlighting-dev_6.10.0-1_amd64.deb
     digest: b7ec35ff0aa44d54dc519df869ae4dac8f004875ac8812428ce0232585e17517
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/k/kf6-syntax-highlighting/libkf6syntaxhighlighting6_6.10.0-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/k/kf6-syntax-highlighting/libkf6syntaxhighlighting6_6.10.0-1_amd64.deb
     digest: 170fb207fb9dc747d9d51d74749dce99f968f29d25cb8f0104d792dd2dd7f42d
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/k/krb5/libkrb5-3_1.20.1-5_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/k/krb5/libkrb5-3_1.20.1-5_amd64.deb
     digest: ae4f1183b97f1f376f8caac13b739865aba4b4b77bcfec8d9dd86c85e6977411
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/k/krb5/libkrb5support0_1.20.1-5_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/k/krb5/libkrb5support0_1.20.1-5_amd64.deb
     digest: bdc056efb59abe666c17a028924d456a5660c45b68259d2525b9a0d08a8524a2
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/l/lcms2/liblcms2-2_2.14-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/l/lcms2/liblcms2-2_2.14-2_amd64.deb
     digest: a8630b7a9f07ca87612fdfe486941211598f4fe3148235746f001e68ce91114b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/o/openldap/libldap-2.5-0_2.5.13+dfsg-5_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/o/openldap/libldap-2.5-0_2.5.13+dfsg-5_amd64.deb
     digest: 35570c1c9b06d39aea8c6d2a149f420dfcd1d7503db10e6e5753e0245e1c681d
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/l/lerc/liblerc-dev_4.0.0+ds-3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/l/lerc/liblerc-dev_4.0.0+ds-3_amd64.deb
     digest: 9bf199c57795a3e4c8e7cce1ef1803e32e9d31fc7cb82b5db8275f654e19b655
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/l/lerc/liblerc4_4.0.0+ds-3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/l/lerc/liblerc4_4.0.0+ds-3_amd64.deb
     digest: 4024f109044643693dad079fce71b942ffba3bf3ec994d523130c33e776ea06e
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/l/litehtml/liblitehtml0_0.9-0deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/l/litehtml/liblitehtml0_0.9-0deepin1_amd64.deb
     digest: 44596cdf0fefdc6412af3e1e0d0a4bdee4762d348cdf3818a2cca0daab437285
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/l/llvm-toolchain-17/libllvm17_17.0.6-5deepin5_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/l/llvm-toolchain-17/libllvm17_17.0.6-5deepin5_amd64.deb
     digest: f2d4e6214fdc72ee0c23079e0418dcf190fb41fc10612f9ef21ac3cbcbd701d3
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/l/llvm-toolchain-19/libllvm19_19.1.4-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/l/llvm-toolchain-19/libllvm19_19.1.4-1_amd64.deb
     digest: ac9aab75b71b3b452d5bc1245e1bea4f62ee9ca50d4e7efdcaa640495888a39d
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/l/lz4/liblz4-1_1.9.3-deepin_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/l/lz4/liblz4-1_1.9.3-deepin_amd64.deb
     digest: 9808e49cf41c4a38f0ff4f4de7080ae392682f3cea166abc079a26625c8233aa
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/x/xz-utils/liblzma-dev_5.4.5-0.3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xz-utils/liblzma-dev_5.4.5-0.3_amd64.deb
     digest: 0e611c43cc8cee4b31dd530ef21f4efbb16caab257685a770b612146e18a6b8b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/x/xz-utils/liblzma5_5.4.5-0.3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xz-utils/liblzma5_5.4.5-0.3_amd64.deb
     digest: e8051c2b44fa1cc020c12ef45f4918c1dd7595532af89df0c583b4b3f333fa56
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libm/libmd/libmd0_1.0.4-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libm/libmd/libmd0_1.0.4-1_amd64.deb
     digest: 755e2a59d76415999f46b0c307ade64df3788013286e902e2531e07ff58ca781
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/md4c/libmd4c0_0.4.8-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/m/md4c/libmd4c0_0.4.8-1_amd64.deb
     digest: 9f1630409adb3464aa42afc519d2163a7741d152b53c937eddea55b9fb6fb10a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libm/libmng/libmng1_1.0.10+dfsg-3.1-deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libm/libmng/libmng1_1.0.10+dfsg-3.1-deepin1_amd64.deb
     digest: 256423c8e3c4afcbdf72973db84b1e919187b65955c685ee16f9a5635d436943
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-linux/libmount-dev_2.40.4-3deepin4_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/u/util-linux/libmount-dev_2.40.4-3deepin4_amd64.deb
     digest: b88f61259a6d84105bed6041a41348d696d49ff8aea65ef1308e84d9399999fe
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-linux/libmount1_2.40.4-3deepin4_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/u/util-linux/libmount1_2.40.4-3deepin4_amd64.deb
     digest: 0034e277c6bcae0dec03e27a6b1ce99bac79a04e2157fd3a8448c5141bfd3fbc
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mtdev/libmtdev-dev_1.1.6-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/m/mtdev/libmtdev-dev_1.1.6-1_amd64.deb
     digest: 92553337dcd1837205a4f136419b0cf40956e0975a938ad8e8e7b586659d0e46
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mtdev/libmtdev1_1.1.6-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/m/mtdev/libmtdev1_1.1.6-1_amd64.deb
     digest: 28686d830a44272e63013aae1e508f0f767ea28c2a4856d6c6724e11b2a6f93e
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/n/ncurses/libncursesw6_6.4-4deepin2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/n/ncurses/libncursesw6_6.4-4deepin2_amd64.deb
     digest: 05ebb9cc9fd97fb54ce586388387e309068c027a45d94f31b5c9dd99b0d06fe2
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/n/nettle/libnettle8_3.7.3-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/n/nettle/libnettle8_3.7.3-1_amd64.deb
     digest: d19dd4ebabccc00232223b414732c26b63d4ee67f4147ad5a105795f4514382a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/n/nghttp2/libnghttp2-14_1.59.0-1deepin0_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/n/nghttp2/libnghttp2-14_1.59.0-1deepin0_amd64.deb
     digest: 9221a35b50f8c23ddb78e93ea4cc66ffaf96586d38503ce4b8b61f6995739847
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/n/nghttp3/libnghttp3-9_1.4.0-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/n/nghttp3/libnghttp3-9_1.4.0-1_amd64.deb
     digest: c8c7b6f84833ae5fb50f7e6d127d07ad09a356f952b191edbf0542af500aa796
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/n/ngtcp2/libngtcp2-16_1.6.0-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/n/ngtcp2/libngtcp2-16_1.6.0-1_amd64.deb
     digest: 81438d30b8448343632bb615c15ac772214df4ffbeba7a4e5fc3e87afae28a45
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/n/ngtcp2/libngtcp2-crypto-gnutls8_1.6.0-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/n/ngtcp2/libngtcp2-crypto-gnutls8_1.6.0-1_amd64.deb
     digest: 526bdadbb91c83e044e49e2f270684e1de60790897c9c912d3abdbef5c7c5796
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libn/libnsl/libnsl-dev_1.3.0-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libn/libnsl/libnsl-dev_1.3.0-2_amd64.deb
     digest: f17e04a96da2dcb260bf75ac750a63d238942ecd9550ce41cc3530774c3ae807
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libn/libnsl/libnsl2_1.3.0-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libn/libnsl/libnsl2_1.3.0-2_amd64.deb
     digest: 27219179fd316e3bdc7f9556d1852fcec175d13334b5aadf6274c19be98fb268
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libopengl-dev_1.7.0-1deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libg/libglvnd/libopengl-dev_1.7.0-1deepin1_amd64.deb
     digest: 178ad33f72e1905c6d777a680fad42295608be7a6f8f95dfe5f2f27dbfcd5505
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libopengl0_1.7.0-1deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libg/libglvnd/libopengl0_1.7.0-1deepin1_amd64.deb
     digest: 8cc2d909d52c3346a714c2eb5d0115db214f8aac5eebfb5e41bc91eb48f7f951
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/p11-kit/libp11-kit0_0.25.5-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/p11-kit/libp11-kit0_0.25.5-2_amd64.deb
     digest: 3aae0a4770a313f4092d89d9603472fe9dbc0bfc9e69230868c168b3b30f860a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libp/libpciaccess/libpciaccess0_0.16-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libp/libpciaccess/libpciaccess0_0.16-1_amd64.deb
     digest: 549736858b99dc151e23c249ff54a69d6c03c03784af6cf8af0b71094df33a69
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pcre2/libpcre2-16-0_10.39-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/pcre2/libpcre2-16-0_10.39-2_amd64.deb
     digest: 1219e0d46f5c584323ad7e41c6fb39cdb8c6ed242a64913b7dadf0c557d84b6b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pcre2/libpcre2-32-0_10.39-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/pcre2/libpcre2-32-0_10.39-2_amd64.deb
     digest: 313cb3eed5be9793ce6db51292ca3d08334e9799856d88c085d268a4a264a586
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pcre2/libpcre2-8-0_10.39-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/pcre2/libpcre2-8-0_10.39-2_amd64.deb
     digest: 26ba66e349a9d46978d24e5b165c327e1ef51007770c43a3a49eb35b5fe0310e
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pcre2/libpcre2-dev_10.39-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/pcre2/libpcre2-dev_10.39-2_amd64.deb
     digest: b2a505ec6ef461644bf946949dc7def6a22ae8627c59ede2a82e9f77500eb856
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pcre2/libpcre2-posix3_10.39-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/pcre2/libpcre2-posix3_10.39-2_amd64.deb
     digest: f1d82802bdf71d13b7fe0b95aa0efbef3d4c661920629686170eabaeb8f4ecff
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/perl/libperl5.36_5.36.0-10deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/perl/libperl5.36_5.36.0-10deepin1_amd64.deb
     digest: 6338341b375c166ec39e466ef0282642c338d30d028a99414aac2b44a7efc3ce
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pkgconf/libpkgconf3_1.8.1-4_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/pkgconf/libpkgconf3_1.8.1-4_amd64.deb
     digest: e4677f42eb04cd63106e75ef1c008595a5b306129d6fdd58171a4b3732f2aca3
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libp/libpng1.6/libpng-dev_1.6.45-1deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libp/libpng1.6/libpng-dev_1.6.45-1deepin1_amd64.deb
     digest: 8d86e3bef4bb2aa5b9a98eab26d7bfc4929e2596808018ab4dcd905d7b045961
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libp/libpng1.6/libpng16-16_1.6.45-1deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libp/libpng1.6/libpng16-16_1.6.45-1deepin1_amd64.deb
     digest: 29d46c1159c18e4c17c103b7e830d5044731d81b0d54c0f346c9ad1b9147e990
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/policykit-1/libpolkit-agent-1-0_123-3deepin7_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/policykit-1/libpolkit-agent-1-0_123-3deepin7_amd64.deb
     digest: 1b67ae47e78e8c2625ced4de739a0bd1362c4e4f3c874360c00646754699ee55
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/policykit-1/libpolkit-gobject-1-0_123-3deepin7_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/policykit-1/libpolkit-gobject-1-0_123-3deepin7_amd64.deb
     digest: c4bb92580ee19b51ab4dbd0f08b0edc1b968a32e718ae3d9615bffa9610ae6d0
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/polkit-qt-1/libpolkit-qt6-1-1_0.200.0-4deepin2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/polkit-qt-1/libpolkit-qt6-1-1_0.200.0-4deepin2_amd64.deb
     digest: c86682628988277af7cba9108403f6b172632071722857e5a9d2fce05e224ecb
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/polkit-qt-1/libpolkit-qt6-1-dev_0.200.0-4deepin2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/polkit-qt-1/libpolkit-qt6-1-dev_0.200.0-4deepin2_amd64.deb
     digest: 1bb88b37aaeead3d3044266b215720eebcfe89d5841fcbd65e89a79f49357f92
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libp/libproxy/libproxy1v5_0.5.9-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libp/libproxy/libproxy1v5_0.5.9-1_amd64.deb
     digest: 4ad4360252e008b89ea7885a7c27e2df5af4a45e0aede319e08b17db3c3af932
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libp/libpsl/libpsl5_0.21.0-1.2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libp/libpsl/libpsl5_0.21.0-1.2_amd64.deb
     digest: 7a00b4f3ca191e7a887cbfc6b0ed619493bf5344b85c8e823577b115ec34f738
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libp/libpthread-stubs/libpthread-stubs0-dev_0.4-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libp/libpthread-stubs/libpthread-stubs0-dev_0.4-1_amd64.deb
     digest: 8be922fba920a96d098288da4fa5f1d5dfb778b362d7a26ed738014305aa3787
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/python3-defaults/libpython3-stdlib_3.12.1-1deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/python3-defaults/libpython3-stdlib_3.12.1-1deepin1_amd64.deb
     digest: 7611dfe764b5a109e1fa516270c304d451aa2980190c480a83b90207a6b84158
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/python3.12/libpython3.12-minimal_3.12.11-0deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/python3.12/libpython3.12-minimal_3.12.11-0deepin1_amd64.deb
     digest: 452e6e2a18330944a7ab46303050baae3385ce7ad2f509a6526c211b077836d3
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/python3.12/libpython3.12-stdlib_3.12.11-0deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/python3.12/libpython3.12-stdlib_3.12.11-0deepin1_amd64.deb
     digest: fc43de68d925c6bfdf632afeeb053f1b28f4050b197ade1c93b701cfea5aaba7
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6concurrent6_6.8.0+dfsg-0deepin8_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/libqt6concurrent6_6.8.0+dfsg-0deepin8_amd64.deb
     digest: 827f947abe65c18f979255506073b5d223d2c81e65a2528da21fefa11c9d1af8
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-5compat/libqt6core5compat6_6.8.0-0deepin_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-5compat/libqt6core5compat6_6.8.0-0deepin_amd64.deb
     digest: ab7b2830d58cf362c4f33c7252a7ffe5130893560082eb6a43a9d208e4407e84
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6core6_6.8.0+dfsg-0deepin8_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/libqt6core6_6.8.0+dfsg-0deepin8_amd64.deb
     digest: b6e687e6926547c0945ff5138495d025ca190f7991b42ea98193c29ef13ec08c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6dbus6_6.8.0+dfsg-0deepin8_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/libqt6dbus6_6.8.0+dfsg-0deepin8_amd64.deb
     digest: 9f7c4a6b688a3c61fd526f22a54959be1a9a5b550ef981a94bf06d7a91e1e4a0
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/libqt6designer6_6.8.0-0deepin3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-tools/libqt6designer6_6.8.0-0deepin3_amd64.deb
     digest: a6864707b38a192dc89ad51546e958fc2095ca3b45e6ee99e190d48ef54793ea
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/libqt6designercomponents6_6.8.0-0deepin3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-tools/libqt6designercomponents6_6.8.0-0deepin3_amd64.deb
     digest: 033f970ed9f2486fa265bf3a10332fc18fec0b9d0a83d74ba999007c4d647fc9
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6gui6_6.8.0+dfsg-0deepin8_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/libqt6gui6_6.8.0+dfsg-0deepin8_amd64.deb
     digest: 33eabd5595bcceca83cfd7747d0cf72a6a9fc6555e2ce3e2ee9c5f1abd23456c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/libqt6help6_6.8.0-0deepin3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-tools/libqt6help6_6.8.0-0deepin3_amd64.deb
     digest: 18db346cbe4e81620934c3b232222482f5c1251725516d3fb620c10ef2bb2611
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6network6_6.8.0+dfsg-0deepin8_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/libqt6network6_6.8.0+dfsg-0deepin8_amd64.deb
     digest: ad1be661bc76e8c62bf7c5a89dedffc7e5e3203119d86e2fb9d5747eb93fe9db
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6opengl6_6.8.0+dfsg-0deepin8_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/libqt6opengl6_6.8.0+dfsg-0deepin8_amd64.deb
     digest: 093d158b5adf7efa268a719648907c412927df1ad770c15987bc8c0b48a8515c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6openglwidgets6_6.8.0+dfsg-0deepin8_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/libqt6openglwidgets6_6.8.0+dfsg-0deepin8_amd64.deb
     digest: 9104c64aa25ec85a9f10a650ffdf1b03aae2321693ad4485d39b67c7bf68ea0a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6printsupport6_6.8.0+dfsg-0deepin8_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/libqt6printsupport6_6.8.0+dfsg-0deepin8_amd64.deb
     digest: b91d897b49c277334fb8a68dd554e749c24e01b3d989b7e85d4c08eec327001c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-declarative/libqt6qml6_6.8.0+dfsg-0deepin3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-declarative/libqt6qml6_6.8.0+dfsg-0deepin3_amd64.deb
     digest: 4f9d66873e7e085fb6909fd47be1fd50a41a8dd4b15b38bc77ab2dff42e43cf8
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-declarative/libqt6qmlcompiler6_6.8.0+dfsg-0deepin3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-declarative/libqt6qmlcompiler6_6.8.0+dfsg-0deepin3_amd64.deb
     digest: a75753e2eff326ca2f7e97f776cb37ed7ff361e89bfe43e6b473b1ae527cc9f3
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-declarative/libqt6qmlmodels6_6.8.0+dfsg-0deepin3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-declarative/libqt6qmlmodels6_6.8.0+dfsg-0deepin3_amd64.deb
     digest: 2fa585bcff6d8630d2e321e265b7cc592172a3676d6d2adf9ed2ff8ea1854c7d
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-declarative/libqt6quick6_6.8.0+dfsg-0deepin3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-declarative/libqt6quick6_6.8.0+dfsg-0deepin3_amd64.deb
     digest: d37c7d36dbe7ec33a2f8693f66505262e8f6b9911acc61e0f0d272f479913ba7
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-declarative/libqt6quickcontrols2-6_6.8.0+dfsg-0deepin3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-declarative/libqt6quickcontrols2-6_6.8.0+dfsg-0deepin3_amd64.deb
     digest: a9c316915aaaf52443e9564eb28f0c5b989d8cac244b9196f445bd823c43b498
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-declarative/libqt6quicktemplates2-6_6.8.0+dfsg-0deepin3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-declarative/libqt6quicktemplates2-6_6.8.0+dfsg-0deepin3_amd64.deb
     digest: a7ddb719e751f11cec25d62dd943fb5929588b1ef76d42529484a8a6e0372c16
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-declarative/libqt6quicktest6_6.8.0+dfsg-0deepin3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-declarative/libqt6quicktest6_6.8.0+dfsg-0deepin3_amd64.deb
     digest: 192c51739fb375d493429385bc2f21f5d619147267263263e646e97f5d2dc2c9
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-declarative/libqt6quickvectorimagegenerator6_6.8.0+dfsg-0deepin3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-declarative/libqt6quickvectorimagegenerator6_6.8.0+dfsg-0deepin3_amd64.deb
     digest: e4440fa3e47867ef969d6b5fb58d17a78921977826de3978cd3cd4a5933e3379
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-declarative/libqt6quickwidgets6_6.8.0+dfsg-0deepin3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-declarative/libqt6quickwidgets6_6.8.0+dfsg-0deepin3_amd64.deb
     digest: 21cd8eda13f476ec71438f56f43ed8933cc0b625302fff4c6f23baacbfb3b5b1
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-shadertools/libqt6shadertools6_6.8.0-0deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-shadertools/libqt6shadertools6_6.8.0-0deepin1_amd64.deb
     digest: 4e5dc0e41f8c49451b4595e605ddbe74d5cb4fca3100d26b552aa6a0931d575c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6sql6-sqlite_6.8.0+dfsg-0deepin8_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/libqt6sql6-sqlite_6.8.0+dfsg-0deepin8_amd64.deb
     digest: 1bfbb5f6771c285ef838eaaf429106eecbdd305baf365766ed05cfb7ac78ff3a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6sql6_6.8.0+dfsg-0deepin8_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/libqt6sql6_6.8.0+dfsg-0deepin8_amd64.deb
     digest: 7af38213ff2d557481dfe8ef0073da0fdc1ad1f70b22116ebd02f4d39bfb4292
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-svg/libqt6svg6_6.8.0-0deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-svg/libqt6svg6_6.8.0-0deepin1_amd64.deb
     digest: 0e43640fc49faf57d8454012338aac69b638356417a4a2361f3c0e47271ffbf1
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-svg/libqt6svgwidgets6_6.8.0-0deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-svg/libqt6svgwidgets6_6.8.0-0deepin1_amd64.deb
     digest: ba29752fae4494fe62f5a4d3f139386078d8beb74e53eee1d7c673028a8adb97
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6test6_6.8.0+dfsg-0deepin8_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/libqt6test6_6.8.0+dfsg-0deepin8_amd64.deb
     digest: 9cc8d7cc8d4290b937bcdcf36c18e63293cbc32821a14bf78d69d336dde918e0
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/libqt6uitools6_6.8.0-0deepin3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-tools/libqt6uitools6_6.8.0-0deepin3_amd64.deb
     digest: 5a2a509181e35a92f6effe0f2ef107c7dfadccefde35548bb1ae568aea003fb3
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-wayland/libqt6waylandclient6_6.8.0-0deepin7_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-wayland/libqt6waylandclient6_6.8.0-0deepin7_amd64.deb
     digest: 70486bbc5555f857aff3ca539dea86df4f800d20ad4e20b3cc5b62b9a6d75b21
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6widgets6_6.8.0+dfsg-0deepin8_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/libqt6widgets6_6.8.0+dfsg-0deepin8_amd64.deb
     digest: 3ee17d593ce177df59677046e7f5a8b62e5f30143a824d6b7dadf327da631d24
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6xml6_6.8.0+dfsg-0deepin8_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/libqt6xml6_6.8.0+dfsg-0deepin8_amd64.deb
     digest: 7ee33cd4857e0c72a6765d62d14d575ad3abe1e74436ff8615f0659c46e60d71
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/r/readline/libreadline8_8.2-3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/r/readline/libreadline8_8.2-3_amd64.deb
     digest: d7d4a492aa183701aad09f9ae4e156df8d4d5e336f40502f51c72cb5135cc296
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/r/rtmpdump/librtmp1_2.4+20151223.gitfa8646d.1-deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/r/rtmpdump/librtmp1_2.4+20151223.gitfa8646d.1-deepin1_amd64.deb
     digest: 9743d579d479e0e2ef99f984986b2d9d40d7e0a43b6f0f74b935f3fd2d5b6caa
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cyrus-sasl2/libsasl2-2_2.1.28+dfsg1-4_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/c/cyrus-sasl2/libsasl2-2_2.1.28+dfsg1-4_amd64.deb
     digest: 9ff9bfa155660e99d78ab3501392fd17381adcb90bdf2457bac8c3af296b3815
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cyrus-sasl2/libsasl2-modules-db_2.1.28+dfsg1-4_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/c/cyrus-sasl2/libsasl2-modules-db_2.1.28+dfsg1-4_amd64.deb
     digest: f02625e8d695be6bc1aa9531c5177097ec906333b60a0fa15861a82ade617762
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libselinux/libselinux1-dev_3.5-1deepin5_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libs/libselinux/libselinux1-dev_3.5-1deepin5_amd64.deb
     digest: f7dfdd9e463828cff8e624ceda7f13cc68f2c9d2e72b27dc7e7315e1193b7d92
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libselinux/libselinux1_3.5-1deepin5_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libs/libselinux/libselinux1_3.5-1deepin5_amd64.deb
     digest: b402ade709a2820f2562dfae7acabdb41e59916ef931e5b9d270812cf2b7fc20
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/l/lm-sensors/libsensors-config_3.6.0-7_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/l/lm-sensors/libsensors-config_3.6.0-7_all.deb
     digest: 164115506dfd335f26101e76cb49e2162b0440398ccf2d0c969ebc465dfd7867
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/l/lm-sensors/libsensors5_3.6.0-7_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/l/lm-sensors/libsensors5_3.6.0-7_amd64.deb
     digest: 5a730040a0326f0124822fb9ffd632d4891c5451873049d630d0f9da63f0db10
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libsepol/libsepol-dev_3.5-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libs/libsepol/libsepol-dev_3.5-2_amd64.deb
     digest: 4a1b7141086a540294dfc0df7eb707f2ef1e57d2a2f4b30f80821164d0f97b7b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libsepol/libsepol2_3.5-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libs/libsepol/libsepol2_3.5-2_amd64.deb
     digest: 47738eed5444661ac0a8a8f2ce6fee7bcd448cfab2701340c51464cf532ccbc9
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/b/binutils/libsframe1_2.41-6deepin7_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/b/binutils/libsframe1_2.41-6deepin7_amd64.deb
     digest: 5e5d2c0bf008d65000ea3447906c80423d4f6f2053cf050f45804514c17d0db2
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libw/libwebp/libsharpyuv-dev_1.3.2-0.2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libw/libwebp/libsharpyuv-dev_1.3.2-0.2_amd64.deb
     digest: 7af3357f80d57fdc31a26596f9e93f0218a625929822228d312498cabdcea72e
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libw/libwebp/libsharpyuv0_1.3.2-0.2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libw/libwebp/libsharpyuv0_1.3.2-0.2_amd64.deb
     digest: 9da48196bd083c4749d1b4814a15780fdfa5a962ce3c19c5abfe0fa98e4e870e
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libsm/libsm6_1.2.3-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libs/libsm/libsm6_1.2.3-1_amd64.deb
     digest: d8a6d0abf65a6fe4c5edcb5fa37b115477736e60c31118df74b701a468b49cab
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/s/spdlog/libspdlog1.12_1.12.0+ds-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/s/spdlog/libspdlog1.12_1.12.0+ds-2_amd64.deb
     digest: 44381cd9ad35fa6ffa7a0b3e27611011602bb32093efaf0c80117dc9f97a371b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/s/sqlite3/libsqlite3-0_3.46.1-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/s/sqlite3/libsqlite3-0_3.46.1-1_amd64.deb
     digest: 73029e73a746e8723afe8e98469774dc3de39cc7ee59a5ad1e9dc4745c11f55a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libssh2/libssh2-1_1.11.1-1deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libs/libssh2/libssh2-1_1.11.1-1deepin1_amd64.deb
     digest: 90258a13940712eca57406b2bb0d274fbdaaa2d62a45c1e60c5b123c4080d663
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/o/openssl/libssl3_3.2.4-0deepin2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/o/openssl/libssl3_3.2.4-0deepin2_amd64.deb
     digest: efe5ea0c1f74ce2ee8c760ba534276c01c0b347fb7eac4285f79b935bea8274c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/s/startup-notification/libstartup-notification0_0.12-deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/s/startup-notification/libstartup-notification0_0.12-deepin1_amd64.deb
     digest: b0e9783da04f53ba8da97660523021322c4477059c63d3684fab283b7f9aef9c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gcc-13/libstdc++6_13.2.0-3deepin4_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/gcc-13/libstdc++6_13.2.0-3deepin4_amd64.deb
     digest: e2c664c12b609801da2f8cdba3ad5b19ba7bd3fcfe3d47dab5b14f5a67919f57
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/s/sysprof/libsysprof-capture-4-dev_46.0-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/s/sysprof/libsysprof-capture-4-dev_46.0-1_amd64.deb
     digest: bbaacdcbf341e500cd8fbe0dfb75fc98156b0a5abf94e43105bb5f745c3168dd
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/s/systemd/libsystemd0_255.2-4deepin11_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/s/systemd/libsystemd0_255.2-4deepin11_amd64.deb
     digest: 75f4b1c1d7e0caf4127313225fb3be35243b09df4cf93e0225f5fb27e6c4074d
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libt/libtasn1-6/libtasn1-6_4.18.0-4_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libt/libtasn1-6/libtasn1-6_4.18.0-4_amd64.deb
     digest: 3f24f7a181f374bd6623bfdc7781e2cee5d948361a456d2f6216aa4ba5c44a2e
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tiff/libtiff-dev_4.5.1+git230720-5_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/t/tiff/libtiff-dev_4.5.1+git230720-5_amd64.deb
     digest: a181a6d9d9fc0e75973f750168a540a2f25719d27e0e7a981a608ed049496f66
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tiff/libtiff6_4.5.1+git230720-5_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/t/tiff/libtiff6_4.5.1+git230720-5_amd64.deb
     digest: dc2eb00fa11dcd6b3cd5ba61474d863b504d5266b1340ffd7e97ad389b0d2f87
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tiff/libtiffxx6_4.5.1+git230720-5_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/t/tiff/libtiffxx6_4.5.1+git230720-5_amd64.deb
     digest: 7da1a52c67cecd4aa048a35c7d1fedab8205b36ca59adf654b518c1604032119
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/n/ncurses/libtinfo6_6.4-4deepin2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/n/ncurses/libtinfo6_6.4-4deepin2_amd64.deb
     digest: 7d248232bd021f95756060036d571d809b1701c670d0e47e2e1f6caabebbf517
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libt/libtirpc/libtirpc-common_1.3.2-2_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libt/libtirpc/libtirpc-common_1.3.2-2_all.deb
     digest: 74bddc18e3289947b20653433e82025873f5679ccba52f258ca4912e435a09ee
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libt/libtirpc/libtirpc-dev_1.3.2-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libt/libtirpc/libtirpc-dev_1.3.2-2_amd64.deb
     digest: 801b243dc8b3ebecf2be9efc9ca69cd987f26830accede2e7142210c5640ee91
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libt/libtirpc/libtirpc3_1.3.2-2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libt/libtirpc/libtirpc3_1.3.2-2_amd64.deb
     digest: 4ded57b843774f3c65449d6ad7bed6efb97bf94cdb4aadb8554fe5cc12210291
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tslib/libts0_1.22-1+rb3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/t/tslib/libts0_1.22-1+rb3_amd64.deb
     digest: d7c7fffd808cd0b765d2287b98bea752d740994788dbf90de6db4f9710e41162
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/uchardet/libuchardet-dev_0.0.7-1deepin0_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/u/uchardet/libuchardet-dev_0.0.7-1deepin0_amd64.deb
     digest: cb40289c2a3a8b8054b7d0ba4a8d1e6dab7bc81d30aa9f43e8acd6ba586bca4e
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/uchardet/libuchardet0_0.0.7-1deepin0_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/u/uchardet/libuchardet0_0.0.7-1deepin0_amd64.deb
     digest: 8a09c59f9380ce99a5d18d8e3d4fcb1b9308a5f40789b1fb4323e0fb75c51a7d
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/s/systemd/libudev-dev_255.2-4deepin11_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/s/systemd/libudev-dev_255.2-4deepin11_amd64.deb
     digest: 248c864cdbddc655b53eaf7a8b3f930d888daf62b279da8506715fbed6e1129f
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/s/systemd/libudev1_255.2-4deepin11_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/s/systemd/libudev1_255.2-4deepin11_amd64.deb
     digest: c7acf7afccba7ded43d8cbd42971a6277a597e1dc1190726cf38667369acad35
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libu/libunistring/libunistring2_0.9.10-6_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libu/libunistring/libunistring2_0.9.10-6_amd64.deb
     digest: dfa507aa9982a3ba8cca86bc571d47e0c30d8adadc833e16cba4edd6e4c68155
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-linux/libuuid1_2.40.4-3deepin4_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/u/util-linux/libuuid1_2.40.4-3deepin4_amd64.deb
     digest: 5ff4edf566b7bbb9d4e6c175a5d58c26aaaf201472f12433f1de46f546945d03
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/v/vulkan-loader/libvulkan-dev_1.3.268.0-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/v/vulkan-loader/libvulkan-dev_1.3.268.0-1_amd64.deb
     digest: b3a78dde8283c64a2dbfe25320506a89b8dff77169e6e195129088047a272d4c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/v/vulkan-loader/libvulkan1_1.3.268.0-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/v/vulkan-loader/libvulkan1_1.3.268.0-1_amd64.deb
     digest: ea988ba1798a25fa13e1a6b852f1f8f8550293daead86a931846e4131a9e6c2e
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libw/libwacom/libwacom-common_1.12-1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libw/libwacom/libwacom-common_1.12-1_all.deb
     digest: ae18d0c6d1b68084756ae6a5ca4d4d680659ad6a9e5384bdbb49de48ffb75bd8
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libw/libwacom/libwacom-dev_1.12-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libw/libwacom/libwacom-dev_1.12-1_amd64.deb
     digest: 2e107e0a55003a2c223c792b5d505e566c553c42b0f6acc98f927f1a88bf4c2d
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libw/libwacom/libwacom2_1.12-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libw/libwacom/libwacom2_1.12-1_amd64.deb
     digest: 2e0eb22e108ff3de178a570dcd21ab3d6cc16f6baf94bec37595008786789280
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/w/wayland/libwayland-client0_1.23.0-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/w/wayland/libwayland-client0_1.23.0-1_amd64.deb
     digest: b5f2ac4f0acf93a0df4efefe38f34ebdc0e1724639c864e5777447bb5f9b7c2e
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/w/wayland/libwayland-cursor0_1.23.0-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/w/wayland/libwayland-cursor0_1.23.0-1_amd64.deb
     digest: e0acb5c50acbe13b427f9aa0ef9dd662d6e824b2f1d17e1a170bdf20422fcc36
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/w/wayland/libwayland-server0_1.23.0-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/w/wayland/libwayland-server0_1.23.0-1_amd64.deb
     digest: a63916b242532f6c621674b8dea3fc9e0c55f6592409edeb9146f8b978ec5a6e
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libw/libwebp/libwebp-dev_1.3.2-0.2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libw/libwebp/libwebp-dev_1.3.2-0.2_amd64.deb
     digest: 0c60cd19f18fbd0cf299480c7e7cfcb7451e6b1b05dc8f2d5cae1cd248e4bc5f
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libw/libwebp/libwebp7_1.3.2-0.2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libw/libwebp/libwebp7_1.3.2-0.2_amd64.deb
     digest: f2271cabfa4d4847bef8a522e2775d4f9c09a2560911df4779a7cc06d650eec6
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libw/libwebp/libwebpdecoder3_1.3.2-0.2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libw/libwebp/libwebpdecoder3_1.3.2-0.2_amd64.deb
     digest: 26d6ff4ed6bf1da7fe3eafe2514ef5c04a8792381b35e3bd3745fab1b6347246
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libw/libwebp/libwebpdemux2_1.3.2-0.2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libw/libwebp/libwebpdemux2_1.3.2-0.2_amd64.deb
     digest: bf245a91bfd56f199fc182030a8b9091c77ee4b3fa99754328ef6e4c31b9eafa
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libw/libwebp/libwebpmux3_1.3.2-0.2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libw/libwebp/libwebpmux3_1.3.2-0.2_amd64.deb
     digest: 4732ad39b0b2d4504983466503fa0ea1ba286c42aca07feeca8055d91e17aede
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libx11/libx11-6_1.8.7-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libx11/libx11-6_1.8.7-1_amd64.deb
     digest: e21e2b12e455664dd8b6ceb201d853c120dea77e0703c95545a3176708ae699f
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libx11/libx11-data_1.8.7-1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libx11/libx11-data_1.8.7-1_all.deb
     digest: 400aaa7eaab268850d8c2c512474228204d47774f2aac79cef29d1c125e0c656
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libx11/libx11-dev_1.8.7-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libx11/libx11-dev_1.8.7-1_amd64.deb
     digest: 93ec6c1345900f791549c12440757ba08e756379278bd6fe5133e6690c544621
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libx11/libx11-xcb1_1.8.7-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libx11/libx11-xcb1_1.8.7-1_amd64.deb
     digest: 68341e587a81b03655ff00f0cc9ba543181285504475e66b422308b1bdd30e5f
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxau/libxau-dev_1.0.9-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxau/libxau-dev_1.0.9-1_amd64.deb
     digest: 784b6358825482c6b8e0a5515c1ea33a84e1ae70999df930a75c344a476dbafa
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxau/libxau6_1.0.9-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxau/libxau6_1.0.9-1_amd64.deb
     digest: 0d55ab9b5634a7b635ebe263526719f3c5c925d847c0f4cb927bc61584cf269b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/x/xcb-util-cursor/libxcb-cursor0_0.1.1-4_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xcb-util-cursor/libxcb-cursor0_0.1.1-4_amd64.deb
     digest: f3575052a14a5ec2d016bc667d466fc5bceec389db5b6ad9ab03ca53b50411f6
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxcb/libxcb-dri3-0_1.15-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxcb/libxcb-dri3-0_1.15-1_amd64.deb
     digest: a55805048ef2bcbc16d6ed58879d173012291066e7e94f8ede8eb456d01c3079
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxcb/libxcb-glx0_1.15-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxcb/libxcb-glx0_1.15-1_amd64.deb
     digest: b049c57d28e8785786edba1d9ff6139fb8e85f17dbeb921aa4437a160f28ecd9
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/x/xcb-util-wm/libxcb-icccm4_0.4.1-1.1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xcb-util-wm/libxcb-icccm4_0.4.1-1.1_amd64.deb
     digest: be2ad80833f41279cad9ff66445251ea6ad3eec32cc9d2b9400ff8ad75ae255c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/x/xcb-util-image/libxcb-image0_0.4.0-deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xcb-util-image/libxcb-image0_0.4.0-deepin1_amd64.deb
     digest: f41b73e88b0dfb9a8b1cf7dc6b7717cdbf19b3eb0c4b9a395323b70cb3f22daf
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/x/xcb-util-keysyms/libxcb-keysyms1_0.4.0-deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xcb-util-keysyms/libxcb-keysyms1_0.4.0-deepin1_amd64.deb
     digest: f240c2c0304a253f65767ab856f995ceea9d999fca674f71e210704210218e65
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxcb/libxcb-present0_1.15-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxcb/libxcb-present0_1.15-1_amd64.deb
     digest: 548641b3568cf21f4359bed39375c1c8e873f92fa38955e310a27c3d0a0bd63c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxcb/libxcb-randr0_1.15-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxcb/libxcb-randr0_1.15-1_amd64.deb
     digest: 20d03b2822771bfeaf4ba3ae40faa96cf48e3a7c9bdf1d8ec37de6064a0ee02b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/x/xcb-util-renderutil/libxcb-render-util0_0.3.9-deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xcb-util-renderutil/libxcb-render-util0_0.3.9-deepin1_amd64.deb
     digest: c7bee3954ed81690c89b297ad68e14b95a634dc57ec1a235348efbf63de095b5
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxcb/libxcb-render0_1.15-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxcb/libxcb-render0_1.15-1_amd64.deb
     digest: ee032e334e48cdd15385fccde4b4baa399775d3a53aafa3a86e621012a47dae5
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxcb/libxcb-shape0_1.15-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxcb/libxcb-shape0_1.15-1_amd64.deb
     digest: 135268523d9957b26d436eee5cbb699815e52d98077b4e99516a9078444c9fa9
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxcb/libxcb-shm0_1.15-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxcb/libxcb-shm0_1.15-1_amd64.deb
     digest: 764d8a7b72cfcd3a4e3f1abb7b19c0af24e307a5595be04f06184b3817df8b44
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxcb/libxcb-sync1_1.15-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxcb/libxcb-sync1_1.15-1_amd64.deb
     digest: 8e5d1b2a5e1bfca4c9408bc7b62c161359f4ef7c2f35a25ef1734fd857c08654
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/x/xcb-util/libxcb-util1_0.4.0-deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xcb-util/libxcb-util1_0.4.0-deepin1_amd64.deb
     digest: f0b0176f922757c116b36801584068ab4e0411c6d97a6ed9acb578a4ef56a7c7
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxcb/libxcb-xfixes0_1.15-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxcb/libxcb-xfixes0_1.15-1_amd64.deb
     digest: c32ee9a285da0ddb94ab374cece23c5403e691539b5d604a1450f5120485d18a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxcb/libxcb-xkb1_1.15-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxcb/libxcb-xkb1_1.15-1_amd64.deb
     digest: d25d2db11b35fb8d8f7122805028094a0df945c59941f9b726b64dc48d0bf515
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxcb/libxcb1-dev_1.15-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxcb/libxcb1-dev_1.15-1_amd64.deb
     digest: 981d5049c153139995fa5d28ca1da252bbd5239a25111dc7bc28ab8c556d1b0b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxcb/libxcb1_1.15-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxcb/libxcb1_1.15-1_amd64.deb
     digest: 7472219060504d69f13cea545dde78da4b42455c3018f211d161315c7d8aa9f1
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxdmcp/libxdmcp-dev_1.1.2-3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxdmcp/libxdmcp-dev_1.1.2-3_amd64.deb
     digest: d0b1950a8dfb16ff2f3c6aac1296b508da0f25eef3bc636feed2116f7ba664bb
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxdmcp/libxdmcp6_1.1.2-3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxdmcp/libxdmcp6_1.1.2-3_amd64.deb
     digest: ebcc2294de7d5fb853478096435000c2c262f0cc27bb6e9cbd1455984e58a72f
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxext/libxext6_1.3.4-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxext/libxext6_1.3.4-1_amd64.deb
     digest: 59a91d747d250b40897b850d0aa7477a92aa671991287137875b1475a7708a85
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxi/libxi6_1.8.1-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxi/libxi6_1.8.1-1_amd64.deb
     digest: d8a2f9bd5ee841567db6b5aae74edb48c2fc11be2fd6354dc83cfca423905aa7
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxkbcommon/libxkbcommon-dev_1.6.0-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxkbcommon/libxkbcommon-dev_1.6.0-1_amd64.deb
     digest: fd7cb0bb0dc64c7417a6418bdf4d67145947902d5dd668eab4949811b170ee51
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxkbcommon/libxkbcommon-x11-0_1.6.0-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxkbcommon/libxkbcommon-x11-0_1.6.0-1_amd64.deb
     digest: d763060cdbffd1ed849ae63e091ca47b8b75c8777ccc2d0ee968fcbe66aa9b51
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxkbcommon/libxkbcommon0_1.6.0-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxkbcommon/libxkbcommon0_1.6.0-1_amd64.deb
     digest: c44ac854dbbe987c4a0ee11ddf526b8fff1b701edaa5d85b7495a81aeacc3686
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxml2/libxml2_2.9.14+dfsg-1.3+rb2_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxml2/libxml2_2.9.14+dfsg-1.3+rb2_amd64.deb
     digest: 36b25f4121dd6765f49a5249a94f675139c4fbaae04be5ccc1ac3ae59f1e40c2
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxshmfence/libxshmfence1_1.3-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxshmfence/libxshmfence1_1.3-1_amd64.deb
     digest: d112a8a931b29eed0b2c058cc53f03be11dcf4fe2dc28a570c38cec52f687c92
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxxf86vm/libxxf86vm1_1.1.4-deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxxf86vm/libxxf86vm1_1.1.4-deepin1_amd64.deb
     digest: 6ab24dd183238d561320ff6ab17df620297d4058d82e02606354740c0b8180f8
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/z/z3/libz3-4_4.8.12-deepin2+rb1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/z/z3/libz3-4_4.8.12-deepin2+rb1_amd64.deb
     digest: 73dced8cb5640743208e7a7cf2d4ae7072610d14314584c21992e84c31179907
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libz/libzstd/libzstd-dev_1.5.6+dfsg-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libz/libzstd/libzstd-dev_1.5.6+dfsg-1_amd64.deb
     digest: 92ec406d537e08271b66dbcf10d5730fff8eee067379c9fce7e74e4c53c6b4c3
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libz/libzstd/libzstd1_1.5.6+dfsg-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libz/libzstd/libzstd1_1.5.6+dfsg-1_amd64.deb
     digest: 2ea949de45dfe27832a6e7816a03103dae4ed45ba2b380669de5d5c89c361cc5
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/linguist-qt6_6.8.0-0deepin3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-tools/linguist-qt6_6.8.0-0deepin3_amd64.deb
     digest: 68fe4a526d73dd2ff6b75c593a5a4059486d1ec2535ec5e42cc52057a52744d2
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/l/linux-upstream/linux-libc-dev_25.01.01.01_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/l/linux-upstream/linux-libc-dev_25.01.01.01_amd64.deb
     digest: 46774d4ce9af0864f44fd0aed7cac874abe926c2ecda9845657acd3e68d1fe66
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/l/lshw/lshw_02.19.git.2021.06.19.996aaad9c7-2deepin0_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/l/lshw/lshw_02.19.git.2021.06.19.996aaad9c7-2deepin0_amd64.deb
     digest: d184d5fd7e340055beee8115e1f28663e539c024ede10773ac03f4ca3f86e343
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mailcap/mailcap_3.70_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/m/mailcap/mailcap_3.70_all.deb
     digest: 7ca67d118c03eaf58346eb1e676ff16f4d1aa5252a8cc6b5b3b1ed44556180f1
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/make-dfsg/make_4.4.1-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/m/make-dfsg/make_4.4.1-1_amd64.deb
     digest: fc03b0233080c11aadc3ef81283bcba5ff4904e0591ecf2beda7a4e7157e9975
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/media-types/media-types_4.0.0_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/m/media-types/media-types_4.0.0_all.deb
     digest: cd124053950ab8b0373203bceb7eab841791017daf1d50db2ece09e4da52406a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mesa/mesa-libgallium_24.3.0-1deepin4_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/m/mesa/mesa-libgallium_24.3.0-1deepin4_amd64.deb
     digest: 9f832c60e3739ceecc42e8d2609e6b0304060479a11d8a4703396b52081e7073
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mime-support/mime-support_3.66_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/m/mime-support/mime-support_3.66_all.deb
     digest: 20294deda4378616c2b48614ee226731ec09663c3497c35a467e8ea5fa03f16a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/n/netbase/netbase_6.4_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/n/netbase/netbase_6.4_all.deb
     digest: 5fd05a5d63864b96453ba55a4c5efa287b8e7e53fbd833e7a944e066d30e1eb1
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/patch/patch_2.7.6-7_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/patch/patch_2.7.6-7_amd64.deb
     digest: 4bf340095bbde164d3ca33360e3b9d89a2f92bb1912cf2b4fb21a266c2ca250c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/perl/perl-base_5.36.0-10deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/perl/perl-base_5.36.0-10deepin1_amd64.deb
     digest: 7b56a354906c81ebfb301c74af9558ec15da38f82963b9002b157d788c1e55f4
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/perl/perl-modules-5.36_5.36.0-10deepin1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/perl/perl-modules-5.36_5.36.0-10deepin1_all.deb
     digest: b79ccae8397e919ee917cd187b8be2d3b10eb598f43cf72a9d9a50c3d81ec288
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/perl/perl_5.36.0-10deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/perl/perl_5.36.0-10deepin1_amd64.deb
     digest: 1f28deb9739ccd0b2569990ea9fe58bdb5c363c8bd2b60a1dd8721da9d33f655
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pkgconf/pkg-config_1.8.1-4_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/pkgconf/pkg-config_1.8.1-4_amd64.deb
     digest: e9751c5efad4e9fb2150686bfb82ad13ff8b8f7d00592d3571f70f17a61ba884
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pkgconf/pkgconf-bin_1.8.1-4_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/pkgconf/pkgconf-bin_1.8.1-4_amd64.deb
     digest: 6d6e880665acf6c1600e779d00259242e7f58e957dda43d760b65df472ddbfbd
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pkgconf/pkgconf_1.8.1-4_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/pkgconf/pkgconf_1.8.1-4_amd64.deb
     digest: 3e8dd26853b621b7b1ef82533bfb3bfa0c9ba07f581df727cb3271e7a35edf33
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/python3-defaults/python3-minimal_3.12.1-1deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/python3-defaults/python3-minimal_3.12.1-1deepin1_amd64.deb
     digest: 44712ddb4dd007c7916d3bb3e2539d0853251b4672e6b76d057733fcfb26fe03
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/python-packaging/python3-packaging_24.0-1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/python-packaging/python3-packaging_24.0-1_all.deb
     digest: acf9e0347764b07624b219b64fa7721705d6eeea5a98871f892aff3ab0293ae4
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/python3.12/python3.12-minimal_3.12.11-0deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/python3.12/python3.12-minimal_3.12.11-0deepin1_amd64.deb
     digest: 052de179f77f52e03dc62849e569130457275528003f3c66b1633aa46750a995
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/python3.12/python3.12_3.12.11-0deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/python3.12/python3.12_3.12.11-0deepin1_amd64.deb
     digest: a0ffedb8e24dfed01e29acc8a207b6e90d40a0b1b1ba39dc5c9c2c51ec7da796
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/python3-defaults/python3_3.12.1-1deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/python3-defaults/python3_3.12.1-1deepin1_amd64.deb
     digest: 3e3840ef15b198763d57c130ef9675a46fbdf534f2d5d721f8ddf91b6d743c1c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/qdbus-qt6_6.8.0-0deepin3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-tools/qdbus-qt6_6.8.0-0deepin3_amd64.deb
     digest: 1ddd2f46a8e6b858e589bb011fcafb498ea673c78dd248283284b8a188cf996d
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qmake6-bin_6.8.0+dfsg-0deepin8_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/qmake6-bin_6.8.0+dfsg-0deepin8_amd64.deb
     digest: 32c3245be7c5c0a778f7d6923c6d0f244fa4a297923d96d0583742477e61a540
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qmake6_6.8.0+dfsg-0deepin8_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/qmake6_6.8.0+dfsg-0deepin8_amd64.deb
     digest: c7bee095c8c3d51a32db1369e90aad0c63339217557b13e494c1ffec0a962abc
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/k/kf6-syntax-highlighting/qml6-module-org-kde-syntaxhighlighting_6.10.0-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/k/kf6-syntax-highlighting/qml6-module-org-kde-syntaxhighlighting_6.10.0-1_amd64.deb
     digest: 43bafb2d6e52997589450d29fb6da275c63ff990b0ad6616396eeca939567919
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-5compat/qml6-module-qt5compat-graphicaleffects_6.8.0-0deepin_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-5compat/qml6-module-qt5compat-graphicaleffects_6.8.0-0deepin_amd64.deb
     digest: e3ab20d4d1cf4ee712ac3e5624e78369d8cb5bdae57f830111ca244abbe9b4fb
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-declarative/qml6-module-qtqml-workerscript_6.8.0+dfsg-0deepin3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-declarative/qml6-module-qtqml-workerscript_6.8.0+dfsg-0deepin3_amd64.deb
     digest: 359f5fd7d83789deee753300437ea35ef2004a4ac03c5367249246addcafc210
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-declarative/qml6-module-qtqml_6.8.0+dfsg-0deepin3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-declarative/qml6-module-qtqml_6.8.0+dfsg-0deepin3_amd64.deb
     digest: dcef2b6339bb7f19c33a710f6817b5f0512824a6139ac038a1626f766c2d3b91
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6declarative/qml6-module-qtquick-controls2-styles-chameleon_6.0.38_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/dtk6declarative/qml6-module-qtquick-controls2-styles-chameleon_6.0.38_amd64.deb
     digest: e7913cf5aa33734eacd2ceb2c5d52aebbc81b71dd82ca38437b31c555d608aa0
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-declarative/qml6-module-qtquick-controls_6.8.0+dfsg-0deepin3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-declarative/qml6-module-qtquick-controls_6.8.0+dfsg-0deepin3_amd64.deb
     digest: dd7f3497cafccabe196a94a26af947fa64099fc99ce455aa90108b9354adfa66
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-declarative/qml6-module-qtquick-effects_6.8.0+dfsg-0deepin3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-declarative/qml6-module-qtquick-effects_6.8.0+dfsg-0deepin3_amd64.deb
     digest: a793bc5fc6af15b73769835a976fe7f47e1e73ab19218ac64b67f1b387fe166a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-declarative/qml6-module-qtquick-shapes_6.8.0+dfsg-0deepin3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-declarative/qml6-module-qtquick-shapes_6.8.0+dfsg-0deepin3_amd64.deb
     digest: d9b65c18f1f3f2d73ef2240775ed2dc1a6b039aa0e5259a682d5e2ced3591b22
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-declarative/qml6-module-qtquick-templates_6.8.0+dfsg-0deepin3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-declarative/qml6-module-qtquick-templates_6.8.0+dfsg-0deepin3_amd64.deb
     digest: 6a54bb65812ceefc976b76c8257302043e563fe85900fd6917a9bf3b3437b8b5
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-declarative/qml6-module-qtquick_6.8.0+dfsg-0deepin3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-declarative/qml6-module-qtquick_6.8.0+dfsg-0deepin3_amd64.deb
     digest: 296735ee17f8ca5ad223bf01d02fc2db8037c128d55f3ede735e0adbd87069be
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-5compat/qt6-5compat-dev_6.8.0-0deepin_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-5compat/qt6-5compat-dev_6.8.0-0deepin_amd64.deb
     digest: a61f1a75f31b6b3ea46551a2801de97d83282870c57ca69f7d916ecac63489ea
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qt6-base-dev-tools_6.8.0+dfsg-0deepin8_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/qt6-base-dev-tools_6.8.0+dfsg-0deepin8_amd64.deb
     digest: 8b33f401a988b6afda0ffd807fcbdad2a4ed487aa3d81e66e62d499b1b7a4510
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qt6-base-dev_6.8.0+dfsg-0deepin8_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/qt6-base-dev_6.8.0+dfsg-0deepin8_amd64.deb
     digest: 30382213970c6d9ef9d09b54dd5d3f6088e7e740382edaa457fa2915e8e527c1
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qt6-base-private-dev_6.8.0+dfsg-0deepin8_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/qt6-base-private-dev_6.8.0+dfsg-0deepin8_amd64.deb
     digest: 5f61b34f7a74b35588afcdd2b362223b8bbb4696d29ae217b087b480158c3bf0
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-declarative/qt6-declarative-dev-tools_6.8.0+dfsg-0deepin3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-declarative/qt6-declarative-dev-tools_6.8.0+dfsg-0deepin3_amd64.deb
     digest: 325b7309058321320af21fc04a30c5fec7083da57ba21b34acdb57c92a27010f
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-declarative/qt6-declarative-dev_6.8.0+dfsg-0deepin3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-declarative/qt6-declarative-dev_6.8.0+dfsg-0deepin3_amd64.deb
     digest: 0e8d96e66842c4afb9ac2113a6bc1bdaed0642431b8008ddfd674aa2007f5f9c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/qt6-documentation-tools_6.8.0-0deepin3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-tools/qt6-documentation-tools_6.8.0-0deepin3_amd64.deb
     digest: b9e766a60ff54dc40cdd1307aead4f3c2c1997388e21fe36ec37650bcf650384
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-imageformats/qt6-image-formats-plugins_6.8.0-0deepin_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-imageformats/qt6-image-formats-plugins_6.8.0-0deepin_amd64.deb
     digest: 820f8a30e3cd001eca5a21403b060ea5f047017fc9450423717ee7a59461a8f5
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/qt6-l10n-tools_6.8.0-0deepin3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-tools/qt6-l10n-tools_6.8.0-0deepin3_amd64.deb
     digest: 9ebce5aacbc3bd447f6fa109d03647369ec93d054f45a4b6f332b2643ebf9c0e
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-declarative/qt6-qmllint-plugins_6.8.0+dfsg-0deepin3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-declarative/qt6-qmllint-plugins_6.8.0+dfsg-0deepin3_amd64.deb
     digest: 77c63ec8306aa1dd822fc77180a534777b8b79ffbcf4d62eba93a0078b2f419c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-declarative/qt6-qmltooling-plugins_6.8.0+dfsg-0deepin3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-declarative/qt6-qmltooling-plugins_6.8.0+dfsg-0deepin3_amd64.deb
     digest: 97de7f274586959ad1b920df510a50a98bcd94ecd9d2dab1aea777508a9087cd
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qt6-qpa-plugins_6.8.0+dfsg-0deepin8_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/qt6-qpa-plugins_6.8.0+dfsg-0deepin8_amd64.deb
     digest: 1e7728aaa16cb4ce8b9baad38f9dba7d047b54a87d3d3c130b3f76bb54ea4212
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-svg/qt6-svg-dev_6.8.0-0deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-svg/qt6-svg-dev_6.8.0-0deepin1_amd64.deb
     digest: 0acef551ad9074060268eabb8d0b2b4703b005b00672a23406346e19d7346de7
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/qt6-tools-dev-tools_6.8.0-0deepin3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-tools/qt6-tools-dev-tools_6.8.0-0deepin3_amd64.deb
     digest: d2521c7f6a5efb286c34d765cf0cdfc2dda504204acb81ed39657315602350dc
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/qt6-tools-dev_6.8.0-0deepin3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-tools/qt6-tools-dev_6.8.0-0deepin3_amd64.deb
     digest: e2b8c1f31715901d773e714ab0105534aa17ed64ce9e5065900e4fc8fa17ed58
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/r/readline/readline-common_8.2-3_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/r/readline/readline-common_8.2-3_all.deb
     digest: 35fe59faceb8d9def8b6aa664e091eac8444887bc1f33ba2cf22099c3646e7bd
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/r/rpcsvc-proto/rpcsvc-proto_1.4.2-4_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/r/rpcsvc-proto/rpcsvc-proto_1.4.2-4_amd64.deb
     digest: 76a363bd052b40394f829486c820967c1386539c2fbdd7aa2e77430132fccab0
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/s/shared-mime-info/shared-mime-info_2.2-1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/s/shared-mime-info/shared-mime-info_2.2-1_amd64.deb
     digest: 545413a218d5cd7e3103b5e277419a7e67044c95f83ed7fb700c6c99ba523c02
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tar/tar_1.35+dfsg-3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/t/tar/tar_1.35+dfsg-3_amd64.deb
     digest: ee27ac0010bb1525067edda7b6b86110a00550232fb154f87491dbc3a3a2c8ff
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tzdata/tzdata_2023d-1deepin1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/t/tzdata/tzdata_2023d-1deepin1_all.deb
     digest: fe503c524801260208482a1dfc061e79c2a7450111dd90f88ed40d70ac935832
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-linux/uuid-dev_2.40.4-3deepin4_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/u/util-linux/uuid-dev_2.40.4-3deepin4_amd64.deb
     digest: 15c9b33ab745cce30a6d51d8af8f0d3ab80e68af8dd21a416e16e60c2af359fe
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/x/xorg/x11-common_7.7+23-deepin1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xorg/x11-common_7.7+23-deepin1_all.deb
     digest: 9a7643db11023a8bec126312edec4b1b7357b93416bdfbaf9b0cb8bc04506d49
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/x/xorgproto/x11proto-core-dev_2024.1-1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xorgproto/x11proto-core-dev_2024.1-1_all.deb
     digest: 82bff9dab1d74e30bdbc6130f94d1bd361c3c1d3cdad660bd92e5b730c4cba7b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/x/xorgproto/x11proto-dev_2024.1-1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xorgproto/x11proto-dev_2024.1-1_all.deb
     digest: 39e14817ff2ab4eedade206fefebb7b2632e4dd7c358a9cfe36bcdd477554a04
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/x/xfonts-encodings/xfonts-encodings_1.0.4-2.1deepin1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xfonts-encodings/xfonts-encodings_1.0.4-2.1deepin1_all.deb
     digest: 07d68c68eeeca62cea0558b4f0bc25896bd82fddfa6c4b02693ee0adc4bde224
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/x/xfonts-utils/xfonts-utils_7.7+6-deepin_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xfonts-utils/xfonts-utils_7.7+6-deepin_amd64.deb
     digest: 5a83d9ea46a19255d820eebcf8c6a8a08339e1e37ad11ac3b8d89d1dcb719e13
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/x/xkeyboard-config/xkb-data_2.38-2deepin1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xkeyboard-config/xkb-data_2.38-2deepin1_all.deb
     digest: 6fdc32f08737735128e20a10f9a8425bde19855e3917d8f26a62ea3a12a9a720
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/x/xorg-sgml-doctools/xorg-sgml-doctools_1.11-1.1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xorg-sgml-doctools/xorg-sgml-doctools_1.11-1.1_all.deb
     digest: c3ac4805a75219ecc8a92a79697d39fa9abf6a7fa16da540800a0d30bdcc2847
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/x/xtrans/xtrans-dev_1.4.0-1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xtrans/xtrans-dev_1.4.0-1_all.deb
     digest: ab37e512128e066d7225deb7f51f0c77f9b0c3913d75f2a7f9b1d708327a099d
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/x/xz-utils/xz-utils_5.4.5-0.3_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xz-utils/xz-utils_5.4.5-0.3_amd64.deb
     digest: 6144e64526111988775c0c78db08e9afded0f1f760fe924895017ac338f87553
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/z/zlib/zlib1g-dev_1.3.dfsg+really1.3.1-1deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/z/zlib/zlib1g-dev_1.3.dfsg+really1.3.1-1deepin1_amd64.deb
     digest: 6d5bf0445a25257bc75a612224498ecddda2fa56edc8d17af5c4bdd2713edd4b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/z/zlib/zlib1g_1.3.dfsg+really1.3.1-1deepin1_amd64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/z/zlib/zlib1g_1.3.dfsg+really1.3.1-1deepin1_amd64.deb
     digest: d0bab03ed3981fbe2bae8799a3c45d9a3b1561ae3d7bcffe37f235d573ae24c6

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -10,7 +10,7 @@ version: "1"
 package:
   id: org.deepin.editor
   name: "deepin-editor"
-  version: 6.5.31.1
+  version: 6.5.32.1
   kind: app
   description: |
     editor for deepin os.
@@ -48,1157 +48,1157 @@ build: |
   bash ./deploy_dep "${LDD_FILES[@]}"
 
 sources:
-  # linglong:gen_deb_source sources loong64 http://10.20.64.92:8080/testing25_daily stable main
+  # linglong:gen_deb_source sources loong64 http://10.20.64.92:8080/crimson_25.0 stable main
   # linglong:gen_deb_source install qt6-5compat-dev, qt6-base-dev, qt6-tools-dev-tools, qt6-tools-dev, qt6-base-private-dev, qt6-svg-dev, libdtk6widget-dev, libdtk6gui-dev, libdtk6core-dev, libdtk6declarative-dev, libpolkit-qt6-1-dev, libkf6syntaxhighlighting-dev, libkf6codecs-dev, libgtest-dev, libgmock-dev, libchardet-dev, libuchardet-dev, libicu-dev, deepin-event-log
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/assistant-qt6_6.8.0-0deepin3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-tools/assistant-qt6_6.8.0-0deepin3_loong64.deb
     digest: f6ff5fd88f299cfe07c0c808da8795d6ba4a6add35435dde5be1a64a4403de0d
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/b/binutils/binutils-common_2.41-6deepin7_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/b/binutils/binutils-common_2.41-6deepin7_loong64.deb
     digest: 6ff45e7708ee8470b2c50a09c2b4a1077b1ffbf53cffe660ad8dc386678eff87
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/b/binutils/binutils-loongarch64-linux-gnu_2.41-6deepin7_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/b/binutils/binutils-loongarch64-linux-gnu_2.41-6deepin7_loong64.deb
     digest: e0b9f5abe0d37451ce205c8a58f946ccaeca97ecd53816c3a1050775ba0459b2
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/b/binutils/binutils_2.41-6deepin7_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/b/binutils/binutils_2.41-6deepin7_loong64.deb
     digest: 6f2af278a75b4eca34ca84b6e3a527cfa423927243fa2381d8e499d011f9b0ec
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/b/bzip2/bzip2_1.0.8-deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/b/bzip2/bzip2_1.0.8-deepin1_loong64.deb
     digest: 08d9f48f571bc206fe4e30a27e535a3a086b9dedba4a5f5055e898ff0dbea7a6
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/debconf/debconf_1.5.79-deepin_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/debconf/debconf_1.5.79-deepin_all.deb
     digest: ded6aaa7927ae27337ceb23d49391b4c7ec460a00ba692020e8f4e28388f345f
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/deepin-event-log/deepin-event-log-daemon_2.1.2-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/deepin-event-log/deepin-event-log-daemon_2.1.2-1_loong64.deb
     digest: 8f1df92485304b3647da45199e99ee8f5cdf9417f37f7de620b7caa2d83489f4
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/deepin-event-log/deepin-event-log_2.1.2-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/deepin-event-log/deepin-event-log_2.1.2-1_loong64.deb
     digest: 7761bdc5732d47d3154ac4101e0d66b78d454a4c34404cce57a5761ad85f7fd0
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/designer-qt6_6.8.0-0deepin3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-tools/designer-qt6_6.8.0-0deepin3_loong64.deb
     digest: eab43bf5b5365d2839d6c319aa489eb239a581d8fadc3132920645bf20948a70
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dpkg/dpkg-dev_1.22.6deepin4_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/dpkg/dpkg-dev_1.22.6deepin4_all.deb
     digest: 8b3ec535c58fd4041effcff798c688ab1f4a36b6c2ac5989412020686c7607f7
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dpkg/dpkg_1.22.6deepin4_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/dpkg/dpkg_1.22.6deepin4_loong64.deb
     digest: ed2c4a87410d3beea4622bbe835dab07b458a8e286be591ca34e97f2a6f6d730
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fontconfig/fontconfig-config_2.15.0-2.3deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/fontconfig/fontconfig-config_2.15.0-2.3deepin1_loong64.deb
     digest: 06fd1e3b51d4e56571e9e974fd7936aa7010220f954b9a78b239b42bbf6e94fc
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fontconfig/fontconfig_2.15.0-2.3deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/fontconfig/fontconfig_2.15.0-2.3deepin1_loong64.deb
     digest: 383b6417f02a2850dc8dc08613ba4f188f63943deef4f707fb03b50e34627c30
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fonts-noto/fonts-croscore_20201225-deepin_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/fonts-noto/fonts-croscore_20201225-deepin_all.deb
     digest: afbaf120869a08aa7dd14da9ad014de48a751aa4330534b531410bb86c411b55
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fonts-dejavu/fonts-dejavu-core_2.37-deepin_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/fonts-dejavu/fonts-dejavu-core_2.37-deepin_all.deb
     digest: 5982963d05dbf4efa009c3ab6db3576a03f680199d75d7d5edda89c55def912c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fonts-freefont/fonts-freefont-otf_20120503-10_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/fonts-freefont/fonts-freefont-otf_20120503-10_all.deb
     digest: c66666da94b9a0477351ee9d6d7a247a0a3c842e428da770991b45f03be2ee72
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fonts-freefont/fonts-freefont-ttf_20120503-10_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/fonts-freefont/fonts-freefont-ttf_20120503-10_all.deb
     digest: 79b23c3945d4628463672a804a0e81bc4c262ef87cb6316afb40167a50bc3145
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fonts-liberation/fonts-liberation_2.1.5-3_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/fonts-liberation/fonts-liberation_2.1.5-3_all.deb
     digest: 9285213fd8d6515bc6c1be5b810bf39918a668a17024a9fd3541879ce7fb5344
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fonts-noto/fonts-noto-core_20201225-deepin_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/fonts-noto/fonts-noto-core_20201225-deepin_all.deb
     digest: fa09d95f516c498d55e516d549b8ee41d9a7b6f17cdf0bb4b43744d672ce1366
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tex-gyre/fonts-texgyre_20180621-3.1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/t/tex-gyre/fonts-texgyre_20180621-3.1_all.deb
     digest: f66d6f798c4b99d8490558cc8209c069b0fe5577c11378c0e01f9e87ddf10824
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fonts-urw-base35/fonts-urw-base35_20200910-7_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/fonts-urw-base35/fonts-urw-base35_20200910-7_all.deb
     digest: 4800c0b08fbeac0335f1e23df2d41528a242383324c256ebece00c8f438eefbd
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gcc-13/gcc-13-base_13.2.0-3deepin4_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/gcc-13/gcc-13-base_13.2.0-3deepin4_loong64.deb
     digest: 8603fe4ed1cd650d10366be27c0f5920c97379955c5a9d628af03d6146411422
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/glib2.0/gir1.2-glib-2.0_2.80.1-1deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/glib2.0/gir1.2-glib-2.0_2.80.1-1deepin1_loong64.deb
     digest: 9adbd030273cfacb0eb6223bfdce65e0106f5c811d96caa66978598bb40f3309
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libgudev/gir1.2-gudev-1.0_238-2deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libg/libgudev/gir1.2-gudev-1.0_238-2deepin1_loong64.deb
     digest: df1346b7d3f97770fe21c1d05024d3d9583cfd1d4dd3da3036f8a306419eb1a1
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/googletest/googletest_1.12.1-0.2_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/googletest/googletest_1.12.1-0.2_all.deb
     digest: 2df57ce8c5c8fdc37e1dbbe302d276f1cb9a784df5dd3423208f87933cfa28a0
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/i/icu/icu-devtools_74.2-1deepin4_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/i/icu/icu-devtools_74.2-1deepin4_loong64.deb
     digest: 29bc31d34206b2ad29fa35e68acc54adc4ac8b94d19ad03e1ba96c8cb0cf0cdd
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/a/acl/libacl1_2.3.1-3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/a/acl/libacl1_2.3.1-3_loong64.deb
     digest: 7388773fe6ec2b0439e0383023e06d26dee49dc9a2adc9b0969c3e24a51f09e7
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/a/attr/libattr1_2.5.1-4_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/a/attr/libattr1_2.5.1-4_loong64.deb
     digest: f9965bc423eee241336a5edf4851ebe8058fd76c5ef227d59d57a4e7accd55bf
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/a/avahi/libavahi-client3_0.8-5_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/a/avahi/libavahi-client3_0.8-5_loong64.deb
     digest: 9ccbd93fc9d06c9ddf2b4fa7a399f4695576f80624ce1742ecce86de1b31006e
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/a/avahi/libavahi-common-data_0.8-5_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/a/avahi/libavahi-common-data_0.8-5_loong64.deb
     digest: 24752d796aa2f23c09e8bff308bffea8e605b818e77cd6af06e6fc2678e80396
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/a/avahi/libavahi-common3_0.8-5_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/a/avahi/libavahi-common3_0.8-5_loong64.deb
     digest: 38d7141a270890e7a5e6dbbf668436061d17b6ec81abae9277b5171cc0677698
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libb/libb2/libb2-1_0.98.1-1.1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libb/libb2/libb2-1_0.98.1-1.1_loong64.deb
     digest: 43c9bedf808d5c2b85351f73dab25e81c5674c499c293be875ac5250c4b8cca0
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/b/binutils/libbinutils_2.41-6deepin7_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/b/binutils/libbinutils_2.41-6deepin7_loong64.deb
     digest: 0072ce1b04c7bc89f5a4a9e0bc9345ea6b7bec1c7469e2ddf3ef5ae1ca955853
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-linux/libblkid-dev_2.40.4-3deepin4_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/u/util-linux/libblkid-dev_2.40.4-3deepin4_loong64.deb
     digest: b8c86c20ac3f591b298fafc9d94b91f81df48f1b59a65493933e79dce235ce07
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-linux/libblkid1_2.40.4-3deepin4_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/u/util-linux/libblkid1_2.40.4-3deepin4_loong64.deb
     digest: 9997f65a9ee404fcfab2ffb048a597d3b44bfd985495375b9b35a4b0b4c8dad2
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/b/brotli/libbrotli-dev_1.1.0-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/b/brotli/libbrotli-dev_1.1.0-2_loong64.deb
     digest: c2388059363813c7ad5e42d91f514b1e93e3dd07432634eca0a6814e2d7edc10
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/b/brotli/libbrotli1_1.1.0-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/b/brotli/libbrotli1_1.1.0-2_loong64.deb
     digest: fa0a0735177fd06de4701acc3ccc180b7b45da0e3573cb82cdcda56dea9ded62
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libb/libbsd/libbsd0_0.11.7-4_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libb/libbsd/libbsd0_0.11.7-4_loong64.deb
     digest: 1a2e574f4385b39b0e1597f0220fb743d8f2cc4ed0a19047e97d361151d30c6b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/b/bzip2/libbz2-1.0_1.0.8-deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/b/bzip2/libbz2-1.0_1.0.8-deepin1_loong64.deb
     digest: a29abfb786ff0410774a943b1835520b9184b7bfeb4bbe24e1c1e244aec2cbfb
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/b/bzip2/libbz2-dev_1.0.8-deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/b/bzip2/libbz2-dev_1.0.8-deepin1_loong64.deb
     digest: b073876e60d9f9ba41ff9f984d0895c37684272da7ea5389b2ceb85598e3154a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/glibc/libc-dev-bin_2.38-6deepin13+rb1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/glibc/libc-dev-bin_2.38-6deepin13+rb1_loong64.deb
     digest: 9fa3bcc93dab003763d83db50c25081e29ded90e14d44fe404f6d5b052f1e006
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/glibc/libc6-dev_2.38-6deepin13+rb1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/glibc/libc6-dev_2.38-6deepin13+rb1_loong64.deb
     digest: b50b71c9c338a8b778c53d3263b155a04f5abae803827cad1f698b015826d2b6
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/glibc/libc6_2.38-6deepin13+rb1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/glibc/libc6_2.38-6deepin13+rb1_loong64.deb
     digest: 4d25699d2b3054ff228cf4e83822adecfdbfebb848f2a9bd0786704ff915b6a1
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libc/libcap2/libcap2_2.66-5_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libc/libcap2/libcap2_2.66-5_loong64.deb
     digest: d4cbe29713f415bd8679e79b2d4558a790c0749b1ee8f829ffa77cfc29695377
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libc/libchardet/libchardet-dev_1.0.4-2deepin_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libc/libchardet/libchardet-dev_1.0.4-2deepin_loong64.deb
     digest: 91cc278925345229fc107e7718ea9293a49305bc335293957d24589693d4a51d
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libc/libchardet/libchardet1_1.0.4-2deepin_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libc/libchardet/libchardet1_1.0.4-2deepin_loong64.deb
     digest: 6ea3ddf926ae9c78f550cc2a90add669d402bbc7fb930f80288ad85be6e215ff
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/l/llvm-toolchain-17/libclang-cpp17_17.0.6-5deepin5_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/l/llvm-toolchain-17/libclang-cpp17_17.0.6-5deepin5_loong64.deb
     digest: 8a7e85de84804dd73ec433de1ad3fb61905c8c8a943365620cea7cedd44a6967
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/l/llvm-toolchain-17/libclang1-17_17.0.6-5deepin5_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/l/llvm-toolchain-17/libclang1-17_17.0.6-5deepin5_loong64.deb
     digest: ee391e47845900e8362b9cc01aa298a4bf662e354f17a91d2cada946f72fbce3
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/e/e2fsprogs/libcom-err2_1.47.0-2deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/e/e2fsprogs/libcom-err2_1.47.0-2deepin1_loong64.deb
     digest: 47f0cbde458a5b5998a470c7ccb6d7d299edda99007d79eede46b23ee2b26401
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxcrypt/libcrypt-dev_4.4.36-5_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxcrypt/libcrypt-dev_4.4.36-5_loong64.deb
     digest: b613149b2665f0c26951cf78b70777ae30ed60feecbd2c86a65233ffffdbebb5
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxcrypt/libcrypt1_4.4.36-5_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxcrypt/libcrypt1_4.4.36-5_loong64.deb
     digest: a9dcd576d5cd80ada64381a1727a3116545e93cf447f59c7414d1777e2993fec
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/b/binutils/libctf-nobfd0_2.41-6deepin7_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/b/binutils/libctf-nobfd0_2.41-6deepin7_loong64.deb
     digest: c06121aeae9359ded8ff84c74ade5b03d1325b77c4a938fbd9931c8fe2caa84b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/b/binutils/libctf0_2.41-6deepin7_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/b/binutils/libctf0_2.41-6deepin7_loong64.deb
     digest: a594bca37501a18b322a46118883ed18bd99ef7d31eb5e5220a2d7c1adc4935d
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cups/libcups2-dev_2.4.2-5deepin2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/c/cups/libcups2-dev_2.4.2-5deepin2_loong64.deb
     digest: 7452bfb8da2bf510f5095db334f7730c914a087571d313172392b1a2b12b986e
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cups/libcups2_2.4.2-5deepin2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/c/cups/libcups2_2.4.2-5deepin2_loong64.deb
     digest: 2215b8b403b997e7ce667895f92cafeb22ceafcec9dd468c6583aa2dbe83393c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cups/libcupsimage2-dev_2.4.2-5deepin2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/c/cups/libcupsimage2-dev_2.4.2-5deepin2_loong64.deb
     digest: 07c0d38b655ad9e1dc4d93ca4a858255adb25dc7b131ae1509781b83f1d2d133
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cups/libcupsimage2_2.4.2-5deepin2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/c/cups/libcupsimage2_2.4.2-5deepin2_loong64.deb
     digest: 054a65c1507942291091fe19cbb3ca046ab48e734b4e8a2a77939fa427a89363
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/curl/libcurl3-gnutls_8.11.0-0deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/c/curl/libcurl3-gnutls_8.11.0-0deepin1_loong64.deb
     digest: 1e92b0e84256009fa0d4afa40bc765076fb97a45ab25e4f27b29a18a8b3445d6
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/db5.3/libdb5.3_5.3.28+dfsg1-0.8deepin0_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/db5.3/libdb5.3_5.3.28+dfsg1-0.8deepin0_loong64.deb
     digest: 976e0ae132630258702d76bc235bec36ea5820e506bc110585aee657fb487472
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dbus/libdbus-1-3_1.14.10-3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/dbus/libdbus-1-3_1.14.10-3_loong64.deb
     digest: 78833b3973000dd505cd32d2301a8d5a9bdc5070360c2de5bebc9e9cc5289b17
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libd/libdeflate/libdeflate-dev_1.18-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libd/libdeflate/libdeflate-dev_1.18-1_loong64.deb
     digest: 6d218959ede7fd5ad4fde3c25dc2c26f113d1e07c487d344a7678c29b9ce0dfa
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libd/libdeflate/libdeflate0_1.18-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libd/libdeflate/libdeflate0_1.18-1_loong64.deb
     digest: 1b60dc1dbbef61987759b5254d408edbd7d653e28b94f857de22578b0ca62dae
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/double-conversion/libdouble-conversion3_3.3.0-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/double-conversion/libdouble-conversion3_3.3.0-1_loong64.deb
     digest: 1cb1deef108f4163f884f564e9fcfd429adc315e9509c30ff3bcf936824ac543
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dpkg/libdpkg-perl_1.22.6deepin4_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/dpkg/libdpkg-perl_1.22.6deepin4_all.deb
     digest: 569373a35267f9cf2e8d0ee6d42c9047f50fa2174a0ac72fa77f494a0f0a9d1b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libd/libdrm/libdrm-amdgpu1_2.4.123-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libd/libdrm/libdrm-amdgpu1_2.4.123-1_loong64.deb
     digest: a26ef022dd15349da87ea50e9a8fa2799ab3f5287c93075bbf6c229c2eafd969
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libd/libdrm/libdrm-common_2.4.123-1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libd/libdrm/libdrm-common_2.4.123-1_all.deb
     digest: b8289eaa6341a8493f4c191a45165fe944248da69f675d09005a29058e7ae5a6
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libd/libdrm/libdrm-radeon1_2.4.123-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libd/libdrm/libdrm-radeon1_2.4.123-1_loong64.deb
     digest: d1ff95314f5b678d51fcbcb5c1adc603db5958e82fef41dfff3431c3274e18bf
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libd/libdrm/libdrm2_2.4.123-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libd/libdrm/libdrm2_2.4.123-1_loong64.deb
     digest: 9b28e3fcb6cff61e26352d3b426fe25b0c19961120d499fd5cb05f5177b411bd
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6core/libdtk6core-dev_6.0.38_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/dtk6core/libdtk6core-dev_6.0.38_loong64.deb
     digest: 46b262c7a9142265d96ed03c896080b6be4931cd96881ee36d450593c1b23185
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6core/libdtk6core_6.0.38_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/dtk6core/libdtk6core_6.0.38_loong64.deb
     digest: 2a051f11ab21c3eb73382db4cb96c892e5c25be60b9ec7b1c436645df09237c4
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6declarative/libdtk6declarative-dev_6.0.38_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/dtk6declarative/libdtk6declarative-dev_6.0.38_loong64.deb
     digest: adb7cb041eca02daac8adb47c2f3f621a7896483056032d70a655d22f7a5f374
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6declarative/libdtk6declarative_6.0.38_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/dtk6declarative/libdtk6declarative_6.0.38_loong64.deb
     digest: 6158c6782fd25ace5eeca01465df509e620b05b1a46875d5b8419585d5aa23da
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6gui/libdtk6gui-dev_6.0.38_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/dtk6gui/libdtk6gui-dev_6.0.38_loong64.deb
     digest: 5c820da0d98e49b0cafcce328abc7b20f79a57fe8e9955eab7c86232ca4d217c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6gui/libdtk6gui_6.0.38_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/dtk6gui/libdtk6gui_6.0.38_loong64.deb
     digest: 204e21dfba6edbcf36a22ffeb1317cfabed65d11eedb04cd53840dca04ba72ef
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6log/libdtk6log-dev_0.0.4_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/dtk6log/libdtk6log-dev_0.0.4_loong64.deb
     digest: 85431680f43cb35350110f025ab764f817a87ef8b87f8aaf1221cf92324a22d3
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6log/libdtk6log_0.0.4_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/dtk6log/libdtk6log_0.0.4_loong64.deb
     digest: 5dd93e358d83fad8b4f44962845e07554f43f36f252c886f694cf165ad67a3d2
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6widget/libdtk6widget-dev_6.0.38_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/dtk6widget/libdtk6widget-dev_6.0.38_loong64.deb
     digest: 17e369876960256cc74b9a89b79f507944aa3f1965f443fc7d6fdbebafb60ea6
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6widget/libdtk6widget_6.0.38_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/dtk6widget/libdtk6widget_6.0.38_loong64.deb
     digest: 18fdea046e17f28b1ace921d4c27f8eeed9a28841c46824138307c9f47722cbd
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtkcommon/libdtkcommon-dev_5.7.18_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/dtkcommon/libdtkcommon-dev_5.7.18_loong64.deb
     digest: 43b505fd21a6fe0c79ecd5c8140b1619d20bcd243d4d4576fb2c84c1644b85c1
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtkcommon/libdtkdata_5.7.18_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/dtkcommon/libdtkdata_5.7.18_loong64.deb
     digest: fef371d4b3e03bf0e9ceb368698a63ac51243fe823d5d7bc19f1654836e5d81a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/duktape/libduktape207_2.7.0-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/duktape/libduktape207_2.7.0-2_loong64.deb
     digest: c46919dfca686178998927311123320eca3c995576736b5b4a0174f567289f13
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libe/libedit/libedit2_3.1-20230828-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libe/libedit/libedit2_3.1-20230828-1_loong64.deb
     digest: 851c5523af03e9dc081aa14afbeade7eeb1a21de5597226f13e0dcbed4a6ade7
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mesa/libegl-mesa0_24.3.0-1deepin4_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/m/mesa/libegl-mesa0_24.3.0-1deepin4_loong64.deb
     digest: 7877f5ac8d6ca3d585de64047278d3f6983e9213b31a3e2d4d8b03218474f4da
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libegl1_1.7.0-1deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libg/libglvnd/libegl1_1.7.0-1deepin1_loong64.deb
     digest: e20c3e83c2e1e4d5787efcc5036312ebedbc4c0fedf0c2578ebb53041042e2e3
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/e/elfutils/libelf1_0.191-1deepin2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/e/elfutils/libelf1_0.191-1deepin2_loong64.deb
     digest: 16e47795eed490234214777685afc5c411a8ad0fdaf3508469e3105fb2b364df
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libe/libevdev/libevdev-dev_1.12.0+dfsg-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libe/libevdev/libevdev-dev_1.12.0+dfsg-1_loong64.deb
     digest: 1bb14f1d3b2a10316e1db8b888585b1486789cf2b060861e0281178dcd75b828
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libe/libevdev/libevdev2_1.12.0+dfsg-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libe/libevdev/libevdev2_1.12.0+dfsg-1_loong64.deb
     digest: f2f047f2363dda33826f748756c5b1c8a2bf809c981a66509876eb150583b278
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/e/expat/libexpat1-dev_2.7.1-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/e/expat/libexpat1-dev_2.7.1-1_loong64.deb
     digest: b766ee38f67bcbe9afec078d8fb2f5fb273e35b506a1d1a3c135c5ff4482121c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/e/expat/libexpat1_2.7.1-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/e/expat/libexpat1_2.7.1-1_loong64.deb
     digest: 4b842b02c3c84ff64ef932b999fdc20e776a4f410cae4c065deed16e9ea5e99a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libf/libffi/libffi-dev_3.4.6-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libf/libffi/libffi-dev_3.4.6-1_loong64.deb
     digest: 864ef36cd80bc0a9fadbdafca5a5ef05ff92458f945bc1c20753d7635d8f17b7
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libf/libffi/libffi8_3.4.6-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libf/libffi/libffi8_3.4.6-1_loong64.deb
     digest: e1d9a61065aea68e96e14f496d7bfd63e024f8874e1d320cb607efd82dd96910
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fmtlib/libfmt10_10.1.1+ds1-4deepin0+rb1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/fmtlib/libfmt10_10.1.1+ds1-4deepin0+rb1_loong64.deb
     digest: afa51b193209a8d67f9f610e43bc9dffadd90f61fd77112ca1f0cfb87a7bd269
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fontconfig/libfontconfig-dev_2.15.0-2.3deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/fontconfig/libfontconfig-dev_2.15.0-2.3deepin1_loong64.deb
     digest: ae8860a596b6ef0831f0c600efca87de921427e30b2b706c6ba682ddbaa624b1
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fontconfig/libfontconfig1_2.15.0-2.3deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/fontconfig/libfontconfig1_2.15.0-2.3deepin1_loong64.deb
     digest: e4faee509dbabd22ea70b8d59aedef53701693356ca681d32eeb855026312c03
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libf/libfontenc/libfontenc1_1.1.4-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libf/libfontenc/libfontenc1_1.1.4-1_loong64.deb
     digest: 36450772f287a243ed0ff6c3b5e491021c7d63f6f68a9e71711fbb6e5884c868
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/freetype/libfreetype-dev_2.13.2+dfsg-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/freetype/libfreetype-dev_2.13.2+dfsg-1_loong64.deb
     digest: acb0c01cf1db9cd8abf2ba2fb1deea3f6c52e90a471d0cba26e403d9fca7c292
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/freetype/libfreetype6_2.13.2+dfsg-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/f/freetype/libfreetype6_2.13.2+dfsg-1_loong64.deb
     digest: ad56d47b6131633a5cd1f2a0e651c4bad65c92c35faf41e664ff79d9ca0df2c4
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mesa/libgbm1_24.3.0-1deepin4_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/m/mesa/libgbm1_24.3.0-1deepin4_loong64.deb
     digest: cc93c2d61fc3c6a93ba49cd4c6fac1caa03a6c330dc1900a43bbe4e747fc7eda
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gcc-13/libgcc-s1_13.2.0-3deepin4_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/gcc-13/libgcc-s1_13.2.0-3deepin4_loong64.deb
     digest: 05d11e942b30ee6974be843ef2b8539426f3891c20bceb2e5bfc823e4c25b673
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libgcrypt20/libgcrypt20_1.10.3-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libg/libgcrypt20/libgcrypt20_1.10.3-2_loong64.deb
     digest: 5bdd589218c3c04dd4c23f14e1815e007f56c84bd45cd497a1bf4e720bdbb6cb
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gdbm/libgdbm-compat4_1.22-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/gdbm/libgdbm-compat4_1.22-1_loong64.deb
     digest: bc7c3017145d403f6935e564bbcf6ee8904dbff103b96ecd876a3a66cebb6ae1
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gdbm/libgdbm6_1.22-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/gdbm/libgdbm6_1.22-1_loong64.deb
     digest: 2d965b1e2624d262111a5a767278f4f4ad51eb1c073096ce2dbc42e0c02f3fcf
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/glib2.0/libgirepository-2.0-0_2.80.1-1deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/glib2.0/libgirepository-2.0-0_2.80.1-1deepin1_loong64.deb
     digest: 02f892b6d38643410cd753637657b9803eb718268927eec5232e68045e81d13c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libgl-dev_1.7.0-1deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libg/libglvnd/libgl-dev_1.7.0-1deepin1_loong64.deb
     digest: 37a693f96d02d97be01c45d972836cbaaac0b9a5043174a04b2e2eeff251b30d
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mesa/libgl1-mesa-dri_24.3.0-1deepin4_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/m/mesa/libgl1-mesa-dri_24.3.0-1deepin4_loong64.deb
     digest: 45cb2d6de8f6e7c898ff76bdbd5255d630d1df174a8cd028d28dcf441bca009e
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libgl1_1.7.0-1deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libg/libglvnd/libgl1_1.7.0-1deepin1_loong64.deb
     digest: b6dc7a60ae6e3530a6caa3e45d5869603685c43ac8937535062fae0b5c8863ca
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mesa/libglapi-mesa_24.3.0-1deepin4_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/m/mesa/libglapi-mesa_24.3.0-1deepin4_loong64.deb
     digest: 0fbe33c65fcd9f8d498846fc628c0fd65f86f0e8664618b83d325bad58b56a10
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/glib2.0/libglib2.0-0_2.80.1-1deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/glib2.0/libglib2.0-0_2.80.1-1deepin1_loong64.deb
     digest: 796a8a4bfcc14d204bc23914f524a0dcb3b0545611060b3056547eb281e277f4
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/glib2.0/libglib2.0-bin_2.80.1-1deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/glib2.0/libglib2.0-bin_2.80.1-1deepin1_loong64.deb
     digest: eb81bcc49501d0e04514a0fa968beb0a0b81d4d4a35199c0d5c660e7ea6a1575
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/glib2.0/libglib2.0-data_2.80.1-1deepin1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/glib2.0/libglib2.0-data_2.80.1-1deepin1_all.deb
     digest: 4e75a1c9e56c81ed2c1737e3e6fe590163a77ff45179101a4fcfb90b4c0d135d
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/glib2.0/libglib2.0-dev-bin_2.80.1-1deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/glib2.0/libglib2.0-dev-bin_2.80.1-1deepin1_loong64.deb
     digest: c7351415720634d89b5ddf7e809d78b458be23d09cf32365e14a72141d6d20c1
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/glib2.0/libglib2.0-dev_2.80.1-1deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/glib2.0/libglib2.0-dev_2.80.1-1deepin1_loong64.deb
     digest: 1828aa1e6fe842d0713e1ae545f874d2335ab0c683638eb5bb594dd76037cd87
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libglvnd0_1.7.0-1deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libg/libglvnd/libglvnd0_1.7.0-1deepin1_loong64.deb
     digest: b3763b7b1910d2692fe39f0b76195b639acf92ea656d4ff61da867393422251f
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libglx-dev_1.7.0-1deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libg/libglvnd/libglx-dev_1.7.0-1deepin1_loong64.deb
     digest: 260b85824035f054f7e25e2b142ee5397c28953f77f463276203b0e5ed8d9bde
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mesa/libglx-mesa0_24.3.0-1deepin4_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/m/mesa/libglx-mesa0_24.3.0-1deepin4_loong64.deb
     digest: b219b07aeb0e70c94dcf3d2161fdbe5478a745b9bf8b660ef6cb8155f1e81e09
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libglx0_1.7.0-1deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libg/libglvnd/libglx0_1.7.0-1deepin1_loong64.deb
     digest: 8b29582e04b7987e1b45b1e7229eb4b772bf6d8ba18b5499b22144108aa2b70a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/googletest/libgmock-dev_1.12.1-0.2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/googletest/libgmock-dev_1.12.1-0.2_loong64.deb
     digest: 693cb72994a9a8931ad53b7881a49c1bad3382313e4959fd241d5cc875055a8d
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gmp/libgmp10_6.3.0+dfsg-2deepin0_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/gmp/libgmp10_6.3.0+dfsg-2deepin0_loong64.deb
     digest: c09ccc302996ba01e2f836ad038b25f5039c750fe2e10bbf66154f65b4ab3e5d
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gnutls28/libgnutls30_3.7.9-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/gnutls28/libgnutls30_3.7.9-2_loong64.deb
     digest: 2b68ea50a264b00dfae6f6b003939b618eb9b4a206e8f3c4e5f6601428d7711a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gcc-13/libgomp1_13.2.0-3deepin4_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/gcc-13/libgomp1_13.2.0-3deepin4_loong64.deb
     digest: a650bc16697eb1e90218fc6c2b5f6b3b4207c81dd511a07729333ab0410f9d00
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libgpg-error/libgpg-error0_1.47-3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libg/libgpg-error/libgpg-error0_1.47-3_loong64.deb
     digest: 432b4819ad1edb46e6d8116596212dbc3a82d0d34c93c3574ded8db352188c8c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/graphite2/libgraphite2-3_1.3.14-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/graphite2/libgraphite2-3_1.3.14-2_loong64.deb
     digest: 3fc95b46c6dc87a3991386255c381d00c68a6ae6bfb4390ccb05f8cc61949331
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/k/krb5/libgssapi-krb5-2_1.20.1-5_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/k/krb5/libgssapi-krb5-2_1.20.1-5_loong64.deb
     digest: a74abdb1e7ddf88624513747e6591d1c799bc8774187470bd05d8d489834d596
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/googletest/libgtest-dev_1.12.1-0.2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/googletest/libgtest-dev_1.12.1-0.2_loong64.deb
     digest: 77c8bbccdff33eb6584b8ddda01e2eb693cc36963ef00f4c16102ae2763cd458
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libgudev/libgudev-1.0-0_238-2deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libg/libgudev/libgudev-1.0-0_238-2deepin1_loong64.deb
     digest: 5930cfa21617d8103fad46534ba6d07b3930e28a3606600755a076d3eb95319b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libgudev/libgudev-1.0-dev_238-2deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libg/libgudev/libgudev-1.0-dev_238-2deepin1_loong64.deb
     digest: 1c2e9030c9a558915577dbf8047628b212c9b48c175709b244dfa794feaccfd2
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gumbo-parser/libgumbo2_0.12.0+dfsg-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/gumbo-parser/libgumbo2_0.12.0+dfsg-2_loong64.deb
     digest: eb28d4bec657f7273f965bde361caca747436978ff2b8dfda5bb4ce292c8868c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/h/harfbuzz/libharfbuzz0b_8.0.1-1+rb1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/h/harfbuzz/libharfbuzz0b_8.0.1-1+rb1_loong64.deb
     digest: 23f39df88cbc47f74e5a77408b2cdbc4fc47e41fdae3e5fb319a9cbe552c12a3
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/n/nettle/libhogweed6_3.7.3-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/n/nettle/libhogweed6_3.7.3-1_loong64.deb
     digest: fca8fa6138c16bfb7f8d8fb78f55799c24b9a01bbac0202816b22624cdd0da6a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libi/libice/libice6_1.0.10-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libi/libice/libice6_1.0.10-1_loong64.deb
     digest: 71f07175fac63f8a51f001299a9329a38c4320df6b46e6bdda20768aa90a3456
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/i/icu/libicu-dev_74.2-1deepin4_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/i/icu/libicu-dev_74.2-1deepin4_loong64.deb
     digest: 90ca2b00fbf2a39a59bc0f9f992eca99951ef6c0ab632c28c2ea9abb8849c16a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/i/icu/libicu74_74.2-1deepin4_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/i/icu/libicu74_74.2-1deepin4_loong64.deb
     digest: d60c34f7df7c6c7b8b950d3b2996bd1dda6ea510d77de2869bd13c614a1fe00a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libi/libidn2/libidn2-0_2.3.2-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libi/libidn2/libidn2-0_2.3.2-2_loong64.deb
     digest: b235fca3fd81c2e6918d54b8d71f79757d6b818cf897fde7cb3826dc23ce85b3
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libi/libinput/libinput-bin_1.26.0-1deepin3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libi/libinput/libinput-bin_1.26.0-1deepin3_loong64.deb
     digest: 0fff2ff2f3f962bcc63f9d7379995197a1727ce30a91f908ea72a3fa662a6b51
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libi/libinput/libinput-dev_1.26.0-1deepin3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libi/libinput/libinput-dev_1.26.0-1deepin3_loong64.deb
     digest: 6d985129e0600d7fe4a411a39bfadf4c73f8563ac1604635d19fda6a9cfc111e
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libi/libinput/libinput10_1.26.0-1deepin3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libi/libinput/libinput10_1.26.0-1deepin3_loong64.deb
     digest: f8251fc25fdbcef6b938b6be532237f63c3dff78dd83b1d3ff665748685f7f4b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/j/jansson/libjansson4_2.14-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/j/jansson/libjansson4_2.14-2_loong64.deb
     digest: 4a8662b90c807a6afaf7ac4d89ae42e33725c60f5a0a26230366cd487425faec
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/j/jbigkit/libjbig-dev_2.1-3.1-deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/j/jbigkit/libjbig-dev_2.1-3.1-deepin1_loong64.deb
     digest: 0c3b4ccc6927abdfddb2d909ca139fbbf1c5e81ccfdba90c1ffcce9f460d4cb7
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/j/jbigkit/libjbig0_2.1-3.1-deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/j/jbigkit/libjbig0_2.1-3.1-deepin1_loong64.deb
     digest: 8940e6f4dce77f526bc32b5211d850389bc0875cf944520e9f0a4d85a170e9a9
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libj/libjpeg-turbo/libjpeg-dev_2.1.5-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libj/libjpeg-turbo/libjpeg-dev_2.1.5-2_loong64.deb
     digest: 152658aba54e2f163ba19c0fe53aa7666e1c6907eda79433f1ec38240a9670b7
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libj/libjpeg-turbo/libjpeg62-turbo-dev_2.1.5-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libj/libjpeg-turbo/libjpeg62-turbo-dev_2.1.5-2_loong64.deb
     digest: 342808c163f19bfdfdb7f36cf51acce6401aa2c0df6fd5695d0b3a9f2731bd9b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libj/libjpeg-turbo/libjpeg62-turbo_2.1.5-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libj/libjpeg-turbo/libjpeg62-turbo_2.1.5-2_loong64.deb
     digest: 47df0f4474b4722b6a741b7c8b33057f38f58245efa92c176abd489665e92c1f
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/j/json-glib/libjson-glib-1.0-0_1.8.0-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/j/json-glib/libjson-glib-1.0-0_1.8.0-2_loong64.deb
     digest: ccb04191b08f91b7eb2f6f5e62299ca38d173d78c813768ef37e9023f73e9f8f
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/j/json-glib/libjson-glib-1.0-common_1.8.0-2_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/j/json-glib/libjson-glib-1.0-common_1.8.0-2_all.deb
     digest: f4ffb8e62cabbb4b691413d38e3c8a03b430f4eba287bef4d8637dd3d708cab1
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/k/krb5/libk5crypto3_1.20.1-5_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/k/krb5/libk5crypto3_1.20.1-5_loong64.deb
     digest: 4a83826bbb0da645b6f48c1de0682bd7ba1d61a2b903fed7738ec7c88f559b8b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/k/keyutils/libkeyutils1_1.6.3-3.1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/k/keyutils/libkeyutils1_1.6.3-3.1_loong64.deb
     digest: 0f7646fd6ba7bcf29756eac9b72ce2b03ad5de6d90e131ce0ab97e51f1da29ab
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/k/kf6-kcodecs/libkf6codecs-data_6.6.0-1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/k/kf6-kcodecs/libkf6codecs-data_6.6.0-1_all.deb
     digest: 961c0272ce73f6d2f872d0dd077b3f1bdcae602bbe1c69ab391021f4e3243301
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/k/kf6-kcodecs/libkf6codecs-dev_6.6.0-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/k/kf6-kcodecs/libkf6codecs-dev_6.6.0-1_loong64.deb
     digest: dde6372ac602dd02a7de999d609075de3def3a8b0a13738d64091390088a8ec0
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/k/kf6-kcodecs/libkf6codecs6_6.6.0-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/k/kf6-kcodecs/libkf6codecs6_6.6.0-1_loong64.deb
     digest: b699fa2417dad1ae9e1614df1d41546ac85e2824ac73844464333ec3867c1d10
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/k/kf6-syntax-highlighting/libkf6syntaxhighlighting-data_6.10.0-1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/k/kf6-syntax-highlighting/libkf6syntaxhighlighting-data_6.10.0-1_all.deb
     digest: 50c8a8aedc9c68416b28cdc5205172e42a8702bb64176ebb1a893e7460ee3c98
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/k/kf6-syntax-highlighting/libkf6syntaxhighlighting-dev_6.10.0-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/k/kf6-syntax-highlighting/libkf6syntaxhighlighting-dev_6.10.0-1_loong64.deb
     digest: 47fd5074d0dbd3622b2980c982ccb8a30b0045a36d794fdb1f98eaffcf8ab899
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/k/kf6-syntax-highlighting/libkf6syntaxhighlighting6_6.10.0-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/k/kf6-syntax-highlighting/libkf6syntaxhighlighting6_6.10.0-1_loong64.deb
     digest: 6522d1ee62e6ee505fe512d2127cee314fe426cd9d843ba1d85e8062e2011827
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/k/krb5/libkrb5-3_1.20.1-5_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/k/krb5/libkrb5-3_1.20.1-5_loong64.deb
     digest: 071d32ffb73b3feca3d9135ec6109730728b20f40dc194abb24d3f4506c964ef
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/k/krb5/libkrb5support0_1.20.1-5_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/k/krb5/libkrb5support0_1.20.1-5_loong64.deb
     digest: 7ec7dcba628cbededb02866a71961599d1fc501303c2797f756381ce2026845c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/l/lcms2/liblcms2-2_2.14-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/l/lcms2/liblcms2-2_2.14-2_loong64.deb
     digest: 0d4c7d34f69d56cc287e478af83d7cfddcf44a5ba77b6c4bf8a8afa7864c9f7d
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/o/openldap/libldap-2.5-0_2.5.13+dfsg-5_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/o/openldap/libldap-2.5-0_2.5.13+dfsg-5_loong64.deb
     digest: 07c9253e9b743f0bc0f696c091a84d08a18f172e600311e0aadf508c494659a5
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/l/lerc/liblerc-dev_4.0.0+ds-3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/l/lerc/liblerc-dev_4.0.0+ds-3_loong64.deb
     digest: c0a9c5a24ac81fd6e5641d36d47600df17b732fe3a5c024753da8e32679a1447
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/l/lerc/liblerc4_4.0.0+ds-3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/l/lerc/liblerc4_4.0.0+ds-3_loong64.deb
     digest: 04d2a5b464a65ed87d48e331080c46b39c6b2e088c5b4d251f06a46355dc905a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/l/litehtml/liblitehtml0_0.9-0deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/l/litehtml/liblitehtml0_0.9-0deepin1_loong64.deb
     digest: 6b486a85ac27b4001d13fb43838047f46ea84c3b97baa48d0ede572ccd47817f
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/l/llvm-toolchain-17/libllvm17_17.0.6-5deepin5_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/l/llvm-toolchain-17/libllvm17_17.0.6-5deepin5_loong64.deb
     digest: c3d8669054edf11e7182e2a5add9e6cd29e324da3ef1e51d6c251719547da66a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/l/llvm-toolchain-19/libllvm19_19.1.4-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/l/llvm-toolchain-19/libllvm19_19.1.4-1_loong64.deb
     digest: 209b06fa65813ba8416031b068949ca03ca9058899dffe337a7b4d7d840d7363
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/l/lz4/liblz4-1_1.9.3-deepin_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/l/lz4/liblz4-1_1.9.3-deepin_loong64.deb
     digest: 223608f8e5ab70c862665634392467d8cdb27b39d749f8367ecf8f709ffd0044
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/x/xz-utils/liblzma-dev_5.4.5-0.3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xz-utils/liblzma-dev_5.4.5-0.3_loong64.deb
     digest: 3ae2965f4f532a1dfc813c0d9ba0461219093f4f0ab50c9f3ca77ba99d71cf34
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/x/xz-utils/liblzma5_5.4.5-0.3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xz-utils/liblzma5_5.4.5-0.3_loong64.deb
     digest: 8922429eeb2d802e40eaba8567afb65504a70988e500d4d7a455f1ea6c79f20f
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libm/libmd/libmd0_1.0.4-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libm/libmd/libmd0_1.0.4-1_loong64.deb
     digest: f54d26b7c46c848e15a460cd03140e8a436ea2f5b6b7e287e47994d1c627dbc8
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/md4c/libmd4c0_0.4.8-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/m/md4c/libmd4c0_0.4.8-1_loong64.deb
     digest: 38b04a9c6431d337342ef954a98ddc75b6ea0da7b17d321cf5f4ba17e73d9dea
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libm/libmng/libmng1_1.0.10+dfsg-3.1-deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libm/libmng/libmng1_1.0.10+dfsg-3.1-deepin1_loong64.deb
     digest: 501c91fa0ba7cc9f6bceff658ffdba2323039a590719a2030f2dd37266d296aa
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-linux/libmount-dev_2.40.4-3deepin4_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/u/util-linux/libmount-dev_2.40.4-3deepin4_loong64.deb
     digest: b6a33875c9e10005da90db18aadaa4f044f4b694ccfe0b69973a41e881d4c104
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-linux/libmount1_2.40.4-3deepin4_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/u/util-linux/libmount1_2.40.4-3deepin4_loong64.deb
     digest: 31a69b95233506e4afc628618c8fc0b9ca0c1cd0b69f97ee83e6bc5f7c17f6c3
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mtdev/libmtdev-dev_1.1.6-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/m/mtdev/libmtdev-dev_1.1.6-1_loong64.deb
     digest: 9b74501e7c7e6f5d5708bfb897a6710f2144da4806717be60cadb34d2e180353
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mtdev/libmtdev1_1.1.6-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/m/mtdev/libmtdev1_1.1.6-1_loong64.deb
     digest: 4a5019080a0454a1380d3353dbc52b5bfebd3ad8f4c210425beeef8b6e5113e8
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/n/ncurses/libncursesw6_6.4-4deepin2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/n/ncurses/libncursesw6_6.4-4deepin2_loong64.deb
     digest: 348b042a2c913c259e223f4ccc0052ff32f358644c10c7263b10860574386b5f
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/n/nettle/libnettle8_3.7.3-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/n/nettle/libnettle8_3.7.3-1_loong64.deb
     digest: b49e593029d91c73f2240ffb5f129e3a47f613aadbf8ab5f50d592b2a5abdc98
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/n/nghttp2/libnghttp2-14_1.59.0-1deepin0_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/n/nghttp2/libnghttp2-14_1.59.0-1deepin0_loong64.deb
     digest: 73c2009828b2dbd6d42c3d6f2c48f38b6c0ba6887c71bf4bf10e997d4072ca08
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/n/nghttp3/libnghttp3-9_1.4.0-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/n/nghttp3/libnghttp3-9_1.4.0-1_loong64.deb
     digest: 2f4801803d9f124c23da8511728b5ef3c46729dce1f3a546bc8a7fa9c2857cdc
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/n/ngtcp2/libngtcp2-16_1.6.0-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/n/ngtcp2/libngtcp2-16_1.6.0-1_loong64.deb
     digest: 59a844a4d9b530458f137a4ad44d01fb7ab1a92a693870fbea4dc788e207772b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/n/ngtcp2/libngtcp2-crypto-gnutls8_1.6.0-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/n/ngtcp2/libngtcp2-crypto-gnutls8_1.6.0-1_loong64.deb
     digest: 87540ce4f8f6865f114b3153ebcb0f623a912010d3cf1e361714e6489260c9ca
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libn/libnsl/libnsl-dev_1.3.0-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libn/libnsl/libnsl-dev_1.3.0-2_loong64.deb
     digest: 20dfccabfb63024f4d18c0dddf6271436dd6b423643d8140ab157055c006b31c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libn/libnsl/libnsl2_1.3.0-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libn/libnsl/libnsl2_1.3.0-2_loong64.deb
     digest: 295c4fdb7405a01bac01bc50e542232014a5225cac5f675bfbe33ea41d1acd67
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libopengl-dev_1.7.0-1deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libg/libglvnd/libopengl-dev_1.7.0-1deepin1_loong64.deb
     digest: cd4ffaeb85402fdee4cd618e5d95b20857b2eb83f25d6109f8026b714b4af470
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libopengl0_1.7.0-1deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libg/libglvnd/libopengl0_1.7.0-1deepin1_loong64.deb
     digest: 5ce97ab48242d9a6440c70f71408b84db1d2417a4e61007e08dfc3f748d1c4c9
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/p11-kit/libp11-kit0_0.25.5-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/p11-kit/libp11-kit0_0.25.5-2_loong64.deb
     digest: 75dc180effd2912fd0a127952cc27c52ff0e900d7c8b79f3bb4b0d1ac1a120e3
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pcre2/libpcre2-16-0_10.39-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/pcre2/libpcre2-16-0_10.39-2_loong64.deb
     digest: c8062fb10212742a2ee3206282e185e1072fb891c17ae8bbb73777d7f4ebd93b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pcre2/libpcre2-32-0_10.39-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/pcre2/libpcre2-32-0_10.39-2_loong64.deb
     digest: c5694b615e555a112c2ec14ecd8002cf48bbeaefaa8a83c4c81f5bcb80825e31
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pcre2/libpcre2-8-0_10.39-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/pcre2/libpcre2-8-0_10.39-2_loong64.deb
     digest: ecc34edbd930aae24bd00654a682592d396e5f0b3d94ad3c40baa300e2cdd0c1
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pcre2/libpcre2-dev_10.39-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/pcre2/libpcre2-dev_10.39-2_loong64.deb
     digest: 165eb3c1854d96d79f71a381b0ce8c04cdc8984d36587f15e77fa36e78320fd9
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pcre2/libpcre2-posix3_10.39-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/pcre2/libpcre2-posix3_10.39-2_loong64.deb
     digest: efb78bfaecc447039df6ceaf21a40055d692ceea4a38e700e280dfd05c521881
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/perl/libperl5.36_5.36.0-10deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/perl/libperl5.36_5.36.0-10deepin1_loong64.deb
     digest: dc6587b5ad4bb6a51f30edd225d1aa4d0f2e5c24107aeaa8bdb41e13f2136fd5
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pkgconf/libpkgconf3_1.8.1-4_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/pkgconf/libpkgconf3_1.8.1-4_loong64.deb
     digest: 7fa4ed870a512323dc2bdebb32e85ab5c08036153b042a932beec468b3ba6089
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libp/libpng1.6/libpng-dev_1.6.45-1deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libp/libpng1.6/libpng-dev_1.6.45-1deepin1_loong64.deb
     digest: e4ec70f1232bf8277e218069968f1504e1324ee03260852234fe852a687a0fa6
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libp/libpng1.6/libpng16-16_1.6.45-1deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libp/libpng1.6/libpng16-16_1.6.45-1deepin1_loong64.deb
     digest: 711fc166523e536c981def0bc709970f34be02ed60226bc129d2b1911b4ac46a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/policykit-1/libpolkit-agent-1-0_123-3deepin7_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/policykit-1/libpolkit-agent-1-0_123-3deepin7_loong64.deb
     digest: abb634edd336c74e93bb9112ac7fe218e7375d824deb0d9eab295bfae60c9708
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/policykit-1/libpolkit-gobject-1-0_123-3deepin7_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/policykit-1/libpolkit-gobject-1-0_123-3deepin7_loong64.deb
     digest: 75d55921f9e8cb11b3f474a947dba74198b19a04b86aa6aa6b62f89c30b19458
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/polkit-qt-1/libpolkit-qt6-1-1_0.200.0-4deepin2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/polkit-qt-1/libpolkit-qt6-1-1_0.200.0-4deepin2_loong64.deb
     digest: 0892fa9207d0dcfd56074ed5889e0d37c8b9d8ae33c091cc21175ed6ae54d207
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/polkit-qt-1/libpolkit-qt6-1-dev_0.200.0-4deepin2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/polkit-qt-1/libpolkit-qt6-1-dev_0.200.0-4deepin2_loong64.deb
     digest: 2a2e5c3f09f76e8bc805987066602e03fccecf09cb51bf010df3e32791636f03
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libp/libproxy/libproxy1v5_0.5.9-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libp/libproxy/libproxy1v5_0.5.9-1_loong64.deb
     digest: 450c63cece1053b61ad1db303e20cf3008cd130f59907df2610dee985a1ac250
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libp/libpsl/libpsl5_0.21.0-1.2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libp/libpsl/libpsl5_0.21.0-1.2_loong64.deb
     digest: 48076d0b45bdee001ab7b435296ab05853ab64402092af005e07437dcc838640
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libp/libpthread-stubs/libpthread-stubs0-dev_0.4-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libp/libpthread-stubs/libpthread-stubs0-dev_0.4-1_loong64.deb
     digest: 9d68b88d2e9de4c313b75ec6ebd8df51105856bf8998470dc7faf770308ddc40
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/python3-defaults/libpython3-stdlib_3.12.1-1deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/python3-defaults/libpython3-stdlib_3.12.1-1deepin1_loong64.deb
     digest: fccfbd0ff96d62aa2476f942b4e819b2bdce28f714ea360e036da7a0b3732597
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/python3.12/libpython3.12-minimal_3.12.11-0deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/python3.12/libpython3.12-minimal_3.12.11-0deepin1_loong64.deb
     digest: 1d472fc15c2ee3bd55b69219903a7ff8fb6a5b880cfc1f2506c8ebb459f9b0f7
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/python3.12/libpython3.12-stdlib_3.12.11-0deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/python3.12/libpython3.12-stdlib_3.12.11-0deepin1_loong64.deb
     digest: 86eda0624899d0be7965e8bf0b2189986b67daa8d280ff596e736b50bc1bc4e5
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6concurrent6_6.8.0+dfsg-0deepin8_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/libqt6concurrent6_6.8.0+dfsg-0deepin8_loong64.deb
     digest: 27f9e657d136a934f173a715d878d3d055b4f380e81fbabc76aacb44b6fc94c9
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-5compat/libqt6core5compat6_6.8.0-0deepin_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-5compat/libqt6core5compat6_6.8.0-0deepin_loong64.deb
     digest: 0516b6c29f4313bb30f9cf7858cf93c4d1ffc237a967eb65b3f0d5b943d83d7b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6core6_6.8.0+dfsg-0deepin8_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/libqt6core6_6.8.0+dfsg-0deepin8_loong64.deb
     digest: 1523b859d621d9a86bca84826591ec2ca94247e2529e9c3a407fba06593552fa
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6dbus6_6.8.0+dfsg-0deepin8_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/libqt6dbus6_6.8.0+dfsg-0deepin8_loong64.deb
     digest: 51e1362bb514f7878aff724ed92035df7451ef96fe7de71c4452057340d8d867
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/libqt6designer6_6.8.0-0deepin3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-tools/libqt6designer6_6.8.0-0deepin3_loong64.deb
     digest: eefebd3f3d07b0f7d2f89e0ba469128aba20e0a1093ee0cc1853c3ddbdfa8616
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/libqt6designercomponents6_6.8.0-0deepin3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-tools/libqt6designercomponents6_6.8.0-0deepin3_loong64.deb
     digest: 0cb93130f4822644f809425794909492760cee0cc6c3d5596883a07edfbf9993
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6gui6_6.8.0+dfsg-0deepin8_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/libqt6gui6_6.8.0+dfsg-0deepin8_loong64.deb
     digest: 0eb4ed0089c77f53f38c49e30098727c78489b0d390a2ced33cba5de167aa5f9
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/libqt6help6_6.8.0-0deepin3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-tools/libqt6help6_6.8.0-0deepin3_loong64.deb
     digest: f748a917685218c990c97766bd2e9cf73caea758ba095bde0c76aed5d8b2c14f
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6network6_6.8.0+dfsg-0deepin8_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/libqt6network6_6.8.0+dfsg-0deepin8_loong64.deb
     digest: 734dbb8e7e72a7e29fdcafa4d17f6dd1f2385c738b075858d68f3e7c06a8c8d9
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6opengl6_6.8.0+dfsg-0deepin8_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/libqt6opengl6_6.8.0+dfsg-0deepin8_loong64.deb
     digest: ce9b72f2477ff977aa84f328fed1bb4f74f1eeb63487bce88634bd2ae819fcdc
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6openglwidgets6_6.8.0+dfsg-0deepin8_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/libqt6openglwidgets6_6.8.0+dfsg-0deepin8_loong64.deb
     digest: 1756c764caeabe3b193dfd61c1d9f8f78e5cd8e63421c1c2e6c6c4d2adf00a20
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6printsupport6_6.8.0+dfsg-0deepin8_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/libqt6printsupport6_6.8.0+dfsg-0deepin8_loong64.deb
     digest: 6321e7ffab0c4908deb4c93b1ea695b9a8e001c3f15cdb1e83af3be2dec5d072
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-declarative/libqt6qml6_6.8.0+dfsg-0deepin3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-declarative/libqt6qml6_6.8.0+dfsg-0deepin3_loong64.deb
     digest: 31feabbf3ad584c4c450c37b5abb61ee289e05b11bbf04533131075201387b35
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-declarative/libqt6qmlcompiler6_6.8.0+dfsg-0deepin3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-declarative/libqt6qmlcompiler6_6.8.0+dfsg-0deepin3_loong64.deb
     digest: fd777d7ec5dad40bcd0e70bd1b51d4bc021494010e794fd67824b06f1b8f117c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-declarative/libqt6qmlmodels6_6.8.0+dfsg-0deepin3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-declarative/libqt6qmlmodels6_6.8.0+dfsg-0deepin3_loong64.deb
     digest: 528f7878f461a24885cc8a1b453918d5225555a719a83cc1daf0d874d97af6a2
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-declarative/libqt6quick6_6.8.0+dfsg-0deepin3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-declarative/libqt6quick6_6.8.0+dfsg-0deepin3_loong64.deb
     digest: 66477a2004afb5d4126dac018fba698d22e6e526f67e4531464ea04f8addd702
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-declarative/libqt6quickcontrols2-6_6.8.0+dfsg-0deepin3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-declarative/libqt6quickcontrols2-6_6.8.0+dfsg-0deepin3_loong64.deb
     digest: 1fc3451b89034d81ccf6505dfa90979392a6ac71ed0f1c52df5fe2e452acb826
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-declarative/libqt6quicktemplates2-6_6.8.0+dfsg-0deepin3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-declarative/libqt6quicktemplates2-6_6.8.0+dfsg-0deepin3_loong64.deb
     digest: 38df21ecc18093d0867fa7aa66efe6fd4643d9412262100b0d749adcc62d72c2
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-declarative/libqt6quicktest6_6.8.0+dfsg-0deepin3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-declarative/libqt6quicktest6_6.8.0+dfsg-0deepin3_loong64.deb
     digest: 373f7d23bdf8c1bc3c947380634efeed05f1d42e0f62a851ee4f3e5fbb19c8b6
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-declarative/libqt6quickvectorimagegenerator6_6.8.0+dfsg-0deepin3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-declarative/libqt6quickvectorimagegenerator6_6.8.0+dfsg-0deepin3_loong64.deb
     digest: 53b322c89c0f64064c29ac7bb47eff2a7e3fe1a360b3738f58bf39eaba639346
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-declarative/libqt6quickwidgets6_6.8.0+dfsg-0deepin3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-declarative/libqt6quickwidgets6_6.8.0+dfsg-0deepin3_loong64.deb
     digest: 889af35681f2708a99b089a4c9aa5f22e487da2125af9132d3f0e7b579b408fd
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-shadertools/libqt6shadertools6_6.8.0-0deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-shadertools/libqt6shadertools6_6.8.0-0deepin1_loong64.deb
     digest: cec7d316516b54ca0babda908001f58c1055f8af78022528d6fe3868f6f90635
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6sql6-sqlite_6.8.0+dfsg-0deepin8_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/libqt6sql6-sqlite_6.8.0+dfsg-0deepin8_loong64.deb
     digest: 017f06d3ed3ed61c79b1305c5143cc23741d512d7e5bed5bb8afdf5409f9dd53
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6sql6_6.8.0+dfsg-0deepin8_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/libqt6sql6_6.8.0+dfsg-0deepin8_loong64.deb
     digest: f8f3e1362f96ce18bbf6ab415b4fca82bf4f057b122c26dc956f3f0bfbc3e571
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-svg/libqt6svg6_6.8.0-0deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-svg/libqt6svg6_6.8.0-0deepin1_loong64.deb
     digest: fc8cb023930b048f2caa531b913d991b4690a9f4692a9e4fbb423618ec67121b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-svg/libqt6svgwidgets6_6.8.0-0deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-svg/libqt6svgwidgets6_6.8.0-0deepin1_loong64.deb
     digest: 7a0239be93289e6b8d54806f5ffec75a9f4aea7cee0af219fc1932e64abde72e
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6test6_6.8.0+dfsg-0deepin8_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/libqt6test6_6.8.0+dfsg-0deepin8_loong64.deb
     digest: 13e6c88915bb0c09c85a950bd41a150ecbab7b6bbac87d72900b3484e217055f
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/libqt6uitools6_6.8.0-0deepin3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-tools/libqt6uitools6_6.8.0-0deepin3_loong64.deb
     digest: a4651ca09a7927998b556155807a65a4b68d19a83f8a3a0907e4129f0ed983a3
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-wayland/libqt6waylandclient6_6.8.0-0deepin7_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-wayland/libqt6waylandclient6_6.8.0-0deepin7_loong64.deb
     digest: 7637f2f08e271e14a5b05007e2fd18a8facc2c6fc3f29fe1ba5e2c5ea0d037c2
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6widgets6_6.8.0+dfsg-0deepin8_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/libqt6widgets6_6.8.0+dfsg-0deepin8_loong64.deb
     digest: 0904fa02b80b91fcce261f02f8aeeacbcb2e166edfc9fbb8e9804639c22e6a56
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6xml6_6.8.0+dfsg-0deepin8_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/libqt6xml6_6.8.0+dfsg-0deepin8_loong64.deb
     digest: 529b35f3c63e834096085de61a2494f89aeb2103b184d5d8bf2e5035e60340aa
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/r/readline/libreadline8_8.2-3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/r/readline/libreadline8_8.2-3_loong64.deb
     digest: a1c114f0856366970ce731783250b16f1a600a917ac54eb45b3fc765a7dc5e8d
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/r/rtmpdump/librtmp1_2.4+20151223.gitfa8646d.1-deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/r/rtmpdump/librtmp1_2.4+20151223.gitfa8646d.1-deepin1_loong64.deb
     digest: 8809a7bd4cd047bccc1e7198bfb8e154716a647cc619ac7d49cbde13b7ebcb1b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cyrus-sasl2/libsasl2-2_2.1.28+dfsg1-4_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/c/cyrus-sasl2/libsasl2-2_2.1.28+dfsg1-4_loong64.deb
     digest: 330cc540349e985f4837e68c0c021dede1939f25516cbbb1dc7016ca0595ce4f
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cyrus-sasl2/libsasl2-modules-db_2.1.28+dfsg1-4_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/c/cyrus-sasl2/libsasl2-modules-db_2.1.28+dfsg1-4_loong64.deb
     digest: 5a7bd78f37915ec3255c7a90b6abff4e0ae332f3555ebcb3cf8fe78c6545de7d
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libselinux/libselinux1-dev_3.5-1deepin5_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libs/libselinux/libselinux1-dev_3.5-1deepin5_loong64.deb
     digest: 3560dfdbcf90fef6f1fe16715e1bc7543a4e84b8759c58f71db0d93054bb7d49
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libselinux/libselinux1_3.5-1deepin5_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libs/libselinux/libselinux1_3.5-1deepin5_loong64.deb
     digest: f03e930d7d2d49c1d6355bce0b584177d61403d2e181c29767f2d853b716702a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/l/lm-sensors/libsensors-config_3.6.0-7_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/l/lm-sensors/libsensors-config_3.6.0-7_all.deb
     digest: 164115506dfd335f26101e76cb49e2162b0440398ccf2d0c969ebc465dfd7867
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/l/lm-sensors/libsensors5_3.6.0-7_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/l/lm-sensors/libsensors5_3.6.0-7_loong64.deb
     digest: 654049e53be85d4dab717bbfeb848f579c19d0cafd926a845357c62813263cb2
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libsepol/libsepol-dev_3.5-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libs/libsepol/libsepol-dev_3.5-2_loong64.deb
     digest: cd6de58ec8972c1be0f4028a31b7b94d8079bd1c0bb6af78c21ab1c1a0b245a2
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libsepol/libsepol2_3.5-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libs/libsepol/libsepol2_3.5-2_loong64.deb
     digest: ffe0ab79dca28bc304448ab0b91016fdd679746ce0d4395abbf9c38cf0c9774d
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/b/binutils/libsframe1_2.41-6deepin7_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/b/binutils/libsframe1_2.41-6deepin7_loong64.deb
     digest: b6b33b68d72cec967790b24d3dd45254886983d05530278cb622c900df0ba341
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libw/libwebp/libsharpyuv-dev_1.3.2-0.2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libw/libwebp/libsharpyuv-dev_1.3.2-0.2_loong64.deb
     digest: 9667bac75f00cdf47520a2ec5d444bcafb4c8eb3e13efdf86218f5c69d68652b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libw/libwebp/libsharpyuv0_1.3.2-0.2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libw/libwebp/libsharpyuv0_1.3.2-0.2_loong64.deb
     digest: ee12b9b2406d779965c510510bd32f01ab931f62eea583bc206c1d41f4a0711c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libsm/libsm6_1.2.3-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libs/libsm/libsm6_1.2.3-1_loong64.deb
     digest: 9af2780f0816a5e2c10bbbe3abb974ba236ecf0beef15a49040433889c678847
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/s/spdlog/libspdlog1.12_1.12.0+ds-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/s/spdlog/libspdlog1.12_1.12.0+ds-2_loong64.deb
     digest: 760ec85164e31b757b0e46274b5a1eafe5a6ce53ccd0e1c4c1d7e5338e93c31e
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/s/sqlite3/libsqlite3-0_3.46.1-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/s/sqlite3/libsqlite3-0_3.46.1-1_loong64.deb
     digest: 7b26d965fb478c5ae7993ed753ffbb881ad0632063875a8c68585b56a7c70ee7
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libssh2/libssh2-1_1.11.1-1deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libs/libssh2/libssh2-1_1.11.1-1deepin1_loong64.deb
     digest: bb45ae77a9bd5170e8616a550c54e2c419435abce629ade62605dcf0aa544d11
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/o/openssl/libssl3_3.2.4-0deepin2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/o/openssl/libssl3_3.2.4-0deepin2_loong64.deb
     digest: 0ecb05782da1c411a407535eb0fe4a9118a0b635cf5577b496fc0698aa1f70fe
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/s/startup-notification/libstartup-notification0_0.12-deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/s/startup-notification/libstartup-notification0_0.12-deepin1_loong64.deb
     digest: d5528cf8ef1dcf19b1b3245d894851bbddc35132ef3fd22e8c399fd5af91a514
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gcc-13/libstdc++6_13.2.0-3deepin4_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/g/gcc-13/libstdc++6_13.2.0-3deepin4_loong64.deb
     digest: 35e491e460731f9dd6e054429c576a0cef5fca817c034943b0463e6cf8503db3
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/s/systemd/libsystemd0_255.2-4deepin11_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/s/systemd/libsystemd0_255.2-4deepin11_loong64.deb
     digest: 2e66a084ee5197d6ca309c766a7fb0d9a4b397359e21a5b7a920dce4695cfcf4
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libt/libtasn1-6/libtasn1-6_4.18.0-4_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libt/libtasn1-6/libtasn1-6_4.18.0-4_loong64.deb
     digest: 75dde4d8be25c4d18dcf4e27dffff588fabf9c2b365b3c22b2cbd12af97d90b3
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tiff/libtiff-dev_4.5.1+git230720-5_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/t/tiff/libtiff-dev_4.5.1+git230720-5_loong64.deb
     digest: 56033bdf7bd17609fa7eb714726113303a0bd3bb7cbc95547389a7167d871510
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tiff/libtiff6_4.5.1+git230720-5_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/t/tiff/libtiff6_4.5.1+git230720-5_loong64.deb
     digest: 7766d08dd3b606d683be1d3856fe5b8717b04b5992b06a6b2ab2dad5c95e27df
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tiff/libtiffxx6_4.5.1+git230720-5_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/t/tiff/libtiffxx6_4.5.1+git230720-5_loong64.deb
     digest: 56f034dd11efeb6bf5d645d2f1d022b75a05b4cc3d3cc460442dfd69cf05d659
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/n/ncurses/libtinfo6_6.4-4deepin2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/n/ncurses/libtinfo6_6.4-4deepin2_loong64.deb
     digest: 467061b6263e636ede974929d823a1758f1ab21c9a25ab998dd89a0d9ad9122b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libt/libtirpc/libtirpc-common_1.3.2-2_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libt/libtirpc/libtirpc-common_1.3.2-2_all.deb
     digest: 74bddc18e3289947b20653433e82025873f5679ccba52f258ca4912e435a09ee
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libt/libtirpc/libtirpc-dev_1.3.2-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libt/libtirpc/libtirpc-dev_1.3.2-2_loong64.deb
     digest: 398023207ec9cd9852423ff943a2471c9e413273d3d6e654251d3a9d66820b34
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libt/libtirpc/libtirpc3_1.3.2-2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libt/libtirpc/libtirpc3_1.3.2-2_loong64.deb
     digest: 9af8a36a1e38bb90c2cf99639596b5368ecdf03c5a51721bd723735eb3e7cfb8
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tslib/libts0_1.22-1+rb3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/t/tslib/libts0_1.22-1+rb3_loong64.deb
     digest: b2217959e0d34e5ce86a75b82acb235e1b887696044937815544c576c7abc9a7
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/uchardet/libuchardet-dev_0.0.7-1deepin0_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/u/uchardet/libuchardet-dev_0.0.7-1deepin0_loong64.deb
     digest: be482251621302c9d405c977a948709268bff3105aa936fec25bece1ad7e5493
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/uchardet/libuchardet0_0.0.7-1deepin0_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/u/uchardet/libuchardet0_0.0.7-1deepin0_loong64.deb
     digest: 40bcfc76cd660dac09bd63c6296b828946c3367242e0e3c42fe5bd8c1cc33552
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/s/systemd/libudev-dev_255.2-4deepin11_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/s/systemd/libudev-dev_255.2-4deepin11_loong64.deb
     digest: bcd190055456a57ecb533f4906186fb0dee6e326adaac353e29a90d17095208c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/s/systemd/libudev1_255.2-4deepin11_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/s/systemd/libudev1_255.2-4deepin11_loong64.deb
     digest: e60fd5fd032a8f940a703134978d2ff8ad7b702ad7f9d8419c0529a720759671
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libu/libunistring/libunistring2_0.9.10-6_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libu/libunistring/libunistring2_0.9.10-6_loong64.deb
     digest: 100d2bd250eff9cdc1ce0492cb7fffc306e620aef5886e1b12245f3f020d569c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-linux/libuuid1_2.40.4-3deepin4_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/u/util-linux/libuuid1_2.40.4-3deepin4_loong64.deb
     digest: f3e5aa1a85b3ab2076819261a56469b215cb519efa66d6417065e1826ca7a6ac
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/v/vulkan-loader/libvulkan-dev_1.3.268.0-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/v/vulkan-loader/libvulkan-dev_1.3.268.0-1_loong64.deb
     digest: 26506d91259634d45f99029bf6f969ca5b0e81c39630b0cacb7bd8f959e628f8
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/v/vulkan-loader/libvulkan1_1.3.268.0-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/v/vulkan-loader/libvulkan1_1.3.268.0-1_loong64.deb
     digest: 6d09f8d682a373ad28cdee87a1b7c0857d759688554d5b3ae751e5d7054c2ed8
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libw/libwacom/libwacom-common_1.12-1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libw/libwacom/libwacom-common_1.12-1_all.deb
     digest: ae18d0c6d1b68084756ae6a5ca4d4d680659ad6a9e5384bdbb49de48ffb75bd8
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libw/libwacom/libwacom-dev_1.12-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libw/libwacom/libwacom-dev_1.12-1_loong64.deb
     digest: 80b9f218239d0521b8c10264860dbf34673b210b56e82ee01ce149a997c57a0a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libw/libwacom/libwacom2_1.12-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libw/libwacom/libwacom2_1.12-1_loong64.deb
     digest: 87c13b7db15b7c19111c5af081825d48550cd48c351e3c5ddfac976939bd67b1
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/w/wayland/libwayland-client0_1.23.0-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/w/wayland/libwayland-client0_1.23.0-1_loong64.deb
     digest: 97b7ea92806efbc9f377c790ca5200dd234c35230a6206927ee090097c4e8c85
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/w/wayland/libwayland-cursor0_1.23.0-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/w/wayland/libwayland-cursor0_1.23.0-1_loong64.deb
     digest: b457f29596f3639d06b47104e9e9f34bea93014798fcce7aa018a27ad6d6b9ed
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/w/wayland/libwayland-server0_1.23.0-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/w/wayland/libwayland-server0_1.23.0-1_loong64.deb
     digest: 4857b80945e09375cdbf0caa322f75fb243f8d6d97cf31bfae8111854f40e11e
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libw/libwebp/libwebp-dev_1.3.2-0.2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libw/libwebp/libwebp-dev_1.3.2-0.2_loong64.deb
     digest: d1393a8e0ee0c5e7110a47cd729f042ac19b418bc2560f4fcb330ff1addddada
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libw/libwebp/libwebp7_1.3.2-0.2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libw/libwebp/libwebp7_1.3.2-0.2_loong64.deb
     digest: 2a7085499257d278cebe95b0cdc5e9f61c0375319a8683959155a6b7fa57dc78
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libw/libwebp/libwebpdecoder3_1.3.2-0.2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libw/libwebp/libwebpdecoder3_1.3.2-0.2_loong64.deb
     digest: 6d33f9002478ee47a87b1906776df767e1248a29ff07c07e03aa44980d5326ef
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libw/libwebp/libwebpdemux2_1.3.2-0.2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libw/libwebp/libwebpdemux2_1.3.2-0.2_loong64.deb
     digest: 09f59a459dbd3ee2c0d7adebaccaa0fb9ce46598f13257bcbdfc6dd4a61dac1c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libw/libwebp/libwebpmux3_1.3.2-0.2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libw/libwebp/libwebpmux3_1.3.2-0.2_loong64.deb
     digest: d52b6cde771aadcec6f49bfa11bcd2b8780f308f9640215fd30c2881d0dcf0a7
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libx11/libx11-6_1.8.7-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libx11/libx11-6_1.8.7-1_loong64.deb
     digest: 0e818e4cdefbcf50c1f4c632eb4f0a45ff5b7582d4072a4c64620dc684b49ccd
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libx11/libx11-data_1.8.7-1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libx11/libx11-data_1.8.7-1_all.deb
     digest: 400aaa7eaab268850d8c2c512474228204d47774f2aac79cef29d1c125e0c656
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libx11/libx11-dev_1.8.7-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libx11/libx11-dev_1.8.7-1_loong64.deb
     digest: 9ff2157ecf2cb67c552cb49d624b32ab2393991a184e5151b233288c9a71113d
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libx11/libx11-xcb1_1.8.7-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libx11/libx11-xcb1_1.8.7-1_loong64.deb
     digest: 727ef7465319b0edc7070f9b440a76a29ac1437608a23d98e5679f06d94f6fd5
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxau/libxau-dev_1.0.9-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxau/libxau-dev_1.0.9-1_loong64.deb
     digest: 15f907de0f88e9aac91b9fca3c609de2330cfe0c847b91d73ed5f3e2c4d098f7
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxau/libxau6_1.0.9-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxau/libxau6_1.0.9-1_loong64.deb
     digest: 13a646d0cdb63a9a5025ab6f5f692e077b51b5735fb06a1300f6fd544d6496bc
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/x/xcb-util-cursor/libxcb-cursor0_0.1.1-4_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xcb-util-cursor/libxcb-cursor0_0.1.1-4_loong64.deb
     digest: faa6e26dcacc1349e55f3d40813207148897ff77d47c34ff17fb6585ede18f79
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxcb/libxcb-dri3-0_1.15-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxcb/libxcb-dri3-0_1.15-1_loong64.deb
     digest: 7bcaa840cef1cb99090ae88b987047b83388b4d2b7aef06b8063a211a8418fea
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxcb/libxcb-glx0_1.15-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxcb/libxcb-glx0_1.15-1_loong64.deb
     digest: 19924e487af19c6fbe893bdf9cec301cf3225013122dbd9b40afce27b9cc3694
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/x/xcb-util-wm/libxcb-icccm4_0.4.1-1.1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xcb-util-wm/libxcb-icccm4_0.4.1-1.1_loong64.deb
     digest: 812dc26f817bf6c032d5301a99fc395df44ad95306f8d6cd9f2aa74cbf547d1f
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/x/xcb-util-image/libxcb-image0_0.4.0-deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xcb-util-image/libxcb-image0_0.4.0-deepin1_loong64.deb
     digest: 5573f2fe0db5d1ba31fee4ac95e63f7c29f05dfc1bd932cf702fe1e6b33461f4
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/x/xcb-util-keysyms/libxcb-keysyms1_0.4.0-deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xcb-util-keysyms/libxcb-keysyms1_0.4.0-deepin1_loong64.deb
     digest: a0fbc54aaff67469c3acf51904c2013621636668bf28b6918a207fd7f819acb1
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxcb/libxcb-present0_1.15-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxcb/libxcb-present0_1.15-1_loong64.deb
     digest: a47fb8a989a5a6844449830afe9a7234458acb96014de72cf64a18dc78a4707f
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxcb/libxcb-randr0_1.15-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxcb/libxcb-randr0_1.15-1_loong64.deb
     digest: bbc5a60430c0641edbdc2736cf3108d35bcb30388ef769e830646b8f4fc01b4f
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/x/xcb-util-renderutil/libxcb-render-util0_0.3.9-deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xcb-util-renderutil/libxcb-render-util0_0.3.9-deepin1_loong64.deb
     digest: fb2143791db0e7dee5969bd2b5459439a0d59052000bf26be30e023e2cff77ce
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxcb/libxcb-render0_1.15-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxcb/libxcb-render0_1.15-1_loong64.deb
     digest: f43e74d65d509258147ed6230046648a92fdc906733abf3445373b311032a2a3
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxcb/libxcb-shape0_1.15-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxcb/libxcb-shape0_1.15-1_loong64.deb
     digest: 6bd302fe80140947738703a1d3a00fde8036d7b423ab9a591f7bad1b34c09606
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxcb/libxcb-shm0_1.15-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxcb/libxcb-shm0_1.15-1_loong64.deb
     digest: f75b6dab7eea8f98e0264c63cbb31b5b21df9679c8b309ce7893d7a4866cb845
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxcb/libxcb-sync1_1.15-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxcb/libxcb-sync1_1.15-1_loong64.deb
     digest: 6646259959aa296666facf3d598730c7789d51338cd2a81bf9aab79ea9a986cd
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/x/xcb-util/libxcb-util1_0.4.0-deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xcb-util/libxcb-util1_0.4.0-deepin1_loong64.deb
     digest: 09d6ff65d108b01df3a41e6ce112545c05e8d246bd441fa41e8c365a8f606272
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxcb/libxcb-xfixes0_1.15-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxcb/libxcb-xfixes0_1.15-1_loong64.deb
     digest: 604e97953f434b25d0f23f6eed233ed6a797612c2de320262fbb1dff394f9075
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxcb/libxcb-xkb1_1.15-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxcb/libxcb-xkb1_1.15-1_loong64.deb
     digest: d00aabdea0d36cb2980759bc6a56de64b6f74810aa8c25a31dc674ffe40c5f2b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxcb/libxcb1-dev_1.15-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxcb/libxcb1-dev_1.15-1_loong64.deb
     digest: 3d4b82cd16df0487be74f8f9f79d27fd7b0c5252c2a1c7bd2e03fa6453059728
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxcb/libxcb1_1.15-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxcb/libxcb1_1.15-1_loong64.deb
     digest: 6977bdf22da615ab81df4414e047090a560e73cffa04acc6f2ed27bf2c77e5fb
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxdmcp/libxdmcp-dev_1.1.2-3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxdmcp/libxdmcp-dev_1.1.2-3_loong64.deb
     digest: fa296588f4f92220332e72311db7631b9e5734469551e34dfbef79b5bbd2b328
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxdmcp/libxdmcp6_1.1.2-3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxdmcp/libxdmcp6_1.1.2-3_loong64.deb
     digest: ce4dc98b358a67e1b9653e4492845673a1f6d75512298389758bfb5f1ca2a463
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxext/libxext6_1.3.4-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxext/libxext6_1.3.4-1_loong64.deb
     digest: 151ada3ad16057453b554909ae0ae403c46b8d5560643043a92f4a18ca069de0
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxi/libxi6_1.8.1-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxi/libxi6_1.8.1-1_loong64.deb
     digest: 87c3b78f2e6507074344c7afe0c56aee5a833e8076da0f43ddee28ab53d922f6
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxkbcommon/libxkbcommon-dev_1.6.0-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxkbcommon/libxkbcommon-dev_1.6.0-1_loong64.deb
     digest: ba47dce288d90726795169d45ddf9b07f57c9391776ab2a4833ac26fe01a9c90
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxkbcommon/libxkbcommon-x11-0_1.6.0-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxkbcommon/libxkbcommon-x11-0_1.6.0-1_loong64.deb
     digest: 0373a8af7f464e5daf826bb10a59fbb7e353b52447842d18555f79a9eff2eee9
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxkbcommon/libxkbcommon0_1.6.0-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxkbcommon/libxkbcommon0_1.6.0-1_loong64.deb
     digest: a4e72ca7887958f24270607f6d7897af906a345aa470bdd4a644fa5b66189538
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxml2/libxml2_2.9.14+dfsg-1.3+rb2_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxml2/libxml2_2.9.14+dfsg-1.3+rb2_loong64.deb
     digest: 6a26f4aaae7e9a8bbc63fd4b6bd8dfdc81a85238a63d7f38d479569bcabeaae0
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxshmfence/libxshmfence1_1.3-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxshmfence/libxshmfence1_1.3-1_loong64.deb
     digest: 0d235925c3c0d5ff0a3be29607a3800e616b58fcb46b0eafb7a9e3ba70d7d0fb
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxxf86vm/libxxf86vm1_1.1.4-deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libx/libxxf86vm/libxxf86vm1_1.1.4-deepin1_loong64.deb
     digest: 8bf8c69d8210c9e7ca528ec7bb43bb8c39c9493cbe05aca024926e68602b83cd
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/z/z3/libz3-4_4.8.12-deepin2+rb1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/z/z3/libz3-4_4.8.12-deepin2+rb1_loong64.deb
     digest: 16dfedbf2e2e2882ca15f980b7c3df0b57a2a0989e5a6bf94b84b4847a68257d
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libz/libzstd/libzstd-dev_1.5.6+dfsg-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libz/libzstd/libzstd-dev_1.5.6+dfsg-1_loong64.deb
     digest: 542cb13caf60619314815e4a117fb1e39c3540a241aa52a34fb9cc7b4717f08e
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libz/libzstd/libzstd1_1.5.6+dfsg-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/libz/libzstd/libzstd1_1.5.6+dfsg-1_loong64.deb
     digest: a4bae41cbfe530058e9c63f4b3c34294f1b4b726d8f022b9eca8f7e81833fe13
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/linguist-qt6_6.8.0-0deepin3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-tools/linguist-qt6_6.8.0-0deepin3_loong64.deb
     digest: e200be025cd227c34cb852eb20d4b7ad0d371095fdba7b7c4febc7ea7a2221e2
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/l/linux-upstream/linux-libc-dev_25.01.01.01_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/l/linux-upstream/linux-libc-dev_25.01.01.01_loong64.deb
     digest: a594841362d365a0b93ae0462935964f0efbb0c90da4be064351388804154202
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/l/lshw/lshw_02.19.git.2021.06.19.996aaad9c7-2deepin0_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/l/lshw/lshw_02.19.git.2021.06.19.996aaad9c7-2deepin0_loong64.deb
     digest: a6b376c2fd149cc6cabd93cd94dea5c9793fe8e9b9773c22bb9a12812ac52cf4
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mailcap/mailcap_3.70_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/m/mailcap/mailcap_3.70_all.deb
     digest: 7ca67d118c03eaf58346eb1e676ff16f4d1aa5252a8cc6b5b3b1ed44556180f1
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/make-dfsg/make_4.4.1-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/m/make-dfsg/make_4.4.1-1_loong64.deb
     digest: 549a2844f1ba5051fd3be57714c0e2498054ebf269ecfe235e532a0b363e4f8d
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/media-types/media-types_4.0.0_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/m/media-types/media-types_4.0.0_all.deb
     digest: cd124053950ab8b0373203bceb7eab841791017daf1d50db2ece09e4da52406a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mesa/mesa-libgallium_24.3.0-1deepin4_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/m/mesa/mesa-libgallium_24.3.0-1deepin4_loong64.deb
     digest: df2142c0fe0e2665b0f4f7068f4c2aa5d4f5fcd564b2fa570b993c83598dd157
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mime-support/mime-support_3.66_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/m/mime-support/mime-support_3.66_all.deb
     digest: 20294deda4378616c2b48614ee226731ec09663c3497c35a467e8ea5fa03f16a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/n/netbase/netbase_6.4_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/n/netbase/netbase_6.4_all.deb
     digest: 5fd05a5d63864b96453ba55a4c5efa287b8e7e53fbd833e7a944e066d30e1eb1
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/patch/patch_2.7.6-7_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/patch/patch_2.7.6-7_loong64.deb
     digest: 713a6fe43f8c66f410ed5eca4b57361868d6da0f05e2ef9f7300f7fe524ee2e5
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/perl/perl-base_5.36.0-10deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/perl/perl-base_5.36.0-10deepin1_loong64.deb
     digest: 0c82d65a772e2396c06bc94b1266087c4f490b0fccf8b55c47b95ed82b7e5ff9
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/perl/perl-modules-5.36_5.36.0-10deepin1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/perl/perl-modules-5.36_5.36.0-10deepin1_all.deb
     digest: b79ccae8397e919ee917cd187b8be2d3b10eb598f43cf72a9d9a50c3d81ec288
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/perl/perl_5.36.0-10deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/perl/perl_5.36.0-10deepin1_loong64.deb
     digest: 030b888ad983a63b0cec1e207f3f372abd6b61d64efbe23c781dae2af2634838
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pkgconf/pkg-config_1.8.1-4_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/pkgconf/pkg-config_1.8.1-4_loong64.deb
     digest: fb2ca56eebecd5c9dd6f9150062f349edcd4863390463d536927b6232658f8f0
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pkgconf/pkgconf-bin_1.8.1-4_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/pkgconf/pkgconf-bin_1.8.1-4_loong64.deb
     digest: 872f0376191a3cc26d0fcf9f60b5a2e81d68576cf18aa24449574147e7ce697f
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pkgconf/pkgconf_1.8.1-4_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/pkgconf/pkgconf_1.8.1-4_loong64.deb
     digest: 3e3b1b4df76ba6899f213996a11d75d1b01acc5ef6a9445ca9bb637cb8cd126b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/python3-defaults/python3-minimal_3.12.1-1deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/python3-defaults/python3-minimal_3.12.1-1deepin1_loong64.deb
     digest: ab21a1c47406aa070515796262c63097b15c72fbcdc2e33d98a646c0471cfebb
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/python-packaging/python3-packaging_24.0-1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/python-packaging/python3-packaging_24.0-1_all.deb
     digest: acf9e0347764b07624b219b64fa7721705d6eeea5a98871f892aff3ab0293ae4
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/python3.12/python3.12-minimal_3.12.11-0deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/python3.12/python3.12-minimal_3.12.11-0deepin1_loong64.deb
     digest: b4144ee10587be066eb49793ff81bdf1e6542b4398a99bce1f61660fee4bedfe
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/python3.12/python3.12_3.12.11-0deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/python3.12/python3.12_3.12.11-0deepin1_loong64.deb
     digest: ea8a8be4b657b9b94b2a1e1fb27fff9a7fabd64a17007147088feaba6a7a970a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/python3-defaults/python3_3.12.1-1deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/p/python3-defaults/python3_3.12.1-1deepin1_loong64.deb
     digest: 2068886f43d893b3d801afe06bdbed2ac6cfbd3dd14b1d2b5658fb691d45615e
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/qdbus-qt6_6.8.0-0deepin3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-tools/qdbus-qt6_6.8.0-0deepin3_loong64.deb
     digest: 99aa344e806f799b1008841a76c4f83ad58f508aa7216f7df5adae3aa860fdbd
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qmake6-bin_6.8.0+dfsg-0deepin8_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/qmake6-bin_6.8.0+dfsg-0deepin8_loong64.deb
     digest: 339c762f9680d23b12e5ac41068c139b969cf6d035fd286bac37cb3dba4433f9
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qmake6_6.8.0+dfsg-0deepin8_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/qmake6_6.8.0+dfsg-0deepin8_loong64.deb
     digest: 8e412a2aa98348c58e7f528fd04c00feb90320acc2b6cbed873c3094890a49ec
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/k/kf6-syntax-highlighting/qml6-module-org-kde-syntaxhighlighting_6.10.0-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/k/kf6-syntax-highlighting/qml6-module-org-kde-syntaxhighlighting_6.10.0-1_loong64.deb
     digest: 1ac69e8d065340902caa801464d7f1c1a18926e0a89946dfc137643cb9e2b739
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-5compat/qml6-module-qt5compat-graphicaleffects_6.8.0-0deepin_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-5compat/qml6-module-qt5compat-graphicaleffects_6.8.0-0deepin_loong64.deb
     digest: ccfaec5003e238ac01b62089ee0f4c52ba30e9ef5370c3afa17e3cf7ee6bb318
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-declarative/qml6-module-qtqml-workerscript_6.8.0+dfsg-0deepin3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-declarative/qml6-module-qtqml-workerscript_6.8.0+dfsg-0deepin3_loong64.deb
     digest: 352c93151474b4e0843755cf4248d5678df53a42e9058d07408427a848b52b08
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-declarative/qml6-module-qtqml_6.8.0+dfsg-0deepin3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-declarative/qml6-module-qtqml_6.8.0+dfsg-0deepin3_loong64.deb
     digest: 5bebc32a419c38803377c01265c89450b74b82ab8098a71593f9292962919432
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6declarative/qml6-module-qtquick-controls2-styles-chameleon_6.0.38_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/d/dtk6declarative/qml6-module-qtquick-controls2-styles-chameleon_6.0.38_loong64.deb
     digest: 2d49c4834c4fa286597fa369ffb01747e40cc204c8fcba6633a1b736912d3549
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-declarative/qml6-module-qtquick-controls_6.8.0+dfsg-0deepin3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-declarative/qml6-module-qtquick-controls_6.8.0+dfsg-0deepin3_loong64.deb
     digest: ad66e90894973d878b512046d6312c4ae337b27f839b664f1f2f6e5c6e776cd7
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-declarative/qml6-module-qtquick-effects_6.8.0+dfsg-0deepin3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-declarative/qml6-module-qtquick-effects_6.8.0+dfsg-0deepin3_loong64.deb
     digest: 91ad1b23eeae6f41bcc71a3f8e1b1ff3b95ab046008d9df443cccee8882225df
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-declarative/qml6-module-qtquick-shapes_6.8.0+dfsg-0deepin3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-declarative/qml6-module-qtquick-shapes_6.8.0+dfsg-0deepin3_loong64.deb
     digest: 7218e4068f55a99e5fa28bef209230378eb589e67318ca191d2863c309bd16fa
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-declarative/qml6-module-qtquick-templates_6.8.0+dfsg-0deepin3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-declarative/qml6-module-qtquick-templates_6.8.0+dfsg-0deepin3_loong64.deb
     digest: 02b572b384ceff5fc245cfcfe5fb224cb3f0b34ffc0f2a15d91a2ee32f7b7079
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-declarative/qml6-module-qtquick_6.8.0+dfsg-0deepin3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-declarative/qml6-module-qtquick_6.8.0+dfsg-0deepin3_loong64.deb
     digest: 137ef29be43e576b0af91b44707a8f53d3c91874534b67ec72619062d6a479f6
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-5compat/qt6-5compat-dev_6.8.0-0deepin_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-5compat/qt6-5compat-dev_6.8.0-0deepin_loong64.deb
     digest: 663ebb93a2d4c641de8c11920366c7b697027bfd35d3e41ca65b514016234b5f
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qt6-base-dev-tools_6.8.0+dfsg-0deepin8_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/qt6-base-dev-tools_6.8.0+dfsg-0deepin8_loong64.deb
     digest: 8bb4163c0c9da5c501f1937e79f1f9db15bc57b502de5d711f51239748d3c1ce
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qt6-base-dev_6.8.0+dfsg-0deepin8_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/qt6-base-dev_6.8.0+dfsg-0deepin8_loong64.deb
     digest: 61fa7ec1e9023d7c55286b469b6238769eb86b1fa2cfdd45aaa291fe2005e57a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qt6-base-private-dev_6.8.0+dfsg-0deepin8_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/qt6-base-private-dev_6.8.0+dfsg-0deepin8_loong64.deb
     digest: 3dea4403705fc32119023d852123e8327e56bd1a68f6aac8acb3c230351b769a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-declarative/qt6-declarative-dev-tools_6.8.0+dfsg-0deepin3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-declarative/qt6-declarative-dev-tools_6.8.0+dfsg-0deepin3_loong64.deb
     digest: e3e538952f21679cb551bd5095a0e1e94fa23aff5bbe6584d09ae15870c775e1
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-declarative/qt6-declarative-dev_6.8.0+dfsg-0deepin3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-declarative/qt6-declarative-dev_6.8.0+dfsg-0deepin3_loong64.deb
     digest: fecb9f5fc91ebafb15f87a11e04c7640a1ed7f386ba481a3f70256b77c3c5157
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/qt6-documentation-tools_6.8.0-0deepin3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-tools/qt6-documentation-tools_6.8.0-0deepin3_loong64.deb
     digest: cf6fafc95fdce9f99b2bfd283100163a1c316fc596dd6ab9da30821d1faeb0d5
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-imageformats/qt6-image-formats-plugins_6.8.0-0deepin_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-imageformats/qt6-image-formats-plugins_6.8.0-0deepin_loong64.deb
     digest: d9703d3d43bc45d7190b56022d278654f40a2ef3a53314a6426f018ed1e0eca0
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/qt6-l10n-tools_6.8.0-0deepin3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-tools/qt6-l10n-tools_6.8.0-0deepin3_loong64.deb
     digest: 64b8adf192160cd12b0e63cba2d112fe0f0f361f83df2666c5017e55e5383fd9
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-declarative/qt6-qmllint-plugins_6.8.0+dfsg-0deepin3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-declarative/qt6-qmllint-plugins_6.8.0+dfsg-0deepin3_loong64.deb
     digest: 4593f2146dac321cbc646500b27812089053750274c25236668df014d193d135
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-declarative/qt6-qmltooling-plugins_6.8.0+dfsg-0deepin3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-declarative/qt6-qmltooling-plugins_6.8.0+dfsg-0deepin3_loong64.deb
     digest: ba1b1a017f8dda8a6afba66ef12d2a79a1f051e394c2ddcc4d55b95fb28f845e
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qt6-qpa-plugins_6.8.0+dfsg-0deepin8_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-base/qt6-qpa-plugins_6.8.0+dfsg-0deepin8_loong64.deb
     digest: 82c70661bd53c58e196bbfede69b23bd2bcbd36829aeafa838cdaa4627893a98
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-svg/qt6-svg-dev_6.8.0-0deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-svg/qt6-svg-dev_6.8.0-0deepin1_loong64.deb
     digest: 8d025380c93576e65ed0941ed9b0a568d366c9554497570335f4426be7068545
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/qt6-tools-dev-tools_6.8.0-0deepin3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-tools/qt6-tools-dev-tools_6.8.0-0deepin3_loong64.deb
     digest: 0f27c4de0f6b1d21b037e49d0d94effc72f061f8fbe742365dd83f2ccbb0c782
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/qt6-tools-dev_6.8.0-0deepin3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/q/qt6-tools/qt6-tools-dev_6.8.0-0deepin3_loong64.deb
     digest: 18aca243a15bb51fb26de8579e2fd58cc2234f31dd4db73fda2d734a41308887
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/r/readline/readline-common_8.2-3_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/r/readline/readline-common_8.2-3_all.deb
     digest: 35fe59faceb8d9def8b6aa664e091eac8444887bc1f33ba2cf22099c3646e7bd
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/r/rpcsvc-proto/rpcsvc-proto_1.4.2-4_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/r/rpcsvc-proto/rpcsvc-proto_1.4.2-4_loong64.deb
     digest: 5a68197175ff3bf8f57fdd1066b62efcb547e877ae2c3b057f5b5a9c8add94c4
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/s/shared-mime-info/shared-mime-info_2.2-1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/s/shared-mime-info/shared-mime-info_2.2-1_loong64.deb
     digest: a0cd2345f1c869975ba98b8ead9048f32746d72966162472ce531ae48ecb0e9e
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tar/tar_1.35+dfsg-3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/t/tar/tar_1.35+dfsg-3_loong64.deb
     digest: 48cc0cc32829c68c7b58e74f141fe552f9a3f5c9e6da77ad54184530debc0cff
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tzdata/tzdata_2023d-1deepin1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/t/tzdata/tzdata_2023d-1deepin1_all.deb
     digest: fe503c524801260208482a1dfc061e79c2a7450111dd90f88ed40d70ac935832
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-linux/uuid-dev_2.40.4-3deepin4_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/u/util-linux/uuid-dev_2.40.4-3deepin4_loong64.deb
     digest: 8097f0f8c46e7619c944b22fb4160d60ac3b3eb5aab3d5ea26a7c83816ed24bd
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/x/xorg/x11-common_7.7+23-deepin1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xorg/x11-common_7.7+23-deepin1_all.deb
     digest: 9a7643db11023a8bec126312edec4b1b7357b93416bdfbaf9b0cb8bc04506d49
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/x/xorgproto/x11proto-core-dev_2024.1-1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xorgproto/x11proto-core-dev_2024.1-1_all.deb
     digest: 82bff9dab1d74e30bdbc6130f94d1bd361c3c1d3cdad660bd92e5b730c4cba7b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/x/xorgproto/x11proto-dev_2024.1-1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xorgproto/x11proto-dev_2024.1-1_all.deb
     digest: 39e14817ff2ab4eedade206fefebb7b2632e4dd7c358a9cfe36bcdd477554a04
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/x/xfonts-encodings/xfonts-encodings_1.0.4-2.1deepin1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xfonts-encodings/xfonts-encodings_1.0.4-2.1deepin1_all.deb
     digest: 07d68c68eeeca62cea0558b4f0bc25896bd82fddfa6c4b02693ee0adc4bde224
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/x/xfonts-utils/xfonts-utils_7.7+6-deepin_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xfonts-utils/xfonts-utils_7.7+6-deepin_loong64.deb
     digest: 7022910932f96b7af8fa6e5ffe31a20515e47e9ae3dbab9781012f132e4e3198
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/x/xkeyboard-config/xkb-data_2.38-2deepin1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xkeyboard-config/xkb-data_2.38-2deepin1_all.deb
     digest: 6fdc32f08737735128e20a10f9a8425bde19855e3917d8f26a62ea3a12a9a720
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/x/xorg-sgml-doctools/xorg-sgml-doctools_1.11-1.1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xorg-sgml-doctools/xorg-sgml-doctools_1.11-1.1_all.deb
     digest: c3ac4805a75219ecc8a92a79697d39fa9abf6a7fa16da540800a0d30bdcc2847
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/x/xtrans/xtrans-dev_1.4.0-1_all.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xtrans/xtrans-dev_1.4.0-1_all.deb
     digest: ab37e512128e066d7225deb7f51f0c77f9b0c3913d75f2a7f9b1d708327a099d
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/x/xz-utils/xz-utils_5.4.5-0.3_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/x/xz-utils/xz-utils_5.4.5-0.3_loong64.deb
     digest: 914f9a81a1be1c08e1489ae0d463c9e68f725da465d2dda0cba519f87a00ddc8
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/z/zlib/zlib1g-dev_1.3.dfsg+really1.3.1-1deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/z/zlib/zlib1g-dev_1.3.dfsg+really1.3.1-1deepin1_loong64.deb
     digest: b40d74ed9b2014e3a3bcb7c6121a17e16424d0ef19c9ee1aef977b7460b1b1b6
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/z/zlib/zlib1g_1.3.dfsg+really1.3.1-1deepin1_loong64.deb
+    url: http://10.20.64.92:8080/crimson_25.0/pool/main/z/zlib/zlib1g_1.3.dfsg+really1.3.1-1deepin1_loong64.deb
     digest: 135455e7368c3c73d5984305019c2574ebc5501f2d650e77addbc4d87db55503

--- a/src/widgets/window.cpp
+++ b/src/widgets/window.cpp
@@ -1390,8 +1390,10 @@ QString Window::saveAsFileToDisk()
         Settings::instance()->setSavePath(PathSettingWgt::LastOptBox, QFileInfo(newFilePath).absolutePath());
         Settings::instance()->setSavePath(PathSettingWgt::CurFileBox, QFileInfo(newFilePath).absolutePath());
 
-        wrapper->updatePath(wrapper->filePath(), newFilePath);
-
+        // 保存原始文件路径，用于后续更新
+        QString oldFilePath = wrapper->filePath();
+        
+        // 先保存文件，不更新路径
         bool needChangeEncode = (encode != wrapper->getTextEncode().toUtf8());
         bool saveSucc = false;
         if (QFileInfo(wrapper->filePath()).absoluteFilePath()
@@ -1411,6 +1413,10 @@ QString Window::saveAsFileToDisk()
             return QString();
         } else {
             qDebug() << "Save successful, updating file path to:" << newFilePath;
+            
+            // 保存成功后再更新路径，防止文件还未保存完成就触发文件是否存在的检测
+            wrapper->updatePath(oldFilePath, newFilePath);
+            
             // 更新文件编码
             wrapper->bottomBar()->setEncodeName(encode);
 
@@ -1444,7 +1450,7 @@ QString Window::saveAsFileToDisk()
             }
         }
 
-        updateSaveAsFileName(wrapper->filePath(), newFilePath);
+        updateSaveAsFileName(oldFilePath, newFilePath);
         qDebug() << "Exit saveAsFileToDisk, return new file path";
         return newFilePath;
     }


### PR DESCRIPTION
fix: Update file path handling in saveAsFileToDisk function

- Save the original file path before updating to prevent premature checks on file existence.
- Update the file path only after a successful save to ensure accuracy.

log: Update file path handling in saveAsFileToDisk function

bug: https://pms.uniontech.com/bug-view-322759.html

## Summary by Sourcery

Correct saveAsFileToDisk logic to hold the original file path during saving and only update it after a successful write; adjust related path‐update call to use the preserved old path.

Bug Fixes:
- Delay updating the wrapper’s file path until after a successful save to prevent premature existence checks

Enhancements:
- Bump deepin-editor package version to 6.5.32.1 and switch linglong.yaml source URL to crimson_25.0