### PR TITLE
feat: Update translations for Lao locale

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.editor
   name: "deepin-editor"
-  version: 6.5.32.1
+  version: 6.5.33.1
   kind: app
   description: |
     editor for deepin os.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+deepin-editor (6.5.33) unstable; urgency=medium
+
+  * Update translations for Lao locale.
+  * update version to 6.5.33. 
+
+ -- Tian ShiLin <tianshilin@uniontech.com>  Thu, 07 Aug 2025 15:18:53 +0800
+
 deepin-editor (6.5.32) unstable; urgency=medium
 
   * fix: Update file path handling in saveAsFileToDisk function

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.editor
   name: "deepin-editor"
-  version: 6.5.32.1
+  version: 6.5.33.1
   kind: app
   description: |
     editor for deepin os.

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -10,7 +10,7 @@ version: "1"
 package:
   id: org.deepin.editor
   name: "deepin-editor"
-  version: 6.5.32.1
+  version: 6.5.33.1
   kind: app
   description: |
     editor for deepin os.

--- a/translations/deepin-editor_lo.ts
+++ b/translations/deepin-editor_lo.ts
@@ -1,0 +1,1328 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="lo">
+<context>
+    <name>BottomBar</name>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="30"/>
+        <source>Row</source>
+        <translation>แถว</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="31"/>
+        <source>Column</source>
+        <translation>คอลัมน์</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="32"/>
+        <source>Characters %1</source>
+        <translation>ตัวอักษร %1</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="44"/>
+        <source>Loading:</source>
+        <translation>ກំລុះ:</translation>
+    </message>
+</context>
+<context>
+    <name>DDropdownMenu</name>
+    <message>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="316"/>
+        <source>None</source>
+        <translation>ຍ៉ាងណាត្រូវ</translation>
+    </message>
+</context>
+<context>
+    <name>EditWrapper</name>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="273"/>
+        <source>Save</source>
+        <translation>រក្សា</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="467"/>
+        <source>Do you want to save this file?</source>
+        <translation>តើអ្នកចងោទ์រក្សាគេហ្សុទ្ធនេះទេ?</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="339"/>
+        <source>Cancel</source>
+        <translation>ប៉ុន្តែ</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="336"/>
+        <source>Encoding changed. Do you want to save the file now?</source>
+        <translation>ប្រអ័រគ្យកម្មប្រែបធែបបានប្រែបប្រូតេអ៊ូកាល់. តើអ្នកចងោទ์រក្សាគេហ្សុទ្ធនេះឥឡូកទេ?</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="471"/>
+        <source>Discard</source>
+        <translation>ប៉ុន្តែ</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="258"/>
+        <source>You do not have permission to save %1</source>
+        <translation>អ្នកមិនមានសិទ្ធិទៅរក្សា %1</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="745"/>
+        <source>File removed on the disk. Save it now?</source>
+        <translation>គេហ្សុទ្ថានត្រូវបានបែបាក់ពីរបូរិន. តើអ្នកចងោទ์រក្សាត្រលប់មកទេ?</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="750"/>
+        <source>File has changed on disk. Reload?</source>
+        <translation>គេហ្សុទ្ថានត្រូវបានផ្លាស់ប្តូរលើរបូរិន. តើអ្នកចងោទ์ផ្លាស់មកម្តងទេ?</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="784"/>
+        <source>INSERT</source>
+        <translation>បញ្ចូល</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="787"/>
+        <source>OVERWRITE</source>
+        <translation>ជំនួស</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="790"/>
+        <source>R/O</source>
+        <translation>อ่าน/เขียน</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="1417"/>
+        <source>The file cannot be read, which may be too large or has been damaged!</source>
+        <translation>ཡིག파일 읽기에 실패했습니다. 파일이 너무 커서거나 손상되었을 수 있습니다!</translation>
+    </message>
+</context>
+<context>
+    <name>FindBar</name>
+    <message>
+        <location filename="../src/controls/findbar.cpp" line="34"/>
+        <source>Find</source>
+        <translation>ຄີດຊອກ</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/findbar.cpp" line="36"/>
+        <source>Previous</source>
+        <translation>ຫົວ້ອງກ່ອນຫົວ້ອງ</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/findbar.cpp" line="37"/>
+        <source>Next</source>
+        <translation>ຫົວ້ອງຕໍ່ໄປ</translation>
+    </message>
+</context>
+<context>
+    <name>JumpLineBar</name>
+    <message>
+        <location filename="../src/controls/jumplinebar.cpp" line="45"/>
+        <source>Go to Line: </source>
+        <translation>страница: </translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../src/editorapplication.cpp" line="12"/>
+        <source>Text Editor is a powerful tool for viewing and editing text files.</source>
+        <translation>Текстовый редактор — это мощный инструмент для просмотра и редактирования текстовых файлов.</translation>
+    </message>
+    <message>
+        <location filename="../src/editorapplication.cpp" line="24"/>
+        <source>Text Editor</source>
+        <translation>Текстовый редактор</translation>
+    </message>
+</context>
+<context>
+    <name>PathSettingWgt</name>
+    <message>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="77"/>
+        <source>Remember the last used path</source>
+        <translation>ການນຳໃຊ້ເສີມ</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="78"/>
+        <source>Same path as the current file</source>
+        <translation>ຈຸດທີ່ໄດ້ໃຊ້ກ່ອນ</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="79"/>
+        <source>Customize the default path</source>
+        <translation>ຄຸ້ມຄອບມາດຕະຖານ</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../src/editorapplication.cpp" line="21"/>
+        <source>Text Editor</source>
+        <translation>Текстовый редактор</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="275"/>
+        <source>Encoding</source>
+        <translation>Кодировка</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="9"/>
+        <source>Basic</source>
+        <translation>ພຼຸ້</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="10"/>
+        <source>Font Style</source>
+        <translation>ປັນທີ່</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="11"/>
+        <source>Font</source>
+        <translation>ເອນශිලිපි</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="12"/>
+        <source>Font Size</source>
+        <translation>ເອນශිලිපි ඥියුරු</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="13"/>
+        <source>Shortcuts</source>
+        <translation>හෂස්තුරු</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="14"/>
+        <source>Keymap</source>
+        <translation>គශුරු ඥියුරු</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="16"/>
+        <source>Window</source>
+        <translation>ප្រាប់បង្អូច</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="17"/>
+        <source>New tab</source>
+        <translation>ថ្មថ្មិតថ្មថ្មិតថ្មថ្មិត</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="18"/>
+        <source>New window</source>
+        <translation>ព្រាប់បង្អូចថ្មថ្មិត</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="19"/>
+        <source>Save</source>
+        <translation>រក្សា</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="20"/>
+        <source>Save as</source>
+        <translation>រក្សាជាមួយ</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="21"/>
+        <source>Next tab</source>
+        <translation>ថ្មថ្មិតបន្ទាប់</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="22"/>
+        <source>Previous tab</source>
+        <translation>ថ្មថ្មិតមុន</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="23"/>
+        <source>Close tab</source>
+        <translation>បង្អូចថ្ម</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="24"/>
+        <source>Close other tabs</source>
+        <translation>ปิดแท็บอื่น</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="25"/>
+        <source>Restore tab</source>
+        <translation>ស្លាប់ថ្ម</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="26"/>
+        <source>Open file</source>
+        <translation>ប្រទោះឯកសារ</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="27"/>
+        <source>Increment font size</source>
+        <translation>ເພิ่มទំហំអក្សរ</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="28"/>
+        <source>Decrement font size</source>
+        <translation>ຫែលទំហំអក្សរ</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="29"/>
+        <source>Reset font size</source>
+        <translation>ត្រូវឡើងទំហំអក្សរ</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="30"/>
+        <source>Help</source>
+        <translation>ជួយ</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="31"/>
+        <source>Toggle fullscreen</source>
+        <translation>สลับโหมดภาพเต็มหน้าจอ</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="32"/>
+        <source>Find</source>
+        <translation>រកหา</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="33"/>
+        <source>Find Next</source>
+        <translation>រកหาต่อไป</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="34"/>
+        <source>Find Previous</source>
+        <translation>រកหาត្រឹមមុន</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="35"/>
+        <source>Replace</source>
+        <translation>ប្រៀបប្រដូប</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="36"/>
+        <source>Go to line</source>
+        <translation>ទៅការៗលំដាប់</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="37"/>
+        <source>Save cursor position</source>
+        <translation>រក្សាកតែប្រវត្តិសន្ធិត</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="38"/>
+        <source>Reset cursor position</source>
+        <translation>ត្រូវឡើងទិតកតែប្រវត្តិសន្ធិត</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="39"/>
+        <source>Exit</source>
+        <translation>ចាក់ចេញ</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="40"/>
+        <source>Display shortcuts</source>
+        <translation>បង្ហាញតួអក្សរខ្លឹមសារ</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="41"/>
+        <source>Print</source>
+        <translation>រុញ</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="42"/>
+        <source>Editor</source>
+        <translation>ແບບແບ່ງແຍ່ງ</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="43"/>
+        <source>Increase indent</source>
+        <translation>ຫີ໇ຫີ໇ໃຫີ້ໃຫຍ່</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="44"/>
+        <source>Decrease indent</source>
+        <translation>ຫີ໇ຫີ໇ໃຫຼ່ຍ</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="45"/>
+        <source>Forward character</source>
+        <translation>ຂໍ້າງ່າຍຂ້າງ່າຍ</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="46"/>
+        <source>Backward character</source>
+        <translation>ຂໍාරා ངා ངා</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="47"/>
+        <source>Forward word</source>
+        <translation>ຂໍ້າງ່າຍຈຳນຳ</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="48"/>
+        <source>Backward word</source>
+        <translation>ຂໍාරා ངා ངා</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="49"/>
+        <source>Next line</source>
+        <translation>ຖືກຫີ໇ຫີ໇ໃຫີ້ຫຼາຍຂຶ້ນ</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="50"/>
+        <source>Previous line</source>
+        <translation>ຖືກຫີ໇ຫີ໇ໃຫຼ່ຍຂຶ້ນ</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="51"/>
+        <source>New line</source>
+        <translation>ຖືກເພີ່ມຂໍ້າງ່າຍໃຫຍ່</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="52"/>
+        <source>New line above</source>
+        <translation>ຖືກເພີ່ມຂໍාරා ངා ངා</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="53"/>
+        <source>New line below</source>
+        <translation>ຖືກເພີ່ມຂໍ້າງ່າຍໃຫຍ່ ང່າຍ</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="54"/>
+        <source>Duplicate line</source>
+        <translation>ຖືກອອກແບບຄຳແບບໃຫຍ່</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="55"/>
+        <source>Delete to end of line</source>
+        <translation>ຖືກລືມຂໍාරා ངා ངා</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="56"/>
+        <source>Delete current line</source>
+        <translation>ຖືກລືມຂໍ້າງ່າຍໃຫຍ່</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="57"/>
+        <source>Swap line up</source>
+        <translation>ປະ교ອນ 줄 위 para</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="58"/>
+        <source>Swap line down</source>
+        <translation>ປະ교ອນ 줄 아래 para</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="59"/>
+        <source>Scroll up one line</source>
+        <translation>ນაໂក 위쪽으로 한 줄</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="60"/>
+        <source>Scroll down one line</source>
+        <translation>ນაໂក 아래쪽으로 한 줄</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="61"/>
+        <source>Page up</source>
+        <translation>페이지 위쪽으로</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="62"/>
+        <source>Page down</source>
+        <translation>페이지 아래쪽으로</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="63"/>
+        <source>Move to end of line</source>
+        <translation>ย้ายไปท้ายบรรทุก</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="64"/>
+        <source>Move to start of line</source>
+        <translation>ย้ายไปต้นบรรทุก</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="65"/>
+        <source>Move to end of text</source>
+        <translation>ย้ายไปท้ายข้อความ</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="66"/>
+        <source>Move to start of text</source>
+        <translation>ย้ายไปต้นข้อความ</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="67"/>
+        <source>Move to line indentation</source>
+        <translation>ย้ายไปที่-indentation บรรทุก</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="68"/>
+        <source>Upper case</source>
+        <translation>대문자</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="69"/>
+        <source>Lower case</source>
+        <translation>소문자</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="70"/>
+        <source>Capitalize</source>
+        <translation>제목 형식</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="71"/>
+        <source>Delete backward word</source>
+        <translation>뒤쪽 단어 삭제</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="72"/>
+        <source>Delete forward word</source>
+        <translation>លិចលោតតាមคำ</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="73"/>
+        <source>Forward over a pair</source>
+        <translation>លិចលោតលើតេរ៉ែបប៉ុន្តេ</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="74"/>
+        <source>Backward over a pair</source>
+        <translation>លើស្និទ្ធិតាមតេរ៉ែប</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="75"/>
+        <source>Select all</source>
+        <translation>ជ្រុងត្រូវគ្រប់គ្រាន់</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="76"/>
+        <source>Copy</source>
+        <translation>ចិត្បាព័ត្ងេ</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="77"/>
+        <source>Cut</source>
+        <translation>កាត់តែលោត</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="78"/>
+        <source>Paste</source>
+        <translation>ត្រូវចំណត់</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="79"/>
+        <source>Transpose character</source>
+        <translation>ផ្លាស់ប្តូរតួអក្សរ៍</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="80"/>
+        <source>Mark</source>
+        <translation>ស្តាប់ត្រួត</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="81"/>
+        <source>Unmark</source>
+        <translation>ប៉ុន្តេស្តាប់ត្រួត</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="82"/>
+        <source>Copy line</source>
+        <translation>ចិត្បាព័ត្ងេខ្លឹម</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="83"/>
+        <source>Cut line</source>
+        <translation>កាត់តែលោតខ្លឹម</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="84"/>
+        <source>Merge lines</source>
+        <translation>រួមបញ្ចូលខ្លឹម</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="85"/>
+        <source>Read-Only mode</source>
+        <translation>មードត្រឹមតែអាន</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="86"/>
+        <source>Add comment</source>
+        <translation>បញ្ចូលការសម្គាល់</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="87"/>
+        <source>Remove comment</source>
+        <translation>លិང་លេខ</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="88"/>
+        <source>Undo</source>
+        <translation>ย้อนกลับ</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="89"/>
+        <source>Redo</source>
+        <translation>ทำซ้ำ</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="90"/>
+        <source>Add/Remove bookmark</source>
+        <translation>เพิ่ม/ลบ ป๊อป</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="91"/>
+        <source>Move to previous bookmark</source>
+        <translation>ย้ายไปป๊อปก่อนหน้า</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="92"/>
+        <source>Move to next bookmark</source>
+        <translation>ย้ายไปป๊อปถัดไป</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="93"/>
+        <source>Advanced</source>
+        <translation>លិចលាកៅ</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="95"/>
+        <source>Window size</source>
+        <translation>ウィンドウのサイズ</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="96"/>
+        <source>Tab width</source>
+        <translation>ទទឹងតារាកេស</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="97"/>
+        <source>Paste by pressing a middle mouse button</source>
+        <translation>ចុចលំនាំនេះពូឡេដោយចុចមធ្ល័យ</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="99"/>
+        <source>Startup</source>
+        <translation>ចាប់ផ្តុត</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="100"/>
+        <source>Reopen last closed tabs</source>
+        <translation>បុរាណបង្កកបានចង្អៀតត្រូវបានបុរាណ</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="102"/>
+        <source>Open/Save Settings</source>
+        <translation>បុរាណរាជូត/រក្សាការកំណត់</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="104"/>
+        <source>Word wrap</source>
+        <translation>បញ្ចាំងពាក់ពែងតាមតែមុខបន្ត</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="105"/>
+        <source>Code folding flag</source>
+        <translation>សញ្ញាស្រាវជ្រាលកូដ</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="106"/>
+        <source>Show line numbers</source>
+        <translation>បង្កើតលំដាប់លេខ</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="107"/>
+        <source>Show bookmarks icon</source>
+        <translation>បង្កើតរូបីមក្រស័ម</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="108"/>
+        <source>Show whitespaces and tabs</source>
+        <translation>បង្កើតរលកទទេងនិងតៅបញ្ចប់</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="109"/>
+        <source>Highlight current line</source>
+        <translation>ធ្វើប្រភេទជ្រើនសម្រាប់បន្តុចបច្ចុប្បន្ន</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="110"/>
+        <source>Color mark</source>
+        <translation>ស្តាបែនជំរុញពណ៌</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="113"/>
+        <source>Unicode</source>
+        <translation>យូនិក</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="114"/>
+        <source>WesternEuropean</source>
+        <translation>អាល៊ូគ្នាអឺរ៉ុបខាងលិច</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="115"/>
+        <source>CentralEuropean</source>
+        <translation>អាល៊ូគ្នាអឺរ៉ុបខាងកណ្តាល</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="116"/>
+        <source>Baltic</source>
+        <translation>បាតុកស្លាប់</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="117"/>
+        <source>Cyrillic</source>
+        <translation>ស្លាប់សៃលេង</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="118"/>
+        <source>Arabic</source>
+        <translation>អាល៊ូគ្នាមេធិក</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="123"/>
+        <source>Celtic</source>
+        <translation>គ្រប់គ្រងភាគច្រើនជៃអាល៊ូគ្នាអឺរ៉ុបខាងកើត</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="124"/>
+        <source>SouthEasternEuropean</source>
+        <translation>អាល៊ូគ្នាអឺរ៉ុបខាងត្បូងកើត</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="119"/>
+        <source>Greek</source>
+        <translation>យូនានេស៊ី</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="120"/>
+        <source>Hebrew</source>
+        <translation>អាល៊ូគ្នាខេស៊ី</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="125"/>
+        <source>ChineseSimplified</source>
+        <translation>លេខចិនបង្កើតចំនួនសាមស្បាប់</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="126"/>
+        <source>ChineseTraditional</source>
+        <translation>លេខចិនបង្កើតចំនួនប្រព័ន្ធតូច</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="127"/>
+        <source>Japanese</source>
+        <translation>ជប់ជួស</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="128"/>
+        <source>Korean</source>
+        <translation>រូបសង្បូរ</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="122"/>
+        <source>Thai</source>
+        <translation>ទូរគ្រង</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="121"/>
+        <source>Turkish</source>
+        <translation>ដែលកំណត់</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/settingsdialog.cpp" line="129"/>
+        <source>Vietnamese</source>
+        <translation>ខ្មែរខ្សាំង</translation>
+    </message>
+    <message>
+        <location filename="../src/startmanager.cpp" line="875"/>
+        <source>File not saved</source>
+        <translation>ບໍ່ໄດ້ບີ້້</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1346"/>
+        <source>Line Endings</source>
+        <translation>ເສົ້າທື່</translation>
+    </message>
+    <message>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="243"/>
+        <source>Please install &apos;UOS AI&apos; from the App Store before using</source>
+        <translation>ກະລູນາຕິດຕັ້ງ &apos;UOS AI&apos; ຈາກ App Store ກ່ອນໃຊ້ງານ</translation>
+    </message>
+    <message>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="245"/>
+        <source>No audio input device detected. Please check and try again</source>
+        <translation>ບໍ່ພີ້ນີ້ມືຖືສີ່ງສຽງໄດ້. ກະລູນາກວດສອບ ກຳນຳໃຫ້ອັກກະນານອັດຕະສະນະ</translation>
+    </message>
+    <message>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="247"/>
+        <source>No audio output device detected. Please check and try again</source>
+        <translation>ບໍ່ພີ້ນີ້ອຸປະກອນອອກສຽງໄດ້. ກະລູນາກວດສອບ ກຳນຳໃຫ້ອັກກະນານອັດຕະສະນະ</translation>
+    </message>
+    <message>
+        <location filename="../src/common/text_file_saver.cpp" line="65"/>
+        <source>File path is empty</source>
+        <translation>ເຄື່ອງມຸງລະຫ຤ຸ້ນເປັນຫວ່າງເຫດ</translation>
+    </message>
+    <message>
+        <location filename="../src/common/text_file_saver.cpp" line="141"/>
+        <source>Insufficient memory to load document content</source>
+        <translation>ບໍ່ພີ້ນພ້ອມພໍເພື່ອອົບຮົມເນື່ອງໃນເນື່ອງຂອງບໍ່ພີ້ນພ້ອມພໍ</translation>
+    </message>
+    <message>
+        <location filename="../src/common/text_file_saver.cpp" line="163"/>
+        <source>Insufficient memory for encoding conversion</source>
+        <translation>ບໍ່ພີ້ນພ້ອມພໍສື່ຂໍ້າງກຳນຳເພື່ອການປ່ອງແລະການແປກ</translation>
+    </message>
+    <message>
+        <location filename="../src/common/text_file_saver.cpp" line="169"/>
+        <source>Encoding conversion failed</source>
+        <translation>ລోຫຼາຍກວດການປ້ອມແປບ້ານບ່າຍກຳນຳໃຊ້ບໍ່ໄດ້</translation>
+    </message>
+    <message>
+        <location filename="../src/common/text_file_saver.cpp" line="175"/>
+        <source>Converted content is empty</source>
+        <translation>ແປບ້ານທຳເລັດມີເນື້ອໃນເປັນຫວ່າງ</translation>
+    </message>
+    <message>
+        <location filename="../src/common/text_file_saver.cpp" line="193"/>
+        <source>Memory allocation failed</source>
+        <translation>ຈົ່ງການຈັດເຈົ້າມີບັນຫາ</translation>
+    </message>
+    <message>
+        <location filename="../src/common/text_file_saver.cpp" line="196"/>
+        <source>Error occurred: %1</source>
+        <translation>ເກີດຂ້ອງຫນ້າ: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/common/text_file_saver.cpp" line="199"/>
+        <source>Unknown error occurred</source>
+        <translation>ບ່າຍຂ້ອງຫນ້າທີ່ບໍ່ຮັບຮູ້ເກີດຂຶ້ນ</translation>
+    </message>
+</context>
+<context>
+    <name>ReplaceBar</name>
+    <message>
+        <location filename="../src/controls/replacebar.cpp" line="32"/>
+        <source>Find</source>
+        <translation>ຊອກຫາ</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/replacebar.cpp" line="34"/>
+        <source>Replace With</source>
+        <translation>ແບ່ງແຍ່ງໃຫ້ພັນທຳ</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/replacebar.cpp" line="36"/>
+        <source>Replace</source>
+        <translation>ແບ່ງແຍ່ງ</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/replacebar.cpp" line="37"/>
+        <source>Skip</source>
+        <translation>ຜ່ອຍວາງ</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/replacebar.cpp" line="38"/>
+        <source>Replace Rest</source>
+        <translation>ແບ່ງແຍ່ງເຫຼົ່າອື່ນ້ອຍ</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/replacebar.cpp" line="39"/>
+        <source>Replace All</source>
+        <translation>ແບ່ງແຍ່ງທີ່ງານ</translation>
+    </message>
+</context>
+<context>
+    <name>S:</name>
+    <message>
+        <location filename="../third/libiconv-1.16/src/iconv.c" line="103"/>
+        <source></source>
+        <comment>The first line of the short usage message.</comment>
+        <translation type="unfinished">ຂໍ້ຄວາມການນຳໃຊ້ແບບສັ້ນແຖວທຳອິດ</translation>
+    </message>
+</context>
+<context>
+    <name>Settings</name>
+    <message>
+        <location filename="../src/common/settings.cpp" line="132"/>
+        <source>Standard</source>
+        <translation>ປະເພຼັກຊັນ</translation>
+    </message>
+    <message>
+        <location filename="../src/common/settings.cpp" line="132"/>
+        <source>Customize</source>
+        <translation>ຈຸດປະສິດທິພາບ</translation>
+    </message>
+    <message>
+        <location filename="../src/common/settings.cpp" line="145"/>
+        <source>Normal</source>
+        <translation>ປະເພຼັກຊັນ</translation>
+    </message>
+    <message>
+        <location filename="../src/common/settings.cpp" line="145"/>
+        <source>Maximum</source>
+        <translation>ລើងវិញ</translation>
+    </message>
+    <message>
+        <location filename="../src/common/settings.cpp" line="145"/>
+        <source>Fullscreen</source>
+        <translation>fullscreen</translation>
+    </message>
+    <message>
+        <location filename="../src/common/settings.cpp" line="438"/>
+        <source>This shortcut conflicts with system shortcut %1</source>
+        <translation>Shortcut %1 ཅង្ប៉າងກັບ system shortcut</translation>
+    </message>
+    <message>
+        <location filename="../src/common/settings.cpp" line="440"/>
+        <source>This shortcut conflicts with %1, click on Replace to make this shortcut effective immediately</source>
+        <translation>ນີ້ແມ່ນ shortcut བ່າຍຂ້ອງຂ້ີ້ມົນ %1, དີ້ກັບຄັນ, ཊັ້ນເປັນ Replace རັບໄດ້ ཁົວໄດ້ དັ້ນ</translation>
+    </message>
+    <message>
+        <location filename="../src/common/settings.cpp" line="606"/>
+        <source>The shortcut %1 is invalid, please set another one.</source>
+        <translation>Shortcut %1 བໍ່ຖືກນັກໃຊ້ໄດ້, དັ້ງນີ້ དີ້ ཐັງ ད້າວ དັ້ງນີ້ ང དີ້ དັ້ງນີ້ ང དີ້ དັ້ງນີ້ ང དີ້ དັ້ງນີ້ ང དີ້ དັ້ງນີ້ ང དີ້ དັ້ງນີ້ ང དີ້ དັ້ງນີ້ ང དີ້ དັ້ງນີ້ ང དີ້ དັ້ງນີ້ ང དີ້ དັ້ງນີ້ ང དີ້ དັ້ງນີ້ ང དີ້ དັ້ງນີ້ ང དີ་</translation>
+    </message>
+    <message>
+        <location filename="../src/common/settings.cpp" line="653"/>
+        <source>Cancel</source>
+        <translation>ຍົກເລື່ອງ</translation>
+    </message>
+    <message>
+        <location filename="../src/common/settings.cpp" line="654"/>
+        <source>Replace</source>
+        <translation>ແທນທີ້</translation>
+    </message>
+    <message>
+        <location filename="../src/common/settings.cpp" line="656"/>
+        <source>OK</source>
+        <translation>ຕິດຕາມ</translation>
+    </message>
+</context>
+<context>
+    <name>StartManager</name>
+    <message>
+        <location filename="../src/startmanager.cpp" line="368"/>
+        <source>Untitled %1</source>
+        <translation>Untitled %1</translation>
+    </message>
+</context>
+<context>
+    <name>Tabbar</name>
+    <message>
+        <location filename="../src/controls/tabbar.cpp" line="567"/>
+        <source>Close tab</source>
+        <translation>ປຸງປະດີງ མົງ</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/tabbar.cpp" line="568"/>
+        <source>Close other tabs</source>
+        <translation>ປຸງປະດີງ མົງອື່ນ</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/tabbar.cpp" line="569"/>
+        <source>More options</source>
+        <translation>ອີ້ນີ້ມີຫຼາຍວົງຢານ</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/tabbar.cpp" line="570"/>
+        <source>Close tabs to the left</source>
+        <translation>ປຸງປະດີງ མົງທີ່ຢັນຂວາ</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/tabbar.cpp" line="571"/>
+        <source>Close tabs to the right</source>
+        <translation>ປຸງປະດີງ མົງທີ່ຢັນຊ່ວງການ</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/tabbar.cpp" line="572"/>
+        <source>Close unmodified tabs</source>
+        <translation>ປຸງປະດີງ མົງທີ່ບໍ່ຖືກແກນແລ້ງ</translation>
+    </message>
+</context>
+<context>
+    <name>TextEdit</name>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="283"/>
+        <source>Undo</source>
+        <translation>ຍល់លើ</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="284"/>
+        <source>Redo</source>
+        <translation>ຍល់ລືງ</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="285"/>
+        <source>Cut</source>
+        <translation>ຕັດ</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="286"/>
+        <source>Copy</source>
+        <translation>ຄຸນມາ</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="287"/>
+        <source>Paste</source>
+        <translation>ຫຼືອົງ</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="288"/>
+        <source>Delete</source>
+        <translation>ລກງ</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="289"/>
+        <source>Select All</source>
+        <translation>ເລັ້ງທີ່ງ້າ</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="290"/>
+        <source>Find</source>
+        <translation>ຊອກຫາ</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="291"/>
+        <source>Replace</source>
+        <translation>ແທນທີ່</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="292"/>
+        <source>Go to Line</source>
+        <translation>ປະ້ອງແຖບ</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="293"/>
+        <source>Turn on Read-Only mode</source>
+        <translation>ເປັນ mode ངບັ້ງ</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="294"/>
+        <source>Turn off Read-Only mode</source>
+        <translation>ປັ້ນ off mode ངບັ້ງ</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="295"/>
+        <source>Fullscreen</source>
+        <translation>ລະບົງຮັບ</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="296"/>
+        <source>Exit fullscreen</source>
+        <translation>ອອກຈາກລະບົງຮັບ</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="297"/>
+        <source>Display in file manager</source>
+        <translation>ສະແບບໃຫ້ເບ຺້ມັນໃນໂຄງການເອົ້າຊື່ມັນ</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="298"/>
+        <source>Add Comment</source>
+        <translation>เพิ่มความคิดเห็น</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="299"/>
+        <source>Text to Speech</source>
+        <translation>ข้อความเป็นเสียง</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="300"/>
+        <source>Stop reading</source>
+        <translation>หยุดอ่าน</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="301"/>
+        <source>Speech to Text</source>
+        <translation>เสียงเป็นข้อความ</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="302"/>
+        <source>Translate</source>
+        <translation>แปลภาษา</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="303"/>
+        <source>Column Mode</source>
+        <translation>โหมดคอลัมน์</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="304"/>
+        <source>Add bookmark</source>
+        <translation>เพิ่มการติดป้าย</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="305"/>
+        <source>Remove Bookmark</source>
+        <translation>ลบการติดป้าย</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="306"/>
+        <source>Previous bookmark</source>
+        <translation>ป้ายก่อนหน้า</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="307"/>
+        <source>Next bookmark</source>
+        <translation>ป้ายถัดไป</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="308"/>
+        <source>Remove All Bookmarks</source>
+        <translation>ลบ semua การติดป้าย</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="309"/>
+        <source>Fold All</source>
+        <translation>ยับยองทั้งหมด</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="310"/>
+        <source>Fold Current Level</source>
+        <translation>ยับยองระดับปัจจุบัน</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="311"/>
+        <source>Unfold All</source>
+        <translation>ขยายทั้งหมด</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="312"/>
+        <source>Unfold Current Level</source>
+        <translation>ขยายระดับปัจจุบัน</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="317"/>
+        <source>Color Mark</source>
+        <translation>ກំណត់ពណ៌</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="321"/>
+        <source>Clear All Marks</source>
+        <translation>លើчистить всі ознаки</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="322"/>
+        <source>Clear Last Mark</source>
+        <translation>លើчистить ознаку</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="331"/>
+        <source>Mark</source>
+        <translation>ກំណត់</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="343"/>
+        <source>Mark All</source>
+        <translation>ກំណត់ всі</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="351"/>
+        <source>Remove Comment</source>
+        <translation>លើдалити комментарий</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="2748"/>
+        <source>Copy failed: not enough memory</source>
+        <translation>&apos;Сбой копирования: недостаточно памяти&apos;</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="2843"/>
+        <source>Press ALT and click lines to edit in column mode</source>
+        <translation>Нажмите ALT и щелкните линии для редактирования в столбцовом режиме</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="394"/>
+        <source>Change Case</source>
+        <translation>Изменить регистр</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="395"/>
+        <source>Upper Case</source>
+        <translation>Заглавные буквы</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="396"/>
+        <source>Lower Case</source>
+        <translation>Строчные буквы</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="397"/>
+        <source>Capitalize</source>
+        <translation>Заглавная первая буква</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="78"/>
+        <source>None</source>
+        <translation>Ничего</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="1189"/>
+        <source>Selected line(s) copied</source>
+        <translation>Скопировано выбранных строк</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="1195"/>
+        <source>Current line copied</source>
+        <translation>Скопирована текущая строка</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="1220"/>
+        <source>Selected line(s) clipped</source>
+        <translation>ລូຫ្គំបានត្រូវបានកាត់ចេញ</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="1231"/>
+        <source>Current line clipped</source>
+        <translation>គ្រប់គ្រាន់បានត្រូវបានកាត់ចេញ</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="2762"/>
+        <source>Paste failed: not enough memory</source>
+        <translation>ត្រូវបានត្រូវបានចំនុចចែកទុកដោយសម្រែកមិនគ្រប់គ្រាន់</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="3859"/>
+        <source>Read-Only mode is off</source>
+        <translation>មードអាចបកិច្ចគួរើមគឺបុរាណ</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="3869"/>
+        <source>Read-Only mode is on</source>
+        <translation>មードអាចបកិច្ចគួរើមគឺថ្មី</translation>
+    </message>
+</context>
+<context>
+    <name>WarningNotices</name>
+    <message>
+        <location filename="../src/controls/warningnotices.cpp" line="24"/>
+        <source>Reload</source>
+        <translation>ផ្ទុកឡើងវិញ</translation>
+    </message>
+</context>
+<context>
+    <name>Window</name>
+    <message>
+        <location filename="../src/controls/warningnotices.cpp" line="25"/>
+        <source>Save as</source>
+        <translation>រក្សាទុកជាមួយ</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="492"/>
+        <source>New window</source>
+        <translation>ប្រព័ន្ធដេកថ្មី</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="493"/>
+        <source>New tab</source>
+        <translation>ប្រភេទបង្គែលថ្មី</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="494"/>
+        <source>Open file</source>
+        <translation>បុរាណលើកទូទៅលើខូចតុក</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="495"/>
+        <source>Save</source>
+        <translation>រក្សាទុក</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="497"/>
+        <source>Print</source>
+        <translation>រុញ</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="498"/>
+        <source>Switch theme</source>
+        <translation>ប្រែបប្រូបសម្រែក</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="499"/>
+        <source>Settings</source>
+        <translation>ការកំណត់</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="618"/>
+        <source>Read-Only</source>
+        <translation>អាចបកិច្ចគួរើម</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="634"/>
+        <source>You do not have permission to open %1</source>
+        <translation>ບ្រាកដណាស់: អ្នកគ្រប់គ្រោះមិនមានសិទ្ធិទៅបុក %1</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="674"/>
+        <source>Invalid file: %1</source>
+        <translation>ឯកសារមិនទាន់បញ្ហា: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="806"/>
+        <source>Do you want to save this file?</source>
+        <translation>តុល្យាក់: អ្នកចងក្រងឯកសារនេះទៅដោយត្រឹមត្រូវទេ?</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1143"/>
+        <source>You do not have permission to save %1</source>
+        <translation>ບ្រាកដណាស់: អ្នកគ្រប់គ្រោះមិនមានសិទ្ធិទៅរក្សាបន្ថែង %1</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1163"/>
+        <source>Saved successfully</source>
+        <translation>រក្សាបានជាសេចក្តីជ័យជាទិច</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1199"/>
+        <source>Save File</source>
+        <translation>រក្សាបន្ថែងឯកសារ</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1304"/>
+        <source>Encoding</source>
+        <translation>ការប៉ាន់ស្មាន</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1557"/>
+        <source>Read-Only mode is on</source>
+        <translation>លក្ខខណ្ឌអានប្រហែលគ្រប់គ្រោះតែប៉ុណ្ណ័ត្នត្រូវបានបុរាណ</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="2035"/>
+        <source>Current location remembered</source>
+        <translation>ទីតាំងបច្ចុប្បន្នត្រូវបានចុចចុចច្រើនលើក</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="2103"/>
+        <source>Ctrl+&apos;=&apos;</source>
+        <translation>Ctrl+&apos;=&apos;</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="2106"/>
+        <source>Ctrl+&apos;-&apos;</source>
+        <translation>Ctrl+&apos;-&apos;</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="2135"/>
+        <source>Editor</source>
+        <translation>កម្រុមកំណត់</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="2717"/>
+        <source>Untitled %1</source>
+        <translation>មិនមានឈ្មោះ %1</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="3081"/>
+        <source>Cancel</source>
+        <translation>បញ្ចាញចេញ</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="3082"/>
+        <source>Discard</source>
+        <translation>ប៉ាប៉ាល់</translation>
+    </message>
+</context>
+</TS>

--- a/translations/desktop/desktop_lo.ts
+++ b/translations/desktop/desktop_lo.ts
@@ -1,0 +1,20 @@
+<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="lo">
+<context>
+    <name>desktop</name>
+    <message>
+        <location filename="Desktop Entry]Name" line="0"/>
+        <source>Deepin Text Editor</source>
+        <translation>ແປິນ བົດບົວພີ່ມ</translation>
+    </message>
+    <message>
+        <location filename="Desktop Entry]GenericName" line="0"/>
+        <source>Text Editor</source>
+        <translation>ບົດບົວພີ່ມ</translation>
+    </message>
+    <message>
+        <location filename="Desktop Entry]Comment" line="0"/>
+        <source>Simple and easy to use text editor</source>
+        <translation>ງ່າຍໃຊ້ འງົບ ཀົງ ཐົງ</translation>
+    </message>
+</context>
+</TS>


### PR DESCRIPTION
log: Translation update

## Summary by Sourcery

Update package version and add Lao locale translations for the text editor and its desktop entry

Enhancements:
- Bump deepin-editor version to 6.5.33.1 in all manifest files
- Introduce Lao locale translation files for the application (deepin-editor_lo.ts) and desktop entry (desktop_lo.ts)