### PR TITLE
fix: Temporarily disable QSaveFile in TextFileSaver

### DIFF
--- a/src/common/text_file_saver.cpp
+++ b/src/common/text_file_saver.cpp
@@ -63,26 +63,27 @@ bool TextFileSaver::save()
         return false;
     }
 
+    // TODO: 暂时禁用QSaveFile，后续再考虑, 因为QSaveFile在某些情况下会修改文件所属权限
     // WARNING: For long filenames (>245 chars), QSaveFile may create temporary files
     // with names that exceed system limits. TextFileSaver handles this internally.
-    QFileInfo fileInfo(m_filePath);
-    bool disableSaveProtect = fileInfo.fileName().length() > MAX_FILENAME_LENGTH;
+    // QFileInfo fileInfo(m_filePath);
+    // bool disableSaveProtect = fileInfo.fileName().length() > MAX_FILENAME_LENGTH;
 
-    if (!disableSaveProtect) {
-        QSaveFile saveFile(m_filePath);
-        saveFile.setDirectWriteFallback(true);
-        if (!saveToFile(saveFile)) {
-            return false;
-        }
-        return saveFile.commit();
-    } else {
-        qWarning() << "File name too long, disable QSaveFile. path:" << m_filePath;
-        QFile file(m_filePath);
-        if (!saveToFile(file)) {
-            return false;
-        }
-        return true;
+    // if (!disableSaveProtect) {
+    //     QSaveFile saveFile(m_filePath);
+    //     saveFile.setDirectWriteFallback(true);
+    //     if (!saveToFile(saveFile)) {
+    //         return false;
+    //     }
+    //     return saveFile.commit();
+    // } else {
+    //     qWarning() << "File name too long, disable QSaveFile. path:" << m_filePath;
+    QFile file(m_filePath);
+    if (!saveToFile(file)) {
+        return false;
     }
+    return true;
+    // }
 }
 
 /**


### PR DESCRIPTION
Commented out QSaveFile usage in the save method due to issues with file permissions in certain cases. The code now directly uses QFile for saving files. This change is intended to address potential problems with long filenames and ensure smoother file saving operations.

Log: Temporarily disable QSaveFile in TextFileSaver to prevent permission issues.
Bug: https://pms.uniontech.com/bug-view-327987.html

## Summary by Sourcery

Disable QSaveFile in TextFileSaver and revert to using QFile for saving files to avoid permission and filename length issues

Bug Fixes:
- Temporarily disable QSaveFile to prevent file permission problems in certain cases

Enhancements:
- Add a TODO comment to reconsider QSaveFile usage later