### PR TITLE
fix: Add find highlight selection functionality

### DIFF
--- a/src/editor/dtextedit.cpp
+++ b/src/editor/dtextedit.cpp
@@ -2237,6 +2237,13 @@ void TextEdit::clearFindMatchSelections()
     m_findMatchSelections.clear();
 }
 
+void TextEdit::setFindHighlightSelection(const QTextCursor &cursor)
+{
+    qDebug() << "Setting find highlight selection";
+    m_findHighlightSelection.cursor = cursor;
+    qDebug() << "Find highlight selection set to position:" << cursor.position() << "with selection:" << cursor.hasSelection();
+}
+
 void TextEdit::updateCursorKeywordSelection(QString keyword, bool findNext)
 {
     qDebug() << "Updating cursor keyword selection";

--- a/src/editor/dtextedit.h
+++ b/src/editor/dtextedit.h
@@ -204,6 +204,7 @@ public:
     bool highlightKeyword(const QString &keyword, int position, Qt::CaseSensitivity caseFlag = Qt::CaseInsensitive);
     bool highlightKeywordInView(const QString &keyword, Qt::CaseSensitivity caseFlag = Qt::CaseInsensitive);
     void clearFindMatchSelections();
+    void setFindHighlightSelection(const QTextCursor &cursor);
     void updateCursorKeywordSelection(QString keyword, bool findNext);
     void updateHighlightLineSelection();
     bool updateKeywordSelections(QString keyword, QTextCharFormat charFormat, QList<QTextEdit::ExtraSelection> &listSelection);

--- a/src/widgets/window.cpp
+++ b/src/widgets/window.cpp
@@ -3310,6 +3310,19 @@ void Window::slotSwitchToReplaceBar()
             column = cursor.columnNumber();
             scrollOffset = wrapper->textEditor()->verticalScrollBar()->value();
             qDebug() << "Current position - file:" << currentFile << "row:" << row << "column:" << column;
+            if (!searchText.isEmpty()) {
+                // 检查当前光标是否有选中文本，且选中文本与搜索文本匹配
+                QTextCursor currentCursor = wrapper->textEditor()->textCursor();
+                if (currentCursor.hasSelection() && currentCursor.selectedText() == searchText) {
+                    qDebug() << "Current selection matches search text, using it as search pointer";
+                    // 直接将当前选中文本设置为搜索指针
+                    wrapper->textEditor()->setFindHighlightSelection(currentCursor);
+                } else {
+                    qDebug() << "No matching selection, setting search pointer from current position";
+                    // 没有匹配的选中文本，从当前位置搜索
+                    wrapper->textEditor()->updateCursorKeywordSelection(searchText, true);
+                }
+            }
         }
         
         // 隐藏查找栏


### PR DESCRIPTION
- Implemented setFindHighlightSelection method in TextEdit to set the current cursor as the highlight selection for find operations.
- Updated Window class to utilize the new method when the current selection matches the search text, enhancing the search experience.

log: Add find highlight selection functionality

bug:  https://pms.uniontech.com/bug-view-331021.html

## Summary by Sourcery

Implement find highlight selection support by adding a new API in TextEdit and updating Window to leverage existing selections for improved search highlighting.

New Features:
- Add setFindHighlightSelection method in TextEdit to record the current cursor selection as the find highlight pointer

Enhancements:
- Enhance search behavior in Window::slotSwitchToReplaceBar to check if the current selection matches the search term and use it for highlighting
- Fall back to updateCursorKeywordSelection when no matching selection is found