### PR TITLE
fix: Fix text-to-speech failure when selecting all text

### DIFF
--- a/src/editor/dtextedit.cpp
+++ b/src/editor/dtextedit.cpp
@@ -2702,6 +2702,23 @@ void TextEdit::setSelectAll()
     m_bIsAltMod = false;
     m_isSelectAll = true;
     selectTextInView();
+
+    if (!document()->isEmpty()) {
+        if (auto clip = qApp->clipboard()) {
+            // limit the size of the text to avoid performance issue
+            static const int kMaxSelectCount = 200000;
+            int charCount = document()->characterCount();
+
+            if (charCount < kMaxSelectCount) {
+                clip->setText(toPlainText(), QClipboard::Selection);
+            } else {
+                auto selectCursor = textCursor();
+                selectCursor.setPosition(0);
+                selectCursor.setPosition(kMaxSelectCount, QTextCursor::KeepAnchor);
+                clip->setText(selectCursor.selectedText(), QClipboard::Selection);
+            }
+        }
+    }
 }
 
 void TextEdit::slotSigColorSelected(bool bSelected, QColor color)


### PR DESCRIPTION
Resolved an issue where using "Select All" (Ctrl+A) or right-clicking "Text-to-Speech" would not read the full text due to selection invalidation. The notepad now manually handles
 selection from start to maximum limit position.

Log: Fix full-text reading failure in notepad
Bug: https://pms.uniontech.com/bug-view-332067.html

## Summary by Sourcery

Bug Fixes:
- Handle “Select All” selections by explicitly loading the text into the clipboard (up to 200k characters) so text-to-speech can read the entire content