### PR TITLE
chore: Update version to 6.5.37

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.editor
   name: "deepin-editor"
-  version: 6.5.36.1
+  version: 6.5.37.1
   kind: app
   description: |
     editor for deepin os.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-editor (6.5.37) unstable; urgency=medium
+
+  * fix: Optimize mark removal logic in TextEdit and enhance file path handling in Window
+
+ -- dengzhongyuan <dengzhongyuan@uniontech.com>  Thu, 04 Sep 2025 17:02:39 +0800
+
 deepin-editor (6.5.36) unstable; urgency=medium
 
   * Update version to 6.5.36.

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.editor
   name: "deepin-editor"
-  version: 6.5.36.1
+  version: 6.5.37.1
   kind: app
   description: |
     editor for deepin os.

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -10,7 +10,7 @@ version: "1"
 package:
   id: org.deepin.editor
   name: "deepin-editor"
-  version: 6.5.36.1
+  version: 6.5.37.1
   kind: app
   description: |
     editor for deepin os.


### PR DESCRIPTION
- update version to 6.5.37

 log: update version to 6.5.37

## Summary by Sourcery

Bump deepin-editor package version to 6.5.37.1 across YAML manifests and update the Debian changelog

Chores:
- Update arm64, loong64, and default linglong.yaml manifests to version 6.5.37.1
- Update debian/changelog to reflect new version 6.5.37