### PR TITLE
chore: Update linglong base and runtime

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -7,13 +7,13 @@ version: "1"
 package:
   id: org.deepin.editor
   name: "deepin-editor"
-  version: 6.5.37.1
+  version: 6.5.38.1
   kind: app
   description: |
     editor for deepin os.
 
-base: org.deepin.base/25.2.0/arm64
-runtime: org.deepin.runtime.webengine/25.2.0/arm64
+base: org.deepin.base/25.2.1/arm64
+runtime: org.deepin.runtime.webengine/25.2.1/arm64
 
 command:
   - deepin-editor

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-editor (6.5.38) unstable; urgency=medium
+
+  * chore: Update linglong base and runtime
+
+ -- wangrong <wangrong@uniontech.com>  Wed, 17 Sep 2025 11:25:22 +0800
+
 deepin-editor (6.5.37) unstable; urgency=medium
 
   * fix: Optimize mark removal logic in TextEdit and enhance file path handling in Window

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,13 +7,13 @@ version: "1"
 package:
   id: org.deepin.editor
   name: "deepin-editor"
-  version: 6.5.37.1
+  version: 6.5.38.1
   kind: app
   description: |
     editor for deepin os.
 
-base: org.deepin.base/25.2.0
-runtime: org.deepin.runtime.webengine/25.2.0
+base: org.deepin.base/25.2.1
+runtime: org.deepin.runtime.webengine/25.2.1
 
 command:
   - deepin-editor

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -10,13 +10,13 @@ version: "1"
 package:
   id: org.deepin.editor
   name: "deepin-editor"
-  version: 6.5.37.1
+  version: 6.5.38.1
   kind: app
   description: |
     editor for deepin os.
 
-base: org.deepin.base/25.2.0/loong64
-runtime: org.deepin.runtime.webengine/25.2.0/loong64
+base: org.deepin.base/25.2.1/loong64
+runtime: org.deepin.runtime.webengine/25.2.1/loong64
 
 command:
   - deepin-editor


### PR DESCRIPTION
Update linglong base and runtime

Log: Update linglong base and runtime

## Summary by Sourcery

Bump Deepin Editor version and update Linglong base and runtime dependencies across architectures.

Enhancements:
- Bump Deepin Editor package version to 6.5.38.1
- Update Linglong base dependency to org.deepin.base/25.2.1
- Update Linglong runtime dependency to org.deepin.runtime.webengine/25.2.1