### PR TITLE
fix(editor): change find/replace default to case-sensitive

### DIFF
--- a/src/editor/dtextedit.h
+++ b/src/editor/dtextedit.h
@@ -1,4 +1,4 @@
-﻿// SPDX-FileCopyrightText: 2011-2023 UnionTech Software Technology Co., Ltd.
+﻿// SPDX-FileCopyrightText: 2011-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -193,23 +193,23 @@ public:
     void setFontSize(qreal fontSize);
     void updateFont();
 
-    void replaceAll(const QString &replaceText, const QString &withText, Qt::CaseSensitivity caseFlag = Qt::CaseInsensitive);
-    void replaceNext(const QString &replaceText, const QString &withText, Qt::CaseSensitivity caseFlag = Qt::CaseInsensitive);
-    void replaceRest(const QString &replaceText, const QString &withText, Qt::CaseSensitivity caseFlag = Qt::CaseInsensitive);
-    void beforeReplace(const QString &strReplaceText, Qt::CaseSensitivity caseFlag = Qt::CaseInsensitive);
+    void replaceAll(const QString &replaceText, const QString &withText, Qt::CaseSensitivity caseFlag = Qt::CaseSensitive);
+    void replaceNext(const QString &replaceText, const QString &withText, Qt::CaseSensitivity caseFlag = Qt::CaseSensitive);
+    void replaceRest(const QString &replaceText, const QString &withText, Qt::CaseSensitivity caseFlag = Qt::CaseSensitive);
+    void beforeReplace(const QString &strReplaceText, Qt::CaseSensitivity caseFlag = Qt::CaseSensitive);
 
     bool findKeywordForward(const QString &keyword);
 
     void removeKeywords();
-    bool highlightKeyword(const QString &keyword, int position, Qt::CaseSensitivity caseFlag = Qt::CaseInsensitive);
-    bool highlightKeywordInView(const QString &keyword, Qt::CaseSensitivity caseFlag = Qt::CaseInsensitive);
+    bool highlightKeyword(const QString &keyword, int position, Qt::CaseSensitivity caseFlag = Qt::CaseSensitive);
+    bool highlightKeywordInView(const QString &keyword, Qt::CaseSensitivity caseFlag = Qt::CaseSensitive);
     void clearFindMatchSelections();
     void setFindHighlightSelection(const QTextCursor &cursor);
     void updateCursorKeywordSelection(QString keyword, bool findNext);
     void updateHighlightLineSelection();
     bool updateKeywordSelections(QString keyword, QTextCharFormat charFormat, QList<QTextEdit::ExtraSelection> &listSelection);
     bool updateKeywordSelectionsInView(QString keyword, QTextCharFormat charFormat, QList<QTextEdit::ExtraSelection> *listSelection,
-                                       Qt::CaseSensitivity caseFlag = Qt::CaseInsensitive);
+                                       Qt::CaseSensitivity caseFlag = Qt::CaseSensitive);
     bool searchKeywordSeletion(QString keyword, QTextCursor cursor, bool findNext);
     void renderAllSelections();
 
@@ -553,7 +553,7 @@ public slots:
 
     void moveText(int from, int to, const QString& text, bool copy = false);
     QTextCursor findCursor(const QString &substr, const QString &text, int from, bool backward = false, int cursorPos = 0,
-                           Qt::CaseSensitivity caseFlag = Qt::CaseInsensitive);
+                           Qt::CaseSensitivity caseFlag = Qt::CaseSensitive);
     void onPressedLineNumber(const QPoint& point);
     QString selectedText(bool checkCRLF = false);
     void onEndlineFormatChanged(BottomBar::EndlineFormat from,BottomBar::EndlineFormat to);
@@ -608,7 +608,7 @@ private:
     // 计算颜色标记替换信息列表
     void calcMarkReplaceList(QList<TextEdit::MarkReplaceInfo> &replaceList, const QString &oldText,
                              const QString &replaceText, const QString &withText, int offset = 0,
-                             Qt::CaseSensitivity caseFlag = Qt::CaseInsensitive) const;
+                             Qt::CaseSensitivity caseFlag = Qt::CaseSensitive) const;
     // 查找行号line起始的折叠区域
     bool findFoldBlock(int line, QTextBlock &beginBlock, QTextBlock &endBlock, QTextBlock &curBlock);
 
@@ -868,6 +868,6 @@ private:
     bool m_isPreeditBefore = false;     // 上一个输入法时间是否是 preedit
     int m_preeditLengthBefore = 0;
 
-    Qt::CaseSensitivity defaultCaseSensitive = Qt::CaseInsensitive; // 查找匹配时默认不区分
+    Qt::CaseSensitivity defaultCaseSensitive = Qt::CaseSensitive; // 查找匹配时默认区分大小写
 };
 #endif


### PR DESCRIPTION
Change all CaseSensitivity default parameters from CaseInsensitive to CaseSensitive in replace and highlight methods to ensure exact matches.

将查找替换相关方法的 CaseSensitivity 默认参数从不区分大小写改为
区分大小写，确保替换操作和高亮定位行为一致。

Log: 修复替换操作未区分大小写的问题
PMS: BUG-282071
Influence: 查找和替换功能现在默认区分大小写，输入大写A只匹配大写A，不再误匹配小写a。