### PR TITLE
fix: sync customize keymap when reverting invalid shortcut

### DIFF
--- a/src/common/settings.cpp
+++ b/src/common/settings.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2011-2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2011-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -371,7 +371,10 @@ QPair<QWidget *, QWidget *> Settings::createKeySequenceEditHandle(QObject *obj)
             instance()->m_pDialog = instance()->createDialog(reason, "", bIsConflicts);
             instance()->m_pDialog->exec();
             // 恢复组合键序列
-            shortCutLineEdit->setKeySequence(instance()->settings->value(keySplitList.join(".")).toString());
+            QString currentValidValue = instance()->settings->value(checkName).toString();
+            QStringList customizeKeySplitList = option->key().split(".");
+            customizeKeySplitList[1] = QString("%1_keymap_customize").arg(customizeKeySplitList[1]);
+            instance()->settings->option(customizeKeySplitList.join("."))->setValue(currentValidValue);
             keymap->setValue("emacs");
             keymap->setValue("customize");
             qDebug() << "Leaving createKeySequenceEditHandle";


### PR DESCRIPTION
When a shortcut is set to an invalid key (e.g. Ctrl+Shift+L), the revert uses the visible option's current value and syncs it to the hidden customize keymap, preventing stale data from overwriting on keymap switch.

修复快捷键设为无效组合键后恢复值不正确的问题，同步更新customize
keymap避免后续keymap切换时用脏数据覆盖。

Log: 修复无效快捷键恢复时使用了旧值的问题
PMS: BUG-353289
Influence: 用户设置无效快捷键后，快捷键将正确恢复为当前有效值而非之前的自定义值。