### PR TITLE
fix(editor): restore CRLF line ending conversion when saving files

### DIFF
--- a/src/common/text_file_saver.cpp
+++ b/src/common/text_file_saver.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2025 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -55,6 +55,11 @@ void TextFileSaver::setEncoding(const QByteArray &toEncode)
 {
     qDebug() << "Setting target encoding to:" << toEncode;
     m_toEncode = toEncode;
+}
+
+void TextFileSaver::setEndlineFormat(bool useCRLF)
+{
+    m_useCRLF = useCRLF;
 }
 
 /**
@@ -150,7 +155,10 @@ bool TextFileSaver::saveToFile(QFileDevice &file)
             return false;
         }
         qDebug() << "memory sufficient";
-        const QString content = m_document->toPlainText();
+        QString content = m_document->toPlainText();
+        if (m_useCRLF) {
+            content.replace(QStringLiteral("\n"), QStringLiteral("\r\n"));
+        }
         const ushort *data = content.utf16();
         const int length = content.length();
 

--- a/src/common/text_file_saver.h
+++ b/src/common/text_file_saver.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2025 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -19,6 +19,7 @@ public:
 
     void setFilePath(const QString &filePath);
     void setEncoding(const QByteArray &toEncode);
+    void setEndlineFormat(bool useCRLF);
     bool save();
     bool saveAs(const QString &newFilePath);
     QString errorString() const;
@@ -32,6 +33,7 @@ private:
     QString m_filePath;
     QByteArray m_fromEncode; // default is UTF-16 (QString)
     QByteArray m_toEncode;   // default is UTF-8
+    bool m_useCRLF = false;
     QString m_errorString;
     static const int MAX_FILENAME_LENGTH = 245;
 };

--- a/src/editor/editwrapper.cpp
+++ b/src/editor/editwrapper.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2017 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -262,7 +262,8 @@ bool EditWrapper::saveAsFile(const QString &newFilePath, const QByteArray &encod
     TextFileSaver saver(m_pTextEdit->document());
     saver.setFilePath(newFilePath);
     saver.setEncoding(encodeName);
-    
+    saver.setEndlineFormat(m_pBottomBar->getEndlineFormat() == BottomBar::EndlineFormat::Windows);
+
     bool saveSuccess = saver.save();
     if (!saveSuccess) {
         qWarning() << "Failed to save file:" << newFilePath << "Error:" << saver.errorString();
@@ -310,7 +311,8 @@ bool EditWrapper::saveAsFile()
         TextFileSaver saver(m_pTextEdit->document());
         saver.setFilePath(newFilePath);
         saver.setEncoding(m_sFirstEncode.toUtf8());
-        
+        saver.setEndlineFormat(m_pBottomBar->getEndlineFormat() == BottomBar::EndlineFormat::Windows);
+
         if (!saver.save()) {
             qWarning() << "EditWrapper saveAsFile, Failed to save file:" << saver.errorString();
             return false;
@@ -603,7 +605,8 @@ bool EditWrapper::saveFile(QByteArray encode)
     TextFileSaver saver(m_pTextEdit->document());
     saver.setFilePath(qstrFilePath);
     saver.setEncoding(m_sCurEncode.toUtf8());
-    
+    saver.setEndlineFormat(m_pBottomBar->getEndlineFormat() == BottomBar::EndlineFormat::Windows);
+
     bool ok = saver.save();
     if (ok) {
         qDebug() << "EditWrapper saveFile, ok is true";
@@ -674,7 +677,8 @@ bool EditWrapper::saveTemFile(QString qstrDir)
     TextFileSaver saver(m_pTextEdit->document());
     saver.setFilePath(qstrDir);
     saver.setEncoding(m_sCurEncode.toUtf8());
-    
+    saver.setEndlineFormat(m_pBottomBar->getEndlineFormat() == BottomBar::EndlineFormat::Windows);
+
     bool ok = saver.save();
     if (ok) {
         qDebug() << "EditWrapper saveTemFile, ok is true";
@@ -782,7 +786,8 @@ bool EditWrapper::saveDraftFile(QString &newFilePath)
         TextFileSaver saver(m_pTextEdit->document());
         saver.setFilePath(newFilePath);
         saver.setEncoding(encode);
-        
+        saver.setEndlineFormat(m_pBottomBar->getEndlineFormat() == BottomBar::EndlineFormat::Windows);
+
         if (!saver.save()) {
             qDebug() << "EditWrapper saveDraftFile, saver.save() failed";
             return false;


### PR DESCRIPTION
Add setEndlineFormat() to TextFileSaver to convert \n to \r\n for Windows format files. All 5 save paths now pass the current endline format to the saver.

修复TextFileSaver重构后丢失CRLF转换逻辑的问题，Windows格式
文件保存后重新打开格式正确显示为Windows。

Log: 修复Windows格式文件保存后换行符丢失的问题
PMS: BUG-342025
Influence: 修复后Windows(CRLF)格式文件保存并重新打开后格式正确显示为Windows，不再回退为Unix。

## Summary by Sourcery

Restore correct handling of Windows (CRLF) line endings when saving text documents via the editor.

Bug Fixes:
- Ensure files saved with Windows (CRLF) line endings preserve that format instead of reverting to Unix (LF) when reopened.

Enhancements:
- Propagate the selected endline format from the editor UI into TextFileSaver so all save paths respect the current line-ending setting.