### PR TITLE
fix(editor): persist file encoding across sessions

### DIFF
--- a/src/common/fileloadthread.cpp
+++ b/src/common/fileloadthread.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2017 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -20,6 +20,11 @@ FileLoadThread::~FileLoadThread()
     qDebug() << "Destroying FileLoadThread for file:" << m_strFilePath;
 }
 
+void FileLoadThread::setEncodeHint(const QByteArray &encode)
+{
+    m_encodeHint = encode;
+}
+
 void FileLoadThread::run()
 {
     qDebug() << "Starting file load thread for:" << m_strFilePath;
@@ -35,7 +40,11 @@ void FileLoadThread::run()
             qDebug() << "Large file detected (" << file.size() << " bytes), using optimized loading strategy";
             // 先读取1MB数据
             indata = file.read(DATA_SIZE_1024 * DATA_SIZE_1024);
-            encode = DetectCode::GetFileEncodingFormat(m_strFilePath, indata);
+            if (!m_encodeHint.isEmpty()) {
+                encode = m_encodeHint;
+            } else {
+                encode = DetectCode::GetFileEncodingFormat(m_strFilePath, indata);
+            }
             qDebug() << "Initial encoding detection result:" << encode;
 
             // 发送文件头信息，用于预先加载数据
@@ -64,7 +73,10 @@ void FileLoadThread::run()
             return;
         }
 
-        if (encode.isEmpty()) {
+        if (!m_encodeHint.isEmpty()) {
+            qDebug() << "Using encoding hint:" << m_encodeHint;
+            encode = m_encodeHint;
+        } else if (encode.isEmpty()) {
             qDebug() << "Performing full encoding detection";
             //编码识别，如果文件数据大于1M，则只裁剪出1M文件数据去做编码探测
             QByteArray dateUsedForCodeIdentify;

--- a/src/common/fileloadthread.h
+++ b/src/common/fileloadthread.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2017 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -14,6 +14,7 @@ public:
     FileLoadThread(const QString &filepath, QObject *QObject = nullptr);
     ~FileLoadThread();
 
+    void setEncodeHint(const QByteArray &encode);
     void run();
 
 signals:
@@ -23,6 +24,7 @@ signals:
 
 private:
     QString m_strFilePath;
+    QByteArray m_encodeHint;
 };
 
 #endif

--- a/src/editor/dtextedit.cpp
+++ b/src/editor/dtextedit.cpp
@@ -5626,6 +5626,28 @@ QStringList TextEdit::readEncodeHistoryRecord()
     return filePathList;
 }
 
+QByteArray TextEdit::getStoredEncode(const QString &filePath)
+{
+    Settings *settings = Settings::instance();
+    if (!settings) return QByteArray();
+
+    QString history = settings->settings->option("advance.editor.browsing_encode_history")->value().toString();
+    QString pattern = "*{*[" + filePath + "]*";
+    int pos = history.indexOf(pattern);
+    if (pos == -1) return QByteArray();
+
+    int encodeStart = pos + pattern.length();
+    int encodeEnd = history.indexOf("}*", encodeStart);
+    if (encodeEnd == -1) return QByteArray();
+
+    return history.mid(encodeStart, encodeEnd - encodeStart).toLocal8Bit();
+}
+
+void TextEdit::setTextEncode(const QString &encode)
+{
+    m_textEncode = encode;
+}
+
 void TextEdit::tellFindBarClose()
 {
     qDebug() << "Tell find bar close";

--- a/src/editor/dtextedit.h
+++ b/src/editor/dtextedit.h
@@ -414,6 +414,8 @@ public:
     void setCursorStart(int pos);
     void writeEncodeHistoryRecord();
     QStringList readEncodeHistoryRecord();
+    static QByteArray getStoredEncode(const QString &filePath);
+    void setTextEncode(const QString &encode);
     /**
      * @brief tellFindBarClose 通知查找框关闭
      */

--- a/src/editor/editwrapper.cpp
+++ b/src/editor/editwrapper.cpp
@@ -197,6 +197,12 @@ void EditWrapper::openFile(const QString &filepath, QString qstrTruePath, bool b
 
     FileLoadThread *thread = new FileLoadThread(filepath);
     qDebug() << "Created file load thread for:" << filepath;
+    // 优先使用历史记录的编码
+    QByteArray storedEncode = TextEdit::getStoredEncode(filepath);
+    if (!storedEncode.isEmpty()) {
+        qDebug() << "Using stored encoding from history:" << storedEncode;
+        thread->setEncodeHint(storedEncode);
+    }
     // begin to load the file.
     connect(thread, &FileLoadThread::sigPreProcess, this, &EditWrapper::handleFilePreProcess);
     connect(thread, &FileLoadThread::sigLoadFinished, this, &EditWrapper::handleFileLoadFinished);
@@ -615,6 +621,9 @@ bool EditWrapper::saveFile(QByteArray encode)
         m_tModifiedDateTime = fi.lastModified();
         updateModifyStatus(false);
         m_bIsTemFile = false;
+        // 记录编码到历史，下次打开时优先使用
+        m_pTextEdit->setTextEncode(m_sCurEncode);
+        m_pTextEdit->writeEncodeHistoryRecord();
     } else {
         qDebug() << "EditWrapper saveFile, ok is false";
         DMessageManager::instance()->sendMessage(
@@ -684,6 +693,8 @@ bool EditWrapper::saveTemFile(QString qstrDir)
         qDebug() << "EditWrapper saveTemFile, ok is true";
         m_sFirstEncode = m_sCurEncode;
         updateModifyStatus(isModified());
+        m_pTextEdit->setTextEncode(m_sCurEncode);
+        m_pTextEdit->writeEncodeHistoryRecord();
     }
     qDebug() << "EditWrapper saveTemFile, ok:" << ok;
     return ok;
@@ -799,6 +810,8 @@ bool EditWrapper::saveDraftFile(QString &newFilePath)
         updateSaveAsFileName(m_pTextEdit->getFilePath(), newFilePath);
         m_pTextEdit->document()->setModified(false);
         m_bIsTemFile = false;
+        m_pTextEdit->setTextEncode(m_sCurEncode);
+        m_pTextEdit->writeEncodeHistoryRecord();
         qDebug() << "EditWrapper saveDraftFile, saver.save() success";
         return true;
     }


### PR DESCRIPTION
Activate the existing but unused encoding history mechanism to remember the user's encoding choice per file, skipping unreliable content-based detection on reopen.

激活已有但未接入的编码历史持久化机制，保存时记录编码，
重新打开时优先使用历史编码而非自动检测。

Log: 激活编码历史持久化，修复切换编码保存后重新打开仍显示UTF-8的问题
PMS: BUG-332119
Influence: 修改编码格式保存后重新打开文件，底栏正确显示用户选择的编码格式。

## Summary by Sourcery

Persist and reuse per-file text encoding selections instead of always relying on automatic detection when reopening files.

Bug Fixes:
- Ensure files reopen using the user-selected encoding stored in history rather than defaulting back to UTF-8 or relying solely on detection.

Enhancements:
- Wire the text encoding history into the file loading pipeline so saved encodings act as hints for background file load threads.
- Record the current text encoding to history on save, temp save, and draft save operations for consistent future reopen behavior.