### PR TITLE
fix(editor): prevent freeze when replacing newline characters

### DIFF
--- a/src/editor/dtextedit.cpp
+++ b/src/editor/dtextedit.cpp
@@ -2446,8 +2446,18 @@ bool TextEdit::updateKeywordSelectionsInView(QString keyword, QTextCharFormat ch
             return false;
         }
 
+        int lastMatchPos = -1;
         while (!cursor.isNull()) {
             extra.cursor = cursor;
+            int currentMatchPos = std::min(extra.cursor.position(), extra.cursor.anchor());
+
+            // 防止光标位置未前进导致死循环
+            if (currentMatchPos <= lastMatchPos) {
+                qDebug() << "Updating keyword selections in view, cursor not advancing, break";
+                break;
+            }
+            lastMatchPos = currentMatchPos;
+
             // 调整为不区分大小写
             Qt::CaseSensitivity option = defaultCaseSensitive;
             /* 查找字符时，查找到完全相等的时候才高亮，如查找小写f时，大写的F不高亮 */
@@ -2465,7 +2475,7 @@ bool TextEdit::updateKeywordSelectionsInView(QString keyword, QTextCharFormat ch
                 cursor = document()->find(keyword, cursor, flags);
             }
 
-            if (cursor.position() > endPos) {
+            if (!cursor.isNull() && cursor.position() > endPos) {
                 qDebug() << "Updating keyword selections in view with position greater than end pos, break";
                 break;
             }


### PR DESCRIPTION
Add position advancement check in updateKeywordSelectionsInView while loop to prevent infinite loop when keyword contains newline.

在 updateKeywordSelectionsInView 的 while 循环中添加光标位置推进检查， 防止搜索关键词包含换行符时因光标未前进而导致死循环。

Log: 修复替换换行符时编辑器卡死的问题
PMS: BUG-332113
Influence: 修复后使用替换功能替换换行符不再导致编辑器卡死，替换功能恢复正常。

## Summary by Sourcery

Prevent the editor from freezing when updating keyword selections for replacements involving newline characters by ensuring the search cursor always advances and remains within bounds.

Bug Fixes:
- Add a cursor position advancement check in keyword selection updates to avoid infinite loops when the search keyword includes newline characters.
- Guard the end-of-range check with a null-cursor check to prevent invalid cursor position access during keyword searches.