### PR TITLE
fix(editor): separate find/replace case sensitivity logic

### DIFF
--- a/src/editor/dtextedit.cpp
+++ b/src/editor/dtextedit.cpp
@@ -2134,10 +2134,10 @@ void TextEdit::replaceNext(const QString &replaceText, const QString &withText, 
         new InsertTextUndoCommand(cursor, withText, this, pChangeMark);
         m_pUndoStack->push(pChangeMark);
         ensureCursorVisible();
+        // Update cursor.
+        setTextCursor(cursor);
     }
 
-    // Update cursor.
-    setTextCursor(cursor);
     highlightKeyword(replaceText, getPosition(), caseFlag);
     qDebug() << "Replace all operation completed for:" << replaceText.left(20);
 }
@@ -2277,7 +2277,7 @@ bool TextEdit::highlightKeyword(const QString &keyword, int position, Qt::CaseSe
     Q_UNUSED(position)
     m_findMatchSelections.clear();
     updateHighlightLineSelection();
-    updateCursorKeywordSelection(keyword, true);
+    updateCursorKeywordSelection(keyword, true, caseFlag);
     bool bRet = updateKeywordSelectionsInView(keyword, m_findMatchFormat, &m_findMatchSelections, caseFlag);
     renderAllSelections();
 
@@ -2311,17 +2311,18 @@ void TextEdit::setFindHighlightSelection(const QTextCursor &cursor)
     qDebug() << "Find highlight selection set to position:" << cursor.position() << "with selection:" << cursor.hasSelection();
 }
 
-void TextEdit::updateCursorKeywordSelection(QString keyword, bool findNext)
+void TextEdit::updateCursorKeywordSelection(QString keyword, bool findNext,
+                                             Qt::CaseSensitivity caseFlag)
 {
     qDebug() << "Updating cursor keyword selection";
-    bool findOne = searchKeywordSeletion(keyword, textCursor(), findNext);
+    bool findOne = searchKeywordSeletion(keyword, textCursor(), findNext, caseFlag);
 
     qDebug() << "Updating cursor keyword selection successfully: " << findOne;
     if (!findOne) {
         qDebug() << "Updating cursor keyword selection with no find";
         QTextCursor cursor = textCursor();
         cursor.movePosition(findNext ? QTextCursor::Start : QTextCursor::End, QTextCursor::MoveAnchor);
-        if (!searchKeywordSeletion(keyword, cursor, findNext)) {
+        if (!searchKeywordSeletion(keyword, cursor, findNext, caseFlag)) {
             m_findHighlightSelection.cursor = textCursor();
             m_findMatchSelections.clear();
             renderAllSelections();
@@ -2489,7 +2490,8 @@ bool TextEdit::updateKeywordSelectionsInView(QString keyword, QTextCharFormat ch
     return false;
 }
 
-bool TextEdit::searchKeywordSeletion(QString keyword, QTextCursor cursor, bool findNext)
+bool TextEdit::searchKeywordSeletion(QString keyword, QTextCursor cursor, bool findNext,
+                                      Qt::CaseSensitivity caseFlag)
 {
     qDebug() << "Searching keyword seletion";
     if (keyword.isEmpty()) {
@@ -2503,7 +2505,7 @@ bool TextEdit::searchKeywordSeletion(QString keyword, QTextCursor cursor, bool f
     if (findNext) {
         qDebug() << "Searching keyword seletion with find next";
         QTextDocument::FindFlags options;
-        if (Qt::CaseSensitive == defaultCaseSensitive) {
+        if (Qt::CaseSensitive == caseFlag) {
             qDebug() << "Searching keyword seletion with find next and case sensitive";
             options |= QTextDocument::FindCaseSensitively;
         }
@@ -2512,7 +2514,7 @@ bool TextEdit::searchKeywordSeletion(QString keyword, QTextCursor cursor, bool f
         if (keyword.contains("\n")) {
             qDebug() << "Searching keyword seletion with find next and contains newline";
             int pos = std::max(cursor.position(), cursor.anchor());
-            next = findCursor(keyword, this->toPlainText(), pos, false, 0, defaultCaseSensitive);
+            next = findCursor(keyword, this->toPlainText(), pos, false, 0, caseFlag);
         }
         if (!next.isNull()) {
             qDebug() << "Searching keyword seletion with find next and not null";
@@ -2524,7 +2526,7 @@ bool TextEdit::searchKeywordSeletion(QString keyword, QTextCursor cursor, bool f
     } else {
         qDebug() << "Searching keyword seletion with find previous";
         QTextDocument::FindFlags options = QTextDocument::FindBackward;
-        if (Qt::CaseSensitive == defaultCaseSensitive) {
+        if (Qt::CaseSensitive == caseFlag) {
             qDebug() << "Searching keyword seletion with find previous and case sensitive";
             options |= QTextDocument::FindCaseSensitively;
         }
@@ -2533,7 +2535,7 @@ bool TextEdit::searchKeywordSeletion(QString keyword, QTextCursor cursor, bool f
         if (keyword.contains("\n")) {
             int pos = std::min(cursor.position(), cursor.anchor());
             qDebug() << "Searching keyword seletion with find previous and contains newline";
-            prev = findCursor(keyword, this->toPlainText().mid(0, pos), -1, true, defaultCaseSensitive);
+            prev = findCursor(keyword, this->toPlainText().mid(0, pos), -1, true, 0, caseFlag);
         }
         if (!prev.isNull()) {
             qDebug() << "Searching keyword seletion with find previous and not null";

--- a/src/editor/dtextedit.h
+++ b/src/editor/dtextedit.h
@@ -201,16 +201,18 @@ public:
     bool findKeywordForward(const QString &keyword);
 
     void removeKeywords();
-    bool highlightKeyword(const QString &keyword, int position, Qt::CaseSensitivity caseFlag = Qt::CaseSensitive);
-    bool highlightKeywordInView(const QString &keyword, Qt::CaseSensitivity caseFlag = Qt::CaseSensitive);
+    bool highlightKeyword(const QString &keyword, int position, Qt::CaseSensitivity caseFlag = Qt::CaseInsensitive);
+    bool highlightKeywordInView(const QString &keyword, Qt::CaseSensitivity caseFlag = Qt::CaseInsensitive);
     void clearFindMatchSelections();
     void setFindHighlightSelection(const QTextCursor &cursor);
-    void updateCursorKeywordSelection(QString keyword, bool findNext);
+    void updateCursorKeywordSelection(QString keyword, bool findNext,
+                                      Qt::CaseSensitivity caseFlag = Qt::CaseInsensitive);
     void updateHighlightLineSelection();
     bool updateKeywordSelections(QString keyword, QTextCharFormat charFormat, QList<QTextEdit::ExtraSelection> &listSelection);
     bool updateKeywordSelectionsInView(QString keyword, QTextCharFormat charFormat, QList<QTextEdit::ExtraSelection> *listSelection,
-                                       Qt::CaseSensitivity caseFlag = Qt::CaseSensitive);
-    bool searchKeywordSeletion(QString keyword, QTextCursor cursor, bool findNext);
+                                       Qt::CaseSensitivity caseFlag = Qt::CaseInsensitive);
+    bool searchKeywordSeletion(QString keyword, QTextCursor cursor, bool findNext,
+                               Qt::CaseSensitivity caseFlag = Qt::CaseInsensitive);
     void renderAllSelections();
 
     bool clearMarkOperationForCursor(QTextCursor cursor);
@@ -555,7 +557,7 @@ public slots:
 
     void moveText(int from, int to, const QString& text, bool copy = false);
     QTextCursor findCursor(const QString &substr, const QString &text, int from, bool backward = false, int cursorPos = 0,
-                           Qt::CaseSensitivity caseFlag = Qt::CaseSensitive);
+                           Qt::CaseSensitivity caseFlag = Qt::CaseInsensitive);
     void onPressedLineNumber(const QPoint& point);
     QString selectedText(bool checkCRLF = false);
     void onEndlineFormatChanged(BottomBar::EndlineFormat from,BottomBar::EndlineFormat to);
@@ -870,6 +872,6 @@ private:
     bool m_isPreeditBefore = false;     // 上一个输入法时间是否是 preedit
     int m_preeditLengthBefore = 0;
 
-    Qt::CaseSensitivity defaultCaseSensitive = Qt::CaseSensitive; // 查找匹配时默认区分大小写
+    Qt::CaseSensitivity defaultCaseSensitive = Qt::CaseInsensitive; // 查找匹配时默认不区分大小写
 };
 #endif


### PR DESCRIPTION
Keep find default as case-insensitive while replace uses case-sensitive. Pass caseFlag through searchKeywordSeletion to prevent cursor jumping to case-mismatched positions during replace.

查找默认不区分大小写，替换默认区分大小写。将caseFlag透传至
searchKeywordSeletion，避免替换时光标跳转到大小写不匹配的位置。

Log: 修复替换时光标跳转到大小写不匹配位置的问题
PMS: BUG-282071
Influence: 查找功能保持不区分大小写，替换功能区分大小写，替换时光标不再跳转到大小写不匹配的位置。

## Summary by Sourcery

Adjust editor find/replace behavior to use case-insensitive search by default while correctly honoring case sensitivity during replace operations.

Bug Fixes:
- Prevent the replace cursor from jumping to positions that only match in a different case than the replacement criteria.

Enhancements:
- Thread case-sensitivity configuration through keyword search and highlighting functions to keep behavior consistent between find and replace.