### PR TITLE
chore: Update version to 6.5.48

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,16 @@
+deepin-editor (6.5.48) unstable; urgency=medium
+
+  * chore: Update version to 6.5.48
+  * fix(editor): separate find/replace case sensitivity logic
+  * fix(editor): prevent freeze when replacing newline characters
+  * fix(editor): persist file encoding across sessions
+  * fix(editor): fix color mark lost when pressing Enter in middle of marked text
+  * fix(editor): restore CRLF line ending conversion when saving files
+  * fix: sync customize keymap when reverting invalid shortcut
+  * fix(editor): change find/replace default to case-sensitive
+
+ -- zhanghongyuan <zhanghongyuan@uniontech.com>  Thu, 16 Apr 2026 21:15:13 +0800
+
 deepin-editor (6.5.47) unstable; urgency=medium
 
   * fix: Update key shortcut for backindentline to Shift+Tab

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.editor
   name: "deepin-editor"
-  version: 6.5.47.1
+  version: 6.5.48.1
   kind: app
   description: |
     editor for deepin os.


### PR DESCRIPTION
- update version to 6.5.48

log: update version to 6.5.48

## Summary by Sourcery

Bump the deepin-editor package version metadata to 6.5.48.1 in linglong configuration.