### PR TITLE
fix(editor): fix blank tab when opening file without read permission

### DIFF
--- a/src/common/fileloadthread.cpp
+++ b/src/common/fileloadthread.cpp
@@ -100,6 +100,9 @@ void FileLoadThread::run()
             emit sigLoadFinished(encode, outData, false);
             qDebug() << "Encoding conversion completed, output size:" << outData.size();
         }
+    } else {
+        qWarning() << "Failed to open file:" << m_strFilePath << "error:" << file.errorString();
+        emit sigLoadFinished("", "", true);
     }
 
     qDebug() << "FileLoadThread finished processing:" << m_strFilePath;

--- a/src/widgets/window.cpp
+++ b/src/widgets/window.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2011 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2011 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -676,12 +676,10 @@ void Window::addTab(const QString &filepath, bool activeTab)
         }
 
         // check if have permission to read the file.
-        QFile file(filepath);
-        QFile::Permissions permissions = file.permissions();
-        bool bIsRead = (permissions & QFile::ReadUser || permissions & QFile::ReadOwner || permissions & QFile::ReadOther);
-        qDebug() << "File permissions:" << permissions << "readable:" << bIsRead;
+        bool bIsReadable = fileInfo.isReadable();
+        qDebug() << "File readable:" << bIsReadable;
 
-        if (fileInfo.exists() && !bIsRead) {
+        if (fileInfo.exists() && !bIsReadable) {
             qWarning() << "No permission to read file:" << filepath;
             DMessageManager::instance()->sendMessage(m_editorWidget->currentWidget(), QIcon(":/images/warning.svg")
                                                      , QString(tr("You do not have permission to open %1")).arg(filepath));


### PR DESCRIPTION
Use QFileInfo::isReadable() instead of manual permission bit check, which incorrectly checked if ANY user had read access rather than the current user. Also add error signal emission in FileLoadThread when file open fails.

使用 QFileInfo::isReadable() 替代手动权限位检查，修复当前用户
无读取权限时仍创建空白标签页的问题。

Log: 修复无权限文件打开时显示空白标签页
PMS: BUG-339655
Influence: 打开无权限文件时不再创建空白标签页，直接提示无权限。

## Summary by Sourcery

Ensure files without read permission do not open as blank tabs and report load failures more robustly.

Bug Fixes:
- Use QFileInfo::isReadable() to correctly respect the current user's read permissions when opening files, avoiding creation of blank editor tabs for unreadable files.
- Emit a failure signal from FileLoadThread when file opening fails so the editor can handle and surface the error instead of silently proceeding.