### PR TITLE
fix(editor): pass caseFlag in replace skip to fix wrong highlight

### DIFF
--- a/src/controls/replacebar.cpp
+++ b/src/controls/replacebar.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2011-2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2011-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -133,7 +133,7 @@ void ReplaceBar::activeInput(QString text, QString file, int row, int column, in
 void ReplaceBar::handleSkip()
 {
     qDebug() << "handleSkip";
-    emit replaceSkip(m_replaceFile, m_replaceLine->lineEdit()->text());
+    emit replaceSkip(m_replaceFile, m_replaceLine->lineEdit()->text(), Qt::CaseSensitive);
 }
 
 void ReplaceBar::replaceClose()

--- a/src/controls/replacebar.h
+++ b/src/controls/replacebar.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2011-2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2011-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -36,7 +36,7 @@ public:
 Q_SIGNALS:
     void pressEsc();
     void replaceNext(QString file, QString replaceText, QString withText);
-    void replaceSkip(QString file, QString keyword);
+    void replaceSkip(QString file, QString keyword, Qt::CaseSensitivity caseFlag);
     void replaceRest(QString replaceText, QString withText);
     void replaceAll(QString replaceText, QString withText);
     void beforeReplace(QString _);

--- a/src/widgets/window.cpp
+++ b/src/widgets/window.cpp
@@ -3419,17 +3419,17 @@ void Window::handleReplaceRest(const QString &replaceText, const QString &withTe
     qDebug() << "handleReplaceRest end";
 }
 
-void Window::handleReplaceSkip(QString file, QString keyword)
+void Window::handleReplaceSkip(QString file, QString keyword, Qt::CaseSensitivity caseFlag)
 {
-    qDebug() << "handleReplaceSkip" << file << keyword;
+    qDebug() << "handleReplaceSkip" << file << keyword << caseFlag;
     EditWrapper *wrapper = currentWrapper();
-    handleUpdateSearchKeyword(m_replaceBar, file, keyword);
+    handleUpdateSearchKeyword(m_replaceBar, file, keyword, caseFlag);
     if (QString::compare(m_keywordForSearch, m_keywordForSearchAll, Qt::CaseInsensitive) != 0) {
         m_keywordForSearchAll.clear();
         wrapper->textEditor()->clearFindMatchSelections();
         qDebug() << "m_keywordForSearchAll is not equal to m_keywordForSearch, clear it";
     } else {
-        wrapper->textEditor()->highlightKeywordInView(m_keywordForSearchAll);
+        wrapper->textEditor()->highlightKeywordInView(m_keywordForSearchAll, caseFlag);
         qDebug() << "m_keywordForSearchAll is equal to m_keywordForSearch, highlight it";
     }
 #if 0
@@ -3450,9 +3450,10 @@ void Window::handleRemoveSearchKeyword()
     qDebug() << "handleRemoveSearchKeyword end";
 }
 
-void Window::handleUpdateSearchKeyword(QWidget *widget, const QString &file, const QString &keyword)
+void Window::handleUpdateSearchKeyword(QWidget *widget, const QString &file, const QString &keyword,
+                                       Qt::CaseSensitivity caseFlag)
 {
-    qDebug() << "handleUpdateSearchKeyword" << file << keyword;
+    qDebug() << "handleUpdateSearchKeyword" << file << keyword << caseFlag;
     if (file == m_tabbar->currentPath() && m_wrappers.contains(file)) {
         qDebug() << "update search keyword";
         EditWrapper* wrapper = m_wrappers.value(file);
@@ -3462,7 +3463,7 @@ void Window::handleUpdateSearchKeyword(QWidget *widget, const QString &file, con
          }
 
         // Update input widget warning status along with keyword match situation.
-        bool findKeyword = wrapper->textEditor()->highlightKeyword(keyword, wrapper->textEditor()->getPosition());
+        bool findKeyword = wrapper->textEditor()->highlightKeyword(keyword, wrapper->textEditor()->getPosition(), caseFlag);
         m_keywordForSearchAll = keyword;
         m_keywordForSearch = keyword;
         bool emptyKeyword = keyword.trimmed().isEmpty();

--- a/src/widgets/window.h
+++ b/src/widgets/window.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2011-2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2011-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -177,10 +177,11 @@ public Q_SLOTS:
     void handleReplaceAll(const QString &replaceText, const QString &withText);
     void handleReplaceNext(const QString &file, const QString &replaceText, const QString &withText);
     void handleReplaceRest(const QString &replaceText, const QString &withText);
-    void handleReplaceSkip(QString file, QString keyword);
+    void handleReplaceSkip(QString file, QString keyword, Qt::CaseSensitivity caseFlag);
 
     void handleRemoveSearchKeyword();
-    void handleUpdateSearchKeyword(QWidget *widget, const QString &file, const QString &keyword);
+    void handleUpdateSearchKeyword(QWidget *widget, const QString &file, const QString &keyword,
+                                   Qt::CaseSensitivity caseFlag = Qt::CaseInsensitive);
 
     void loadTheme(const QString &path);
 

--- a/tests/src/widgets/ut_window.cpp
+++ b/tests/src/widgets/ut_window.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -1502,7 +1502,7 @@ TEST(UT_Window_handleReplaceSkip, UT_Window_handleReplaceSkip)
     window->addTabWithWrapper(a,"aa","aad","aadd",0);
     window->addTabWithWrapper(a,"bb","aad","aadd",1);
     window->m_settings =Settings::instance();
-    window->handleReplaceSkip("aa", "");
+    window->handleReplaceSkip("aa", "", Qt::CaseSensitive);
 
     EXPECT_NE(window,nullptr);
     window->deleteLater();


### PR DESCRIPTION
Pass Qt::CaseSensitive through replaceSkip signal to highlightKeyword and highlightKeywordInView, preventing case-mismatched highlights.

替换跳过时透传 caseFlag 至高亮方法，避免大小写不匹配的选中底色。

Log: 修复替换跳过时大小写不匹配的高亮问题
PMS: BUG-358129
Influence: 替换操作点击跳过后，高亮底色仅匹配相同大小写的内容，不再误匹配。

## Summary by Sourcery

Ensure replace-skip operations respect case sensitivity when updating and highlighting search results.

Bug Fixes:
- Fix incorrect highlight behavior after skipping a replace by propagating the case-sensitivity flag through replaceSkip, search update, and highlight calls.

Tests:
- Update the handleReplaceSkip unit test to use the new case-sensitivity parameter.