### PR TITLE
fix(editor): make tabbar and bottombar follow system font changes

### DIFF
--- a/src/controls/tabbar.cpp
+++ b/src/controls/tabbar.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2017 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -58,6 +58,10 @@ Tabbar::Tabbar(QWidget *parent)
     m_rightClickTab = -1;
 
     installEventFilter(this);
+
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+    qApp->installEventFilter(this);
+#endif
 
     setMovable(true);
     setTabsClosable(true);
@@ -606,7 +610,12 @@ void Tabbar::handleDragActionChanged(Qt::DropAction action)
 
 bool Tabbar::eventFilter(QObject *, QEvent *event)
 {
-    qDebug() << "Enter eventFilter";
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+    if (event->type() == QEvent::ApplicationFontChange) {
+        setFont(qApp->font());
+        return false;
+    }
+#endif
     if (event->type() == QEvent::MouseButtonPress) {
         QMouseEvent *mouseEvent = static_cast<QMouseEvent *>(event);
 

--- a/src/widgets/bottombar.cpp
+++ b/src/widgets/bottombar.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2017 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -55,6 +55,10 @@ BottomBar::BottomBar(QWidget *parent)
     DFontSizeManager::instance()->bind(m_pCursorStatus, DFontSizeManager::T9);
     DFontSizeManager::instance()->bind(m_scaleLabel, DFontSizeManager::T9);
     DFontSizeManager::instance()->bind(m_progressLabel, DFontSizeManager::T9);
+
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+    qApp->installEventFilter(this);
+#endif
 
     initFormatMenu();
 
@@ -279,6 +283,22 @@ DDropdownMenu *BottomBar::getEncodeMenu()
 DDropdownMenu *BottomBar::getHighlightMenu()
 {
     return m_pHighlightMenu;
+}
+
+bool BottomBar::eventFilter(QObject *watched, QEvent *event)
+{
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+    if (event->type() == QEvent::ApplicationFontChange) {
+        QFont font = qApp->font();
+        m_pPositionLabel->setFont(font);
+        m_pCharCountLabel->setFont(font);
+        m_pCursorStatus->setFont(font);
+        m_scaleLabel->setFont(font);
+        m_progressLabel->setFont(font);
+        return false;
+    }
+#endif
+    return QWidget::eventFilter(watched, event);
 }
 
 void BottomBar::paintEvent(QPaintEvent *)

--- a/src/widgets/bottombar.h
+++ b/src/widgets/bottombar.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2017 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -53,6 +53,7 @@ public:
 
 protected:
     void paintEvent(QPaintEvent *);
+    bool eventFilter(QObject *, QEvent *) override;
 
 private:
     void initFormatMenu();

--- a/src/widgets/ddropdownmenu.cpp
+++ b/src/widgets/ddropdownmenu.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2017 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -494,8 +494,11 @@ void DDropdownMenu::OnFontChangedSlot(const QFont &font)
 {
     qDebug() << "DDropdownMenu OnFontChangedSlot";
     m_font = font;
-    int fontsize =DFontSizeManager::instance()->fontPixelSize(DFontSizeManager::T8);
+#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
+    int fontsize = DFontSizeManager::instance()->fontPixelSize(DFontSizeManager::T8);
     m_font.setPixelSize(fontsize);
+#endif
+    m_pToolButton->setFont(m_font);
     m_pToolButton->setIcon(createIcon());
     qDebug() << "DDropdownMenu OnFontChangedSlot end";
 }
@@ -508,8 +511,7 @@ bool DDropdownMenu::eventFilter(QObject *object, QEvent *event)
         // 处理字体变化
         QFont font = qApp->font(); // 获取当前应用程序字体
         OnFontChangedSlot(font);   // 调用槽函数更新字体
-        qDebug() << "DDropdownMenu eventFilter ApplicationFontChange, return true";
-        return true;
+        return false;
     }
 #endif
 


### PR DESCRIPTION
In Qt6, DDropdownMenu's eventFilter returned true for ApplicationFontChange, blocking the event filter chain and preventing Tabbar/BottomBar from receiving the event.

Fix by returning false instead, and adding ApplicationFontChange handling in Tabbar and BottomBar via qApp eventFilter.

Qt6下DDropdownMenu的eventFilter对ApplicationFontChange事件 返回true阻断了事件过滤器链，导致Tabbar和BottomBar无法接收
字体变化事件。修复为返回false，并在Tabbar和BottomBar中添加
ApplicationFontChange事件处理。

Log: 修复标签栏和底部工具栏不跟随系统字体变化的问题
PMS: BUG-358185
Influence: 标签栏文字、底部工具栏文字及下拉菜单文字现在能正确跟随系统字体变化，Qt5行为不受影响。

## Summary by Sourcery

Ensure Tabbar, BottomBar, and dropdown menus respond correctly to system font change events, particularly under Qt6.

Bug Fixes:
- Fix Tabbar text not updating when the system application font changes in Qt6.
- Fix BottomBar labels not updating to follow system font changes in Qt6.
- Fix dropdown menu button text not following application font changes due to event filtering issues in Qt6.

Enhancements:
- Align font handling logic across Tabbar, BottomBar, and dropdown menu so Qt5 behavior remains unchanged while Qt6 correctly uses the application font.