### PR TITLE
fix(editor): hardcode CaseSensitive in replace skip to fix highlight

### DIFF
--- a/src/controls/replacebar.cpp
+++ b/src/controls/replacebar.cpp
@@ -133,7 +133,7 @@ void ReplaceBar::activeInput(QString text, QString file, int row, int column, in
 void ReplaceBar::handleSkip()
 {
     qDebug() << "handleSkip";
-    emit replaceSkip(m_replaceFile, m_replaceLine->lineEdit()->text(), Qt::CaseSensitive);
+    emit replaceSkip(m_replaceFile, m_replaceLine->lineEdit()->text());
 }
 
 void ReplaceBar::replaceClose()

--- a/src/controls/replacebar.h
+++ b/src/controls/replacebar.h
@@ -36,7 +36,7 @@ public:
 Q_SIGNALS:
     void pressEsc();
     void replaceNext(QString file, QString replaceText, QString withText);
-    void replaceSkip(QString file, QString keyword, Qt::CaseSensitivity caseFlag);
+    void replaceSkip(QString file, QString keyword);
     void replaceRest(QString replaceText, QString withText);
     void replaceAll(QString replaceText, QString withText);
     void beforeReplace(QString _);

--- a/src/widgets/window.cpp
+++ b/src/widgets/window.cpp
@@ -3419,17 +3419,17 @@ void Window::handleReplaceRest(const QString &replaceText, const QString &withTe
     qDebug() << "handleReplaceRest end";
 }
 
-void Window::handleReplaceSkip(QString file, QString keyword, Qt::CaseSensitivity caseFlag)
+void Window::handleReplaceSkip(QString file, QString keyword)
 {
-    qDebug() << "handleReplaceSkip" << file << keyword << caseFlag;
+    qDebug() << "handleReplaceSkip" << file << keyword;
     EditWrapper *wrapper = currentWrapper();
-    handleUpdateSearchKeyword(m_replaceBar, file, keyword, caseFlag);
+    handleUpdateSearchKeyword(m_replaceBar, file, keyword, Qt::CaseSensitive);
     if (QString::compare(m_keywordForSearch, m_keywordForSearchAll, Qt::CaseInsensitive) != 0) {
         m_keywordForSearchAll.clear();
         wrapper->textEditor()->clearFindMatchSelections();
         qDebug() << "m_keywordForSearchAll is not equal to m_keywordForSearch, clear it";
     } else {
-        wrapper->textEditor()->highlightKeywordInView(m_keywordForSearchAll, caseFlag);
+        wrapper->textEditor()->highlightKeywordInView(m_keywordForSearchAll, Qt::CaseSensitive);
         qDebug() << "m_keywordForSearchAll is equal to m_keywordForSearch, highlight it";
     }
 #if 0

--- a/src/widgets/window.h
+++ b/src/widgets/window.h
@@ -177,7 +177,7 @@ public Q_SLOTS:
     void handleReplaceAll(const QString &replaceText, const QString &withText);
     void handleReplaceNext(const QString &file, const QString &replaceText, const QString &withText);
     void handleReplaceRest(const QString &replaceText, const QString &withText);
-    void handleReplaceSkip(QString file, QString keyword, Qt::CaseSensitivity caseFlag);
+    void handleReplaceSkip(QString file, QString keyword);
 
     void handleRemoveSearchKeyword();
     void handleUpdateSearchKeyword(QWidget *widget, const QString &file, const QString &keyword,

--- a/tests/src/widgets/ut_window.cpp
+++ b/tests/src/widgets/ut_window.cpp
@@ -1502,7 +1502,7 @@ TEST(UT_Window_handleReplaceSkip, UT_Window_handleReplaceSkip)
     window->addTabWithWrapper(a,"aa","aad","aadd",0);
     window->addTabWithWrapper(a,"bb","aad","aadd",1);
     window->m_settings =Settings::instance();
-    window->handleReplaceSkip("aa", "", Qt::CaseSensitive);
+    window->handleReplaceSkip("aa", "");
 
     EXPECT_NE(window,nullptr);
     window->deleteLater();


### PR DESCRIPTION
Remove Qt::CaseSensitivity from replaceSkip signal to avoid QueuedConnection enum serialization failure. Hardcode CaseSensitive directly in handleReplaceSkip for correct case-sensitive highlight.

替换跳过信号不再传递caseFlag枚举参数，避免QueuedConnection
序列化丢失。在handleReplaceSkip中直接使用CaseSensitive，
确保跳过后仅高亮精确匹配的内容。

Log: 修复替换跳过后大小写不敏感的高亮问题
PMS: BUG-358129
Influence: 替换跳过后高亮仅匹配相同大小写的内容，不再误匹配不同大小写的文本。

## Summary by Sourcery

Ensure replace-skip operations always use case-sensitive matching and highlighting by simplifying the replaceSkip signal/slot interface.

Bug Fixes:
- Fix incorrect case-insensitive highlighting after skipping a replace by forcing case-sensitive matching in the skip handler.

Tests:
- Update the replace-skip unit test to reflect the new signal/slot signature without the case-sensitivity parameter.