### PR TITLE
fix: Skip case insensitive

### DIFF
--- a/src/editor/dtextedit.cpp
+++ b/src/editor/dtextedit.cpp
@@ -1055,10 +1055,12 @@ void TextEdit::nextLine()
     if (m_wrapper != nullptr) {
         qDebug() << "Updating highlighter";
         m_wrapper->OnUpdateHighlighter();
-        if ((m_wrapper->window()->findBarIsVisiable() || m_wrapper->window()->replaceBarIsVisiable()) &&
-                (QString::compare(m_wrapper->window()->getKeywordForSearchAll(), m_wrapper->window()->getKeywordForSearch(), Qt::CaseInsensitive) == 0)) {
+        Window *win = m_wrapper->window();
+        const QString keyword = win->getKeywordForSearchAll();
+        if ((win->findBarIsVisiable() || win->replaceBarIsVisiable()) &&
+                (QString::compare(keyword, win->getKeywordForSearch(), Qt::CaseInsensitive) == 0)) {
             qDebug() << "Highlighting keyword in view";
-            highlightKeywordInView(m_wrapper->window()->getKeywordForSearchAll());
+            highlightKeywordInView(keyword, win->getSearchCaseFlag());
         }
 
         qDebug() << "Marking all keyword in view";
@@ -1090,10 +1092,12 @@ void TextEdit::prevLine()
     if (m_wrapper != nullptr) {
         qDebug() << "Updating highlighter";
         m_wrapper->OnUpdateHighlighter();
-        if ((m_wrapper->window()->findBarIsVisiable() || m_wrapper->window()->replaceBarIsVisiable()) &&
-                (QString::compare(m_wrapper->window()->getKeywordForSearchAll(), m_wrapper->window()->getKeywordForSearch(), Qt::CaseInsensitive) == 0)) {
+        Window *win = m_wrapper->window();
+        const QString keyword = win->getKeywordForSearchAll();
+        if ((win->findBarIsVisiable() || win->replaceBarIsVisiable()) &&
+                (QString::compare(keyword, win->getKeywordForSearch(), Qt::CaseInsensitive) == 0)) {
             qDebug() << "Highlighting keyword in view";
-            highlightKeywordInView(m_wrapper->window()->getKeywordForSearchAll());
+            highlightKeywordInView(keyword, win->getSearchCaseFlag());
         }
 
         qDebug() << "Marking all keyword in view";
@@ -1302,10 +1306,12 @@ void TextEdit::scrollUp()
     if (m_wrapper != nullptr) {
         qDebug() << "Updating highlighter";
         m_wrapper->OnUpdateHighlighter();
-        if ((m_wrapper->window()->findBarIsVisiable() || m_wrapper->window()->replaceBarIsVisiable()) &&
-                (QString::compare(m_wrapper->window()->getKeywordForSearchAll(), m_wrapper->window()->getKeywordForSearch(), Qt::CaseInsensitive) == 0)) {
+        Window *win = m_wrapper->window();
+        const QString keyword = win->getKeywordForSearchAll();
+        if ((win->findBarIsVisiable() || win->replaceBarIsVisiable()) &&
+                (QString::compare(keyword, win->getKeywordForSearch(), Qt::CaseInsensitive) == 0)) {
             qDebug() << "Highlighting keyword in view";
-            highlightKeywordInView(m_wrapper->window()->getKeywordForSearchAll());
+            highlightKeywordInView(keyword, win->getSearchCaseFlag());
         }
 
         markAllKeywordInView();
@@ -1336,10 +1342,12 @@ void TextEdit::scrollDown()
     if (m_wrapper != nullptr) {
         qDebug() << "Updating highlighter";
         m_wrapper->OnUpdateHighlighter();
-        if ((m_wrapper->window()->findBarIsVisiable() || m_wrapper->window()->replaceBarIsVisiable()) &&
-                (QString::compare(m_wrapper->window()->getKeywordForSearchAll(), m_wrapper->window()->getKeywordForSearch(), Qt::CaseInsensitive) == 0)) {
+        Window *win = m_wrapper->window();
+        const QString keyword = win->getKeywordForSearchAll();
+        if ((win->findBarIsVisiable() || win->replaceBarIsVisiable()) &&
+                (QString::compare(keyword, win->getKeywordForSearch(), Qt::CaseInsensitive) == 0)) {
             qDebug() << "Highlighting keyword in view";
-            highlightKeywordInView(m_wrapper->window()->getKeywordForSearchAll());
+            highlightKeywordInView(keyword, win->getSearchCaseFlag());
         }
 
         markAllKeywordInView();

--- a/src/editor/editwrapper.cpp
+++ b/src/editor/editwrapper.cpp
@@ -126,7 +126,7 @@ EditWrapper::EditWrapper(Window *window, QWidget *parent)
         if ((m_pWindow->findBarIsVisiable() || m_pWindow->replaceBarIsVisiable()) &&
                 (QString::compare(m_pWindow->getKeywordForSearchAll(), m_pWindow->getKeywordForSearch(), Qt::CaseInsensitive) == 0)) {
             qDebug() << "EditWrapper connect verticalScrollBar valueChanged, highlightKeywordInView";
-            m_pTextEdit->highlightKeywordInView(m_pWindow->getKeywordForSearchAll());
+            m_pTextEdit->highlightKeywordInView(m_pWindow->getKeywordForSearchAll(), m_pWindow->getSearchCaseFlag());
         }
 
         m_pTextEdit->markAllKeywordInView();

--- a/src/widgets/window.cpp
+++ b/src/widgets/window.cpp
@@ -11,6 +11,7 @@
 #include <DSettings>
 #include <DSettingsOption>
 #include <QApplication>
+#include <QTimer>
 #include <QPrintDialog>
 #include <QPrintPreviewDialog>
 #include <QPrinter>
@@ -294,7 +295,7 @@ Window::Window(DMainWindow *parent)
     connect(m_replaceBar, &ReplaceBar::replaceRest, this, &Window::handleReplaceRest, Qt::QueuedConnection);
     connect(m_replaceBar, &ReplaceBar::replaceSkip, this, &Window::handleReplaceSkip, Qt::QueuedConnection);
     connect(m_replaceBar, &ReplaceBar::updateSearchKeyword, this, [ = ](QString file, QString keyword) {
-        handleUpdateSearchKeyword(m_replaceBar, file, keyword);
+        handleUpdateSearchKeyword(m_replaceBar, file, keyword, Qt::CaseSensitive);
     });
     connect(m_replaceBar, &ReplaceBar::sigReplacebarClose, this, &Window::slotReplacebarClose, Qt::QueuedConnection);
 
@@ -1730,8 +1731,9 @@ void Window::popupFindBar()
     int scrollOffset = wrapper->textEditor()->getScrollOffset();
 
     m_findBar->activeInput(text, tabPath, row, column, scrollOffset);
-    // highlight keyword when findbar show
-    wrapper->textEditor()->highlightKeywordInView(text);
+    // highlight keyword when findbar show (find bar uses case-insensitive by default)
+    m_searchCaseFlag = Qt::CaseInsensitive;
+    wrapper->textEditor()->highlightKeywordInView(text, m_searchCaseFlag);
     // set keywords
     m_keywordForSearchAll = m_keywordForSearch = text;
 
@@ -1794,6 +1796,8 @@ void Window::popupReplaceBar()
     int scrollOffset = wrapper->textEditor()->getScrollOffset();
 
     m_replaceBar->activeInput(text, tabPath, row, column, scrollOffset);
+    // replace bar uses case-sensitive search by default
+    m_searchCaseFlag = Qt::CaseSensitive;
 
     QTimer::singleShot(10, this, [ = ] { m_replaceBar->focus(); });
     qDebug() << "Popup replace bar completed";
@@ -3288,7 +3292,7 @@ void Window::handleFindKeyword(const QString &keyword, bool state)
         wrapper->textEditor()->clearFindMatchSelections();
     } else {
         qDebug() << "m_keywordForSearchAll is equal to m_keywordForSearch, highlight it";
-        wrapper->textEditor()->highlightKeywordInView(m_keywordForSearchAll);
+        wrapper->textEditor()->highlightKeywordInView(m_keywordForSearchAll, m_searchCaseFlag);
     }
 
     wrapper->textEditor()->markAllKeywordInView();
@@ -3406,6 +3410,7 @@ void Window::handleReplaceNext(const QString &file, const QString &replaceText, 
     Q_UNUSED(file);
     m_keywordForSearch = replaceText;
     m_keywordForSearchAll = replaceText;
+    m_searchCaseFlag = Qt::CaseSensitive;
     EditWrapper *wrapper = currentWrapper();
     wrapper->textEditor()->replaceNext(replaceText, withText);
     qDebug() << "handleReplaceNext end";
@@ -3466,6 +3471,7 @@ void Window::handleUpdateSearchKeyword(QWidget *widget, const QString &file, con
         bool findKeyword = wrapper->textEditor()->highlightKeyword(keyword, wrapper->textEditor()->getPosition(), caseFlag);
         m_keywordForSearchAll = keyword;
         m_keywordForSearch = keyword;
+        m_searchCaseFlag = caseFlag;
         bool emptyKeyword = keyword.trimmed().isEmpty();
 
         auto *findBarWidget = qobject_cast<FindBar *>(widget);
@@ -3966,6 +3972,8 @@ void Window::resizeEvent(QResizeEvent *e)
     DMainWindow::resizeEvent(e);
 }
 
+
+
 void Window::closeEvent(QCloseEvent *e)
 {
     qDebug() << "close event";
@@ -4300,6 +4308,11 @@ QString Window::getKeywordForSearch()
 {
     qDebug() << "get keyword for search";
     return m_keywordForSearch;
+}
+
+Qt::CaseSensitivity Window::getSearchCaseFlag()
+{
+    return m_searchCaseFlag;
 }
 
 void Window::setPrintEnabled(bool enabled)

--- a/src/widgets/window.h
+++ b/src/widgets/window.h
@@ -132,6 +132,7 @@ public:
     bool findBarIsVisiable();
     QString getKeywordForSearchAll();
     QString getKeywordForSearch();
+    Qt::CaseSensitivity getSearchCaseFlag();
     void setPrintEnabled(bool enabled);
     QStackedWidget *getStackedWgt();
 
@@ -280,6 +281,7 @@ private:
 
     QString m_keywordForSearch;
     QString m_keywordForSearchAll;
+    Qt::CaseSensitivity m_searchCaseFlag = Qt::CaseInsensitive;
 
     QString m_themePath;
     QString m_tabbarActiveColor;


### PR DESCRIPTION
log: m_searchCaseFlag was not persisted. After a replace bar operation, any cursor movement or scrolling would re-highlight using the default CaseInsensitive, overwriting the correct case-sensitive setting. Added m_searchCaseFlag to store the current search case flag, set replace bar related operations to CaseSensitive uniformly, and changed all highlightKeywordInView calls to read this flag.

pms: bug-358129