### PR TITLE
Revert "fix: Skip case insensitive"

### DIFF
--- a/src/editor/dtextedit.cpp
+++ b/src/editor/dtextedit.cpp
@@ -1055,12 +1055,10 @@ void TextEdit::nextLine()
     if (m_wrapper != nullptr) {
         qDebug() << "Updating highlighter";
         m_wrapper->OnUpdateHighlighter();
-        Window *win = m_wrapper->window();
-        const QString keyword = win->getKeywordForSearchAll();
-        if ((win->findBarIsVisiable() || win->replaceBarIsVisiable()) &&
-                (QString::compare(keyword, win->getKeywordForSearch(), Qt::CaseInsensitive) == 0)) {
+        if ((m_wrapper->window()->findBarIsVisiable() || m_wrapper->window()->replaceBarIsVisiable()) &&
+                (QString::compare(m_wrapper->window()->getKeywordForSearchAll(), m_wrapper->window()->getKeywordForSearch(), Qt::CaseInsensitive) == 0)) {
             qDebug() << "Highlighting keyword in view";
-            highlightKeywordInView(keyword, win->getSearchCaseFlag());
+            highlightKeywordInView(m_wrapper->window()->getKeywordForSearchAll());
         }
 
         qDebug() << "Marking all keyword in view";
@@ -1092,12 +1090,10 @@ void TextEdit::prevLine()
     if (m_wrapper != nullptr) {
         qDebug() << "Updating highlighter";
         m_wrapper->OnUpdateHighlighter();
-        Window *win = m_wrapper->window();
-        const QString keyword = win->getKeywordForSearchAll();
-        if ((win->findBarIsVisiable() || win->replaceBarIsVisiable()) &&
-                (QString::compare(keyword, win->getKeywordForSearch(), Qt::CaseInsensitive) == 0)) {
+        if ((m_wrapper->window()->findBarIsVisiable() || m_wrapper->window()->replaceBarIsVisiable()) &&
+                (QString::compare(m_wrapper->window()->getKeywordForSearchAll(), m_wrapper->window()->getKeywordForSearch(), Qt::CaseInsensitive) == 0)) {
             qDebug() << "Highlighting keyword in view";
-            highlightKeywordInView(keyword, win->getSearchCaseFlag());
+            highlightKeywordInView(m_wrapper->window()->getKeywordForSearchAll());
         }
 
         qDebug() << "Marking all keyword in view";
@@ -1306,12 +1302,10 @@ void TextEdit::scrollUp()
     if (m_wrapper != nullptr) {
         qDebug() << "Updating highlighter";
         m_wrapper->OnUpdateHighlighter();
-        Window *win = m_wrapper->window();
-        const QString keyword = win->getKeywordForSearchAll();
-        if ((win->findBarIsVisiable() || win->replaceBarIsVisiable()) &&
-                (QString::compare(keyword, win->getKeywordForSearch(), Qt::CaseInsensitive) == 0)) {
+        if ((m_wrapper->window()->findBarIsVisiable() || m_wrapper->window()->replaceBarIsVisiable()) &&
+                (QString::compare(m_wrapper->window()->getKeywordForSearchAll(), m_wrapper->window()->getKeywordForSearch(), Qt::CaseInsensitive) == 0)) {
             qDebug() << "Highlighting keyword in view";
-            highlightKeywordInView(keyword, win->getSearchCaseFlag());
+            highlightKeywordInView(m_wrapper->window()->getKeywordForSearchAll());
         }
 
         markAllKeywordInView();
@@ -1342,12 +1336,10 @@ void TextEdit::scrollDown()
     if (m_wrapper != nullptr) {
         qDebug() << "Updating highlighter";
         m_wrapper->OnUpdateHighlighter();
-        Window *win = m_wrapper->window();
-        const QString keyword = win->getKeywordForSearchAll();
-        if ((win->findBarIsVisiable() || win->replaceBarIsVisiable()) &&
-                (QString::compare(keyword, win->getKeywordForSearch(), Qt::CaseInsensitive) == 0)) {
+        if ((m_wrapper->window()->findBarIsVisiable() || m_wrapper->window()->replaceBarIsVisiable()) &&
+                (QString::compare(m_wrapper->window()->getKeywordForSearchAll(), m_wrapper->window()->getKeywordForSearch(), Qt::CaseInsensitive) == 0)) {
             qDebug() << "Highlighting keyword in view";
-            highlightKeywordInView(keyword, win->getSearchCaseFlag());
+            highlightKeywordInView(m_wrapper->window()->getKeywordForSearchAll());
         }
 
         markAllKeywordInView();

--- a/src/editor/editwrapper.cpp
+++ b/src/editor/editwrapper.cpp
@@ -126,7 +126,7 @@ EditWrapper::EditWrapper(Window *window, QWidget *parent)
         if ((m_pWindow->findBarIsVisiable() || m_pWindow->replaceBarIsVisiable()) &&
                 (QString::compare(m_pWindow->getKeywordForSearchAll(), m_pWindow->getKeywordForSearch(), Qt::CaseInsensitive) == 0)) {
             qDebug() << "EditWrapper connect verticalScrollBar valueChanged, highlightKeywordInView";
-            m_pTextEdit->highlightKeywordInView(m_pWindow->getKeywordForSearchAll(), m_pWindow->getSearchCaseFlag());
+            m_pTextEdit->highlightKeywordInView(m_pWindow->getKeywordForSearchAll());
         }
 
         m_pTextEdit->markAllKeywordInView();

--- a/src/widgets/window.cpp
+++ b/src/widgets/window.cpp
@@ -11,7 +11,6 @@
 #include <DSettings>
 #include <DSettingsOption>
 #include <QApplication>
-#include <QTimer>
 #include <QPrintDialog>
 #include <QPrintPreviewDialog>
 #include <QPrinter>
@@ -295,7 +294,7 @@ Window::Window(DMainWindow *parent)
     connect(m_replaceBar, &ReplaceBar::replaceRest, this, &Window::handleReplaceRest, Qt::QueuedConnection);
     connect(m_replaceBar, &ReplaceBar::replaceSkip, this, &Window::handleReplaceSkip, Qt::QueuedConnection);
     connect(m_replaceBar, &ReplaceBar::updateSearchKeyword, this, [ = ](QString file, QString keyword) {
-        handleUpdateSearchKeyword(m_replaceBar, file, keyword, Qt::CaseSensitive);
+        handleUpdateSearchKeyword(m_replaceBar, file, keyword);
     });
     connect(m_replaceBar, &ReplaceBar::sigReplacebarClose, this, &Window::slotReplacebarClose, Qt::QueuedConnection);
 
@@ -1731,9 +1730,8 @@ void Window::popupFindBar()
     int scrollOffset = wrapper->textEditor()->getScrollOffset();
 
     m_findBar->activeInput(text, tabPath, row, column, scrollOffset);
-    // highlight keyword when findbar show (find bar uses case-insensitive by default)
-    m_searchCaseFlag = Qt::CaseInsensitive;
-    wrapper->textEditor()->highlightKeywordInView(text, m_searchCaseFlag);
+    // highlight keyword when findbar show
+    wrapper->textEditor()->highlightKeywordInView(text);
     // set keywords
     m_keywordForSearchAll = m_keywordForSearch = text;
 
@@ -1796,8 +1794,6 @@ void Window::popupReplaceBar()
     int scrollOffset = wrapper->textEditor()->getScrollOffset();
 
     m_replaceBar->activeInput(text, tabPath, row, column, scrollOffset);
-    // replace bar uses case-sensitive search by default
-    m_searchCaseFlag = Qt::CaseSensitive;
 
     QTimer::singleShot(10, this, [ = ] { m_replaceBar->focus(); });
     qDebug() << "Popup replace bar completed";
@@ -3292,7 +3288,7 @@ void Window::handleFindKeyword(const QString &keyword, bool state)
         wrapper->textEditor()->clearFindMatchSelections();
     } else {
         qDebug() << "m_keywordForSearchAll is equal to m_keywordForSearch, highlight it";
-        wrapper->textEditor()->highlightKeywordInView(m_keywordForSearchAll, m_searchCaseFlag);
+        wrapper->textEditor()->highlightKeywordInView(m_keywordForSearchAll);
     }
 
     wrapper->textEditor()->markAllKeywordInView();
@@ -3410,7 +3406,6 @@ void Window::handleReplaceNext(const QString &file, const QString &replaceText, 
     Q_UNUSED(file);
     m_keywordForSearch = replaceText;
     m_keywordForSearchAll = replaceText;
-    m_searchCaseFlag = Qt::CaseSensitive;
     EditWrapper *wrapper = currentWrapper();
     wrapper->textEditor()->replaceNext(replaceText, withText);
     qDebug() << "handleReplaceNext end";
@@ -3471,7 +3466,6 @@ void Window::handleUpdateSearchKeyword(QWidget *widget, const QString &file, con
         bool findKeyword = wrapper->textEditor()->highlightKeyword(keyword, wrapper->textEditor()->getPosition(), caseFlag);
         m_keywordForSearchAll = keyword;
         m_keywordForSearch = keyword;
-        m_searchCaseFlag = caseFlag;
         bool emptyKeyword = keyword.trimmed().isEmpty();
 
         auto *findBarWidget = qobject_cast<FindBar *>(widget);
@@ -3972,8 +3966,6 @@ void Window::resizeEvent(QResizeEvent *e)
     DMainWindow::resizeEvent(e);
 }
 
-
-
 void Window::closeEvent(QCloseEvent *e)
 {
     qDebug() << "close event";
@@ -4308,11 +4300,6 @@ QString Window::getKeywordForSearch()
 {
     qDebug() << "get keyword for search";
     return m_keywordForSearch;
-}
-
-Qt::CaseSensitivity Window::getSearchCaseFlag()
-{
-    return m_searchCaseFlag;
 }
 
 void Window::setPrintEnabled(bool enabled)

--- a/src/widgets/window.h
+++ b/src/widgets/window.h
@@ -132,7 +132,6 @@ public:
     bool findBarIsVisiable();
     QString getKeywordForSearchAll();
     QString getKeywordForSearch();
-    Qt::CaseSensitivity getSearchCaseFlag();
     void setPrintEnabled(bool enabled);
     QStackedWidget *getStackedWgt();
 
@@ -281,7 +280,6 @@ private:
 
     QString m_keywordForSearch;
     QString m_keywordForSearchAll;
-    Qt::CaseSensitivity m_searchCaseFlag = Qt::CaseInsensitive;
 
     QString m_themePath;
     QString m_tabbarActiveColor;


### PR DESCRIPTION
Reverts linuxdeepin/deepin-editor#448

## Summary by Sourcery

Revert the previous change that introduced explicit case-sensitivity handling for search highlighting and restore the prior default behavior.

Bug Fixes:
- Remove explicit tracking of search case sensitivity in the main window and rely on the editor’s default search behavior to avoid regressions introduced by the prior fix.

Enhancements:
- Simplify search/highlight integration between the window, edit wrapper, and text editor by dropping the search case flag parameter and associated state.