### PR TITLE
fix: Opening a file without permission results in a blank page

### DIFF
--- a/src/widgets/window.cpp
+++ b/src/widgets/window.cpp
@@ -676,15 +676,22 @@ void Window::addTab(const QString &filepath, bool activeTab)
             }
         }
 
-        // check if have permission to read the file.
-        bool bIsReadable = fileInfo.isReadable();
-        qDebug() << "File readable:" << bIsReadable;
-
-        if (fileInfo.exists() && !bIsReadable) {
-            qWarning() << "No permission to read file:" << filepath;
-            DMessageManager::instance()->sendMessage(m_editorWidget->currentWidget(), QIcon(":/images/warning.svg")
-                                                     , QString(tr("You do not have permission to open %1")).arg(filepath));
-            return;
+        // Verify the file is actually readable by attempting to open it.
+        // This is more reliable than QFileInfo::isReadable(), which can be incorrect
+        // in some edge cases (e.g. setuid processes, certain filesystems).
+        if (fileInfo.exists()) {
+            QFile testFile(filepath);
+            if (testFile.open(QIODevice::ReadOnly)) {
+                testFile.close();
+            } else if (testFile.error() == QFileDevice::PermissionsError) {
+                qWarning() << "No permission to read file:" << filepath << "error:" << testFile.errorString();
+                QWidget *const msgParent = m_editorWidget->currentWidget() ? m_editorWidget->currentWidget() : this;
+                DMessageManager::instance()->sendMessage(msgParent, QIcon(":/images/warning.svg"),
+                                                         QString(tr("You do not have permission to open %1")).arg(filepath));
+                return;
+            } else {
+                qWarning() << "Failed to open file:" << filepath << "error:" << testFile.errorString();
+            }
         }
 
         if (StartManager::instance()->checkPath(filepath)) {


### PR DESCRIPTION
log: QFileInfo::isReadable() is unreliable in certain scenarios, causing files without permission to pass the permission check and create a tab, but then failing to open via FileLoadThread
, leaving a blank tab and displaying an error message. Solution: Use QFile::open() to actually attempt to open the file for permission verification, and fix onReadAllocError() to display the correct prompt when a permission error occurs.

pms: bug-339655

## Summary by Sourcery

Improve file readability checks to prevent opening tabs for files without read permissions and show accurate error messages when reads fail.

Bug Fixes:
- Prevent opening an editor tab for files that exist but cannot actually be opened due to missing read permissions.
- Display a specific permission error message when a read failure is caused by insufficient file permissions instead of a generic read error notice.