### PR TITLE
fix(tab): use Window as message parent when lacking file permission

### DIFF
--- a/src/widgets/window.cpp
+++ b/src/widgets/window.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2011 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2011 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -642,7 +642,7 @@ void Window::addTab(const QString &filepath, bool activeTab)
         QFile::Permissions permissions = file.permissions();
         bool bIsRead = (permissions & QFile::ReadUser || permissions & QFile::ReadOwner || permissions & QFile::ReadOther);
         if (fileInfo.exists() && !bIsRead) {
-            DMessageManager::instance()->sendMessage(m_editorWidget->currentWidget(), QIcon(":/images/warning.svg")
+            DMessageManager::instance()->sendMessage(this, QIcon(":/images/warning.svg")
                                                      , QString(tr("You do not have permission to open %1")).arg(filepath));
             return;
         }


### PR DESCRIPTION
Use Window instance instead of currentWidget as the parent for permission denied messages to prevent potential null pointer issues.

当文件无权限时，使用 Window 实例替代 currentWidget 作为消息父控件，
避免潜在的空指针问题。

Log: 修复无权限文件打开时的消息提示目标
Bug: https://pms.uniontech.com/bug-view-353539.html
Influence: 修复后打开无权限文件时，权限不足提示能稳定显示，不会因 currentWidget 为空而失败。

## Summary by Sourcery

Bug Fixes:
- Ensure permission-denied messages are reliably shown even when there is no current editor widget for the tab.