### PR TITLE
fix(editor): prevent incorrect scroll position when opening files

### DIFF
--- a/src/editor/dtextedit.cpp
+++ b/src/editor/dtextedit.cpp
@@ -7547,7 +7547,9 @@ void TextEdit::resizeEvent(QResizeEvent *e)
     markAllKeywordInView();
 
     // 当前处于文档页面尾部时，缩放后保持焦点在文档页面尾部
-    if (e->oldSize().width() < e->size().width() && verticalScrollBar()->maximum() == verticalScrollBar()->value()) {
+    // maximum() > 0: 排除文档为空或尚未加载的情况（此时 max==val==0 恒成立）
+    if (e->oldSize().width() < e->size().width() && verticalScrollBar()->maximum() == verticalScrollBar()->value()
+            && verticalScrollBar()->maximum() > 0) {
         // 使用 QPointer 检查对象是否还存在
         QPointer<TextEdit> self(this);
         QTimer::singleShot(0, [self]() {

--- a/src/editor/editwrapper.cpp
+++ b/src/editor/editwrapper.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2017 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -1312,6 +1312,8 @@ void EditWrapper::loadContent(const QByteArray &strContent)
                 QByteArray text = strContent.mid(InitContentPos, len - InitContentPos);
                 data = codec->toUnicode(text.constData(), text.size(), &state);
                 cursor.insertText(data);
+                // 第二次insertText会导致Qt内部跟随滚动，需重置视口到文档开头
+                m_pTextEdit->verticalScrollBar()->setValue(0);
                 inserted += (len - InitContentPos);
                 progress = (inserted * 1.0) / len * 100;
                 m_pBottomBar->setProgress(static_cast<int>(progress));


### PR DESCRIPTION
log: The resizeEvent "keep at bottom" logic triggers when
  maximum()==value()==0 during widget creation with empty
  document, causing a deferred setValue(maximum()) to scroll
  the viewport to the wrong position after content is loaded.

Bug: https://pms.uniontech.com/bug-view-358723.html