### PR TITLE
fix(perf): improve file opening performance with lazy loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ tasks/
 .specstory/
 .windsurf/src/resources/settings.json
 src/resources/settings.json
+obj-x86_64-linux-gnu/

--- a/src/widgets/window.cpp
+++ b/src/widgets/window.cpp
@@ -1265,14 +1265,30 @@ void Window::openFile()
         } else {
             otherfiles.append(canonicalFile);
         }
-
-        //先添加支持的文件
-    }
-    foreach (QString var, supportfileNames) {
-        addTab(var, true);
     }
 
-    //后添加不支持文件　在最后编辑页面显示
+    // 使用懒加载机制：只立即加载并激活第一个支持的文件
+    // 其他支持的文件作为待加载标签页，用户点击时才加载内容
+    if (!supportfileNames.isEmpty()) {
+        // 第一个文件立即加载并激活
+        addTab(supportfileNames.first(), true);
+
+        // 剩余支持的文件使用懒加载
+        for (int i = 1; i < supportfileNames.size(); ++i) {
+            const QString &filepath = supportfileNames[i];
+            QFileInfo fileInfo(filepath);
+            PendingTabInfo pendingInfo;
+            pendingInfo.filepath = filepath;
+            pendingInfo.truePath = filepath;
+            pendingInfo.displayName = fileInfo.fileName();
+            pendingInfo.isTemFile = false;
+            pendingInfo.cursorPosition = -1;
+            addPendingTab(pendingInfo);
+        }
+    }
+
+    // 后添加不支持文件（在最后编辑页面显示）
+    // 不支持的文件无法懒加载，需要立即加载以显示错误提示
     foreach (QString var, otherfiles) {
         addTab(var, true);
     }


### PR DESCRIPTION
Implement lazy loading mechanism for multiple files to improve performance. Only load first file immediately, defer others.

实现文件打开的懒加载机制，提升性能。只立即加载第一个文件，
其他文件延迟加载。

Log: 优化文件打开性能，实现懒加载机制
PMS: BUG-360259
Influence: 打开多个文件时性能显著提升，应用启动更快，用户体验改善。

## Summary by Sourcery

Implement lazy loading when opening multiple files so that only the first supported file is loaded immediately while others are deferred, while keeping unsupported files eagerly loaded to surface errors.

New Features:
- Introduce pending tab entries to represent additional supported files that are only loaded when the user activates them.

Enhancements:
- Improve multi-file open performance by reducing initial file loading to a single supported file and deferring the rest.