### PR TITLE
chore: Update version to 6.5.50

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+deepin-editor (6.5.50) unstable; urgency=medium
+
+  * chore: Update version to 6.5.50
+  * fix(perf): improve file opening performance with lazy loading
+  * wip: lazy tab restore for faster startup
+
+ -- zhanghongyuan <zhanghongyuan@uniontech.com>  Thu, 14 May 2026 16:26:09 +0800
+
 deepin-editor (6.5.49) unstable; urgency=medium
 
   * fix(editor): resolve tab bar jitter when adding new tabs

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.editor
   name: "deepin-editor"
-  version: 6.5.49.1
+  version: 6.5.50.1
   kind: app
   description: |
     editor for deepin os.


### PR DESCRIPTION
- update version to 6.5.50

log: update version to 6.5.50

## Summary by Sourcery

Bump the deepin-editor package version metadata to 6.5.50.1 across packaging files.

Build:
- Update linglong packaging configuration to reference version 6.5.50.1.

Chores:
- Align package versioning for the 6.5.50.1 release.