### PR TITLE
chore: update version to 6.5.52

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-editor (6.5.52) unstable; urgency=medium
+
+  * fix: support opening JSON files detected as MIME subtype
+
+ -- Wang Yu <wangyu@uniontech.com>  Wed, 20 May 2026 14:06:49 +0800
+
 deepin-editor (6.5.51) unstable; urgency=medium
 
   * chore: bump version to 6.5.51

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.editor
   name: "deepin-editor"
-  version: 6.5.51.1
+  version: 6.5.52.1
   kind: app
   description: |
     editor for deepin os.


### PR DESCRIPTION
- bump version to 6.5.52

Log : bump version to 6.5.52

## Summary by Sourcery

Chores:
- Update project metadata to reference version 6.5.52.1 in linglong.yaml.