### PR TITLE
fix(editor): check parent MIME types to support subtype files in isMimeTypeSupport

### DIFF
--- a/src/common/utils.cpp
+++ b/src/common/utils.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2011-2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2011-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -40,6 +40,50 @@ DCORE_USE_NAMESPACE
 QT_BEGIN_NAMESPACE
 extern Q_WIDGETS_EXPORT void qt_blurImage(QPainter *p, QImage &blurImage, qreal radius, bool quality, bool alphaOnly, int transposed = 0);
 QT_END_NAMESPACE
+
+static const QStringList SupportedTextMimeTypes = {
+    "application/cmd",
+    "application/javascript",
+    "application/json",
+    "application/pkix-cert",
+    "application/octet-stream",
+    "application/sql",
+    "application/vnd.apple.mpegurl",
+    "application/vnd.nokia.qt.qmakeprofile",
+    "application/vnd.nokia.xml.qt.resource",
+    "application/x-desktop",
+    "application/x-designer",
+    "application/x-empty",
+    "application/x-msdos-program",
+    "application/x-pearl",
+    "application/x-php",
+    "application/x-shellscript",
+    "application/x-sh",
+    "application/x-theme",
+    "application/x-cue",
+    "application/x-csh",
+    "application/x-asp",
+    "application/x-subrip",
+    "application/x-text",
+    "application/x-trash",
+    "application/x-xbel",
+    "application/x-yaml",
+    "application/x-pem-key",
+    "application/xml",
+    "application/yaml",
+    "application/x-zerosize",
+    "image/svg+xml",
+    "application/x-perl",
+    "application/x-ruby",
+    "application/x-mpegURL",
+    "application/x-wine-extension-ini",
+    "model/vrml",
+    "application/pkix-cert+pem",
+    "application/x-pak",
+    "application/x-code-workspace",
+    "application/toml",
+    "audio/x-mod"
+};
 
 QString Utils::m_systemLanguage;
 
@@ -525,7 +569,8 @@ QVariantMap Utils::getThemeMapFromPath(const QString &filepath)
 
 bool Utils::isMimeTypeSupport(const QString &filepath)
 {
-    QString mimeType = QMimeDatabase().mimeTypeForFile(filepath, QMimeDatabase::MatchMode::MatchContent).name();
+    const QMimeType mime = QMimeDatabase().mimeTypeForFile(filepath, QMimeDatabase::MatchMode::MatchContent);
+    const QString mimeType = mime.name();
 
     if (mimeType.startsWith("text/")) {
         return true;
@@ -534,52 +579,17 @@ bool Utils::isMimeTypeSupport(const QString &filepath)
     if (filepath.endsWith("pub")) {
         return true;
     }
-    // Please check full mime type list from: https://www.freeformatter.com/mime-types-list.html
-    QStringList textMimeTypes;
-    textMimeTypes << "application/cmd"
-                  << "application/javascript"
-                  << "application/json"
-                  << "application/pkix-cert"
-                  << "application/octet-stream"
-                  << "application/sql"
-                  << "application/vnd.apple.mpegurl"
-                  << "application/vnd.nokia.qt.qmakeprofile"
-                  << "application/vnd.nokia.xml.qt.resource"
-                  << "application/x-desktop"
-                  << "application/x-designer"
-                  << "application/x-empty"
-                  << "application/x-msdos-program"
-                  << "application/x-pearl"
-                  << "application/x-php"
-                  << "application/x-shellscript"
-                  << "application/x-sh"
-                  << "application/x-theme"
-                  << "application/x-cue"
-                  << "application/x-csh"
-                  << "application/x-asp"
-                  << "application/x-subrip"
-                  << "application/x-text"
-                  << "application/x-trash"
-                  << "application/x-xbel"
-                  << "application/x-yaml"
-                  << "application/x-pem-key"
-                  << "application/xml"
-                  << "application/yaml"
-                  << "application/x-zerosize"
-                  << "image/svg+xml"
-                  << "application/x-perl"
-                  << "application/x-ruby"
-                  << "application/x-mpegURL"
-                  << "application/x-wine-extension-ini"
-                  << "model/vrml"
-                  << "application/pkix-cert+pem"
-                  << "application/x-pak"
-                  << "application/x-code-workspace"
-                  << "application/toml"
-                  << "audio/x-mod";
 
-    if (textMimeTypes.contains(mimeType)) {
+    if (SupportedTextMimeTypes.contains(mimeType)) {
         return true;
+    }
+
+    if (mime.isValid()) {
+        for (const QString &supportedType : SupportedTextMimeTypes) {
+            if (mime.inherits(supportedType)) {
+                return true;
+            }
+        }
     }
 
     return false;


### PR DESCRIPTION
fix(editor): check parent MIME types to support subtype files in isMimeTypeSupport

- Retain QMimeType object to enable parent type lookup
- Add parentMimeTypes() fallback to match subtypes against whitelist

修复(editor): 在 isMimeTypeSupport 中检查父 MIME 类型以支持子类型文件打开

Log: 通过父 MIME 类型继承关系扩展白名单匹配范围，修复子类型文件无法打开的问题
Bug: https://pms.uniontech.com/bug-view-362023.html