### PR TITLE
fix: use readAll() for virtual files with zero reported size

### DIFF
--- a/src/common/fileloadthread.cpp
+++ b/src/common/fileloadthread.cpp
@@ -62,7 +62,13 @@ void FileLoadThread::run()
         try {
             qDebug() << "Reading remaining file content";
             // reads all remaining data from the file.
-            indata += file.read(file.size());
+            // 对于 /proc、/sys 等虚拟文件，file.size() 返回 0 但实际有内容，
+            // 需要使用 readAll() 来正确读取。
+            if (file.size() == 0) {
+                indata += file.readAll();
+            } else {
+                indata += file.read(file.size());
+            }
             file.close();
             qDebug() << "Total bytes read:" << indata.size();
         } catch (const std::exception &e) {


### PR DESCRIPTION
For /proc, /sys and other virtual filesystem files, stat() reports size as 0 but they contain actual readable content. Use readAll() instead of read(file.size()) when file size is zero.

对于/proc、/sys等虚拟文件系统，stat()报告大小为0但实际包含
可读内容，当文件大小为0时使用readAll()替代read(file.size())。

Log: 修复虚拟文件打开显示空白的问题
PMS: BUG-364057
Influence: 修复后/proc、/sys等虚拟文件（如/proc/meminfo）能正确加载显示内容。