### PR TITLE
fix(test): resolve ASAN heap-buffer-overflow in textedit unit tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,6 @@ add_definitions(-DKF5_HIGHLIGHT_PATH=\"${KF5_HIGHLIGHT_INSTALL_PATH}\")
 
 add_subdirectory(src)
 
-if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+if (CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "Release")
     add_subdirectory(tests)
 endif()

--- a/src/controls/tabbar.cpp
+++ b/src/controls/tabbar.cpp
@@ -627,11 +627,23 @@ void Tabbar::handleDragActionChanged(Qt::DropAction action)
     qDebug() << "Exit handleDragActionChanged";
 }
 
-bool Tabbar::eventFilter(QObject *, QEvent *event)
+bool Tabbar::eventFilter(QObject *object, QEvent *event)
 {
 #if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
-    if (event->type() == QEvent::ApplicationFontChange) {
-        setFont(qApp->font());
+    // Only handle ApplicationFontChange for this widget itself,
+    // not for every widget in the application.
+    if (event->type() == QEvent::ApplicationFontChange && object == this) {
+        if (this->font() != qApp->font()) {
+            setFont(qApp->font());
+        }
+        return false;
+    }
+    // Early return for non-mouse, non-drag events to avoid log spam
+    if (event->type() != QEvent::MouseButtonPress &&
+        event->type() != QEvent::DragEnter &&
+        event->type() != QEvent::DragLeave &&
+        event->type() != QEvent::Drop &&
+        event->type() != QEvent::DragMove) {
         return false;
     }
 #endif
@@ -789,7 +801,6 @@ bool Tabbar::eventFilter(QObject *, QEvent *event)
         qDebug() << "event->type() == QEvent::DragMove";
         event->accept();
     }
-    qDebug() << "Exit eventFilter";
     return false;
 }
 

--- a/src/editor/dtextedit.cpp
+++ b/src/editor/dtextedit.cpp
@@ -24,6 +24,7 @@
 #include <KSyntaxHighlighting/theme.h>
 
 #include <QAbstractTextDocumentLayout>
+#include <QPointer>
 #include <QTextDocumentFragment>
 #include <QInputMethodEvent>
 #include <DDesktopServices>
@@ -110,7 +111,8 @@ TextEdit::TextEdit(QWidget *parent)
     connect(this->verticalScrollBar(), &QScrollBar::valueChanged, this, &TextEdit::slotValueChanged);
     connect(this, &QPlainTextEdit::textChanged, this, &TextEdit::updateLeftAreaWidget);
     connect(this, &QPlainTextEdit::textChanged, this, [this]() {
-        this->m_wrapper->UpdateBottomBarWordCnt(this->characterCount());
+        if (this->m_wrapper)
+            this->m_wrapper->UpdateBottomBarWordCnt(this->characterCount());
     });
 
     connect(this, &QPlainTextEdit::cursorPositionChanged, this, &TextEdit::cursorPositionChanged);
@@ -7086,15 +7088,23 @@ void TextEdit::slotSelectionChanged()
 void TextEdit::slotCanRedoChanged(bool bCanRedo)
 {
     Q_UNUSED(bCanRedo)
+    if (!m_wrapper)
+        return;
     bool isModified = this->m_wrapper->isTemFile() | (m_pUndoStack->canUndo() || m_pUndoStack->index() != m_lastSaveIndex);
-    this->m_wrapper->window()->updateModifyStatus(m_sFilePath, isModified);
+    Window *wnd = dynamic_cast<Window *>(m_wrapper->window());
+    if (wnd)
+        wnd->updateModifyStatus(m_sFilePath, isModified);
     this->m_wrapper->OnUpdateHighlighter();
 }
 
 void TextEdit::slotCanUndoChanged(bool bCanUndo)
 {
+    if (!m_wrapper)
+        return;
     bool isModified = this->m_wrapper->isTemFile() | (bCanUndo || m_pUndoStack->index() != m_lastSaveIndex);
-    this->m_wrapper->window()->updateModifyStatus(m_sFilePath, isModified);
+    Window *wnd = dynamic_cast<Window *>(m_wrapper->window());
+    if (wnd)
+        wnd->updateModifyStatus(m_sFilePath, isModified);
     this->m_wrapper->OnUpdateHighlighter();
 }
 
@@ -8560,12 +8570,15 @@ void TextEdit::resizeEvent(QResizeEvent *e)
 
     // 当前处于文档页面尾部时，缩放后保持焦点在文档页面尾部
     if (e->oldSize().width() < e->size().width() && verticalScrollBar()->maximum() == verticalScrollBar()->value()) {
-        QTimer::singleShot(0, [this]() {
+        QPointer<TextEdit> guard(this);
+        QTimer::singleShot(0, [guard]() {
+            if (!guard)
+                return;
             // 宽度变大时文档布局大小变更信号未触发，手动通知
-            auto docLayout = this->document()->documentLayout();
+            auto docLayout = guard->document()->documentLayout();
             Q_EMIT docLayout->documentSizeChanged(docLayout->documentSize());
 
-            verticalScrollBar()->setValue(verticalScrollBar()->maximum());
+            guard->verticalScrollBar()->setValue(guard->verticalScrollBar()->maximum());
         });
     }
 

--- a/src/widgets/window.cpp
+++ b/src/widgets/window.cpp
@@ -618,12 +618,13 @@ bool Window::checkBlockShutdown()
     qDebug() << "checkBlockShutdown called";
     //判断是否有未保存的tab项
     for (int i = 0; i < m_tabbar->count(); i++) {
-        if (m_tabbar->textAt(i).isNull()) {
-            qDebug() << "Tab name is null, return false";
+        QString tabText = m_tabbar->textAt(i);
+        if (tabText.isNull() || tabText.isEmpty()) {
+            qDebug() << "Tab name is null or empty, return false";
             return false;
         }
         //如果有未保存的tab项，return true阻塞系统关机
-        if (m_tabbar->textAt(i).at(0) == '*') {
+        if (tabText.at(0) == '*') {
             qDebug() << "There are unsaved tabs, return true";
             return true;
         }

--- a/tests/src/common/ut_utils.cpp
+++ b/tests/src/common/ut_utils.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2019 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2019-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -280,6 +280,12 @@ TEST(UT_Utils_detectEncode, UT_Utils_detectEncode_006)
 
 TEST(UT_Utils_detectEncode, UT_Utils_detectEncode_007)
 {
+    // Qt6 note: removed QString::size stub because Qt6's QStringView
+    // asserts "str || !len" when constructing from a null pointer with
+    // a non-zero length.  Instead we provide real XML data containing a
+    // Content-Language meta tag so the code path is exercised without
+    // relying on the dangerous size stub.
+
     Utils *utils = new Utils;
 
     typedef QTextCodec *(*fptr)(const QByteArray &, QTextCodec *);
@@ -288,44 +294,41 @@ TEST(UT_Utils_detectEncode, UT_Utils_detectEncode_007)
     Stub st;
     st.set(A_foo, stub_codecForUtfText);
 
-    Stub s1;
-    s1.set(ADDR(QMimeType, name), namestub);
-    namevalue = "application/xml";
-
-    Stub s2;
-    s2.set(ADDR(QString, size), retintstub);
-
     Stub s3;
     s3.set((QLocale::Script(QLocale::*)() const)ADDR(QLocale, script), scriptstub2);
-    scriptvalue2 = QLocale::SimplifiedChineseScript;
 
-    QByteArray array("-");
-    EXPECT_NE(utils->detectEncode(array).size(), 0);
+    // Provide real XML data with Content-Language header for each script
+    // so the proberType switching path is exercised naturally.
+    auto makeXml = [](const QString &lang) -> QByteArray {
+        return QString("<meta http-equiv=\"Content-Language\" content=\"%1\">").arg(lang).toLatin1();
+    };
+
+    scriptvalue2 = QLocale::SimplifiedChineseScript;
+    EXPECT_NE(utils->detectEncode(makeXml("zh-CN")).size(), 0);
 
     scriptvalue2 = QLocale::TraditionalChineseScript;
-    EXPECT_NE(utils->detectEncode(array).size(), 0);
+    EXPECT_NE(utils->detectEncode(makeXml("zh-TW")).size(), 0);
 
     scriptvalue2 = QLocale::CyrillicScript;
-    EXPECT_NE(utils->detectEncode(array).size(), 0);
+    EXPECT_NE(utils->detectEncode(makeXml("ru")).size(), 0);
 
     scriptvalue2 = QLocale::GreekScript;
-    EXPECT_NE(utils->detectEncode(array).size(), 0);
+    EXPECT_NE(utils->detectEncode(makeXml("el")).size(), 0);
 
     scriptvalue2 = QLocale::HebrewScript;
-    EXPECT_NE(utils->detectEncode(array).size(), 0);
+    EXPECT_NE(utils->detectEncode(makeXml("he")).size(), 0);
 
     scriptvalue2 = QLocale::JapaneseScript;
-    EXPECT_NE(utils->detectEncode(array).size(), 0);
+    EXPECT_NE(utils->detectEncode(makeXml("ja")).size(), 0);
 
     scriptvalue2 = QLocale::KoreanScript;
-    EXPECT_NE(utils->detectEncode(array).size(), 0);
+    EXPECT_NE(utils->detectEncode(makeXml("ko")).size(), 0);
 
     scriptvalue2 = QLocale::ThaiScript;
-    EXPECT_NE(utils->detectEncode(array).size(), 0);
+    EXPECT_NE(utils->detectEncode(makeXml("th")).size(), 0);
 
     scriptvalue2 = QLocale::AvestanScript;
-    EXPECT_NE(utils->detectEncode(array).size(), 0);
-
+    EXPECT_NE(utils->detectEncode(makeXml("av")).size(), 0);
 
     delete utils;
     utils = nullptr;

--- a/tests/src/controls/ut_tabbar.cpp
+++ b/tests/src/controls/ut_tabbar.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -540,7 +540,7 @@ TEST(UT_Tabbar_mousePressEvent, UT_Tabbar_mousePressEvent)
 #if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
     QMouseEvent* event = new QMouseEvent(QEvent::None, QPoint(), Qt::MidButton, Qt::MidButton, Qt::NoModifier);
 #else
-    QMouseEvent* event = new QMouseEvent(QEvent::None, QPoint(), Qt::MiddleButton, Qt::MiddleButton, Qt::NoModifier);
+    QMouseEvent* event = new QMouseEvent(QEvent::None, QPoint(), QPoint(), Qt::MiddleButton, Qt::MiddleButton, Qt::NoModifier);
 #endif
 
 
@@ -569,7 +569,7 @@ TEST(UT_Tabbar_dropEvent, UT_Tabbar_dropEvent)
     QPoint p;
     QMimeData *mimeData = new QMimeData;
     mimeData->setData("dedit/tabbar","test");
-    QDropEvent* event = new QDropEvent(QPointF(100,100),Qt::CopyAction,mimeData,Qt::LeftButton,Qt::NoModifier);
+    QDropEvent* event = new QDropEvent(QPointF(100,100),Qt::CopyAction,mimeData,Qt::LeftButton,Qt::NoModifier, QEvent::Drop);
 
 
     Window * window = new Window;

--- a/tests/src/editor/ut_textedit.cpp
+++ b/tests/src/editor/ut_textedit.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -1151,6 +1151,21 @@ void stub_updateModifyStatus(const QString &path, bool isModified)
 {
     Q_UNUSED(path);
     Q_UNUSED(isModified);
+}
+
+void stub_insertMultiTextEx(const QList<QPair<QTextCursor, QString>> &multiText)
+{
+    Q_UNUSED(multiText);
+}
+
+void stub_deleteMultiTextEx(const QList<QTextCursor> &multiText)
+{
+    Q_UNUSED(multiText);
+}
+
+void stub_slotCanUndoChanged(bool bCanUndo)
+{
+    Q_UNUSED(bCanUndo);
 }
 
 bool popRightMenu_001_canRedo_stub()
@@ -5052,7 +5067,7 @@ TEST_F(test_textedit, mousePressEvent)
     startManager->setWrapper(ee);
     QPoint a(1, 2);
     QPointF b(a);
-    QMouseEvent *e = new QMouseEvent(QMouseEvent::Type::Enter, b, Qt::MouseButton::LeftButton, Qt::MouseButton::LeftButton, Qt::KeyboardModifier::NoModifier);
+    QMouseEvent *e = new QMouseEvent(QMouseEvent::Type::Enter, b, b, Qt::MouseButton::LeftButton, Qt::MouseButton::LeftButton, Qt::KeyboardModifier::NoModifier);
     startManager->mousePressEvent(e);
 
     EXPECT_NE(ee->m_pTextEdit , nullptr);
@@ -5067,7 +5082,7 @@ TEST(UT_TextEdit_mousePressEvent, UT_TextEdit_mousePressEvent_002)
     TextEdit* edit = new TextEdit;
     EditWrapper* wra = new EditWrapper;
     edit->m_wrapper = wra;
-    QMouseEvent* e = new QMouseEvent(QEvent::MouseButtonPress,QPointF(20.0,20.0),Qt::RightButton,Qt::RightButton,Qt::AltModifier);
+    QMouseEvent* e = new QMouseEvent(QEvent::MouseButtonPress,QPointF(20.0,20.0),QPointF(20.0,20.0),Qt::RightButton,Qt::RightButton,Qt::AltModifier);
 
     Stub s1;
     s1.set(ADDR(QMouseEvent,source),retintstub);
@@ -5099,7 +5114,7 @@ TEST_F(test_textedit, mouseMoveEvent)
     startManager->setWrapper(ee);
     QPoint a(1, 2);
     QPointF b(a);
-    QMouseEvent *e = new QMouseEvent(QMouseEvent::Type::Enter, b, Qt::MouseButton::LeftButton, Qt::MouseButton::LeftButton, Qt::KeyboardModifier::NoModifier);
+    QMouseEvent *e = new QMouseEvent(QMouseEvent::Type::Enter, b, b, Qt::MouseButton::LeftButton, Qt::MouseButton::LeftButton, Qt::KeyboardModifier::NoModifier);
     startManager->mouseMoveEvent(e);
 
     EXPECT_NE(ee->m_pTextEdit , nullptr);
@@ -5114,7 +5129,7 @@ TEST(UT_TextEdit_mouseMoveEvent, UT_TextEdit_mouseMoveEvent_002)
     TextEdit* edit = new TextEdit;
     EditWrapper* wra = new EditWrapper;
     edit->m_wrapper = wra;
-    QMouseEvent* e = new QMouseEvent(QEvent::MouseMove,QPointF(20.0,20.0),Qt::LeftButton,Qt::LeftButton,Qt::AltModifier);
+    QMouseEvent* e = new QMouseEvent(QEvent::MouseMove,QPointF(20.0,20.0),QPointF(20.0,20.0),Qt::LeftButton,Qt::LeftButton,Qt::AltModifier);
 
     Stub s1;
     s1.set(ADDR(QMouseEvent,source),retintstub);
@@ -5145,7 +5160,7 @@ TEST_F(test_textedit, mouseReleaseEvent)
     startManager->setWrapper(ee);
     QPoint a(1, 2);
     QPointF b(a);
-    QMouseEvent *e = new QMouseEvent(QMouseEvent::Type::Enter, b, Qt::MouseButton::LeftButton, Qt::MouseButton::LeftButton, Qt::KeyboardModifier::NoModifier);
+    QMouseEvent *e = new QMouseEvent(QMouseEvent::Type::Enter, b, b, Qt::MouseButton::LeftButton, Qt::MouseButton::LeftButton, Qt::KeyboardModifier::NoModifier);
     startManager->mouseReleaseEvent(e);
 
     EXPECT_NE(ee->m_pTextEdit , nullptr);
@@ -5160,7 +5175,7 @@ TEST(UT_TextEdit_mouseReleaseEvent, UT_TextEdit_mouseReleaseEvent_002)
     TextEdit* edit = new TextEdit;
     EditWrapper* wra = new EditWrapper;
     edit->m_wrapper = wra;
-    QMouseEvent* e = new QMouseEvent(QEvent::MouseButtonRelease,QPointF(20.0,20.0),Qt::LeftButton,Qt::LeftButton,Qt::NoModifier);
+    QMouseEvent* e = new QMouseEvent(QEvent::MouseButtonRelease,QPointF(20.0,20.0),QPointF(20.0,20.0),Qt::LeftButton,Qt::LeftButton,Qt::NoModifier);
 
     Stub s1;
     s1.set(ADDR(QMouseEvent,source),retintstub);
@@ -5228,7 +5243,7 @@ TEST_F(test_textedit, contextMenuEvent)
     startManager->setWrapper(ee);
     Stub stub;
     stub.set((QAction * (QMenu::*)(const QPoint &, QAction *)) ADDR(QMenu, exec), stub_exec);
-    QContextMenuEvent *e = new QContextMenuEvent(QContextMenuEvent::Reason::Keyboard, b);
+    QContextMenuEvent *e = new QContextMenuEvent(QContextMenuEvent::Reason::Keyboard, b, b);
     //startManager->contextMenuEvent(e);
 
     EXPECT_NE(ee->m_pTextEdit , nullptr);
@@ -6111,6 +6126,8 @@ TEST(UT_TextEdit_setComment, UT_TextEdit_setComment_002)
     s7.set(ADDR(TextEdit,deleteTextEx),rettruestub);
     Stub s8;
     s8.set(ADDR(TextEdit,insertTextEx),rettruestub);
+    Stub s9;
+    s9.set(ADDR(TextEdit,insertMultiTextEx),stub_insertMultiTextEx);
 
 
     intvalue = -1000;
@@ -6147,6 +6164,8 @@ TEST(UT_TextEdit_setComment, UT_TextEdit_setComment_003)
     s9.set(ADDR(TextEdit,deleteTextEx),rettruestub);
     Stub s10;
     s10.set(ADDR(TextEdit,insertTextEx),rettruestub);
+    Stub s11;
+    s11.set(ADDR(TextEdit,insertMultiTextEx),stub_insertMultiTextEx);
 
 
     intvalue = -1000;
@@ -6183,6 +6202,8 @@ TEST(UT_TextEdit_setComment, UT_TextEdit_setComment_004)
     s9.set(ADDR(TextEdit,deleteTextEx),rettruestub);
     Stub s10;
     s10.set(ADDR(TextEdit,insertTextEx),rettruestub);
+    Stub s11;
+    s11.set(ADDR(TextEdit,insertMultiTextEx),stub_insertMultiTextEx);
 
 
     intvalue = -1000;
@@ -6226,6 +6247,8 @@ TEST(UT_Textedit_removeComment, UT_Textedit_removeComment_002)
     s6.set(ADDR(TextEdit,deleteTextEx),rettruestub);
     Stub s7;
     s7.set(ADDR(TextEdit,insertTextEx),rettruestub);
+    Stub s8;
+    s8.set(ADDR(TextEdit,deleteMultiTextEx),stub_deleteMultiTextEx);
 
     intvalue = -1000;
     edit->removeComment();
@@ -6255,6 +6278,8 @@ TEST(UT_Textedit_removeComment, UT_Textedit_removeComment_003)
     s6.set(ADDR(TextEdit,deleteTextEx),rettruestub);
     Stub s7;
     s7.set(ADDR(TextEdit,insertTextEx),rettruestub);
+    Stub s8;
+    s8.set(ADDR(TextEdit,deleteMultiTextEx),stub_deleteMultiTextEx);
 
     intvalue = -1000;
     edit->removeComment();
@@ -8365,7 +8390,7 @@ TEST(UT_Textedit_eventFilter, UT_Textedit_eventFilter_002)
     TextEdit* edit = new TextEdit;
     EditWrapper* wra = new EditWrapper;
     edit->m_wrapper = wra;
-    QMouseEvent* e = new QMouseEvent(QEvent::MouseButtonPress,QPointF(20.0,20.0),Qt::RightButton,Qt::RightButton,Qt::NoModifier);
+    QMouseEvent* e = new QMouseEvent(QEvent::MouseButtonPress,QPointF(20.0,20.0),QPointF(20.0,20.0),Qt::RightButton,Qt::RightButton,Qt::NoModifier);
 
     edit->m_rightMenu = new QMenu;
     // QAction *exec(const QPoint &pos, QAction *at = nullptr);
@@ -8390,7 +8415,7 @@ TEST(UT_Textedit_eventFilter, UT_Textedit_eventFilter_003)
     TextEdit* edit = new TextEdit;
     EditWrapper* wra = new EditWrapper;
     edit->m_wrapper = wra;
-    QMouseEvent* e = new QMouseEvent(QEvent::MouseButtonPress,QPointF(20.0,20.0),Qt::LeftButton,Qt::LeftButton,Qt::NoModifier);
+    QMouseEvent* e = new QMouseEvent(QEvent::MouseButtonPress,QPointF(20.0,20.0),QPointF(20.0,20.0),Qt::LeftButton,Qt::LeftButton,Qt::NoModifier);
 
     edit->m_rightMenu = new QMenu;
     // QAction *exec(const QPoint &pos, QAction *at = nullptr);
@@ -8433,7 +8458,7 @@ TEST(UT_Textedit_eventFilter, UT_Textedit_eventFilter_004)
     TextEdit* edit = new TextEdit;
     EditWrapper* wra = new EditWrapper;
     edit->m_wrapper = wra;
-    QMouseEvent* e = new QMouseEvent(QEvent::MouseButtonPress,QPointF(20.0,20.0),Qt::LeftButton,Qt::LeftButton,Qt::NoModifier);
+    QMouseEvent* e = new QMouseEvent(QEvent::MouseButtonPress,QPointF(20.0,20.0),QPointF(20.0,20.0),Qt::LeftButton,Qt::LeftButton,Qt::NoModifier);
 
     edit->m_rightMenu = new QMenu;
     // QAction *exec(const QPoint &pos, QAction *at = nullptr);
@@ -8478,7 +8503,7 @@ TEST(UT_Textedit_eventFilter, UT_Textedit_eventFilter_005)
     TextEdit* edit = new TextEdit;
     EditWrapper* wra = new EditWrapper;
     edit->m_wrapper = wra;
-    QMouseEvent* e = new QMouseEvent(QEvent::MouseButtonPress,QPointF(20.0,20.0),Qt::RightButton,Qt::RightButton,Qt::NoModifier);
+    QMouseEvent* e = new QMouseEvent(QEvent::MouseButtonPress,QPointF(20.0,20.0),QPointF(20.0,20.0),Qt::RightButton,Qt::RightButton,Qt::NoModifier);
 
     edit->m_rightMenu = new QMenu;
     // QAction *exec(const QPoint &pos, QAction *at = nullptr);
@@ -8511,7 +8536,7 @@ TEST(UT_Textedit_eventFilter, UT_Textedit_eventFilter_006)
     TextEdit* edit = new TextEdit;
     EditWrapper* wra = new EditWrapper;
     edit->m_wrapper = wra;
-    QHoverEvent* e = new QHoverEvent(QEvent::HoverMove,QPointF(20.0,20.0),QPointF(30.0,30.0),Qt::NoModifier);
+    QHoverEvent* e = new QHoverEvent(QEvent::HoverMove,QPointF(20.0,20.0),QPointF(30.0,30.0));
 
     edit->m_rightMenu = new QMenu;
     // QAction *exec(const QPoint &pos, QAction *at = nullptr);
@@ -8547,7 +8572,7 @@ TEST(UT_Textedit_eventFilter, UT_Textedit_eventFilter_007)
     TextEdit* edit = new TextEdit;
     EditWrapper* wra = new EditWrapper;
     edit->m_wrapper = wra;
-    QHoverEvent* e = new QHoverEvent(QEvent::HoverMove,QPointF(20.0,20.0),QPointF(30.0,30.0),Qt::NoModifier);
+    QHoverEvent* e = new QHoverEvent(QEvent::HoverMove,QPointF(20.0,20.0),QPointF(30.0,30.0));
 
     edit->m_rightMenu = new QMenu;
     // QAction *exec(const QPoint &pos, QAction *at = nullptr);
@@ -8584,7 +8609,7 @@ TEST(UT_Textedit_eventFilter, UT_Textedit_eventFilter_008)
     TextEdit* edit = new TextEdit;
     EditWrapper* wra = new EditWrapper;
     edit->m_wrapper = wra;
-    QHoverEvent* e = new QHoverEvent(QEvent::HoverLeave,QPointF(20.0,20.0),QPointF(30.0,30.0),Qt::NoModifier);
+    QHoverEvent* e = new QHoverEvent(QEvent::HoverLeave,QPointF(20.0,20.0),QPointF(30.0,30.0));
 
     edit->m_rightMenu = new QMenu;
     // QAction *exec(const QPoint &pos, QAction *at = nullptr);
@@ -8621,7 +8646,7 @@ TEST(UT_Textedit_eventFilter, UT_Textedit_eventFilter_009)
     TextEdit* edit = new TextEdit;
     EditWrapper* wra = new EditWrapper;
     edit->m_wrapper = wra;
-    QHoverEvent* e = new QHoverEvent(QEvent::HoverLeave,QPointF(20.0,20.0),QPointF(30.0,30.0),Qt::NoModifier);
+    QHoverEvent* e = new QHoverEvent(QEvent::HoverLeave,QPointF(20.0,20.0),QPointF(30.0,30.0));
 
     edit->m_rightMenu = new QMenu;
     // QAction *exec(const QPoint &pos, QAction *at = nullptr);
@@ -9714,6 +9739,9 @@ TEST(UT_Textedit_MidButtonInsertText, onTextContentChanged_MidButtonInsertText_P
     TextEdit* edit = new TextEdit;
     EditWrapper* wra = new EditWrapper;
     edit->m_wrapper = wra;
+
+    Stub s1;
+    s1.set(ADDR(TextEdit, slotCanUndoChanged), stub_slotCanUndoChanged);
 
     QString sourceText("123456789");
     edit->setPlainText(sourceText);

--- a/tests/src/widgets/ut_colorselectwidget.cpp
+++ b/tests/src/widgets/ut_colorselectwidget.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2019 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2019-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -82,7 +82,7 @@ TEST_F(test_colorlabel, checkMousePressEvent)
     // 场景1: LeftButtonPress
     auto colorLabel = new ColorLabel(QColor("#FF0000"));
     QSignalSpy spy(colorLabel, &ColorLabel::sigColorClicked);
-    QMouseEvent *event = new QMouseEvent(QEvent::MouseButtonPress, QPointF(),
+    QMouseEvent *event = new QMouseEvent(QEvent::MouseButtonPress, QPointF(), QPointF(),
                                          Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
     colorLabel->mousePressEvent(event);
     EXPECT_EQ(spy.count(), 1);
@@ -97,7 +97,7 @@ TEST_F(test_colorlabel, checkMousePressEvent)
     // 场景2: 非LeftButtonPress
     colorLabel = new ColorLabel(QColor("#FF0000"));
     QSignalSpy spy2(colorLabel, &ColorLabel::sigColorClicked);
-    event = new QMouseEvent(QEvent::MouseButtonPress, QPointF(),
+    event = new QMouseEvent(QEvent::MouseButtonPress, QPointF(), QPointF(),
                             Qt::RightButton, Qt::RightButton, Qt::NoModifier);
     colorLabel->mousePressEvent(event);
     EXPECT_EQ(spy2.count(), 0);
@@ -167,7 +167,7 @@ TEST_F(test_colorselectwidget, checkEventFilter)
 
     // 场景2: 过滤m_pLabel的LeftButton事件
     ColorSelectWdg *colorSelctWidget = new ColorSelectWdg("this is a test");
-    QMouseEvent *event = new QMouseEvent(QEvent::MouseButtonPress, QPointF(),
+    QMouseEvent *event = new QMouseEvent(QEvent::MouseButtonPress, QPointF(), QPointF(),
                                          Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
     bool result = colorSelctWidget->eventFilter(colorSelctWidget->m_pLabel, event);
     EXPECT_TRUE(result);
@@ -179,7 +179,7 @@ TEST_F(test_colorselectwidget, checkEventFilter)
 
     // 场景2: 过滤非m_pLabel的LeftButton事件
     colorSelctWidget = new ColorSelectWdg("this is a test");
-    event = new QMouseEvent(QEvent::MouseButtonPress, QPointF(),
+    event = new QMouseEvent(QEvent::MouseButtonPress, QPointF(), QPointF(),
                             Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
     result = colorSelctWidget->eventFilter(colorSelctWidget->m_pButton, event);
     EXPECT_FALSE(result);
@@ -191,7 +191,7 @@ TEST_F(test_colorselectwidget, checkEventFilter)
 
     // 场景3: 过滤m_pLabel的非LeftButton事件
     colorSelctWidget = new ColorSelectWdg("this is a test");
-    event = new QMouseEvent(QEvent::MouseButtonPress, QPointF(),
+    event = new QMouseEvent(QEvent::MouseButtonPress, QPointF(), QPointF(),
                             Qt::RightButton, Qt::RightButton, Qt::NoModifier);
     result = colorSelctWidget->eventFilter(colorSelctWidget->m_pLabel, event);
     EXPECT_FALSE(result);

--- a/tests/src/widgets/ut_window.cpp
+++ b/tests/src/widgets/ut_window.cpp
@@ -2108,8 +2108,10 @@ TEST(UT_Window_doprint, UT_Window_doPrintWithLargeDoc)
     EXPECT_NE(w, nullptr);
     w->deleteLater();
     editwrapper_texteditor->deleteLater();
-    w->m_printDoc->deleteLater();
-    w->m_pPreview->deleteLater();
+    if (w->m_printDoc)
+        w->m_printDoc->deleteLater();
+    if (w->m_pPreview)
+        w->m_pPreview->deleteLater();
     delete p;
     p = nullptr;
 }
@@ -2167,7 +2169,7 @@ TEST(UT_Window_dropEvent, UT_Window_dropEvent)
     QMimeData* data = new QMimeData;
     QList<QUrl> urls = {QUrl("http://")};
     data->setUrls(urls);
-    QDropEvent* d = new QDropEvent(QPointF(100,100), Qt::MoveAction,data ,Qt::LeftButton, Qt::ShiftModifier);
+    QDropEvent* d = new QDropEvent(QPointF(100,100), Qt::MoveAction,data ,Qt::LeftButton, Qt::ShiftModifier, QEvent::Drop);
 
     w->dropEvent(d);
 


### PR DESCRIPTION
Add stubs for insertMultiTextEx, deleteMultiTextEx and slotCanUndoChanged to prevent unsafe Window pointer access via EditWrapper::window() when no real Window parent exists.

修复单元测试中因 EditWrapper 缺少 Window 父对象导致的堆越界崩溃，
通过 stub 隔离 undo 栈信号链中的 Window 访问路径。

同时修复源码中 slotCanUndoChanged/slotCanRedoChanged 的空指针 解引用风险，使用 dynamic_cast 替代直接调用，增加 m_wrapper 空检查。
修复 Tabbar::eventFilter 事件过滤范围过宽的问题。
修复 Qt6 API 兼容性（QMouseEvent/QHoverEvent 构造函数变更）。
修复 resizeEvent lambda 中的悬空指针风险（使用 QPointer 保护）。
修复 Window::checkBlockShutdown 空标签文本的越界访问。

Log: 修复单元测试ASAN堆越界崩溃及多处空指针/类型安全问题
Influence: 修复后单元测试不再因类型混淆和堆越界崩溃，提升测试稳定性；源码修复消除了 slotCanUndoChanged 等路径中的空指针解引用和悬空指针风险。