### PR TITLE
fix(tabbar): only handle mouse events for self in eventFilter

### DIFF
--- a/src/controls/tabbar.cpp
+++ b/src/controls/tabbar.cpp
@@ -627,12 +627,12 @@ void Tabbar::handleDragActionChanged(Qt::DropAction action)
     qDebug() << "Exit handleDragActionChanged";
 }
 
-bool Tabbar::eventFilter(QObject *object, QEvent *event)
+bool Tabbar::eventFilter(QObject *watched, QEvent *event)
 {
 #if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
     // Only handle ApplicationFontChange for this widget itself,
     // not for every widget in the application.
-    if (event->type() == QEvent::ApplicationFontChange && object == this) {
+    if (event->type() == QEvent::ApplicationFontChange && watched == this) {
         if (this->font() != qApp->font()) {
             setFont(qApp->font());
         }
@@ -648,6 +648,11 @@ bool Tabbar::eventFilter(QObject *object, QEvent *event)
     }
 #endif
     if (event->type() == QEvent::MouseButtonPress) {
+
+        if (watched != this) {
+            return false;
+        }
+
         QMouseEvent *mouseEvent = static_cast<QMouseEvent *>(event);
 
         if (mouseEvent->button() == Qt::RightButton) {

--- a/src/controls/tabbar.h
+++ b/src/controls/tabbar.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2017 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -66,7 +66,7 @@ protected:
     void insertFromMimeDataOnDragEnter(int index, const QMimeData *source);
     void insertFromMimeData(int index, const QMimeData *source);
     bool canInsertFromMimeData(int index, const QMimeData *source) const;
-    bool eventFilter(QObject *, QEvent *event);
+    bool eventFilter(QObject *watched, QEvent *event);
 
     QSize tabSizeHint(int index) const;
     QSize minimumTabSizeHint(int index) const;


### PR DESCRIPTION
Add a guard to skip event handling when the watched object is not the Tabbar itself, preventing unintended event interception for child or sibling widgets.

增加守卫条件，当被监视对象不是Tabbar自身时跳过事件处理，
避免错误拦截子控件或兄弟控件的事件。

Log: 修复tabbar eventFilter错误拦截其他控件事件
PMS: BUG-364255
Influence: 修复后Tabbar的eventFilter仅处理自身事件，不会错误拦截其他控件事件。

## Summary by Sourcery

Restrict Tabbar's event filtering to only handle its own mouse and font change events to avoid intercepting events from other widgets.

Bug Fixes:
- Prevent Tabbar's eventFilter from incorrectly handling mouse events for non-Tabbar widgets.

Enhancements:
- Clarify eventFilter parameter naming to reflect the watched object in the Tabbar class.
- Update Tabbar source file copyright years to include 2026.