### PR TITLE
chore: only build tests in Debug mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,6 @@ add_definitions(-DKF5_HIGHLIGHT_PATH=\"${KF5_HIGHLIGHT_INSTALL_PATH}\")
 
 add_subdirectory(src)
 
-if (CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "Release")
+if (CMAKE_BUILD_TYPE STREQUAL "Debug")
     add_subdirectory(tests)
 endif()


### PR DESCRIPTION
Simplify build configuration to only compile tests when CMAKE_BUILD_TYPE is "Debug", reducing unnecessary build overhead in Release mode.

Log: 优化测试模块编译配置
Influence: Release 构建不再编译测试代码，减少构建产物大小和编译时间。