### PR TITLE
fix: handle non-existent file paths in tab management

### DIFF
--- a/src/common/urlinfo.h
+++ b/src/common/urlinfo.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2017 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -10,6 +10,7 @@
 #include <QUrl>
 #include <QDir>
 #include <QDebug>
+#include "utils.h"
 
 class UrlInfo
 {
@@ -37,7 +38,7 @@ public:
         // assume a local file and just convert it to an url.
         if (!url.isValid()) {
             // create absolute file path, we will e.g. pass this over dbus to other processes
-            url = QUrl::fromLocalFile(QFileInfo(path).canonicalFilePath());
+            url = QUrl::fromLocalFile(Utils::getFilePath(path));
         }
     }
 

--- a/src/common/utils.cpp
+++ b/src/common/utils.cpp
@@ -476,6 +476,18 @@ bool Utils::fileExists(const QString &path)
     return exists;
 }
 
+QString Utils::getFilePath(const QString &filePath)
+{
+    QFileInfo info(filePath);
+    QString canonicalPath = info.canonicalFilePath();
+    // canonicalFilePath() returns empty string for non-existent files
+    // Use absoluteFilePath() as fallback to support creating new files
+    if (canonicalPath.isEmpty()) {
+        return info.absoluteFilePath();
+    }
+    return canonicalPath;
+}
+
 bool Utils::fileIsWritable(const QString &path)
 {
     qDebug() << "Enter fileIsWritable, path:" << path;
@@ -1430,7 +1442,7 @@ bool Utils::isMemorySufficientForOperation(OperationType operationType, qlonglon
                 return false;
             }
             break;
-            
+
         case OperationType::CopyOperation: {
             // Copy operation: Estimated memory consumption = data size * factor
             qlonglong estimatedMemoryNeeded = operationDataSize * COPY_CONSUME_MEMORY_MULTIPLE;
@@ -1440,7 +1452,7 @@ bool Utils::isMemorySufficientForOperation(OperationType operationType, qlonglon
             }
             break;
         }
-            
+
         case OperationType::PasteOperation: {
             // Paste operation: Estimated memory consumption = paste data size * factor
             qlonglong estimatedMemoryNeededForPaste = operationDataSize * PASTE_CONSUME_MEMORY_MULTIPLE;

--- a/src/common/utils.h
+++ b/src/common/utils.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2011-2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2011-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -86,6 +86,15 @@ public:
     static bool fileExists(const QString &path);
     static bool fileIsWritable(const QString &path);
     static bool fileIsHome(const QString &path);
+    /**
+     * @brief getFilePath 获取文件路径
+     * @param filePath 原始文件路径
+     * @return 文件路径
+     * @note 优先使用 canonicalFilePath()（解析符号链接），当文件不存在时
+     *       返回空字符串，此时使用 absoluteFilePath() 作为后备方案。
+     *       确保即使是新建文件，标签页也能正确显示和关闭。
+     */
+    static QString getFilePath(const QString &filePath);
     static void passInputEvent(int wid);
     static QPixmap dropShadow(const QPixmap &source, qreal radius, const QColor &color, const QPoint &offset);
     static QImage dropShadow(const QPixmap &px, qreal radius, const QColor &color);

--- a/src/editor/editwrapper.cpp
+++ b/src/editor/editwrapper.cpp
@@ -180,7 +180,7 @@ bool EditWrapper::getFileLoading()
 void EditWrapper::openFile(const QString &filepath, QString qstrTruePath, bool bIsTemFile)
 {
     qDebug() << "Opening file:" << filepath << "Real path:" << qstrTruePath << "Is temp:" << bIsTemFile;
-    
+
     m_bIsTemFile = bIsTemFile;
     // update file path.
     updatePath(filepath, qstrTruePath);
@@ -221,7 +221,7 @@ bool EditWrapper::readFile(QByteArray encode)
     qDebug() << "Reading file with encoding:" << encode;
     QString filePath = m_pTextEdit->getTruePath();
     qDebug() << "Reading file:" << filePath << "with encode:" << encode;
-    
+
     QFile file(filePath);
     if (file.open(QIODevice::ReadOnly)) {
         qDebug() << "File opened successfully";
@@ -263,7 +263,7 @@ bool EditWrapper::readFile(QByteArray encode)
 bool EditWrapper::saveAsFile(const QString &newFilePath, const QByteArray &encodeName)
 {
     qDebug() << "Attempting to save file to:" << newFilePath << "with encoding:" << encodeName;
-    
+
     // Use TextFileSaver for safe file saving
     TextFileSaver saver(m_pTextEdit->document());
     saver.setFilePath(newFilePath);
@@ -339,7 +339,7 @@ bool EditWrapper::saveAsFile()
 bool EditWrapper::reloadFileEncode(QByteArray encode)
 {
     qDebug() << "Reloading file with new encoding:" << encode.size();
-    
+
     //切换编码相同不重写加载
     if (m_sCurEncode == encode) {
         qDebug() << "Encoding unchanged, skipping reload";
@@ -971,7 +971,7 @@ void EditWrapper::handleFilePreProcess(const QByteArray &encode, const QByteArra
 void EditWrapper::handleFileLoadFinished(const QByteArray &encode, const QByteArray &content, bool error)
 {
     qDebug() << "File load finished. Encoding:" << encode << "Error:" << error << "Preprocessed:" << m_bHasPreProcess;
-    
+
     // 判断是否预加载，若已预加载，则无需重新初始化
     if (!m_bHasPreProcess) {
         qDebug() << "Performing initial file load initialization";
@@ -1094,7 +1094,12 @@ void EditWrapper::handleFileLoadFinished(const QByteArray &encode, const QByteAr
     // 提示读取错误信息
     if (error) {
         qDebug() << "EditWrapper handleFileLoadFinished, error is true, onReadAllocError()";
-        onReadAllocError();
+        // 如果文件不存在，静默处理（可能是新建文件），不显示错误提示
+        if (!QFileInfo::exists(m_pTextEdit->getTruePath())) {
+            qDebug() << "File does not exist, skipping error notification (new file scenario)";
+        } else {
+            onReadAllocError();
+        }
     }
     qDebug() << "EditWrapper handleFileLoadFinished, exit";
 }
@@ -1309,15 +1314,15 @@ void EditWrapper::updateModifyStatus(bool bModified)
         qDebug() << "Skipping modify status update during file loading";
         return;
     }
-    
+
     QString filePath = m_pTextEdit->getFilePath();
     qDebug() << "Updating modify status for:" << filePath << "New status:" << bModified;
-    
+
     if (!bModified) {
         qDebug() << "Updating save index for:" << filePath;
         m_pTextEdit->updateSaveIndex();
     }
-    
+
     m_pTextEdit->document()->setModified(bModified);
     Window *pWindow = static_cast<Window *>(QWidget::window());
     pWindow->updateModifyStatus(filePath, bModified);

--- a/src/startmanager.cpp
+++ b/src/startmanager.cpp
@@ -522,9 +522,9 @@ void StartManager::openFilesInWindow(QStringList files)
     } else {
         qDebug() << "Processing files to open in window:" << files;
         for (const QString &file : files) {
-            QString canonicalFile = QFileInfo(file).canonicalFilePath();
-            qDebug() << "Processing file:" << file << "canonical path:" << canonicalFile;
-            FileTabInfo info = getFileTabInfo(canonicalFile);
+            QString resolvedFile = Utils::getFilePath(file);
+            qDebug() << "Processing file:" << file << "resolved path:" << resolvedFile;
+            FileTabInfo info = getFileTabInfo(resolvedFile);
 
             // Open exist tab if file has opened.
             if (info.windowIndex != -1) {
@@ -536,8 +536,8 @@ void StartManager::openFilesInWindow(QStringList files)
                 qDebug() << "File not open, creating new window and tab";
                 Window *window = createWindow();
                 window->showCenterWindow(true);
-                window->addTab(canonicalFile);
-                qDebug() << "Added tab for file:" << canonicalFile;
+                window->addTab(resolvedFile);
+                qDebug() << "Added tab for file:" << resolvedFile;
             }
         }
     }
@@ -594,16 +594,16 @@ void StartManager::openFilesInTab(QStringList files)
     } else {
         qDebug() << "Processing" << files.size() << "files to open in tabs";
         for (const QString &file : files) {
-            QString canonicalFile = QFileInfo(file).canonicalFilePath();
-            qDebug() << "Processing file:" << file << "canonical path:" << canonicalFile;
-            
-            if (!checkPath(canonicalFile)) {
-                qDebug() << "File already open, skipping:" << canonicalFile;
+            QString resolvedFile = Utils::getFilePath(file);
+            qDebug() << "Processing file:" << file << "resolved path:" << resolvedFile;
+
+            if (!checkPath(resolvedFile)) {
+                qDebug() << "File already open, skipping:" << resolvedFile;
                 // 存在已打开文件时，进行下一文件判断
                 continue;
             }
 
-            FileTabInfo info = getFileTabInfo(canonicalFile);
+            FileTabInfo info = getFileTabInfo(resolvedFile);
 
             // Open exist tab if file has opened.
             if (info.windowIndex != -1) {
@@ -616,17 +616,17 @@ void StartManager::openFilesInTab(QStringList files)
                 Window *window = createWindow(true);
                 window->showCenterWindow(true);
                 QTimer::singleShot(50, [ = ] {
-                    qDebug() << "Delayed file opening for:" << canonicalFile;
+                    qDebug() << "Delayed file opening for:" << resolvedFile;
                     recoverFile(window);
-                    window->addTab(canonicalFile);
+                    window->addTab(resolvedFile);
                 });
             }
             // Open file tab in first window of window list.
             else {
                 qDebug() << "Opening file in first existing window";
                 Window *window = m_windows[0];
-                window->addTab(canonicalFile);
-                qDebug() << "Added tab for file:" << canonicalFile << "in existing window";
+                window->addTab(resolvedFile);
+                qDebug() << "Added tab for file:" << resolvedFile << "in existing window";
                 //window->setWindowState(Qt::WindowActive);
                 //通过dbus接口从任务栏激活窗口
                 if (!Q_LIKELY(Utils::activeWindowFromDock(window->winId()))) {


### PR DESCRIPTION
1. Added Utils::getFilePath() that returns canonicalFilePath() for
existing files and falls back to absoluteFilePath() for non-existent
files to support new file creation.
2. Updated StartManager to use Utils::getFilePath() instead of directly
using canonicalFilePath() when opening files in windows/tabs.
3. Modified EditWrapper::handleFileLoadFinished to suppress error
notifications for non-existent files (new file scenario).
4. Fixed issue where tabs for new files could not be properly displayed
or closed due to empty canonical paths.

Log: When creating new files, the editor no longer shows spurious error
popups or fails to manage tabs correctly.

Influence:
1. Test creating new files from various entry points (e.g., double-click
in file manager, command line, DBus).
2. Verify that existing files still open correctly with symlinks
resolved.
3. Verify that tabs for new files display correctly and can be closed
without errors.
4. Verify that opening non-existent files via recent files list does not
cause error dialogs.

fix: 处理标签页管理中不存在的文件路径

1. 新增 Utils::getFilePath() 方法，对已存在文件返回规范路径，对不存在的
文件返回绝对路径，以支持新建文件场景。
2. 更新 StartManager 中使用 Utils::getFilePath() 替代直接使用
canonicalFilePath() 打开文件。
3. 修改 EditWrapper::handleFileLoadFinished，对于不存在的文件静默处理
（新建文件场景），不显示错误提示。
4. 修复新建文件时标签页无法正确显示或关闭的问题。

Log: 新建文件时，编辑器不再显示错误弹窗，标签页管理恢复正常。

Influence:
1. 测试从不同入口新建文件（如双击文件管理器、命令行、DBus接口）。
2. 验证已存在文件仍能正确打开，且符号链接解析正常。
3. 验证新建文件的标签页显示正确且可以正常关闭。
4. 验证从最近文件列表打开不存在的文件时不会弹出错误对话框。

BUG: https://pms.uniontech.com/bug-view-336931.html
