### PR TITLE
chore: update version to 6.5.53

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+deepin-editor (6.5.53) unstable; urgency=medium
+
+  * fix: use readAll() for virtual files with zero reported size
+  * fix(tabbar): only handle mouse events for self in eventFilter
+  * fix(test): resolve ASAN heap-buffer-overflow in textedit unit tests
+  * fix: handle non-existent file paths in tab management
+
+ -- Liu Zhangjian <liuzhangjian@uniontech.com>  Fri, 05 Jun 2026 11:48:15 +0800
+
 deepin-editor (6.5.52) unstable; urgency=medium
 
   * fix: support opening JSON files detected as MIME subtype

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.editor
   name: "deepin-editor"
-  version: 6.5.52.1
+  version: 6.5.53.1
   kind: app
   description: |
     editor for deepin os.


### PR DESCRIPTION
as title

Log: update version

## Summary by Sourcery

Build:
- Update linglong package configuration to reference version 6.5.53.1.