### PR TITLE
fix(editor): deduplicate blank tab indexes to fix incorrect new docum…

### DIFF
--- a/src/widgets/window.cpp
+++ b/src/widgets/window.cpp
@@ -3097,6 +3097,9 @@ int Window::getBlankFileIndex()
         }
     }
     std::sort(tabIndexes.begin(), tabIndexes.end());
+    // Remove duplicates to avoid incorrect index calculation when tabs with
+    // the same "Untitled N" name are dragged between windows.
+    tabIndexes.erase(std::unique(tabIndexes.begin(), tabIndexes.end()), tabIndexes.end());
 
     // Return 1 if no blank file exists.
     if (tabIndexes.size() == 0) {


### PR DESCRIPTION
…ent naming

- Add std::unique + erase after sorting in getBlankFileIndex() to remove duplicate index numbers
- Prevent newly created documents from being stuck with the same "Untitled N" name when tabs with duplicate titles are dragged between windows

修复(editor): 对空白标签索引去重以修复新文档命名错误

- 在 getBlankFileIndex() 的排序后增加 std::unique + erase 去除重复的索引编号
- 修复跨窗口拖入同名"未命名文档"标签后，新建文档名称始终为同一编号的问题

Log: 修复跨窗口拖拽标签导致新文档命名计数器异常的 bug
Bug: https://pms.uniontech.com/bug-view-251843.html