### PR TITLE
fix(logging): add Qt logging filter rules initialization

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -25,11 +25,24 @@
 #include <QDebug>
 
 #include <iostream>
+#include <QLoggingCategory>
 
 DWIDGET_USE_NAMESPACE
 
+static const char *DEFAULT_LOGGING_RULES = "*.debug=false";
+
+static void initLoggingRules()
+{
+    QByteArray rules = qgetenv("QT_LOGGING_RULES");
+    if (rules.isEmpty()) {
+        QLoggingCategory::setFilterRules(DEFAULT_LOGGING_RULES);
+    }
+}
+
 int main(int argc, char *argv[])
 {
+    initLoggingRules();
+
     qDebug() << "Application starting with arguments:" << QCoreApplication::arguments();
     DCORE_USE_NAMESPACE
     PerformanceMonitor::initializeAppStart();


### PR DESCRIPTION
Add initLoggingRules() to read QT_LOGGING_RULES environment variable for log filtering. Default to disabling debug logs when unset.

添加 Qt 日志过滤规则初始化，通过 QT_LOGGING_RULES 环境变量控制日志输出，
未设置时默认关闭 debug 日志。

Log: 添加 Qt 日志过滤规则初始化功能
PMS: https://pms.uniontech.com/bug-view-348319.html
Influence: 应用启动时可通过环境变量控制日志级别，默认关闭 debug 日志减少输出噪音。