### PR TITLE
fix(editor): fix window close logic and lambda capture

### DIFF
--- a/src/startmanager.cpp
+++ b/src/startmanager.cpp
@@ -805,8 +805,8 @@ void StartManager::slotCloseWindow()
         // 导致被附加到上一文本编辑器进程
         QDBusConnection::sessionBus().unregisterService("com.deepin.Editor");
 
-        QTimer::singleShot(1000, []() {
-             StartManager::instance()->delayMallocTrim();
+        QTimer::singleShot(1000, [this]() {
+            this->delayMallocTrim();
             QApplication::quit();
         });
 

--- a/src/widgets/window.cpp
+++ b/src/widgets/window.cpp
@@ -1199,8 +1199,10 @@ void Window::removeWrapper(const QString &filePath, bool isDelete)
         }
     }
 
-    // Exit window after close all tabs.
-    if (m_wrappers.isEmpty()) {
+    // Exit window after close all tabs (including pending and blank tabs).
+    // Pending tabs are kept in m_pendingTabs, blank tabs are managed by the tabbar.
+    // Only close the window when the tabbar has no tabs left.
+    if (m_wrappers.isEmpty() && m_tabbar->count() == 0) {
         close();
         qInfo() << "after close";
     }


### PR DESCRIPTION
Fix window close timing by checking tabbar count instead of just wrappers. Use proper lambda capture [this] to avoid StartManager::instance() race condition.

修复窗口关闭时机判断，添加标签页计数检查。
修复lambda捕获问题，使用this指针避免instance()竞态条件。

Log: 修复窗口关闭逻辑
PMS: BUG-365421
Influence: 修复编辑器关闭时可能出现的窗口未正确关闭问题，提升应用稳定性。