### PR TITLE
chore: Update version to 6.5.55

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+deepin-editor (6.5.55) unstable; urgency=medium
+
+  * chore: Update version to 6.5.55
+  * fix(editor): fix window close logic and lambda capture
+  * fix(editor): deduplicate blank tab indexes to fix incorrect new document naming
+
+ -- zhanghongyuan <zhanghongyuan@uniontech.com>  Fri, 12 Jun 2026 09:02:18 +0800
+
 deepin-editor (6.5.54) unstable; urgency=medium
 
   * chore: Update version to 6.5.54

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.editor
   name: "deepin-editor"
-  version: 6.5.54.1
+  version: 6.5.55.1
   kind: app
   description: |
     editor for deepin os.


### PR DESCRIPTION
- update version to 6.5.55

log: update version to 6.5.55

## Summary by Sourcery

Bump application package version metadata to 6.5.55.1 in linglong configuration and Debian packaging changelog.