### PR TITLE
fix: remove deepin prefix from Chinese translations in desktop file

### DIFF
--- a/deepin-editor.desktop
+++ b/deepin-editor.desktop
@@ -121,6 +121,6 @@ Name[ug]=Deepin تېكىست تەھرىرلىگۈچ
 Name[uk]=Текстовий редактор Deepin
 Name[lo]=ຕົວແກ້ໄຂຂໍ້ຄວາມ
 Name[zh_CN]=文本编辑器
-Name[zh_HK]=Deepin 文本編輯器
-Name[zh_TW]=Deepin 文字編輯器
+Name[zh_HK]=文本編輯器
+Name[zh_TW]=文字編輯器
 


### PR DESCRIPTION
Remove "深度"/"deepin"/"Deepin" prefix from Name/Comment fields in zh_CN, zh_HK, zh_TW translations.

去除 desktop 文件中 zh_CN/zh_HK/zh_TW 翻译的"深度"/"deepin"前缀。

Log: 去除desktop文件中文翻译中的深度/deepin前缀
PMS: BUG-369185
Influence: 自研应用 desktop 文件中文翻译不再包含"深度"/"deepin"品牌前缀。

## Summary by Sourcery

Bug Fixes:
- Correct Chinese desktop entry translations by removing redundant "深度"/"deepin"/"Deepin" prefixes from Name and Comment fields.