### PR TITLE
fix: add X-Deepin-Singleton flag to desktop file (#392841)

### DIFF
--- a/deepin-editor.desktop
+++ b/deepin-editor.desktop
@@ -11,6 +11,7 @@ Type=Application
 X-Deepin-AppID=deepin-editor
 X-Deepin-CreatedBy=com.deepin.dde.daemon.Launcher
 X-Deepin-Vendor=deepin
+X-Deepin-Singleton=true
 X-MultipleArgs=false
 
 # Translations:


### PR DESCRIPTION
Add X-Deepin-Singleton=true to desktop file to mark the application as a singleton app. This allows AM to identify singleton apps and inform Treeland to skip the splash screen for these apps.

Refs: https://pms.uniontech.com/task-view-392841.html

## Summary by Sourcery

New Features:
- Introduce X-Deepin-Singleton flag in the deepin-editor desktop entry to identify it as a singleton app.