### PR TITLE
fix(CI): update cppcheck workflow to use checkout@v7

### DIFF
--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -14,10 +14,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: export
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
+          allow-unsafe-pr-checkout: true
       - uses: linuxdeepin/action-cppcheck@main
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
参考: https://github.com/linuxdeepin/deepin-camera/pull/501

将 cppcheck 工作流中的 actions/checkout 从 v3 升级到 v7，并添加 allow-unsafe-pr-checkout 参数，修复 fork 仓库提交 PR 时 CI 运行失败的问题。

## Summary by Sourcery

CI:
- Bump actions/checkout in the cppcheck workflow from v3 to v7 and enable unsafe PR checkout to fix CI failures for forks.