### PR TITLE
feat: add safe preview and controlled save for files containing NUL bytes

### DIFF
--- a/src/common/CSyntaxHighlighter.cpp
+++ b/src/common/CSyntaxHighlighter.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2017-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -23,6 +23,16 @@ void CSyntaxHighlighter::setEnableHighlight(bool isEnable)
     m_bHighlight = isEnable;
 }
 
+void CSyntaxHighlighter::setInvalidCharHighlight(bool enable)
+{
+    qDebug() << "CSyntaxHighlighter::setInvalidCharHighlight()" << enable;
+    m_bInvalidCharHighlight = enable;
+    if (enable) {
+        setEnableHighlight(true);
+    }
+    rehighlight();
+}
+
 void CSyntaxHighlighter::highlightBlock(const QString &text)
 {
     if (!m_bHighlight) {
@@ -30,4 +40,18 @@ void CSyntaxHighlighter::highlightBlock(const QString &text)
     }
 
     KSyntaxHighlighting::SyntaxHighlighter::highlightBlock(text);
+
+    // 叠加 \00 无效字符高亮：红色背景 + 白色文字
+    if (m_bInvalidCharHighlight) {
+        QTextCharFormat fmt;
+        fmt.setBackground(QColor("#FF0000"));
+        fmt.setForeground(QColor("#FFFFFF"));
+        // 匹配字面量 \00（反斜杠 + 两个零）
+        static const QRegularExpression re("\\\\00");
+        QRegularExpressionMatchIterator it = re.globalMatch(text);
+        while (it.hasNext()) {
+            QRegularExpressionMatch match = it.next();
+            setFormat(match.capturedStart(), match.capturedLength(), fmt);
+        }
+    }
 }

--- a/src/common/CSyntaxHighlighter.h
+++ b/src/common/CSyntaxHighlighter.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2017-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -6,6 +6,9 @@
 #include <KSyntaxHighlighting/Repository>
 #include <KSyntaxHighlighting/Definition>
 #include <KSyntaxHighlighting/SyntaxHighlighter>
+#include <QRegularExpression>
+#include <QTextCharFormat>
+#include <QColor>
 
 using namespace KSyntaxHighlighting;
 class CSyntaxHighlighter : public SyntaxHighlighter
@@ -15,10 +18,12 @@ public:
     explicit CSyntaxHighlighter(QObject *parent = nullptr);
     explicit CSyntaxHighlighter(QTextDocument *pDocument);
     void setEnableHighlight(bool isEnable);
+    void setInvalidCharHighlight(bool enable);
 
 protected:
     virtual void highlightBlock(const QString & text) override;
 
 private:
     bool m_bHighlight = false;
+    bool m_bInvalidCharHighlight = false;
 };

--- a/src/common/fileloadthread.cpp
+++ b/src/common/fileloadthread.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2017-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -36,11 +36,20 @@ void FileLoadThread::run()
 
             // 发送文件头信息，用于预先加载数据
             QString textEncode = QString::fromLocal8Bit(encode);
-            if (textEncode.contains("ASCII", Qt::CaseInsensitive) || textEncode.contains("UTF-8", Qt::CaseInsensitive)) {
-                emit sigPreProcess(encode, indata);
+           if (textEncode.contains("ASCII", Qt::CaseInsensitive) || textEncode.contains("UTF-8", Qt::CaseInsensitive)) {
+                if (indata.contains('\x00')) {
+                    QByteArray headData = indata;
+                    headData.replace('\x00', "\\00");
+                    emit sigPreProcess(encode, headData);
+                } else {
+                    emit sigPreProcess(encode, indata);
+                }
             } else {
                 QByteArray outHeadData;
                 DetectCode::ChangeFileEncodingFormat(indata, outHeadData, textEncode, QString("UTF-8"));
+                if (outHeadData.contains('\x00')) {
+                    outHeadData.replace('\x00', "\\00");
+                }
                 emit sigPreProcess(encode, outHeadData);
             }
         }
@@ -54,8 +63,14 @@ void FileLoadThread::run()
             qWarning() << Q_FUNC_INFO << "Read file data error, " << QString(e.what());
 
             file.close();
-            emit sigLoadFinished(encode, indata, true);
+            emit sigLoadFinished(encode, indata, true, false);
             return;
+        }
+
+        // NUL 字节检测与转义：将每个 \x00 替换为三个 ASCII 字符 \00
+        bool hasNul = indata.contains('\x00');
+        if (hasNul) {
+            indata.replace('\x00', "\\00");
         }
 
         if (encode.isEmpty()) {
@@ -71,11 +86,11 @@ void FileLoadThread::run()
 
         QString textEncode = QString::fromLocal8Bit(encode);
         if (textEncode.contains("ASCII", Qt::CaseInsensitive) || textEncode.contains("UTF-8", Qt::CaseInsensitive)) {
-            emit sigLoadFinished(encode, indata, false);
+            emit sigLoadFinished(encode, indata, false, hasNul);
         } else {
             QByteArray outData;
             DetectCode::ChangeFileEncodingFormat(indata, outData, textEncode, QString("UTF-8"));
-            emit sigLoadFinished(encode, outData, false);
+            emit sigLoadFinished(encode, outData, false, hasNul);
         }
     }
 

--- a/src/common/fileloadthread.h
+++ b/src/common/fileloadthread.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2017-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -19,7 +19,7 @@ public:
 signals:
     // 预处理信号，优先处理文件头，防止出现加载时间过长的情况
     void sigPreProcess(const QByteArray &encode, const QByteArray &content);
-    void sigLoadFinished(const QByteArray &encode, const QByteArray &content, bool error = false);
+    void sigLoadFinished(const QByteArray &encode, const QByteArray &content, bool error = false, bool hasNul = false);
 
 private:
     QString m_strFilePath;

--- a/src/controls/warningnotices.cpp
+++ b/src/controls/warningnotices.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2019 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2019-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -22,11 +22,15 @@ WarningNotices::WarningNotices(MessageType notifyType, QWidget *parent)
     setIcon(QIcon(":/images/warning.svg"));
     m_reloadBtn = new QPushButton(tr("Reload"), this);
     m_saveAsBtn = new QPushButton(qApp->translate("Window", "Save as"), this);
+    m_editAnywayBtn = new QPushButton(tr("Edit Anyway"), this);
     m_reloadBtn->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
     m_saveAsBtn->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+    m_editAnywayBtn->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+    m_editAnywayBtn->setVisible(false);
 
     connect(m_reloadBtn, &QPushButton::clicked, this, &WarningNotices::slotreloadBtnClicked);
     connect(m_saveAsBtn, &QPushButton::clicked, this, &WarningNotices::slotsaveAsBtnClicked);
+    connect(m_editAnywayBtn, &QPushButton::clicked, this, &WarningNotices::slotEditAnywayBtnClicked);
 
 #ifdef DTKWIDGET_CLASS_DSizeMode
     DDialogCloseButton *closeBtn = findChild<DDialogCloseButton *>();
@@ -82,4 +86,18 @@ void WarningNotices::slotsaveAsBtnClicked()
 {
     this->hide();
     emit saveAsBtnClicked();
+}
+
+void WarningNotices::setEditAnywayBtn()
+{
+    m_reloadBtn->setVisible(false);
+    m_saveAsBtn->setVisible(false);
+    m_editAnywayBtn->setVisible(true);
+    setWidget(m_editAnywayBtn);
+}
+
+void WarningNotices::slotEditAnywayBtnClicked()
+{
+    this->hide();
+    emit editAnywayBtnClicked();
 }

--- a/src/controls/warningnotices.h
+++ b/src/controls/warningnotices.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2019 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2019-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -23,19 +23,23 @@ public:
     void setReloadBtn();
     void setSaveAsBtn();
     void clearBtn();
+    void setEditAnywayBtn();
 
 signals:
     void reloadBtnClicked();
     void saveAsBtnClicked();
     void closeBtnClicked();
+    void editAnywayBtnClicked();
 
 public slots:
     void slotreloadBtnClicked();
     void slotsaveAsBtnClicked();
+    void slotEditAnywayBtnClicked();
 
 private:
     QPushButton *m_reloadBtn;
     QPushButton *m_saveAsBtn;
+    QPushButton *m_editAnywayBtn;
     QHBoxLayout *m_pLayout;
 };
 

--- a/src/editor/editwrapper.cpp
+++ b/src/editor/editwrapper.cpp
@@ -114,6 +114,7 @@ EditWrapper::EditWrapper(Window *window, QWidget *parent)
     connect(m_pTextEdit, &TextEdit::cursorModeChanged, this, &EditWrapper::handleCursorModeChanged);
     connect(m_pWaringNotices, &WarningNotices::reloadBtnClicked, this, &EditWrapper::reloadModifyFile);
     connect(m_pWaringNotices, &WarningNotices::saveAsBtnClicked, m_pWindow, &Window::saveAsFile);
+    connect(m_pWaringNotices, &WarningNotices::editAnywayBtnClicked, this, &EditWrapper::onEditAnyway);
     // NOTE: 文本高亮会触发重新布局，与界面布局(拖拽、放大窗口)变更时的布局操作冲突，因此调整更新顺序，在布局后刷新高亮
     connect(m_pTextEdit->verticalScrollBar(), &QScrollBar::valueChanged, this, [this](int) {
         OnUpdateHighlighter();
@@ -507,6 +508,11 @@ QString EditWrapper::getTextEncode()
  */
 bool EditWrapper::saveFile(QByteArray encode)
 {
+    // 预览模式下不允许直接静默保存，交由 Window 层确认弹窗
+    if (m_bInvalidCharPreview) {
+        return false;
+    }
+
     QString qstrFilePath = m_pTextEdit->getTruePath();
     hideWarningNotices();
 
@@ -538,6 +544,47 @@ bool EditWrapper::saveFile(QByteArray encode)
         );
     }
 
+    return ok;
+}
+
+void EditWrapper::onEditAnyway()
+{
+    m_bInvalidCharEditAllowed = true;
+    m_pTextEdit->setReadOnly(false);
+    m_pWaringNotices->hide();
+    // 保持 m_bInvalidCharPreview = true，直到 Save As 或 Save Anyway 成功
+}
+
+void EditWrapper::exitInvalidCharPreview()
+{
+    m_bInvalidCharPreview = false;
+    m_bInvalidCharEditAllowed = false;
+    m_sInvalidCharOriginalPath.clear();
+    m_pTextEdit->setReadOnly(false);
+    m_pWaringNotices->hide();
+    if (m_pSyntaxHighlighter) {
+        m_pSyntaxHighlighter->setInvalidCharHighlight(false);
+    }
+    updateModifyStatus(false);
+}
+
+bool EditWrapper::forceSaveInvalidCharFile()
+{
+    QString savePath = m_sInvalidCharOriginalPath;
+    TextFileSaver saver(m_pTextEdit->document());
+    if (BottomBar::EndlineFormat::Windows == m_pBottomBar->getEndlineFormat())
+        saver.setWindowsEndlineFormat(true);
+    saver.setFilePath(savePath);
+    saver.setEncoding(m_sCurEncode.toUtf8());
+
+    bool ok = saver.save();
+    if (ok) {
+        m_sFirstEncode = m_sCurEncode;
+        QFileInfo fi(savePath);
+        m_tModifiedDateTime = fi.lastModified();
+        m_bIsTemFile = false;
+        exitInvalidCharPreview();
+    }
     return ok;
 }
 
@@ -823,7 +870,7 @@ void EditWrapper::handleFilePreProcess(const QByteArray &encode, const QByteArra
  * @param encode    文件编码
  * @param content   完整文件内容
  */
-void EditWrapper::handleFileLoadFinished(const QByteArray &encode, const QByteArray &content, bool error)
+void EditWrapper::handleFileLoadFinished(const QByteArray &encode, const QByteArray &content, bool error, bool hasNul)
 {
     // 判断是否预加载，若已预加载，则无需重新初始化
     if (!m_bHasPreProcess) {
@@ -855,6 +902,31 @@ void EditWrapper::handleFileLoadFinished(const QByteArray &encode, const QByteAr
         m_bFileLoading = false;
         if (flag == true) {
             m_pTextEdit->setReadOnly(true);
+        }
+
+        // 无效字符（NUL）预览模式初始化
+        if (hasNul) {
+            m_bInvalidCharPreview = true;
+            m_bInvalidCharEditAllowed = false;
+            m_sInvalidCharOriginalPath = m_pTextEdit->getTruePath();
+            m_pTextEdit->setReadOnly(true);
+            m_pWaringNotices->setMessage(tr("The file contains invalid characters (NUL). Preview mode is read-only."));
+            m_pWaringNotices->setEditAnywayBtn();
+            m_pWaringNotices->show();
+            DMessageManager::instance()->sendMessage(m_pTextEdit, m_pWaringNotices);
+            // 确保 CSyntaxHighlighter 存在（无语法定义的文件如 .txt 不会在 reinitOnFileLoad 中创建）
+            if (!m_pSyntaxHighlighter) {
+                m_pSyntaxHighlighter = new CSyntaxHighlighter(m_pTextEdit->document());
+                QString themePath = Settings::instance()->settings->option("advance.editor.theme")->value().toString();
+                if (themePath.contains("dark")) {
+                    m_pSyntaxHighlighter->setTheme(m_Repository.defaultTheme(KSyntaxHighlighting::Repository::DarkTheme));
+                } else {
+                    m_pSyntaxHighlighter->setTheme(m_Repository.defaultTheme(KSyntaxHighlighting::Repository::LightTheme));
+                }
+            }
+            if (m_pSyntaxHighlighter) {
+                m_pSyntaxHighlighter->setInvalidCharHighlight(true);
+            }
         }
 
         if (m_bQuit) {
@@ -1023,7 +1095,12 @@ void EditWrapper::OnUpdateHighlighter()
         auto rehighlightBlock = [this](const QTextBlock &block) {
             m_pSyntaxHighlighter->setEnableHighlight(true);
             m_pSyntaxHighlighter->rehighlightBlock(block);
-            m_pSyntaxHighlighter->setEnableHighlight(false);
+            // NUL 预览模式下保持 m_bHighlight=true，使 loadContent 的 insertText 触发的
+            // 延迟重排（contentsChange → _q_reformatBlocks）能正常重新应用 \00 高亮，
+            // 首屏立即可见无需滚动（与 master 行为一致）；普通文件仍重置 false 保留性能优化。
+            if (!m_bInvalidCharPreview) {
+                m_pSyntaxHighlighter->setEnableHighlight(false);
+            }
         };
 
         if (foundBlock.isValid() && foundBlock < beginBlock) {

--- a/src/editor/editwrapper.h
+++ b/src/editor/editwrapper.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2017-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -119,6 +119,16 @@ public:
     inline CSyntaxHighlighter *getSyntaxHighlighter() const
     { return m_pSyntaxHighlighter; }
 
+    // 无效字符预览模式访问器
+    inline bool isInvalidCharPreview() const
+    { return m_bInvalidCharPreview; }
+    inline bool isInvalidCharEditAllowed() const
+    { return m_bInvalidCharEditAllowed; }
+    inline QString invalidCharOriginalPath() const
+    { return m_sInvalidCharOriginalPath; }
+    void exitInvalidCharPreview();
+    bool forceSaveInvalidCharFile();
+
 signals:
     void sigClearDoubleCharaterEncode();
 
@@ -139,12 +149,13 @@ private:
 public slots:
     // 处理文档预加载数据
     void handleFilePreProcess(const QByteArray &encode, const QByteArray &content);
-    void handleFileLoadFinished(const QByteArray &encode, const QByteArray &content, bool error);
+    void handleFileLoadFinished(const QByteArray &encode, const QByteArray &content, bool error, bool hasNul = false);
     void OnThemeChangeSlot(QString theme);
     void UpdateBottomBarWordCnt(int cnt);
     void OnUpdateHighlighter();
     //set the value of m_bIsTemFile
     void setTemFile(bool value);
+    void onEditAnyway();
 
 private:
     //第一次打开文件编码
@@ -180,6 +191,11 @@ private:
 
     bool m_bAsyncReadFileFinished = false;
     bool m_bHasPreProcess = false;               // 预处理标识
+
+    // 无效字符（NUL）预览模式状态
+    bool m_bInvalidCharPreview = false;
+    bool m_bInvalidCharEditAllowed = false;
+    QString m_sInvalidCharOriginalPath;
 };
 
 #endif

--- a/src/widgets/window.cpp
+++ b/src/widgets/window.cpp
@@ -862,6 +862,44 @@ bool Window::closeTab(const QString &filePath)
         if (m_tabbar->textAt(m_tabbar->currentIndex()).front() == "*") {
             isModified = true;
         }
+
+        // 无效字符预览模式拦截：复用与 Ctrl+S 相同的三按钮确认弹窗
+        if (wrapper->isInvalidCharPreview()) {
+            if (wrapper->isInvalidCharEditAllowed() && isModified) {
+                QString fileName = QFileInfo(filePath).fileName();
+                int res = confirmInvalidCharSave(fileName);
+                switch (res) {
+                case 0:  // Don't Save
+                    removeWrapper(filePath, true);
+                    m_tabbar->closeCurrentTab(filePath);
+                    return true;
+                case 1:  // Save As
+                {
+                    QString newPath = saveAsFileToDisk();
+                    if (!newPath.isEmpty()) {
+                        removeWrapper(newPath, true);
+                        m_tabbar->closeCurrentTab(newPath);
+                        return true;
+                    }
+                    return false;
+                }
+                case 2:  // Save Anyway
+                    if (wrapper->forceSaveInvalidCharFile()) {
+                        removeWrapper(filePath, true);
+                        m_tabbar->closeCurrentTab(filePath);
+                        return true;
+                    }
+                    return false;
+                default:  // 取消
+                    return false;
+                }
+            } else {
+                removeWrapper(filePath, true);
+                m_tabbar->closeCurrentTab(filePath);
+                return true;
+            }
+        }
+
         if (isModified) {
             DDialog *dialog = createDialog(tr("Do you want to save this file?"), "");
             int res = dialog->exec();
@@ -1127,12 +1165,53 @@ void Window::openFile()
     }
 }
 
+int Window::confirmInvalidCharSave(const QString &fileName)
+{
+    DDialog *dialog = new DDialog(
+        tr("Invalid characters detected while saving \"%1\"").arg(fileName),
+        tr("If you force save this file, it may cause file corruption. Still want to save?"),
+        this);
+    dialog->setIcon(QIcon::fromTheme("dialog-warning"));
+    dialog->addButton(tr("Don't Save"), false, DDialog::ButtonNormal);
+    dialog->addButton(tr("Save As"), true, DDialog::ButtonRecommend);
+    dialog->addButton(tr("Save Anyway"), false, DDialog::ButtonWarning);
+    dialog->setCloseButtonVisible(false);
+    int res = dialog->exec();
+    dialog->deleteLater();
+    // 0=Don't Save, 1=Save As, 2=Save Anyway, -1=取消
+    return res;
+}
+
 bool Window::saveFile()
 {
     EditWrapper *wrapperEdit = currentWrapper();
 
     //大文本加载过程不允许保存
     if (!wrapperEdit || wrapperEdit->getFileLoading()) return false;
+
+    // 无效字符预览模式拦截：弹出三按钮确认框
+    if (wrapperEdit->isInvalidCharPreview()) {
+        if (!wrapperEdit->isInvalidCharEditAllowed()) {
+            return false;
+        }
+        QString filePath = wrapperEdit->textEditor()->getTruePath();
+        QString fileName = QFileInfo(filePath).fileName();
+        int res = confirmInvalidCharSave(fileName);
+        switch (res) {
+        case 0:  // Don't Save
+            return false;
+        case 1:  // Save As
+            return saveAsFile();
+        case 2:  // Save Anyway
+            if (wrapperEdit->forceSaveInvalidCharFile()) {
+                showNotify(tr("Saved successfully"));
+                return true;
+            }
+            return false;
+        default:  // 取消
+            return false;
+        }
+    }
 
     bool isDraftFile = wrapperEdit->isDraftFile();
     //bool isEmpty = wrapperEdit->isPlainTextEmpty();
@@ -1243,6 +1322,18 @@ QString Window::saveAsFileToDisk()
         Settings::instance()->setSavePath(PathSettingWgt::LastOptBox, QFileInfo(newFilePath).absolutePath());
         Settings::instance()->setSavePath(PathSettingWgt::CurFileBox, QFileInfo(newFilePath).absolutePath());
 
+        // 预览模式下拒绝另存为原文件路径
+        if (wrapper->isInvalidCharPreview()) {
+            QString originalPath = wrapper->invalidCharOriginalPath();
+            if (QFileInfo(originalPath).absoluteFilePath() == QFileInfo(newFilePath).absoluteFilePath()) {
+                DMessageManager::instance()->sendMessage(
+                    m_editorWidget->currentWidget(),
+                    QIcon(":/images/warning.svg"),
+                    tr("Cannot save as the original file in preview mode. Please choose a different path."));
+                return QString();
+            }
+        }
+
         wrapper->updatePath(wrapper->filePath(), newFilePath);
 
         bool needChangeEncode = (encode != wrapper->getTextEncode().toUtf8());
@@ -1262,6 +1353,11 @@ QString Window::saveAsFileToDisk()
         } else {
             // 更新文件编码
             wrapper->bottomBar()->setEncodeName(encode);
+
+            // 预览模式 Save As 成功后退出预览模式
+            if (wrapper->isInvalidCharPreview()) {
+                wrapper->exitInvalidCharPreview();
+            }
 
             // 若编码变更，保存完成后，重新加载文件
             if (needChangeEncode) {
@@ -2533,7 +2629,12 @@ void Window::backupFile()
         QJsonDocument document;
         jsonObject.insert("localPath", localPath);
         jsonObject.insert("cursorPosition", QString::number(wrapper->textEditor()->textCursor().position()));
-        jsonObject.insert("modify", wrapper->isModified());
+        // 预览模式下不持久化修改状态
+        if (wrapper->isInvalidCharPreview()) {
+            jsonObject.insert("modify", false);
+        } else {
+            jsonObject.insert("modify", wrapper->isModified());
+        }
         jsonObject.insert("lastModifiedTime", wrapper->getLastModifiedTime().toString());
         QList<int> bookmarkList = wrapper->textEditor()->getBookmarkInfo();
         if (!bookmarkList.isEmpty()) {
@@ -2557,7 +2658,9 @@ void Window::backupFile()
         }
 
         //保存备份文件
-        if (Utils::isDraftFile(filePath)) {
+        if (wrapper->isInvalidCharPreview()) {
+            // 预览模式跳过备份，不写 temFilePath，不保存临时文件
+        } else if (Utils::isDraftFile(filePath)) {
             wrapper->saveTemFile(filePath);
         } else {
             if (wrapper->isModified()) {

--- a/src/widgets/window.h
+++ b/src/widgets/window.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2011-2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2011-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -194,6 +194,7 @@ public Q_SLOTS:
     int getBlankFileIndex();
 
     DDialog *createDialog(const QString &title, const QString &content);
+    int confirmInvalidCharSave(const QString &fileName);
 
     void slotLoadContentTheme(DGuiApplicationHelper::ColorType themeType);
     void slotSettingResetTheme(const QString &path);

--- a/translations/deepin-editor.ts
+++ b/translations/deepin-editor.ts
@@ -102,6 +102,11 @@
         <source>The file cannot be read, which may be too large or has been damaged!</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="1020"/>
+        <source>The file contains invalid characters (NUL). Preview mode is read-only.</source>
+        <translation>The file contains invalid characters (NUL). Preview mode is read-only.</translation>
+    </message>
 </context>
 <context>
     <name>FindBar</name>
@@ -1174,6 +1179,11 @@
         <source>Reload</source>
         <translation>Reload</translation>
     </message>
+    <message>
+        <location filename="../src/controls/warningnotices.cpp" line="26"/>
+        <source>Edit Anyway</source>
+        <translation>Edit Anyway</translation>
+    </message>
 </context>
 <context>
     <name>Window</name>
@@ -1304,6 +1314,36 @@
         <location filename="../src/widgets/window.cpp" line="2975"/>
         <source>Discard</source>
         <translation>Discard</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1317"/>
+        <source>Invalid characters detected while saving "%1"</source>
+        <translation>Invalid characters detected while saving "%1"</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1318"/>
+        <source>If you force save this file, it may cause file corruption. Still want to save?</source>
+        <translation>If you force save this file, it may cause file corruption. Still want to save?</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1321"/>
+        <source>Don&apos;t Save</source>
+        <translation>Don&apos;t Save</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1322"/>
+        <source>Save As</source>
+        <translation>Save As</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1323"/>
+        <source>Save Anyway</source>
+        <translation>Save Anyway</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1521"/>
+        <source>Cannot save as the original file in preview mode. Please choose a different path.</source>
+        <translation>Cannot save as the original file in preview mode. Please choose a different path.</translation>
     </message>
 </context>
 </TS>

--- a/translations/deepin-editor_zh_CN.ts
+++ b/translations/deepin-editor_zh_CN.ts
@@ -100,6 +100,11 @@
         <source>The file cannot be read, which may be too large or has been damaged!</source>
         <translation>无法读取该文件，文件可能过大或损坏</translation>
     </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="1020"/>
+        <source>The file contains invalid characters (NUL). Preview mode is read-only.</source>
+        <translation>文件包含无效字符（NUL）。预览模式为只读。</translation>
+    </message>
 </context>
 <context>
     <name>FindBar</name>
@@ -1194,6 +1199,11 @@
         <source>Reload</source>
         <translation>重新载入</translation>
     </message>
+    <message>
+        <location filename="../src/controls/warningnotices.cpp" line="26"/>
+        <source>Edit Anyway</source>
+        <translation>仍然编辑</translation>
+    </message>
 </context>
 <context>
     <name>Window</name>
@@ -1324,6 +1334,36 @@
         <location filename="../src/widgets/window.cpp" line="2975"/>
         <source>Discard</source>
         <translation>不保存</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1317"/>
+        <source>Invalid characters detected while saving "%1"</source>
+        <translation>保存"%1"时检测到无效字符</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1318"/>
+        <source>If you force save this file, it may cause file corruption. Still want to save?</source>
+        <translation>强制保存此文件可能导致文件损坏。仍然要保存吗？</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1321"/>
+        <source>Don&apos;t Save</source>
+        <translation>不保存</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1322"/>
+        <source>Save As</source>
+        <translation>另存为</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1323"/>
+        <source>Save Anyway</source>
+        <translation>强制保存</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1521"/>
+        <source>Cannot save as the original file in preview mode. Please choose a different path.</source>
+        <translation>预览模式下不能另存为原文件。请选择其他路径。</translation>
     </message>
 </context>
 </TS>

--- a/translations/deepin-editor_zh_HK.ts
+++ b/translations/deepin-editor_zh_HK.ts
@@ -100,6 +100,11 @@
         <source>The file cannot be read, which may be too large or has been damaged!</source>
         <translation>無法讀取該文件，文件可能過大或損壞</translation>
     </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="1020"/>
+        <source>The file contains invalid characters (NUL). Preview mode is read-only.</source>
+        <translation>文件包含無效字元（NUL）。預覽模式為唯讀。</translation>
+    </message>
 </context>
 <context>
     <name>FindBar</name>
@@ -1172,6 +1177,11 @@
         <source>Reload</source>
         <translation>重新載入</translation>
     </message>
+    <message>
+        <location filename="../src/controls/warningnotices.cpp" line="26"/>
+        <source>Edit Anyway</source>
+        <translation>仍然編輯</translation>
+    </message>
 </context>
 <context>
     <name>Window</name>
@@ -1302,6 +1312,36 @@
         <location filename="../src/widgets/window.cpp" line="2975"/>
         <source>Discard</source>
         <translation>不保存</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1317"/>
+        <source>Invalid characters detected while saving "%1"</source>
+        <translation>保存「%1」時偵測到無效字元</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1318"/>
+        <source>If you force save this file, it may cause file corruption. Still want to save?</source>
+        <translation>強制保存此文件可能導致文件損壞。仍然要保存嗎？</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1321"/>
+        <source>Don&apos;t Save</source>
+        <translation>不保存</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1322"/>
+        <source>Save As</source>
+        <translation>另存為</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1323"/>
+        <source>Save Anyway</source>
+        <translation>強制保存</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1521"/>
+        <source>Cannot save as the original file in preview mode. Please choose a different path.</source>
+        <translation>預覽模式下不能另存為原文件。請選擇其他路徑。</translation>
     </message>
 </context>
 </TS>

--- a/translations/deepin-editor_zh_TW.ts
+++ b/translations/deepin-editor_zh_TW.ts
@@ -100,6 +100,11 @@
         <source>The file cannot be read, which may be too large or has been damaged!</source>
         <translation>無法讀取該文件，文件可能過大或損壞</translation>
     </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="1020"/>
+        <source>The file contains invalid characters (NUL). Preview mode is read-only.</source>
+        <translation>文件包含無效字元（NUL）。預覽模式為唯讀。</translation>
+    </message>
 </context>
 <context>
     <name>FindBar</name>
@@ -1172,6 +1177,11 @@
         <source>Reload</source>
         <translation>重新載入</translation>
     </message>
+    <message>
+        <location filename="../src/controls/warningnotices.cpp" line="26"/>
+        <source>Edit Anyway</source>
+        <translation>仍然編輯</translation>
+    </message>
 </context>
 <context>
     <name>Window</name>
@@ -1302,6 +1312,36 @@
         <location filename="../src/widgets/window.cpp" line="2975"/>
         <source>Discard</source>
         <translation>捨棄</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1317"/>
+        <source>Invalid characters detected while saving "%1"</source>
+        <translation>儲存「%1」時偵測到無效字元</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1318"/>
+        <source>If you force save this file, it may cause file corruption. Still want to save?</source>
+        <translation>強制儲存此文件可能導致文件損壞。仍然要儲存嗎？</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1321"/>
+        <source>Don&apos;t Save</source>
+        <translation>不儲存</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1322"/>
+        <source>Save As</source>
+        <translation>另存為</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1323"/>
+        <source>Save Anyway</source>
+        <translation>強制儲存</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1521"/>
+        <source>Cannot save as the original file in preview mode. Please choose a different path.</source>
+        <translation>預覽模式下不能另存為原文件。請選擇其他路徑。</translation>
     </message>
 </context>
 </TS>


### PR DESCRIPTION
## 概述

将 PR #489（已合入 master）的 NUL 安全预览与受控保存功能同步到 `release/eagle` 分支。

## 同步说明

- Base: `release/eagle` HEAD `fa2f750`
- 冲突解决策略：以 `release/eagle` 现状为准，保留 NUL 安全预览全部功能
- `release/eagle` 与 master 的差异（如 `m_encodeHint`、debug 日志、`setEndlineFormat` API 等）已按 release/eagle 既有风格适配，不影响功能语义

## 主要改动

| 模块 | 改动 |
|---|---|
| `FileLoadThread` | 在原始字节层面检测 NUL，转义为 `\00` |
| `EditWrapper` | 预览态字段、只读切换、Edit Anyway、保存成功后退出预览 |
| `WarningNotices` | 新增 "Edit Anyway" 按钮与信号 |
| `Window` | 统一 `confirmInvalidCharSave` 三按钮确认弹窗，Ctrl+S 与关闭 Tab 共用同一入口；预览模式拒绝同路径 Save As；备份短路 |
| `CSyntaxHighlighter` | `\00` 高亮（红色背景 + 白色文字） |
| 翻译文件 | 新增 en / zh_CN / zh_HK / zh_TW 文案 |

## 关联

- 原 PR: https://github.com/linuxdeepin/deepin-editor/pull/489
- Task: https://pms.uniontech.com/task-view-392417.html
- Multica Issue: https://agent-dev.uniontech.com/issues/14dc6e9a-d392-4a6a-b8a9-f295ea204c96
