### PR TITLE
fix(editor): persist file encoding across sessions

### DIFF
--- a/src/common/fileloadthread.cpp
+++ b/src/common/fileloadthread.cpp
@@ -19,6 +19,11 @@ FileLoadThread::~FileLoadThread()
 {
 }
 
+void FileLoadThread::setPreferredEncode(const QByteArray &encode)
+{
+    m_preferredEncode = encode;
+}
+
 void FileLoadThread::run()
 {
     QFile file(m_strFilePath);
@@ -27,12 +32,19 @@ void FileLoadThread::run()
         QByteArray encode;
         QByteArray indata;
 
+        // 优先使用历史记录的编码格式，跳过自动探测
+        if (!m_preferredEncode.isEmpty()) {
+            encode = m_preferredEncode;
+        }
+
         // 判断文件大小是否超过40MB, 超过40MB的文件过大，需要调整读取策略，优先加载头部文件
         static const int s_maxDirectReadLen = 40 * DATA_SIZE_1024 * DATA_SIZE_1024;
         if (file.size() > s_maxDirectReadLen) {
             // 先读取1MB数据
             indata = file.read(DATA_SIZE_1024 * DATA_SIZE_1024);
-            encode = DetectCode::GetFileEncodingFormat(m_strFilePath, indata);
+            if (encode.isEmpty()) {
+                encode = DetectCode::GetFileEncodingFormat(m_strFilePath, indata);
+            }
 
             // 发送文件头信息，用于预先加载数据
             QString textEncode = QString::fromLocal8Bit(encode);

--- a/src/common/fileloadthread.h
+++ b/src/common/fileloadthread.h
@@ -16,6 +16,12 @@ public:
 
     void run();
 
+    /**
+     * @brief setPreferredEncode 设置优先使用的编码格式，用于跳过自动探测
+     * @param encode 优先编码格式，为空时自动探测
+     */
+    void setPreferredEncode(const QByteArray &encode);
+
 signals:
     // 预处理信号，优先处理文件头，防止出现加载时间过长的情况
     void sigPreProcess(const QByteArray &encode, const QByteArray &content);
@@ -23,6 +29,7 @@ signals:
 
 private:
     QString m_strFilePath;
+    QByteArray m_preferredEncode;
 };
 
 #endif

--- a/src/editor/dtextedit.cpp
+++ b/src/editor/dtextedit.cpp
@@ -4729,6 +4729,31 @@ QStringList TextEdit::readEncodeHistoryRecord()
     return filePathList;
 }
 
+QString TextEdit::readEncodeHistoryRecord(const QString &filepath)
+{
+    QString history = m_settings->settings->option("advance.editor.browsing_encode_history")->value().toString();
+    if (history.isEmpty()) {
+        return QString();
+    }
+
+    int nLeftPosition = history.indexOf("*[" + filepath + "]*");
+    if (nLeftPosition == -1) {
+        return QString();
+    }
+
+    nLeftPosition = history.indexOf("]*", nLeftPosition);
+    if (nLeftPosition == -1) {
+        return QString();
+    }
+
+    int nRightPosition = history.indexOf("}*", nLeftPosition);
+    if (nRightPosition == -1) {
+        return QString();
+    }
+
+    return history.mid(nLeftPosition + 2, nRightPosition - nLeftPosition - 2);
+}
+
 void TextEdit::tellFindBarClose()
 {
     m_bIsFindClose = true;

--- a/src/editor/dtextedit.h
+++ b/src/editor/dtextedit.h
@@ -119,6 +119,8 @@ public:
     inline QString getFilePath() { return m_sFilePath;}
     // 设置文件路径
     inline void setFilePath(const QString &file) { m_sFilePath = file;}
+    // 设置文件编码，用于记录编码历史
+    inline void setTextEncode(const QString &encode) { m_textEncode = encode;}
     // 取得左侧的导航控件，包含行号、书签、折叠控件等
     inline LeftAreaTextEdit *getLeftAreaWidget() { return m_pLeftAreaWidget;}
 
@@ -413,6 +415,12 @@ public:
     void setCursorStart(int pos);
     void writeEncodeHistoryRecord();
     QStringList readEncodeHistoryRecord();
+    /**
+     * @brief readEncodeHistoryRecord 读取指定文件路径的历史编码记录
+     * @param filepath 文件路径
+     * @return 返回该文件路径对应的历史编码，若无记录返回空字符串
+     */
+    QString readEncodeHistoryRecord(const QString &filepath);
     /**
      * @brief tellFindBarClose 通知查找框关闭
      */

--- a/src/editor/editwrapper.cpp
+++ b/src/editor/editwrapper.cpp
@@ -177,6 +177,14 @@ void EditWrapper::openFile(const QString &filepath, QString qstrTruePath, bool b
     }
 
     FileLoadThread *thread = new FileLoadThread(filepath);
+
+    // 读取历史编码记录，优先使用历史编码格式，避免自动探测导致编码不一致
+    m_pTextEdit->setFilePath(filepath);
+    QString historyEncode = m_pTextEdit->readEncodeHistoryRecord(filepath);
+    if (!historyEncode.isEmpty()) {
+        thread->setPreferredEncode(historyEncode.toLocal8Bit());
+    }
+
     // begin to load the file.
     connect(thread, &FileLoadThread::sigPreProcess, this, &EditWrapper::handleFilePreProcess);
     connect(thread, &FileLoadThread::sigLoadFinished, this, &EditWrapper::handleFileLoadFinished);
@@ -536,6 +544,10 @@ bool EditWrapper::saveFile(QByteArray encode)
         m_tModifiedDateTime = fi.lastModified();
         updateModifyStatus(false);
         m_bIsTemFile = false;
+
+        // 保存成功后，记录文件编码历史，用于下次打开时优先使用
+        m_pTextEdit->setTextEncode(m_sCurEncode);
+        m_pTextEdit->writeEncodeHistoryRecord();
     } else {
         DMessageManager::instance()->sendMessage(
             this->window()->getStackedWgt()->currentWidget(),
@@ -584,6 +596,10 @@ bool EditWrapper::forceSaveInvalidCharFile()
         m_tModifiedDateTime = fi.lastModified();
         m_bIsTemFile = false;
         exitInvalidCharPreview();
+
+        // 保存成功后，记录文件编码历史
+        m_pTextEdit->setTextEncode(m_sCurEncode);
+        m_pTextEdit->writeEncodeHistoryRecord();
     }
     return ok;
 }
@@ -740,6 +756,11 @@ bool EditWrapper::saveDraftFile(QString &newFilePath)
         updateSaveAsFileName(m_pTextEdit->getFilePath(), newFilePath);
         m_pTextEdit->document()->setModified(false);
         m_bIsTemFile = false;
+
+        // 保存成功后，记录文件编码历史
+        m_pTextEdit->setTextEncode(QString::fromUtf8(encode));
+        m_pTextEdit->writeEncodeHistoryRecord();
+
         return true;
     }
 

--- a/src/widgets/window.cpp
+++ b/src/widgets/window.cpp
@@ -1385,6 +1385,11 @@ QString Window::saveAsFileToDisk()
         }
 
         updateSaveAsFileName(wrapper->filePath(), newFilePath);
+
+        // 另存为成功后，路径已更新为新路径，记录文件编码历史
+        wrapper->textEditor()->setTextEncode(QString::fromUtf8(encode));
+        wrapper->textEditor()->writeEncodeHistoryRecord();
+
         return newFilePath;
     }
 


### PR DESCRIPTION
## 修复 BUG-365847：切换编码格式并保存后再打开，部分格式无法保存

### 问题
用户在文本编辑器中切换文件编码格式（如 GB18030、ISO-8859-1、CP1252 等）并保存后，关闭标签页重新打开，编码格式回退为 UTF-8，无法保持用户选择的编码。

### 根因
deepin-editor 打开文件时完全依赖 `DetectCode::GetFileEncodingFormat` 对内容做编码探测。对于与 UTF-8/ASCII 字节重叠的编码（ASCII 内容保存为 GB18030 等），探测器无法区分，必然回退为 UTF-8。项目中已有编码历史持久化机制（隐藏配置项 `browsing_encode_history` + `writeEncodeHistoryRecord`/`readEncodeHistoryRecord`），但该机制是死代码，从未接入保存/打开流程。

### 修复方案
激活已有但未接入的编码历史持久化机制：
1. **FileLoadThread**：新增 `setPreferredEncode`/`m_preferredEncode`，打开文件时优先使用历史编码，跳过不可靠的内容自动探测
2. **TextEdit**：新增 `readEncodeHistoryRecord(filepath)` 重载，按文件路径查询历史编码；新增 `setTextEncode` setter
3. **EditWrapper::openFile**：读取历史编码并设为 preferred hint
4. **EditWrapper 各保存路径**（saveFile/saveTemFile/saveDraftFile/forceSaveInvalidCharFile）：保存成功后记录编码历史
5. **Window::saveAsFileToDisk**：另存为成功后（路径已更新为新路径）记录编码历史

### 审查说明
基于用户提供的 fix.patch，审查发现并修复了 `saveAsFile(newFilePath, encode)` 中的路径键问题：原 patch 在 `writeEncodeHistoryRecord()` 时 `m_sFilePath` 仍为旧路径（调用方 `saveAsFileToDisk` 在 `updateSaveAsFileName` 之后才更新为新路径），导致历史记录键到错误路径。已将另存为的历史记录从 `saveAsFile` 移至 `saveAsFileToDisk` 中 `updateSaveAsFileName` 之后。

PMS: https://pms.uniontech.com/bug-view-365847.html

## Summary by Sourcery

Persist user-selected text encoding across file saves and reopen, avoiding incorrect fallback to UTF-8 by reusing stored encoding history when loading files.

Bug Fixes:
- Ensure files reopen using their last saved encoding by preferring persisted encoding history over automatic detection, especially for encodings overlapping with UTF-8/ASCII.

Enhancements:
- Add per-file encoding history lookup and use it as a preferred hint when opening files.
- Record encoding history on successful save, draft save, invalid-character forced save, and save-as operations.
- Allow the file loading thread to accept a preferred encoding to bypass unreliable automatic detection for known files.