### PR TITLE
Revert "fix(editor): persist file encoding across sessions" (bug-fix-365847)

### DIFF
--- a/src/common/fileloadthread.cpp
+++ b/src/common/fileloadthread.cpp
@@ -19,11 +19,6 @@ FileLoadThread::~FileLoadThread()
 {
 }
 
-void FileLoadThread::setPreferredEncode(const QByteArray &encode)
-{
-    m_preferredEncode = encode;
-}
-
 void FileLoadThread::run()
 {
     QFile file(m_strFilePath);
@@ -32,19 +27,12 @@ void FileLoadThread::run()
         QByteArray encode;
         QByteArray indata;
 
-        // 优先使用历史记录的编码格式，跳过自动探测
-        if (!m_preferredEncode.isEmpty()) {
-            encode = m_preferredEncode;
-        }
-
         // 判断文件大小是否超过40MB, 超过40MB的文件过大，需要调整读取策略，优先加载头部文件
         static const int s_maxDirectReadLen = 40 * DATA_SIZE_1024 * DATA_SIZE_1024;
         if (file.size() > s_maxDirectReadLen) {
             // 先读取1MB数据
             indata = file.read(DATA_SIZE_1024 * DATA_SIZE_1024);
-            if (encode.isEmpty()) {
-                encode = DetectCode::GetFileEncodingFormat(m_strFilePath, indata);
-            }
+            encode = DetectCode::GetFileEncodingFormat(m_strFilePath, indata);
 
             // 发送文件头信息，用于预先加载数据
             QString textEncode = QString::fromLocal8Bit(encode);

--- a/src/common/fileloadthread.h
+++ b/src/common/fileloadthread.h
@@ -16,12 +16,6 @@ public:
 
     void run();
 
-    /**
-     * @brief setPreferredEncode 设置优先使用的编码格式，用于跳过自动探测
-     * @param encode 优先编码格式，为空时自动探测
-     */
-    void setPreferredEncode(const QByteArray &encode);
-
 signals:
     // 预处理信号，优先处理文件头，防止出现加载时间过长的情况
     void sigPreProcess(const QByteArray &encode, const QByteArray &content);
@@ -29,7 +23,6 @@ signals:
 
 private:
     QString m_strFilePath;
-    QByteArray m_preferredEncode;
 };
 
 #endif

--- a/src/editor/dtextedit.cpp
+++ b/src/editor/dtextedit.cpp
@@ -4729,31 +4729,6 @@ QStringList TextEdit::readEncodeHistoryRecord()
     return filePathList;
 }
 
-QString TextEdit::readEncodeHistoryRecord(const QString &filepath)
-{
-    QString history = m_settings->settings->option("advance.editor.browsing_encode_history")->value().toString();
-    if (history.isEmpty()) {
-        return QString();
-    }
-
-    int nLeftPosition = history.indexOf("*[" + filepath + "]*");
-    if (nLeftPosition == -1) {
-        return QString();
-    }
-
-    nLeftPosition = history.indexOf("]*", nLeftPosition);
-    if (nLeftPosition == -1) {
-        return QString();
-    }
-
-    int nRightPosition = history.indexOf("}*", nLeftPosition);
-    if (nRightPosition == -1) {
-        return QString();
-    }
-
-    return history.mid(nLeftPosition + 2, nRightPosition - nLeftPosition - 2);
-}
-
 void TextEdit::tellFindBarClose()
 {
     m_bIsFindClose = true;

--- a/src/editor/dtextedit.h
+++ b/src/editor/dtextedit.h
@@ -119,8 +119,6 @@ public:
     inline QString getFilePath() { return m_sFilePath;}
     // 设置文件路径
     inline void setFilePath(const QString &file) { m_sFilePath = file;}
-    // 设置文件编码，用于记录编码历史
-    inline void setTextEncode(const QString &encode) { m_textEncode = encode;}
     // 取得左侧的导航控件，包含行号、书签、折叠控件等
     inline LeftAreaTextEdit *getLeftAreaWidget() { return m_pLeftAreaWidget;}
 
@@ -415,12 +413,6 @@ public:
     void setCursorStart(int pos);
     void writeEncodeHistoryRecord();
     QStringList readEncodeHistoryRecord();
-    /**
-     * @brief readEncodeHistoryRecord 读取指定文件路径的历史编码记录
-     * @param filepath 文件路径
-     * @return 返回该文件路径对应的历史编码，若无记录返回空字符串
-     */
-    QString readEncodeHistoryRecord(const QString &filepath);
     /**
      * @brief tellFindBarClose 通知查找框关闭
      */

--- a/src/editor/editwrapper.cpp
+++ b/src/editor/editwrapper.cpp
@@ -177,14 +177,6 @@ void EditWrapper::openFile(const QString &filepath, QString qstrTruePath, bool b
     }
 
     FileLoadThread *thread = new FileLoadThread(filepath);
-
-    // 读取历史编码记录，优先使用历史编码格式，避免自动探测导致编码不一致
-    m_pTextEdit->setFilePath(filepath);
-    QString historyEncode = m_pTextEdit->readEncodeHistoryRecord(filepath);
-    if (!historyEncode.isEmpty()) {
-        thread->setPreferredEncode(historyEncode.toLocal8Bit());
-    }
-
     // begin to load the file.
     connect(thread, &FileLoadThread::sigPreProcess, this, &EditWrapper::handleFilePreProcess);
     connect(thread, &FileLoadThread::sigLoadFinished, this, &EditWrapper::handleFileLoadFinished);
@@ -544,10 +536,6 @@ bool EditWrapper::saveFile(QByteArray encode)
         m_tModifiedDateTime = fi.lastModified();
         updateModifyStatus(false);
         m_bIsTemFile = false;
-
-        // 保存成功后，记录文件编码历史，用于下次打开时优先使用
-        m_pTextEdit->setTextEncode(m_sCurEncode);
-        m_pTextEdit->writeEncodeHistoryRecord();
     } else {
         DMessageManager::instance()->sendMessage(
             this->window()->getStackedWgt()->currentWidget(),
@@ -596,10 +584,6 @@ bool EditWrapper::forceSaveInvalidCharFile()
         m_tModifiedDateTime = fi.lastModified();
         m_bIsTemFile = false;
         exitInvalidCharPreview();
-
-        // 保存成功后，记录文件编码历史
-        m_pTextEdit->setTextEncode(m_sCurEncode);
-        m_pTextEdit->writeEncodeHistoryRecord();
     }
     return ok;
 }
@@ -756,11 +740,6 @@ bool EditWrapper::saveDraftFile(QString &newFilePath)
         updateSaveAsFileName(m_pTextEdit->getFilePath(), newFilePath);
         m_pTextEdit->document()->setModified(false);
         m_bIsTemFile = false;
-
-        // 保存成功后，记录文件编码历史
-        m_pTextEdit->setTextEncode(QString::fromUtf8(encode));
-        m_pTextEdit->writeEncodeHistoryRecord();
-
         return true;
     }
 

--- a/src/widgets/window.cpp
+++ b/src/widgets/window.cpp
@@ -1385,11 +1385,6 @@ QString Window::saveAsFileToDisk()
         }
 
         updateSaveAsFileName(wrapper->filePath(), newFilePath);
-
-        // 另存为成功后，路径已更新为新路径，记录文件编码历史
-        wrapper->textEditor()->setTextEncode(QString::fromUtf8(encode));
-        wrapper->textEditor()->writeEncodeHistoryRecord();
-
         return newFilePath;
     }
 


### PR DESCRIPTION
## 回退 PR #491（bug-fix-365847）

### 背景
PR #491（commit `1d549851`，"fix(editor): persist file encoding across sessions"）已合并入 `release/eagle`，用于修复 BUG-365847（切换编码保存后重新打开编码丢失）。

由于当前需求调整，需要回退该提交。

### 回退内容
使用 `git revert 1d549851` 精确反向应用 PR #491 的全部变更，将代码恢复到该 PR 合并前（`9735678e`）的状态：

| 文件 | 回退内容 |
|------|----------|
| `src/common/fileloadthread.h` | 移除 `setPreferredEncode()` 方法和 `m_preferredEncode` 成员变量 |
| `src/common/fileloadthread.cpp` | 移除 `setPreferredEncode()` 实现；`run()` 恢复为完全依赖自动探测 |
| `src/editor/dtextedit.h` | 移除 `setTextEncode()` setter 和 `readEncodeHistoryRecord(filepath)` 重载声明 |
| `src/editor/dtextedit.cpp` | 移除 `readEncodeHistoryRecord(filepath)` 重载实现 |
| `src/editor/editwrapper.cpp` | 移除 `openFile`/`saveFile`/`forceSaveInvalidCharFile`/`saveDraftFile` 中编码历史相关调用 |
| `src/widgets/window.cpp` | 移除 `saveAsFileToDisk` 中编码历史记录调用 |

变更规模：6 个文件，+1 行 / -79 行（与 PR #491 的 +79/-1 互为逆操作）。已逐文件校验，回退后内容与合并前提交 `9735678e` 完全一致。

### 验证
- `git revert` 无冲突（PR #491 为 `release/eagle` 的 HEAD，其上无后续提交依赖）
- 回退后 6 个文件内容与 `9735678e` 对应文件完全一致（逐文件 diff 校验通过）
- 回退不影响 PR #491 之前已存在的 `writeEncodeHistoryRecord()`/`readEncodeHistoryRecord()` 原始实现（恢复为"死代码"状态）

### 关联
- 待回退 PR: https://github.com/linuxdeepin/deepin-editor/pull/491
- PMS Bug: https://pms.uniontech.com/bug-view-365847.html
- Multica Issue: WS-539

Log: 回退编码历史持久化机制改动
Bug: https://pms.uniontech.com/bug-view-365847.html

## Summary by Sourcery

Revert the previously introduced file encoding persistence behavior and restore the editor’s prior encoding handling.

Enhancements:
- Remove use of saved encoding history when opening and saving files so file loading reverts to automatic encoding detection behavior.

Chores:
- Delete APIs and data members related to preferred file encoding and per-file encoding history that were added for BUG-365847.