### PR TITLE
fix(editor): prevent main thread deadlock in selectTextInView

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -76,6 +76,9 @@ link_directories(${chardet_LIBRARY_DIRS})
 
 # Tell CMake to create the executable
 add_executable(deepin-editor ${SRCS} deepin-editor.qrc)
+if(CMAKE_BUILD_TYPE STREQUAL "Release")
+    target_compile_definitions(deepin-editor PRIVATE QT_NO_DEBUG_OUTPUT)
+endif()
 target_link_libraries(deepin-editor
     ${LINK_LIBS}
     ${chardet_LIBRARY_DIRS}

--- a/src/editor/dtextedit.cpp
+++ b/src/editor/dtextedit.cpp
@@ -3289,6 +3289,16 @@ void TextEdit::highlight()
 void TextEdit::selectTextInView()
 {
     qDebug() << "Selecting text in view";
+    // 重入守卫：setTextCursor 会触发 QInputMethod::update（在 fcitx5 环境下会
+    // 异步回查光标矩形），并改变滚动条/布局，这些会分别触发 slotValueChanged、
+    // resizeEvent；它们在 m_isSelectAll 时会再次调用 selectTextInView，形成
+    // 自激振荡导致主线程死循环卡死。这里阻断重入。
+    if (m_isSelectingInView) {
+        qDebug() << "Selecting text in view skipped: already in progress";
+        return;
+    }
+    m_isSelectingInView = true;
+
     int startPos = cursorForPosition(QPoint(0, 0)).position();
     QPoint endPoint = QPoint(this->viewport()->width(), this->viewport()->height());
     int endPos = cursorForPosition(endPoint).position();
@@ -3298,6 +3308,8 @@ void TextEdit::selectTextInView()
     cursor.setPosition(startPos, QTextCursor::KeepAnchor);
     this->setTextCursor(cursor);
     this->horizontalScrollBar()->setValue(0);
+
+    m_isSelectingInView = false;
     qDebug() << "Selecting text in view completed";
 }
 

--- a/src/editor/dtextedit.h
+++ b/src/editor/dtextedit.h
@@ -860,6 +860,8 @@ private:
 
     bool m_isSelectAll {false};
 
+    bool m_isSelectingInView = false;   ///< selectTextInView 重入守卫：阻断 setTextCursor→inputMethod/scrollbar 信号→selectTextInView 的自激振荡
+
 private:
     LeftAreaTextEdit *m_pLeftAreaWidget = nullptr;
     QString m_sFilePath;///＜打开文件路径


### PR DESCRIPTION
Add re-entry guard to selectTextInView to break the self-excitation loop caused by setTextCursor triggering QInputMethod::update (fcitx5 async cursor query) and scrollbar/layout signals re-entering the function.

为 selectTextInView 添加重入守卫，阻断 setTextCursor 触发
QInputMethod::update（fcitx5 环境下异步回查光标矩形）及滚动条/布局
信号再次回调 selectTextInView 形成的自激振荡导致主线程死循环卡死。
同时 Release 构建禁用调试输出，调整默认主题资源路径。

Log: 修复全选时主线程死循环卡死问题
PMS: BUG-371465
Influence: 解决在 fcitx5 环境下执行视区内全选导致编辑器卡死的问题，同时优化 Release 构建输出与默认主题路径。

## Summary by Sourcery

Prevent editor main thread deadlock when selecting text in view and adjust release build behavior.

Bug Fixes:
- Add a re-entry guard flag to selectTextInView to prevent recursive calls that could deadlock the main thread during view-wide selection, especially under fcitx5 input method environments.

Enhancements:
- Disable Qt debug output in Release builds to reduce unnecessary logging.
- Adjust application resource handling by defining build-time defaults for the editor executable (including theme-related paths).

Build:
- Conditionally define QT_NO_DEBUG_OUTPUT for the deepin-editor target in Release builds to suppress debug logs.