### PR TITLE
test(editor): add unit tests for editor command classes

### DIFF
--- a/tests/src/editor/ut_changemarkcommand.cpp
+++ b/tests/src/editor/ut_changemarkcommand.cpp
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: 2020 - 2022 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "gtest/gtest.h"
+#include "../../src/editor/changemarkcommand.h"
+#include "../../src/editor/dtextedit.h"
+#include "../stub.h"
+
+// ChangeMarkCommand::redo() (exercise the redo path as well)
+TEST(UT_ChangeMarkCommand, redo)
+{
+    TextEdit *edit = new TextEdit;
+    edit->setPlainText("hello world");
+
+    QList<TextEdit::MarkReplaceInfo> newMark;
+    TextEdit::MarkReplaceInfo info;
+    info.start = 0;
+    info.end = 5;
+    info.time = 1;
+    newMark.append(info);
+
+    ChangeMarkCommand *cmd = new ChangeMarkCommand(edit,
+                                                    QList<TextEdit::MarkReplaceInfo>(),
+                                                    newMark);
+    cmd->redo();
+
+    delete cmd;
+    delete edit;
+}
+
+// ChangeMarkCommand::undo()
+TEST(UT_ChangeMarkCommand, undo)
+{
+    TextEdit *edit = new TextEdit;
+    edit->setPlainText("hello world");
+
+    QList<TextEdit::MarkReplaceInfo> oldMark;
+    TextEdit::MarkReplaceInfo info;
+    info.start = 0;
+    info.end = 5;
+    info.time = 1;
+    oldMark.append(info);
+
+    ChangeMarkCommand *cmd = new ChangeMarkCommand(edit, oldMark,
+                                                    QList<TextEdit::MarkReplaceInfo>());
+    cmd->undo();
+
+    delete cmd;
+    delete edit;
+}
+
+// ChangeMarkCommand::~ChangeMarkCommand (both destructor variants)
+TEST(UT_ChangeMarkCommand, destructor)
+{
+    TextEdit *edit = new TextEdit;
+    edit->setPlainText("hello");
+
+    ChangeMarkCommand *cmd = new ChangeMarkCommand(edit,
+                                                    QList<TextEdit::MarkReplaceInfo>(),
+                                                    QList<TextEdit::MarkReplaceInfo>());
+    delete cmd;
+
+    delete edit;
+}

--- a/tests/src/editor/ut_changemarkcommand.cpp
+++ b/tests/src/editor/ut_changemarkcommand.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/tests/src/editor/ut_endlineformatcommond.cpp
+++ b/tests/src/editor/ut_endlineformatcommond.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2019 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/tests/src/editor/ut_endlineformatcommond.cpp
+++ b/tests/src/editor/ut_endlineformatcommond.cpp
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: 2019 - 2023 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "gtest/gtest.h"
+#include "../../src/editor/endlineformatcommond.h"
+#include "../../src/editor/dtextedit.h"
+#include "../../src/widgets/bottombar.h"
+#include "../stub.h"
+
+// EndlineFormartCommand::EndlineFormartCommand + ~EndlineFormartCommand (both variants)
+TEST(UT_EndlineFormartCommand, constructor_and_destructor)
+{
+    TextEdit *edit = new TextEdit;
+    edit->setPlainText("hello");
+    BottomBar *bar = new BottomBar;
+
+    EndlineFormartCommand *cmd = new EndlineFormartCommand(edit, bar,
+                                                           BottomBar::EndlineFormat::Unix,
+                                                           BottomBar::EndlineFormat::Windows);
+    ASSERT_TRUE(cmd != nullptr);
+    delete cmd;
+
+    delete bar;
+    delete edit;
+}
+
+// EndlineFormartCommand::redo()
+TEST(UT_EndlineFormartCommand, redo)
+{
+    TextEdit *edit = new TextEdit;
+    edit->setPlainText("hello");
+    BottomBar *bar = new BottomBar;
+
+    EndlineFormartCommand *cmd = new EndlineFormartCommand(edit, bar,
+                                                           BottomBar::EndlineFormat::Unix,
+                                                           BottomBar::EndlineFormat::Windows);
+    cmd->redo();
+
+    delete cmd;
+    delete bar;
+    delete edit;
+}
+
+// EndlineFormartCommand::undo()
+TEST(UT_EndlineFormartCommand, undo)
+{
+    TextEdit *edit = new TextEdit;
+    edit->setPlainText("hello");
+    BottomBar *bar = new BottomBar;
+
+    EndlineFormartCommand *cmd = new EndlineFormartCommand(edit, bar,
+                                                           BottomBar::EndlineFormat::Unix,
+                                                           BottomBar::EndlineFormat::Windows);
+    cmd->undo();
+
+    delete cmd;
+    delete bar;
+    delete edit;
+}

--- a/tests/src/editor/ut_indenttextcommond.cpp
+++ b/tests/src/editor/ut_indenttextcommond.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/tests/src/editor/ut_indenttextcommond.cpp
+++ b/tests/src/editor/ut_indenttextcommond.cpp
@@ -1,0 +1,95 @@
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "gtest/gtest.h"
+#include "../../src/editor/indenttextcommond.h"
+#include "../../src/editor/dtextedit.h"
+#include "../stub.h"
+
+// IndentTextCommand::~IndentTextCommand (both destructor variants)
+TEST(UT_IndentTextCommand, destructor)
+{
+    TextEdit *edit = new TextEdit;
+    edit->setPlainText("aaa\nbbb\nccc");
+    QTextCursor c = edit->textCursor();
+    c.setPosition(0);
+    edit->setTextCursor(c);
+
+    IndentTextCommand *cmd = new IndentTextCommand(edit, 0, 0, 0, 0);
+    delete cmd;
+
+    delete edit;
+}
+
+// IndentTextCommand::undo()
+TEST(UT_IndentTextCommand, undo)
+{
+    TextEdit *edit = new TextEdit;
+    edit->setPlainText("aaa\nbbb\nccc");
+    QTextCursor c = edit->textCursor();
+    c.setPosition(0);
+    c.setPosition(3, QTextCursor::KeepAnchor);
+    edit->setTextCursor(c);
+
+    IndentTextCommand *cmd = new IndentTextCommand(edit, 0, 3, 0, 0);
+    cmd->redo();   // add a tab to the first line
+    cmd->undo();   // remove the tab from the first line
+    EXPECT_EQ(edit->toPlainText(), QString("aaa\nbbb\nccc"));
+
+    delete cmd;
+    delete edit;
+}
+
+// UnindentTextCommand::UnindentTextCommand(...) + ~UnindentTextCommand (both variants)
+TEST(UT_UnindentTextCommand, constructor_and_destructor)
+{
+    TextEdit *edit = new TextEdit;
+    edit->setPlainText("aaa");
+    QTextCursor c = edit->textCursor();
+    c.setPosition(0);
+    edit->setTextCursor(c);
+
+    UnindentTextCommand *cmd = new UnindentTextCommand(edit, 0, 0, 0, 0, 4);
+    ASSERT_TRUE(cmd != nullptr);
+    delete cmd;
+
+    delete edit;
+}
+
+// UnindentTextCommand::redo()
+TEST(UT_UnindentTextCommand, redo)
+{
+    TextEdit *edit = new TextEdit;
+    edit->setPlainText("\taaa\n  bbb\nccc");
+    QTextCursor c = edit->textCursor();
+    c.setPosition(0);
+    edit->setTextCursor(c);
+
+    UnindentTextCommand *cmd = new UnindentTextCommand(edit, 0, 0, 0, 2, 4);
+    cmd->redo();
+    // first line tab removed, second line two spaces removed
+    EXPECT_EQ(edit->toPlainText(), QString("aaa\nbbb\nccc"));
+
+    delete cmd;
+    delete edit;
+}
+
+// UnindentTextCommand::undo()
+TEST(UT_UnindentTextCommand, undo)
+{
+    TextEdit *edit = new TextEdit;
+    edit->setPlainText("\taaa\n  bbb\nccc");
+    QTextCursor c = edit->textCursor();
+    c.setPosition(0);
+    edit->setTextCursor(c);
+
+    UnindentTextCommand *cmd = new UnindentTextCommand(edit, 0, 0, 0, 2, 4);
+    cmd->redo();
+    cmd->undo();
+    // restored after a redo/undo round-trip
+    EXPECT_EQ(edit->toPlainText(), QString("\taaa\n  bbb\nccc"));
+
+    delete cmd;
+    delete edit;
+}

--- a/tests/src/editor/ut_linenumberarea.cpp
+++ b/tests/src/editor/ut_linenumberarea.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/tests/src/editor/ut_linenumberarea.cpp
+++ b/tests/src/editor/ut_linenumberarea.cpp
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: 2017 - 2022 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "gtest/gtest.h"
+#include "../../src/editor/linenumberarea.h"
+#include "../../src/editor/leftareaoftextedit.h"
+#include "../../src/editor/dtextedit.h"
+#include "../stub.h"
+#include <QMouseEvent>
+
+// LineNumberArea::getPressPoint()
+TEST(UT_LineNumberArea, getPressPoint)
+{
+    TextEdit *edit = new TextEdit;
+    edit->setPlainText("aaa\nbbb\nccc");
+    LeftAreaTextEdit *leftArea = new LeftAreaTextEdit(edit);
+    LineNumberArea *area = new LineNumberArea(leftArea);
+
+    // default press point
+    QPoint pt = area->getPressPoint();
+    EXPECT_TRUE(pt.isNull());
+
+    delete area;
+    delete leftArea;
+    delete edit;
+}
+
+// LineNumberArea::mousePressEvent(QMouseEvent*)
+TEST(UT_LineNumberArea, mousePressEvent)
+{
+    TextEdit *edit = new TextEdit;
+    edit->setPlainText("aaa\nbbb\nccc");
+    LeftAreaTextEdit *leftArea = new LeftAreaTextEdit(edit);
+    LineNumberArea *area = new LineNumberArea(leftArea);
+
+    // use an out-of-range x so onPressedLineNumber returns early (safe path)
+    QMouseEvent *event = new QMouseEvent(QEvent::MouseButtonPress,
+                                         QPoint(-1, 0),
+                                         Qt::LeftButton,
+                                         Qt::LeftButton,
+                                         Qt::NoModifier);
+    area->mousePressEvent(event);
+
+    delete event;
+    delete area;
+    delete leftArea;
+    delete edit;
+}

--- a/tests/src/editor/ut_undolist.cpp
+++ b/tests/src/editor/ut_undolist.cpp
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "gtest/gtest.h"
+#include "../../src/editor/undolist.h"
+#include "../../src/editor/indenttextcommond.h"
+#include "../../src/editor/dtextedit.h"
+#include "../stub.h"
+
+// UndoList::UndoList() + UndoList::~UndoList() (both destructor variants)
+TEST(UT_UndoList, constructor_and_destructor)
+{
+    UndoList *list = new UndoList;
+    ASSERT_TRUE(list != nullptr);
+    delete list;
+}
+
+// destructor with appended child commands to exercise the cleanup loop
+TEST(UT_UndoList, destructor_with_children)
+{
+    UndoList *list = new UndoList;
+    TextEdit *edit = new TextEdit;
+    edit->setPlainText("aaa\nbbb");
+
+    QTextCursor c = edit->textCursor();
+    c.setPosition(0);
+    edit->setTextCursor(c);
+
+    // append some child commands; UndoList destructor takes ownership and deletes them
+    list->appendCom(new IndentTextCommand(edit, 0, 0, 0, 0));
+    list->appendCom(new IndentTextCommand(edit, 0, 0, 0, 0));
+    list->appendCom(nullptr);  // nullptr should be safely ignored
+
+    delete list;
+    delete edit;
+}
+
+// also exercise undo/redo for fuller coverage of the class
+TEST(UT_UndoList, undo_redo)
+{
+    UndoList *list = new UndoList;
+    TextEdit *edit = new TextEdit;
+    edit->setPlainText("aaa\nbbb");
+
+    QTextCursor c = edit->textCursor();
+    c.setPosition(0);
+    edit->setTextCursor(c);
+
+    list->appendCom(new IndentTextCommand(edit, 0, 0, 0, 0));
+    list->redo();
+    list->undo();
+
+    delete list;
+    delete edit;
+}

--- a/tests/src/editor/ut_undolist.cpp
+++ b/tests/src/editor/ut_undolist.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 


### PR DESCRIPTION
Add tests for ChangeMarkCommand, EndlineFormartCommand, IndentTextCommand, LineNumberArea and UndoList.

Log: 新增editor模块命令类的单元测试
Influence: 覆盖编辑器撤销/重做命令类的未覆盖函数

## Summary by Sourcery

Add unit tests for editor command and UI helper classes to improve undo/redo and interaction coverage.

Tests:
- Introduce tests for IndentTextCommand and UnindentTextCommand covering construction, destruction, undo, and redo behavior.
- Add tests for ChangeMarkCommand covering redo, undo, and destructor paths.
- Add tests for EndlineFormartCommand covering construction, destruction, undo, and redo behavior.
- Add tests for UndoList covering lifecycle, child command cleanup, and undo/redo operations.
- Add tests for LineNumberArea covering press point retrieval and mouse press event handling.