### PR TITLE
test(common): add unit tests for common and encodes modules

### DIFF
--- a/tests/src/common/ut_config.cpp
+++ b/tests/src/common/ut_config.cpp
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "../../src/common/config.h"
+
+#include <gtest/gtest.h>
+#include <QDBusInterface>
+
+// Cover Config::Config(QObject*) and Config::~Config() by constructing and
+// destructing a fresh instance (constructor is private, accessible via
+// -fno-access-control compile flag used by the test target).
+TEST(UT_Config, Destructor)
+{
+    Config *cfg = new Config();
+    ASSERT_NE(cfg, nullptr);
+
+    delete cfg;
+    SUCCEED();
+}
+
+// Cover Config::instance() singleton access path.
+TEST(UT_Config, Instance)
+{
+    Config *cfg = Config::instance();
+    ASSERT_NE(cfg, nullptr);
+    EXPECT_EQ(Config::instance(), cfg);
+}
+
+// Cover Config::enableImproveGB18030 / enablePatchedIconv / defaultEncoding getters.
+TEST(UT_Config, Getters)
+{
+    Config *cfg = Config::instance();
+    EXPECT_FALSE(cfg->defaultEncoding().isEmpty());
+}
+
+// Cover the lambda connected to DConfig::valueChanged inside the constructor.
+// dconfig member is private; accessible via -fno-access-control.
+#ifdef DTKCORE_CLASS_DConfigFile
+TEST(UT_Config, ValueChangedLambda)
+{
+    Config *cfg = Config::instance();
+    if (cfg->dconfig && cfg->dconfig->isValid()) {
+        QMetaObject::invokeMethod(cfg->dconfig, "valueChanged",
+                                  Qt::DirectConnection,
+                                  Q_ARG(QString, "disableImproveGB18030"));
+        QMetaObject::invokeMethod(cfg->dconfig, "valueChanged",
+                                  Qt::DirectConnection,
+                                  Q_ARG(QString, "enablePatchedIconv"));
+        QMetaObject::invokeMethod(cfg->dconfig, "valueChanged",
+                                  Qt::DirectConnection,
+                                  Q_ARG(QString, "defaultEncoding"));
+    }
+    SUCCEED();
+}
+#endif

--- a/tests/src/common/ut_eventlogutils.cpp
+++ b/tests/src/common/ut_eventlogutils.cpp
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "../../src/common/eventlogutils.h"
+
+#include <gtest/gtest.h>
+#include <QJsonObject>
+#include <QJsonDocument>
+
+// Cover Eventlogutils::GetInstance() and the private Eventlogutils::Eventlogutils()
+// constructor (invoked on first GetInstance call).
+TEST(UT_Eventlogutils, GetInstance)
+{
+    Eventlogutils *p1 = Eventlogutils::GetInstance();
+    ASSERT_NE(p1, nullptr);
+
+    Eventlogutils *p2 = Eventlogutils::GetInstance();
+    EXPECT_EQ(p1, p2);
+}
+
+// Cover Eventlogutils::writeLogs(QJsonObject&).
+// writeEventLogFunc may be null when libdeepin-event-log.so is unavailable,
+// the function still executes and returns early in that case.
+TEST(UT_Eventlogutils, writeLogs)
+{
+    QJsonObject data;
+    data["tid"] = static_cast<int>(Eventlogutils::StartUp);
+    data["msg"] = QStringLiteral("unit test message");
+
+    Eventlogutils::GetInstance()->writeLogs(data);
+    SUCCEED();
+}
+
+// Cover writeLogs with empty json object.
+TEST(UT_Eventlogutils, writeLogs_empty)
+{
+    QJsonObject data;
+    Eventlogutils::GetInstance()->writeLogs(data);
+    SUCCEED();
+}

--- a/tests/src/common/ut_iflytek_ai_assistant.cpp
+++ b/tests/src/common/ut_iflytek_ai_assistant.cpp
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "../../src/common/iflytek_ai_assistant.h"
+
+#include <gtest/gtest.h>
+#include <QDBusInterface>
+#include <QSharedPointer>
+#include <QDebug>
+
+// Cover IflytekAiAssistant::launchCopilotChat(QSharedPointer<QDBusInterface> const&)
+// which is a private static method (accessible via -fno-access-control).
+// Using an invalid interface, call() returns an error message so the function
+// returns Disable. The exact result depends on the DBus environment, so we
+// only assert the function executes and returns a known enum value.
+TEST(UT_IflytekAiAssistant, launchCopilotChat)
+{
+    QSharedPointer<QDBusInterface> copilot =
+        QSharedPointer<QDBusInterface>::create("com.deepin.copilot",
+                                               "/com/deepin/copilot",
+                                               "com.deepin.copilot");
+    ASSERT_FALSE(copilot.isNull());
+
+    IflytekAiAssistant::CallStatus ret =
+        IflytekAiAssistant::launchCopilotChat(copilot);
+    // The return value is either Disable (error path) or Enable (no error msg).
+    EXPECT_TRUE(ret == IflytekAiAssistant::Disable ||
+                ret == IflytekAiAssistant::Enable);
+}
+
+// Cover IflytekAiAssistant::stopTtsDirectlyInternal() const (private method).
+// When status() != Enable it returns the current status immediately.
+TEST(UT_IflytekAiAssistant, stopTtsDirectlyInternal_notEnabled)
+{
+    IflytekAiAssistant *ins = IflytekAiAssistant::instance();
+    IflytekAiAssistant::CallStatus ret = ins->stopTtsDirectlyInternal();
+    EXPECT_EQ(ret, ins->status());
+}
+
+// Cover IflytekAiAssistant::stopTtsDirectlyInternal() const on the success path.
+// Force m_status to Enable so the DBus call branch is exercised.
+TEST(UT_IflytekAiAssistant, stopTtsDirectlyInternal_enabled)
+{
+    IflytekAiAssistant *ins = IflytekAiAssistant::instance();
+    IflytekAiAssistant::CallStatus oldStatus = ins->m_status;
+    ins->m_status = IflytekAiAssistant::Enable;
+
+    IflytekAiAssistant::CallStatus ret = ins->stopTtsDirectlyInternal();
+    EXPECT_EQ(ret, IflytekAiAssistant::Success);
+
+    ins->m_status = oldStatus;
+}
+
+// Cover IflytekAiAssistant::~IflytekAiAssistant() (private, defaulted destructor)
+// by constructing and destructing a fresh instance.
+TEST(UT_IflytekAiAssistant, Destructor)
+{
+    IflytekAiAssistant *p = new IflytekAiAssistant();
+    ASSERT_NE(p, nullptr);
+    delete p;
+    SUCCEED();
+}

--- a/tests/src/common/ut_textfilesaver.cpp
+++ b/tests/src/common/ut_textfilesaver.cpp
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "../../src/common/text_file_saver.h"
+
+#include <gtest/gtest.h>
+#include <QTextDocument>
+#include <QTemporaryDir>
+#include <QFile>
+#include <QFileInfo>
+
+// Cover TextFileSaver::saveAs(QString const&) - success path with a temp file.
+TEST(UT_TextFileSaver, saveAs_success)
+{
+    QTextDocument doc;
+    doc.setPlainText(QStringLiteral("Hello world\nSecond line"));
+
+    TextFileSaver saver(&doc);
+
+    QTemporaryDir dir;
+    ASSERT_TRUE(dir.isValid());
+    QString filePath = dir.path() + "/test_saveas.txt";
+
+    bool ret = saver.saveAs(filePath);
+    EXPECT_TRUE(ret);
+
+    // The file should exist and contain content.
+    QFile file(filePath);
+    EXPECT_TRUE(file.exists());
+}
+
+// Cover TextFileSaver::saveAs(QString const&) - failure path (unwritable path)
+// which should restore the original path and return false.
+TEST(UT_TextFileSaver, saveAs_failure)
+{
+    QTextDocument doc;
+    doc.setPlainText(QStringLiteral("content"));
+
+    TextFileSaver saver(&doc);
+    saver.setFilePath(QStringLiteral("/tmp/original_path_keep.txt"));
+
+    // An invalid directory path cannot be opened for writing.
+    bool ret = saver.saveAs(QStringLiteral("/nonexistent_dir_xyz/path/file.txt"));
+    EXPECT_FALSE(ret);
+
+    // On failure the original path is restored.
+    EXPECT_FALSE(saver.errorString().isEmpty());
+}

--- a/tests/src/encodes/ut_detectcode_helpers.cpp
+++ b/tests/src/encodes/ut_detectcode_helpers.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 //

--- a/tests/src/encodes/ut_detectcode_helpers.cpp
+++ b/tests/src/encodes/ut_detectcode_helpers.cpp
@@ -1,0 +1,157 @@
+// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// 覆盖 detectcode.cpp 中文件作用域的自由函数 (未在头文件导出，具有外部链接):
+//   utf8MultiByteCount / checkGB18030ToUtf8Error / checkUTF8ToGB18030Error
+// 及 utf8MultiByteCount 内部的 lambda。
+
+#include <gtest/gtest.h>
+#include <QByteArray>
+
+// 声明 detectcode.cpp 中的文件作用域函数
+int utf8MultiByteCount(char *buf, size_t size);
+bool checkGB18030ToUtf8Error(char *buf, size_t size, size_t &replaceLen, QByteArray &appendChar);
+bool checkUTF8ToGB18030Error(char *buf, size_t size, size_t &replaceLen, QByteArray &appendChar);
+
+// utf8MultiByteCount: 单字节 ASCII
+TEST(UT_Utf8MultiByteCount, SingleByte)
+{
+    char buf[] = {'A'};
+    EXPECT_EQ(utf8MultiByteCount(buf, 1), 1);
+}
+
+// utf8MultiByteCount: 双字节起始符 (110xxxxx)
+TEST(UT_Utf8MultiByteCount, DoubleBytes)
+{
+    char buf[] = {static_cast<char>(0xC2), static_cast<char>(0x80)};
+    EXPECT_EQ(utf8MultiByteCount(buf, 2), 2);
+}
+
+// utf8MultiByteCount: 三字节起始符 (1110xxxx)
+TEST(UT_Utf8MultiByteCount, ThreeBytes)
+{
+    char buf[] = {static_cast<char>(0xE0), static_cast<char>(0x80), static_cast<char>(0x80)};
+    EXPECT_EQ(utf8MultiByteCount(buf, 3), 3);
+}
+
+// utf8MultiByteCount: 四字节起始符 (11110xxx)
+TEST(UT_Utf8MultiByteCount, FourBytes)
+{
+    char buf[] = {static_cast<char>(0xF0), static_cast<char>(0x80), static_cast<char>(0x80), static_cast<char>(0x80)};
+    EXPECT_EQ(utf8MultiByteCount(buf, 4), 4);
+}
+
+// utf8MultiByteCount: 连续字节 (10xxxxxx)，累加至 4 (触发内部 lambda)
+TEST(UT_Utf8MultiByteCount, ContinuationBytes)
+{
+    char buf[] = {static_cast<char>(0x80), static_cast<char>(0x80), static_cast<char>(0x80), static_cast<char>(0x80)};
+    EXPECT_EQ(utf8MultiByteCount(buf, 4), 4);
+}
+
+// utf8MultiByteCount: 连续字节，size 先耗尽
+TEST(UT_Utf8MultiByteCount, ContinuationBytesShort)
+{
+    char buf[] = {static_cast<char>(0x80), static_cast<char>(0x80)};
+    EXPECT_EQ(utf8MultiByteCount(buf, 2), 2);
+}
+
+// utf8MultiByteCount: 超过 4 个前导 1 的非法字节，default 返回 1
+TEST(UT_Utf8MultiByteCount, InvalidLeadingBits)
+{
+    char buf[] = {static_cast<char>(0xF8)};
+    EXPECT_EQ(utf8MultiByteCount(buf, 1), 1);
+}
+
+// checkGB18030ToUtf8Error: size 小于 4，返回 false
+TEST(UT_CheckGB18030ToUtf8Error, ShortBuffer)
+{
+    char buf[] = {static_cast<char>(0x82), static_cast<char>(0x35)};
+    size_t replaceLen = 0;
+    QByteArray appendChar;
+    bool ret = checkGB18030ToUtf8Error(buf, 2, replaceLen, appendChar);
+
+    EXPECT_FALSE(ret);
+    EXPECT_EQ(replaceLen, static_cast<size_t>(1));
+    EXPECT_EQ(appendChar, QByteArray("?"));
+}
+
+// checkGB18030ToUtf8Error: 不匹配的 4 字节，返回 false
+TEST(UT_CheckGB18030ToUtf8Error, NoMatch)
+{
+    char buf[] = {0x00, 0x01, 0x02, 0x03};
+    size_t replaceLen = 0;
+    QByteArray appendChar;
+    bool ret = checkGB18030ToUtf8Error(buf, 4, replaceLen, appendChar);
+
+    EXPECT_FALSE(ret);
+    EXPECT_EQ(replaceLen, static_cast<size_t>(1));
+    EXPECT_EQ(appendChar, QByteArray("?"));
+}
+
+// checkGB18030ToUtf8Error: 命中 PUA 映射 (小端序 0x37903582 -> \uE81E)
+TEST(UT_CheckGB18030ToUtf8Error, MatchPUA)
+{
+    char buf[] = {static_cast<char>(0x82), static_cast<char>(0x35), static_cast<char>(0x90), static_cast<char>(0x37)};
+    size_t replaceLen = 0;
+    QByteArray appendChar;
+    bool ret = checkGB18030ToUtf8Error(buf, 4, replaceLen, appendChar);
+
+    EXPECT_TRUE(ret);
+    EXPECT_EQ(replaceLen, static_cast<size_t>(4));
+    EXPECT_FALSE(appendChar.isEmpty());
+}
+
+// checkUTF8ToGB18030Error: size 小于 3，返回 false
+TEST(UT_CheckUTF8ToGB18030Error, ShortBuffer)
+{
+    char buf[] = {static_cast<char>(0xEE), static_cast<char>(0xA0)};
+    size_t replaceLen = 0;
+    QByteArray appendChar;
+    bool ret = checkUTF8ToGB18030Error(buf, 2, replaceLen, appendChar);
+
+    EXPECT_FALSE(ret);
+    EXPECT_EQ(replaceLen, static_cast<size_t>(1));
+    EXPECT_EQ(appendChar, QByteArray("?"));
+}
+
+// checkUTF8ToGB18030Error: 命中 gs_UTF8MapGB18030Data (U+E81E -> 0x37903582)
+TEST(UT_CheckUTF8ToGB18030Error, MatchPUA)
+{
+    // U+E81E 的 UTF-8 编码: EE A0 9E
+    char buf[] = {static_cast<char>(0xEE), static_cast<char>(0xA0), static_cast<char>(0x9E)};
+    size_t replaceLen = 0;
+    QByteArray appendChar;
+    bool ret = checkUTF8ToGB18030Error(buf, 3, replaceLen, appendChar);
+
+    EXPECT_TRUE(ret);
+    EXPECT_EQ(replaceLen, static_cast<size_t>(3));
+    EXPECT_FALSE(appendChar.isEmpty());
+}
+
+// checkUTF8ToGB18030Error: 命中 gs_ReplaceUtf8ToGB18030_2005Error (U+E816 -> FE51)
+TEST(UT_CheckUTF8ToGB18030Error, Match2005Error)
+{
+    // U+E816 的 UTF-8 编码: EE A0 96
+    char buf[] = {static_cast<char>(0xEE), static_cast<char>(0xA0), static_cast<char>(0x96)};
+    size_t replaceLen = 0;
+    QByteArray appendChar;
+    bool ret = checkUTF8ToGB18030Error(buf, 3, replaceLen, appendChar);
+
+    EXPECT_TRUE(ret);
+    EXPECT_EQ(replaceLen, static_cast<size_t>(3));
+    EXPECT_FALSE(appendChar.isEmpty());
+}
+
+// checkUTF8ToGB18030Error: 不匹配的 3 字节，返回 false
+TEST(UT_CheckUTF8ToGB18030Error, NoMatch)
+{
+    char buf[] = {0x00, 0x01, 0x02};
+    size_t replaceLen = 0;
+    QByteArray appendChar;
+    bool ret = checkUTF8ToGB18030Error(buf, 3, replaceLen, appendChar);
+
+    EXPECT_FALSE(ret);
+    EXPECT_EQ(replaceLen, static_cast<size_t>(1));
+    EXPECT_EQ(appendChar, QByteArray("?"));
+}


### PR DESCRIPTION
Add tests for Config, Eventlogutils, IflytekAiAssistant, TextFileSaver and detectcode helper functions.

Log: 新增common和encodes模块的单元测试
Influence: 覆盖Config、Eventlogutils等类的未覆盖函数

## Summary by Sourcery

Add unit tests to cover previously untested functionality in the common and encodes modules.

Tests:
- Add unit tests for UTF-8 and GB18030 encoding helper functions in the encodes module.
- Add unit tests for IflytekAiAssistant private and singleton behaviors, including DBus-related paths and destructor.
- Add unit tests for Config singleton lifecycle, configuration getters, and value-changed handling.
- Add unit tests for TextFileSaver saveAs success and failure paths.
- Add unit tests for Eventlogutils singleton access and log writing behavior with various JSON inputs.