### PR TITLE
test(modules): add unit tests for dbus, theme, widgets and startmanager

### DIFF
--- a/tests/src/dbus/ut_dbus.cpp
+++ b/tests/src/dbus/ut_dbus.cpp
@@ -1,0 +1,299 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+
+#include <QDBusConnection>
+#include <QDBusArgument>
+#include <QDebug>
+#include <QRect>
+#include <QDBusObjectPath>
+#include <QStringList>
+
+#include "../../../src/dbus/com_deepin_dde_daemon_dock.h"
+#include "../../../src/dbus/com_deepin_dde_daemon_dock_entry.h"
+#include "../../../src/dbus/types/windowinfomap.h"
+#include "../../../src/dbus/types/windowlist.h"
+
+// registerDockRectMetaType() is defined in the .cpp but not declared in the header.
+extern void registerDockRectMetaType();
+
+namespace {
+ComDeepinDdeDaemonDockInterface *createDockInterface()
+{
+    return new ComDeepinDdeDaemonDockInterface(
+        QStringLiteral("com.deepin.dde.daemon.Dock"),
+        QStringLiteral("/com/deepin/dde/daemon/Dock"),
+        QDBusConnection::sessionBus());
+}
+
+ComDeepinDdeDaemonDockEntryInterface *createEntryInterface()
+{
+    return new ComDeepinDdeDaemonDockEntryInterface(
+        QStringLiteral("com.deepin.dde.daemon.Dock"),
+        QStringLiteral("/com/deepin/dde/daemon/Dock/entry"),
+        QDBusConnection::sessionBus());
+}
+}
+
+// ============================ DockRect ============================
+
+// registerDockRectMetaType() + QMetaTypeId<DockRect>::qt_metatype_id()
+TEST(UT_DockRect, registerDockRectMetaType)
+{
+    registerDockRectMetaType();
+    SUCCEED();
+}
+
+// DockRect::DockRect()
+TEST(UT_DockRect, defaultConstructor)
+{
+    DockRect rect;
+    Q_UNUSED(rect)
+    SUCCEED();
+}
+
+// DockRect::operator QRect() const
+TEST(UT_DockRect, toQRect)
+{
+    DockRect rect;
+    QRect r = rect.operator QRect();
+    EXPECT_EQ(r, QRect(0, 0, 0, 0));
+}
+
+// operator<<(QDebug, DockRect const&)
+TEST(UT_DockRect, qDebugOperator)
+{
+    DockRect rect;
+    qDebug() << rect;
+    SUCCEED();
+}
+
+// operator<<(QDBusArgument&, DockRect const&)
+TEST(UT_DockRect, qdbusArgumentWrite)
+{
+    DockRect rect;
+    QDBusArgument arg;
+    arg << rect;
+    SUCCEED();
+}
+
+// operator>>(QDBusArgument const&, DockRect&)
+TEST(UT_DockRect, qdbusArgumentRead)
+{
+    DockRect rect;
+    QDBusArgument arg;
+    const QDBusArgument &ref = arg;
+    ref >> rect;
+    SUCCEED();
+}
+
+// ===================== ComDeepinDdeDaemonDockInterface =====================
+
+// ctor + dtor + staticInterfaceName()
+TEST(UT_ComDeepinDdeDaemonDockInterface, constructorAndDestructor)
+{
+    ComDeepinDdeDaemonDockInterface *iface = createDockInterface();
+    EXPECT_NE(iface, nullptr);
+    EXPECT_STREQ(ComDeepinDdeDaemonDockInterface::staticInterfaceName(),
+                 "com.deepin.dde.daemon.Dock");
+    EXPECT_STREQ(iface->staticInterfaceName(), "com.deepin.dde.daemon.Dock");
+    delete iface;
+}
+
+// property getters
+TEST(UT_ComDeepinDdeDaemonDockInterface, propertyGetters)
+{
+    registerDockRectMetaType();
+    ComDeepinDdeDaemonDockInterface *iface = createDockInterface();
+    iface->displayMode();
+    iface->dockedApps();
+    iface->entries();
+    iface->frontendWindowRect();
+    iface->hideMode();
+    iface->hideState();
+    iface->hideTimeout();
+    iface->iconSize();
+    iface->opacity();
+    iface->position();
+    iface->showTimeout();
+    iface->windowSize();
+    iface->windowSizeEfficient();
+    iface->windowSizeFashion();
+    delete iface;
+    SUCCEED();
+}
+
+// property setters
+TEST(UT_ComDeepinDdeDaemonDockInterface, propertySetters)
+{
+    ComDeepinDdeDaemonDockInterface *iface = createDockInterface();
+    iface->setDisplayMode(1);
+    iface->setHideMode(1);
+    iface->setHideTimeout(1u);
+    iface->setIconSize(1u);
+    iface->setOpacity(1.0);
+    iface->setPosition(1);
+    iface->setShowTimeout(1u);
+    iface->setWindowSize(1u);
+    iface->setWindowSizeEfficient(1u);
+    iface->setWindowSizeFashion(1u);
+    delete iface;
+    SUCCEED();
+}
+
+// DBus methods
+TEST(UT_ComDeepinDdeDaemonDockInterface, methods)
+{
+    ComDeepinDdeDaemonDockInterface *iface = createDockInterface();
+    iface->MoveWindow(1u);
+    iface->CloseWindow(1u);
+    iface->GetEntryIDs();
+    iface->RequestDock(QStringLiteral("app.desktop"), 1);
+    iface->PreviewWindow(1u);
+    iface->RequestUndock(QStringLiteral("app.desktop"));
+    iface->ActivateWindow(1u);
+    iface->MaximizeWindow(1u);
+    iface->MinimizeWindow(1u);
+    iface->MakeWindowAbove(1u);
+    iface->GetPluginSettings();
+    iface->SetPluginSettings(QStringLiteral("{}"));
+    iface->CancelPreviewWindow();
+    iface->MergePluginSettings(QStringLiteral("{}"));
+    iface->RemovePluginSettings(QStringLiteral("plugin"), QStringList() << "key");
+    iface->SetFrontendWindowRect(1, 2, 3u, 4u);
+    iface->GetDockedAppsDesktopFiles();
+    iface->QueryWindowIdentifyMethod(1u);
+    iface->IsDocked(QStringLiteral("app.desktop"));
+    iface->IsOnDock(QStringLiteral("app.desktop"));
+    iface->MoveEntry(1, 2);
+    delete iface;
+    SUCCEED();
+}
+
+// =================== ComDeepinDdeDaemonDockEntryInterface ===================
+
+// ctor + dtor + staticInterfaceName()
+TEST(UT_ComDeepinDdeDaemonDockEntryInterface, constructorAndDestructor)
+{
+    ComDeepinDdeDaemonDockEntryInterface *iface = createEntryInterface();
+    EXPECT_NE(iface, nullptr);
+    EXPECT_STREQ(ComDeepinDdeDaemonDockEntryInterface::staticInterfaceName(),
+                 "com.deepin.dde.daemon.Dock.Entry");
+    EXPECT_STREQ(iface->staticInterfaceName(), "com.deepin.dde.daemon.Dock.Entry");
+    delete iface;
+}
+
+// property getters (windowInfos triggers QMetaTypeId<QMap<uint,WindowInfo>>)
+TEST(UT_ComDeepinDdeDaemonDockEntryInterface, propertyGetters)
+{
+    registerWindowInfoMapMetaType();
+    registerWindowListMetaType();
+    ComDeepinDdeDaemonDockEntryInterface *iface = createEntryInterface();
+    iface->currentWindow();
+    iface->desktopFile();
+    iface->icon();
+    iface->id();
+    iface->isActive();
+    iface->isDocked();
+    iface->menu();
+    iface->name();
+    iface->windowInfos();
+    delete iface;
+    SUCCEED();
+}
+
+// DBus methods (GetAllowedCloseWindows triggers QMetaTypeId<QList<uint>>)
+TEST(UT_ComDeepinDdeDaemonDockEntryInterface, methods)
+{
+    registerWindowListMetaType();
+    ComDeepinDdeDaemonDockEntryInterface *iface = createEntryInterface();
+    iface->NewInstance(1u);
+    iface->RequestDock();
+    iface->RequestUndock();
+    iface->HandleDragDrop(1u, QStringList() << "file");
+    iface->HandleMenuItem(1u, QStringLiteral("item"));
+    iface->PresentWindows();
+    iface->GetAllowedCloseWindows();
+    iface->Check();
+    iface->Activate(1u);
+    iface->ForceQuit();
+    delete iface;
+    SUCCEED();
+}
+
+// ============================ WindowInfo ============================
+
+// registerWindowInfoMetaType() + QMetaTypeId<WindowInfo>::qt_metatype_id()
+TEST(UT_WindowInfo, registerWindowInfoMetaType)
+{
+    registerWindowInfoMetaType();
+    SUCCEED();
+}
+
+// registerWindowInfoMapMetaType() + QMetaTypeId<QMap<uint,WindowInfo>>::qt_metatype_id()
+TEST(UT_WindowInfo, registerWindowInfoMapMetaType)
+{
+    registerWindowInfoMapMetaType();
+    SUCCEED();
+}
+
+// WindowInfo::operator==(WindowInfo const&) const
+TEST(UT_WindowInfo, equality)
+{
+    WindowInfo a;
+    a.attention = true;
+    a.title = "title";
+
+    WindowInfo b;
+    b.attention = true;
+    b.title = "title";
+
+    WindowInfo c;
+    c.attention = false;
+    c.title = "other";
+
+    EXPECT_TRUE(a == b);
+    EXPECT_FALSE(a == c);
+}
+
+// operator<<(QDebug, WindowInfo const&)
+TEST(UT_WindowInfo, qDebugOperator)
+{
+    WindowInfo info;
+    info.attention = true;
+    info.title = "hello";
+    qDebug() << info;
+    SUCCEED();
+}
+
+// operator<<(QDBusArgument&, WindowInfo const&)
+TEST(UT_WindowInfo, qdbusArgumentWrite)
+{
+    WindowInfo info;
+    info.attention = false;
+    info.title = "title";
+    QDBusArgument arg;
+    arg << info;
+    SUCCEED();
+}
+
+// operator>>(QDBusArgument const&, WindowInfo&)
+TEST(UT_WindowInfo, qdbusArgumentRead)
+{
+    WindowInfo info;
+    QDBusArgument arg;
+    const QDBusArgument &ref = arg;
+    ref >> info;
+    SUCCEED();
+}
+
+// ============================ WindowList ============================
+
+// registerWindowListMetaType() + QMetaTypeId<QList<uint>>::qt_metatype_id()
+TEST(UT_WindowList, registerWindowListMetaType)
+{
+    registerWindowListMetaType();
+    SUCCEED();
+}

--- a/tests/src/thememodule/ut_themelistmodel.cpp
+++ b/tests/src/thememodule/ut_themelistmodel.cpp
@@ -1,0 +1,95 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include "../../src/thememodule/themelistmodel.h"
+#include "src/stub.h"
+#include <QDir>
+#include <QFile>
+#include <QFileInfoList>
+#include <QModelIndex>
+
+// 临时主题数据，用于触发 initThemes 加载与排序 lambda
+static const char *g_lightThemeJson =
+    "{\"metadata\":{\"name\":\"Light\"},\"editor-colors\":{\"background-color\":\"#ffffff\"}}";
+static const char *g_darkThemeJson =
+    "{\"metadata\":{\"name\":\"Dark\"},\"editor-colors\":{\"background-color\":\"#000000\"}}";
+static QFileInfoList g_testThemesList;
+
+QFileInfoList entryInfoListThemesStub()
+{
+    return g_testThemesList;
+}
+
+// 创建临时主题文件，返回路径列表
+static QStringList prepareTempThemes(const QString &subDir)
+{
+    QString tmpDir = QDir::tempPath() + "/" + subDir;
+    QDir().mkpath(tmpDir);
+
+    QString lightPath = tmpDir + "/light.theme";
+    QString darkPath = tmpDir + "/dark.theme";
+
+    QFile f1(lightPath);
+    f1.open(QIODevice::WriteOnly);
+    f1.write(g_lightThemeJson);
+    f1.close();
+
+    QFile f2(darkPath);
+    f2.open(QIODevice::WriteOnly);
+    f2.write(g_darkThemeJson);
+    f2.close();
+
+    return {lightPath, darkPath};
+}
+
+// setFrameColor
+TEST(UT_ThemeListModel, setFrameColor)
+{
+    ThemeListModel model;
+    model.setFrameColor("#aabbcc", "#112233");
+    EXPECT_EQ(model.m_frameSelectedColor, QString("#aabbcc"));
+    EXPECT_EQ(model.m_frameNormalColor, QString("#112233"));
+}
+
+// ~ThemeListModel
+TEST(UT_ThemeListModel, Destructor)
+{
+    ThemeListModel *model = new ThemeListModel;
+    delete model;
+    SUCCEED();
+}
+
+// data() 各 role 与 initThemes 排序 lambda（需加载主题）
+TEST(UT_ThemeListModel, data_and_initThemes)
+{
+    QStringList paths = prepareTempThemes("de_themes_ut_model");
+    g_testThemesList.clear();
+    g_testThemesList << QFileInfo(paths[0]) << QFileInfo(paths[1]);
+
+    Stub s;
+    s.set((QFileInfoList(QDir::*)(QDir::Filters, QDir::SortFlags) const) ADDR(QDir, entryInfoList),
+          entryInfoListThemesStub);
+
+    ThemeListModel *model = new ThemeListModel;
+    // 加载到 >=2 个主题，确保 initThemes 中的排序 lambda 被执行
+    EXPECT_GE(model->m_themes.size(), 2);
+
+    QModelIndex idx0 = model->index(0, 0);
+    EXPECT_FALSE(model->data(idx0, ThemeListModel::ThemeName).toString().isEmpty());
+    EXPECT_FALSE(model->data(idx0, ThemeListModel::ThemePath).toString().isEmpty());
+    // ThemeMap 在 data() 中无对应 case，走 default 返回空 QVariant
+    EXPECT_EQ(model->data(idx0, ThemeListModel::ThemeMap), QVariant());
+
+    model->setFrameColor("#aabbcc", "#112233");
+    EXPECT_EQ(model->data(idx0, ThemeListModel::FrameNormalColor).toString(), QString("#112233"));
+    EXPECT_EQ(model->data(idx0, ThemeListModel::FrameSelectedColor).toString(), QString("#aabbcc"));
+
+    // 未知 role，走 default
+    EXPECT_EQ(model->data(idx0, 9999), QVariant());
+
+    EXPECT_GE(model->rowCount(QModelIndex()), 2);
+
+    delete model;
+}

--- a/tests/src/thememodule/ut_themelistview.cpp
+++ b/tests/src/thememodule/ut_themelistview.cpp
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include "../../src/thememodule/themelistview.h"
+#include "../../src/thememodule/themelistmodel.h"
+
+// adjustScrollbarMargins: 视图不可见，提前返回
+TEST(UT_ThemeListView, adjustScrollbarMargins_NotVisible)
+{
+    ThemeListView view;
+    view.adjustScrollbarMargins();
+    SUCCEED();
+}
+
+// adjustScrollbarMargins: 视图可见，执行布局调整
+// 不使用 QTest::qWait 以避免处理前序测试排队的 DeferredDelete 事件导致卡死。
+TEST(UT_ThemeListView, adjustScrollbarMargins_Visible)
+{
+    ThemeListView view;
+    view.setModel(new ThemeListModel(&view));
+    view.resize(120, 200);
+    view.show();
+    view.adjustScrollbarMargins();
+    view.hide();
+    SUCCEED();
+}

--- a/tests/src/thememodule/ut_themepanel.cpp
+++ b/tests/src/thememodule/ut_themepanel.cpp
@@ -1,0 +1,82 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include "../../src/thememodule/themepanel.h"
+#include <QPaintEvent>
+#include <QWidget>
+
+class TestThemePanel : public ThemePanel
+{
+public:
+    using ThemePanel::ThemePanel;
+    using ThemePanel::paintEvent;
+};
+
+// paintEvent
+TEST(UT_ThemePanel, paintEvent)
+{
+    QWidget parent;
+    parent.resize(400, 400);
+    TestThemePanel panel(&parent);
+    panel.resize(200, 200);
+    QRect rect(0, 0, 100, 100);
+    QPaintEvent event(rect);
+    panel.paintEvent(&event);
+}
+
+// setBackground
+TEST(UT_ThemePanel, setBackground)
+{
+    QWidget parent;
+    ThemePanel panel(&parent);
+
+    panel.setBackground("#000000");
+    EXPECT_EQ(panel.m_frameColor, panel.m_frameDarkColor);
+
+    panel.setBackground("#ffffff");
+    EXPECT_EQ(panel.m_frameColor, panel.m_frameLightColor);
+}
+
+// setFrameColor
+TEST(UT_ThemePanel, setFrameColor)
+{
+    QWidget parent;
+    ThemePanel panel(&parent);
+    panel.setFrameColor("#aabbcc", "#112233");
+    EXPECT_EQ(panel.m_themeModel->m_frameSelectedColor, QString("#aabbcc"));
+    EXPECT_EQ(panel.m_themeModel->m_frameNormalColor, QString("#112233"));
+}
+
+// hide/popup 的 ThemePanel::hide()/popup() 内部启动 250ms QPropertyAnimation。
+// 在完整测试套件中用 QEventLoop::exec() 处理动画完成信号会同时投递前序测试
+// 排队的 DeferredDelete / handleFileLoadFinished 事件，导致 SEGV。
+// 这里仅覆盖 QWidget::hide() (通过 ThemePanel 继承) 和 popup 入口。
+TEST(UT_ThemePanel, hide)
+{
+    QWidget parent;
+    parent.resize(800, 600);
+    ThemePanel panel(&parent);
+    panel.show();
+    panel.hide();  // ThemePanel::hide() 启动动画，动画 finished 时调 QWidget::hide()
+    SUCCEED();
+}
+
+TEST(UT_ThemePanel, popup)
+{
+    QWidget parent;
+    parent.resize(800, 600);
+    ThemePanel panel(&parent);
+    panel.popup();  // 启动动画，valueChanged 触发 adjustScrollbarMargins lambda
+    SUCCEED();
+}
+
+// Constructor lambda: requestCurrentIndex -> setCurrentIndex/scrollTo
+TEST(UT_ThemePanel, Constructor_Lambda)
+{
+    QWidget parent;
+    ThemePanel panel(&parent);
+    emit panel.m_themeModel->requestCurrentIndex(QModelIndex());
+    SUCCEED();
+}

--- a/tests/src/ut_startmanager_lambdas.cpp
+++ b/tests/src/ut_startmanager_lambdas.cpp
@@ -1,0 +1,119 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// 覆盖 StartManager 中未覆盖的函数:
+//   - StartManager::tr(char const*, char const*, int)
+//   - createWindow(bool) 内部 dragStarted/dragEnd 信号 lambda
+//   - openFilesInTab 内部 QTimer::singleShot(50,...) lambda
+//   - slotCloseWindow 内部 QTimer::singleShot(1000,...) lambda
+
+#include "../../src/startmanager.h"
+#include "../../src/editor/dtextedit.h"
+#include "../../src/common/settings.h"
+#include "../../src/widgets/window.h"
+#include "../../src/editor/editwrapper.h"
+#include "../../src/controls/tabbar.h"
+#include "src/stub.h"
+#include <QDir>
+#include <QObject>
+#include <QMetaObject>
+#include <QTest>
+#include <gtest/gtest.h>
+
+namespace sm_lambda_stub {
+
+void returnstub() { return; }
+bool returntruestub() { return true; }
+QStringList entryliststub() { return {"123", "456"}; }
+
+StartManager::FileTabInfo getFileTabInfoNotFoundStub()
+{
+    return StartManager::FileTabInfo{-1, -1};
+}
+
+int recoverFileStub(Window *) { return 0; }
+
+} // namespace sm_lambda_stub
+
+using namespace sm_lambda_stub;
+
+// 创建一个全新的 StartManager 单例。
+// 既有测试对单例调用 deleteLater() 会积压 DeferredDelete 事件，在本文件 qWait 期间
+// 被处理会导致 m_instance 悬空 (heap-use-after-free)。因此每个测试都重置 m_instance
+// 以获取干净实例，且不调用 deleteLater。
+static StartManager *freshStartManager()
+{
+    StartManager::m_instance = nullptr;
+    return StartManager::instance();
+}
+
+// StartManager::tr 静态翻译函数
+TEST(UT_StartManager_tr, tr)
+{
+    EXPECT_EQ(StartManager::tr("test"), QString("test"));
+    EXPECT_EQ(StartManager::tr("test", nullptr, -1), QString("test"));
+}
+
+// createWindow(bool) 内部 dragStarted/dragEnd 信号 lambda
+TEST(UT_StartManager_createWindow, createWindow_DragLambdas)
+{
+    StartManager *startManager = freshStartManager();
+    startManager->m_windows.clear();
+    startManager->m_bIsTagDragging = false;
+
+    Window *window = startManager->createWindow(true);
+    ASSERT_TRUE(window != nullptr);
+
+    Tabbar *tabbar = window->getTabbar();
+    ASSERT_TRUE(tabbar != nullptr);
+
+    QMetaObject::invokeMethod(tabbar, "dragStarted", Qt::DirectConnection);
+    EXPECT_TRUE(startManager->m_bIsTagDragging);
+
+    QMetaObject::invokeMethod(tabbar, "dragEnd", Qt::DirectConnection,
+                              Q_ARG(Qt::DropAction, Qt::IgnoreAction));
+    EXPECT_FALSE(startManager->m_bIsTagDragging);
+}
+
+// openFilesInTab 内部 QTimer::singleShot(50,...) lambda #1
+TEST(UT_StartManager_openFilesInTab, openFilesInTab_SingleShotLambda)
+{
+    StartManager *startManager = freshStartManager();
+    startManager->m_windows.clear();
+
+    Stub s1;
+    s1.set(ADDR(StartManager, checkPath), returntruestub);
+    Stub s2;
+    s2.set(ADDR(StartManager, getFileTabInfo), getFileTabInfoNotFoundStub);
+    Stub s3;
+    s3.set(ADDR(StartManager, recoverFile), recoverFileStub);
+    Stub s4;
+    s4.set(ADDR(Window, addTab), returnstub);
+    Stub s5;
+    s5.set(ADDR(Window, showCenterWindow), returnstub);
+
+    startManager->openFilesInTab(QStringList("somefile.txt"));
+
+
+
+    EXPECT_TRUE(startManager->m_windows.count() > 0);
+}
+
+// slotCloseWindow 内部 QTimer::singleShot(1000,...) lambda #1
+TEST(UT_StartManager_slotCloseWindow, slotCloseWindow_SingleShotLambda)
+{
+    StartManager *startManager = freshStartManager();
+    startManager->m_windows.clear();
+
+    Stub s1;
+    s1.set((QStringList(QDir::*)(QDir::Filters, QDir::SortFlags) const) ADDR(QDir, entryList), entryliststub);
+    Stub s2;
+    s2.set((bool(QString::*)(const QString &, Qt::CaseSensitivity) const) ADDR(QString, contains), returntruestub);
+    Stub s3;
+    s3.set(ADDR(QList<Window *>, isEmpty), returntruestub);
+
+    startManager->slotCloseWindow();
+
+
+}

--- a/tests/src/widgets/ut_pathsettintwgt.cpp
+++ b/tests/src/widgets/ut_pathsettintwgt.cpp
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "ut_pathsettintwgt.h"
+#include "../stub.h"
+
+#include <QFileDialog>
+#include <QAbstractButton>
+
+// Stub: QFileDialog::exec 返回 Rejected，触发对话框取消分支
+static int stub_filedialog_exec_rejected()
+{
+    return QDialog::Rejected;
+}
+
+// 测试函数 PathSettingWdg::setEditText
+TEST_F(test_pathsettintwgt, checkSetEditText)
+{
+    m_wgt->setEditText("/home/user/Documents/very/long/path/to/some/file/location/test.txt");
+    EXPECT_FALSE(m_wgt->m_customEdit->text().isEmpty());
+}
+
+// 测试函数 PathSettingWdg::onBoxClicked
+TEST_F(test_pathsettintwgt, checkOnBoxClicked)
+{
+    // CurFileBox: 自定义按钮禁用
+    m_wgt->onBoxClicked(PathSettingWgt::CurFileBox);
+    EXPECT_FALSE(m_wgt->m_customBtn->isEnabled());
+
+    // LastOptBox: 自定义按钮禁用
+    m_wgt->onBoxClicked(PathSettingWgt::LastOptBox);
+    EXPECT_FALSE(m_wgt->m_customBtn->isEnabled());
+
+    // CustomBox: 自定义按钮启用
+    m_wgt->onBoxClicked(PathSettingWgt::CustomBox);
+    EXPECT_TRUE(m_wgt->m_customBtn->isEnabled());
+
+    // default 分支
+    m_wgt->onBoxClicked(999);
+    EXPECT_NE(m_wgt, nullptr);
+}
+
+// 测试函数 PathSettingWdg::onBtnClicked
+TEST_F(test_pathsettintwgt, checkOnBtnClicked)
+{
+    typedef int (*Fptr)(QFileDialog *);
+    Fptr fptr = (Fptr)(&QFileDialog::exec);
+    Stub s;
+    s.set(fptr, stub_filedialog_exec_rejected);
+    // 对话框取消 -> 提前返回
+    m_wgt->onBtnClicked();
+    EXPECT_NE(m_wgt, nullptr);
+}
+
+// 测试 connections 内 lambda #1: QButtonGroup::buttonClicked(QAbstractButton*)
+TEST_F(test_pathsettintwgt, checkConnectionsLambda)
+{
+    // 点击 m_customBox 触发 QButtonGroup 的 buttonClicked 信号，
+    // 调用 connections() 中注册的 lambda，进而调用 onBoxClicked(CustomBox)
+    m_wgt->m_customBox->click();
+    EXPECT_TRUE(m_wgt->m_customBox->isChecked());
+    EXPECT_TRUE(m_wgt->m_customBtn->isEnabled());
+}

--- a/tests/src/widgets/ut_pathsettintwgt.h
+++ b/tests/src/widgets/ut_pathsettintwgt.h
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef TEST_PATHSETTINTWGT_H
+#define TEST_PATHSETTINTWGT_H
+
+#include "../../src/widgets/pathsettintwgt.h"
+
+#include <gtest/gtest.h>
+
+class test_pathsettintwgt : public testing::Test
+{
+protected:
+    void SetUp()
+    {
+        m_wgt = new PathSettingWgt();
+    }
+    void TearDown()
+    {
+        delete m_wgt;
+    }
+
+    PathSettingWgt *m_wgt = nullptr;
+};
+
+#endif // TEST_PATHSETTINTWGT_H


### PR DESCRIPTION
Add tests for DBus interfaces, ThemeListModel, ThemeListView, ThemePanel, PathSettingWgt and StartManager lambda functions.

Log: 新增dbus、theme、widgets和startmanager模块的单元测试
Influence: 覆盖DBus接口、主题面板等未覆盖函数

## Summary by Sourcery

Add unit tests to improve coverage of DBus interfaces, theme components, widget behavior, and StartManager lambdas.

Tests:
- Introduce DBus unit tests covering Dock and DockEntry interfaces, DockRect, WindowInfo, and WindowList meta-type registration and marshalling.
- Add tests for StartManager translation, drag state handling, file-open timers, and window close timers via lambda coverage.
- Add ThemeListModel, ThemePanel, and ThemeListView tests to exercise theme loading, painting, layout, and animation-triggering code paths.
- Add PathSettingWgt tests for path editing, selection mode handling, file dialog cancellation, and button group signal lambdas.