### PR TITLE
test(editor): fix heap-buffer-overflow crash in UT_Editwrapper_loadContent

### DIFF
--- a/tests/src/editor/ut_editwrapper.cpp
+++ b/tests/src/editor/ut_editwrapper.cpp
@@ -1381,8 +1381,17 @@ TEST(UT_Editwrapper_loadContent, UT_Editwrapper_loadContent_001)
     Window* window = new Window();
     EditWrapper* wra = new EditWrapper(window);
 
+    // loadContent() determines the file size via `strContent.length()` where
+    // strContent is a QByteArray, so the size must be faked on QByteArray, not
+    // QString. Stubbing QString::length globally corrupts every QString in the
+    // process: QDebug::operator<<(const QString&) (qdebug.h) calls t.length(),
+    // which then makes qDebug read past the string buffer and triggers a
+    // heap-buffer-overflow (e.g. when DDropdownMenu::setText prints the endline
+    // text). QByteArray::length is safe to stub here because qDebug prints a
+    // QByteArray through size() and the actual data reads in loadContent use
+    // size()/d->size rather than length().
     Stub s1;
-    s1.set(ADDR(QString,length),retintstub);
+    s1.set(ADDR(QByteArray,length),retintstub);
 
     intvalue = 41*1024*1024;
     wra->loadContent("ddd");
@@ -1398,8 +1407,11 @@ TEST(UT_Editwrapper_loadContent, UT_Editwrapper_loadContent_002)
     Window* window = new Window();
     EditWrapper* wra = new EditWrapper(window);
 
+    // See UT_Editwrapper_loadContent_001: stub QByteArray::length (the real
+    // type of strContent) instead of QString::length to avoid corrupting all
+    // QString operations (which makes qDebug abort on a heap-buffer-overflow).
     Stub s1;
-    s1.set(ADDR(QString,length),retintstub);
+    s1.set(ADDR(QByteArray,length),retintstub);
 
     intvalue = 10*1024;
     wra->loadContent("ddd");


### PR DESCRIPTION
## Problem

Running the deepin-editor unit tests with ASan+UBSan aborted the whole test process at `UT_Editwrapper_loadContent.UT_Editwrapper_loadContent_001`:

```
==492409==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x504008a22872
READ of size 12 at 0x504008a22872 thread T0
    #0 __interceptor_memcpy
    #1 QString::append(QChar const*, int)
    #2 QDebug::putString(QChar const*, unsigned long)
    #3 QDebug::operator<<(QString const&)            qdebug.h:161
    #4 DDropdownMenu::setText(QString const&)         src/widgets/ddropdownmenu.cpp:214
    #5 DDropdownMenu::setCurrentTextOnly(QString const&)
    #6 BottomBar::setEndlineMenuText(BottomBar::EndlineFormat)  src/widgets/bottombar.cpp:436
    #7 EditWrapper::loadContent(QByteArray const&)    src/editor/editwrapper.cpp:1700
    #8 UT_Editwrapper_loadContent_001_Test::TestBody() tests/src/editor/ut_editwrapper.cpp:1388
...
==492409==ABORTING
```

## Root cause

`UT_Editwrapper_loadContent_001/002` installed a global stub that made `QString::length()` return a very large value (`41 * 1024 * 1024` / `10 * 1024`):

```cpp
Stub s1;
s1.set(ADDR(QString,length),retintstub);
intvalue = 41*1024*1024;
wra->loadContent("ddd");
```

This was both **ineffective** and **harmful**:

- `EditWrapper::loadContent()` decides the branch from `int len = strContent.length();`, and `strContent` is a `QByteArray`. Stubbing `QString::length` therefore never influenced the branch selection — `len` always stayed the real size of `"ddd"`.
- `QString::length()` is an **out-of-line** symbol in `libQt5Core`, so the stub globally corrupted *every* `QString::length()` call in the whole process. `QDebug::operator<<(const QString&)` (`qdebug.h:161`) is `putString(t.constData(), uint(t.length()))`, so when `DDropdownMenu::setText()` later printed the endline menu text (`"Unix"`) via `qDebug()`, it tried to append `41M` characters from a tiny string buffer, reading past the end of the heap allocation and aborting under ASan.

## Fix

Stub `QByteArray::length` instead — the real type of `strContent`:

```cpp
s1.set(ADDR(QByteArray,length),retintstub);
```

This makes `loadContent()` actually take the intended large-file / instant-open branches. It is safe because:

- `qDebug()` prints a `QByteArray` through `size()` (not `length()`), and prints a `QString` through `QString::length()` which is **no longer stubbed** — so no out-of-bounds read is introduced.
- The actual data reads inside `loadContent()` / `customEvent()` use `size()` / `d->size` (e.g. `codec->toUnicode(..., text.size(), ...)`, `QByteArray::mid()`) rather than `length()`, so the large stubbed length only drives the loop/branch control flow, never a data copy.

## Verification

Built with the project's UT configuration (`-DCMAKE_BUILD_TYPE=Debug -DCMAKE_SAFETYTEST_ARG=CMAKE_SAFETYTEST_ARG_ON`, which enables `-fsanitize=undefined,address`):

```
$ ./tests/deepin-editor-test --gtest_filter='UT_Editwrapper_loadContent.*'
[ RUN      ] UT_Editwrapper_loadContent.UT_Editwrapper_loadContent_001
[       OK ] UT_Editwrapper_loadContent.UT_Editwrapper_loadContent_001 (1299 ms)
[ RUN      ] UT_Editwrapper_loadContent.UT_Editwrapper_loadContent_002
[       OK ] UT_Editwrapper_loadContent.UT_Editwrapper_loadContent_002 (171 ms)
[==========] 2 tests from 1 test suite ran.
[  PASSED  ] 2 tests.
```

No `heap-buffer-overflow`, no `ABORTING`. The full `UT_Editwrapper_*` suite shows no regressions; the remaining `UT_Editwrapper_saveFile_004/005`, `UT_Editwrapper_saveAsFile_003` and `UT_Editwrapper_handleFileLoadFinished_004_error` failures are pre-existing (they already fail on master before this change) and unrelated to this crash.

## Summary by Sourcery

Adjust EditWrapper loadContent unit tests to stub the correct QByteArray length API and document the rationale to prevent sanitizer-detected crashes.

Bug Fixes:
- Fix heap-buffer-overflow in UT_Editwrapper_loadContent tests caused by globally stubbing QString::length instead of the QByteArray length used by loadContent.

Tests:
- Update UT_Editwrapper_loadContent_001 and _002 to stub QByteArray::length instead of QString::length and add inline documentation explaining the safe stubbing behavior.