### PR TITLE
fix: rename "UOS AI" to "小U同学" in Chinese translation

### DIFF
--- a/translations/deepin-editor_zh_CN.ts
+++ b/translations/deepin-editor_zh_CN.ts
@@ -1029,7 +1029,7 @@
         <location filename="../src/editor/dtextedit.cpp" line="2868"/>
         <location filename="../src/editor/dtextedit.cpp" line="2870"/>
         <source>Please install UOS AI from the app store first.</source>
-        <translation>请前往应用商店安装“UOS AI”后再使用</translation>
+        <translation>请前往应用商店安装“小U同学”后再使用</translation>
     </message>
     <message>
         <location filename="../src/editor/dtextedit.cpp" line="292"/>


### PR DESCRIPTION
## 根因分析

文本编辑器（deepin-editor）在右键菜单提供"语音朗读"和"语音听写"功能，依赖 UOS AI（`com.iflytek.aiassistant` DBus 服务）。卸载 UOS AI 后使用这些功能时，弹出提示"请前往应用商店安装"UOS AI"后再使用"。

产品品牌已从"UOS AI"更名为"小U同学"，但简体中文翻译文件 `translations/deepin-editor_zh_CN.ts` 未同步更新。

- **缺陷位置**: `translations/deepin-editor_zh_CN.ts:1032`
- **源码调用**: `src/editor/dtextedit.cpp` 中 `slotVoiceReadingAction()` 和 `slotdictationAction()` 共 4 处 `tr("Please install UOS AI from the app store first.")`，共用同一条翻译条目。

## 修复方案

仅修改 `translations/deepin-editor_zh_CN.ts` 一行，将翻译值中的"UOS AI"替换为"小U同学"。不修改英文源字符串（Qt `tr()` 翻译键），不影响其他语言。

## 改动安全评估

低风险。仅修改翻译文案值，不涉及代码逻辑、函数签名或外部调用者（0 处引用）。
