### PR TITLE
feat(editor): add search match count display in find/replace bars

### DIFF
--- a/src/controls/findbar.cpp
+++ b/src/controls/findbar.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2011-2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2011-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -126,6 +126,7 @@ void FindBar::activeInput(QString text, QString file, int row, int column, int s
 void FindBar::findCancel()
 {
     qDebug() << "Find operation cancelled";
+    m_editLine->setMatchCount(0, 0);
     QWidget::hide();
     emit sigFindbarClose();
     qDebug() << "Find bar hidden and close signal emitted";
@@ -269,6 +270,12 @@ void FindBar::handleSwitchToReplace()
     qDebug() << "handleSwitchToReplace - switching from find bar to replace bar";
     emit sigSwitchToReplaceBar();
     qDebug() << "Switch to replace bar signal emitted";
+}
+
+void FindBar::slotUpdateMatchCount(int current, int total)
+{
+    qDebug() << "slotUpdateMatchCount current:" << current << "total:" << total;
+    m_editLine->setMatchCount(current, total);
 }
 
 QString FindBar::getCurrentSearchText() const

--- a/src/controls/findbar.h
+++ b/src/controls/findbar.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2011-2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2011-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -62,6 +62,7 @@ public Q_SLOTS:
     void handleFindNext();
     void handleFindPrev();
     void handleSwitchToReplace();
+    void slotUpdateMatchCount(int current, int total);
 
 protected:
     void hideEvent(QHideEvent *event) override;

--- a/src/controls/linebar.cpp
+++ b/src/controls/linebar.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2011-2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2011-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -6,19 +6,47 @@
 #include "../common/utils.h"
 
 #include <DGuiApplicationHelper>
+#include <DFontSizeManager>
 
 #include <QDebug>
+#include <QGraphicsOpacityEffect>
 
 // 不同布局模式(紧凑)
 const int s_nLineBarHeight = 36;
 const int s_nLineBarHeightCompact = 24;
 
+// 计数 label 与自绘清除按钮的布局参数（像素）
+const int s_nClearButtonSize = 22;     // 自绘清除按钮尺寸
+const int s_nLabelButtonSpacing = 6;   // label 与清除按钮之间的间距
+const int s_nRightMargin = 6;          // 清除按钮右边缘距输入框右边缘的间距
+
 LineBar::LineBar(DLineEdit *parent)
     : DLineEdit(parent)
 {
     qDebug() << "LineBar constructor start";
-    // Init.
-    setClearButtonEnabled(true);
+
+    // ★ 关键：禁用 DLineEdit 内置清除按钮。
+    // 原因：Qt6 下 QLineEdit::addAction(TrailingPosition) 和 DLineEdit::setRightWidgets
+    // 都把自定义 widget 放在内置清除按钮的右侧，无法让计数 label 处于清除按钮左侧，
+    // 且 setRightWidgets 会压缩文本区域。
+    setClearButtonEnabled(false);
+
+    // label 和清除按钮直接 parent 到内嵌 lineEdit，覆盖在输入框内部
+    m_matchCountLabel = new QLabel(lineEdit());
+    int fontsize = DFontSizeManager::instance()->fontPixelSize(DFontSizeManager::T9);
+    QFont labelFont = m_matchCountLabel->font();
+    labelFont.setPixelSize(fontsize);
+    m_matchCountLabel->setFont(labelFont);
+    QGraphicsOpacityEffect *opacityEffect = new QGraphicsOpacityEffect(m_matchCountLabel);
+    opacityEffect->setOpacity(0.7);
+    m_matchCountLabel->setGraphicsEffect(opacityEffect);
+    m_matchCountLabel->hide();
+
+    m_clearButton = new DIconButton(QStyle::SP_LineEditClearButton, lineEdit());
+    m_clearButton->setFixedSize(s_nClearButtonSize, s_nClearButtonSize);
+    m_clearButton->setIconSize(QSize(s_nClearButtonSize, s_nClearButtonSize));
+    m_clearButton->setFocusPolicy(Qt::NoFocus);
+    m_clearButton->hide();
 
     m_autoSaveInternal = 50;
     m_autoSaveTimer = new QTimer(this);
@@ -29,6 +57,12 @@ LineBar::LineBar(DLineEdit *parent)
     connect(this, &DLineEdit::textEdited, this, &LineBar::sendText, Qt::QueuedConnection);
     connect(this, &DLineEdit::textChanged, this, &LineBar::handleTextChanged, Qt::QueuedConnection);
     qDebug() << "Signal connections established";
+
+    // 自绘清除按钮：点击清空文本；可见性跟随文本是否为空
+    connect(m_clearButton, &DIconButton::clicked, this, [this]() {
+        lineEdit()->clear();
+    });
+
 #ifdef DTKWIDGET_CLASS_DSizeMode
     setFixedHeight(DGuiApplicationHelper::isCompactMode() ? s_nLineBarHeightCompact : s_nLineBarHeight);
     connect(DGuiApplicationHelper::instance(), &DGuiApplicationHelper::sizeModeChanged, this, [this](){
@@ -54,6 +88,9 @@ void LineBar::handleTextChanged(const QString &str)
     if(str.isEmpty()) {
         qDebug() << "Text cleared, disabling alert";
         setAlert(false);
+        m_clearButton->hide();          // 文本为空时隐藏清除按钮
+    } else {
+        m_clearButton->show();          // 有文本时显示清除按钮
     }
     // Start new timer.
     m_autoSaveTimer->start(m_autoSaveInternal);
@@ -97,4 +134,47 @@ void LineBar::keyPressEvent(QKeyEvent *e)
       // Pass event to DLineEdit continue, otherwise you can't type anything after here. ;)
        DLineEdit::keyPressEvent(e);
     }
+}
+
+void LineBar::setMatchCount(int current, int total)
+{
+    if (total == 0) {
+        m_matchCountLabel->hide();
+    } else {
+        m_matchCountLabel->setText(tr("第%1/%2项").arg(current).arg(total));
+        m_matchCountLabel->show();
+    }
+    // label 文本变化导致宽度变化，重新计算坐标
+    updateRightWidgetsGeometry();
+}
+
+void LineBar::resizeEvent(QResizeEvent *event)
+{
+    DLineEdit::resizeEvent(event);
+    updateRightWidgetsGeometry();
+}
+
+void LineBar::updateRightWidgetsGeometry()
+{
+    QWidget *le = lineEdit();
+    if (!le) {
+        return;
+    }
+
+    const int editWidth  = le->width();
+    const int editHeight = le->height();
+    const int buttonWidth  = m_clearButton->width();
+    const int buttonHeight = m_clearButton->height();
+    const int labelWidth   = m_matchCountLabel->sizeHint().width();
+    const int labelHeight  = m_matchCountLabel->sizeHint().height();
+
+    // button 垂直居中，右边缘距 lineEdit 右边缘 s_nRightMargin
+    const int buttonX = editWidth - s_nRightMargin - buttonWidth;
+    const int buttonY = (editHeight - buttonHeight) / 2;
+    m_clearButton->setGeometry(buttonX, buttonY, buttonWidth, buttonHeight);
+
+    // label 垂直居中，水平紧贴 button 左侧 s_nLabelButtonSpacing
+    const int labelX = buttonX - s_nLabelButtonSpacing - labelWidth;
+    const int labelY = (editHeight - labelHeight) / 2;
+    m_matchCountLabel->setGeometry(labelX, labelY, labelWidth, labelHeight);
 }

--- a/src/controls/linebar.h
+++ b/src/controls/linebar.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2011-2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2011-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -7,6 +7,10 @@
 
 #include "dlineedit.h"
 
+#include <DIconButton>
+#include <DStyle>
+
+#include <QLabel>
 #include <QTimer>
 
 DWIDGET_USE_NAMESPACE
@@ -17,6 +21,8 @@ class LineBar : public DLineEdit
 
 public:
     explicit LineBar(DLineEdit *parent = 0);
+
+    void setMatchCount(int current, int total);
 
 public slots:
     void handleTextChangeTimer();
@@ -35,10 +41,15 @@ signals:
 protected:
     virtual void focusOutEvent(QFocusEvent *e);
     virtual void keyPressEvent(QKeyEvent *e);
+    void resizeEvent(QResizeEvent *event) override;
 
 private:
+    void updateRightWidgetsGeometry();
+
     QTimer *m_autoSaveTimer;
     int m_autoSaveInternal;
+    QLabel *m_matchCountLabel;
+    DIconButton *m_clearButton;
 };
 
 #endif

--- a/src/controls/replacebar.cpp
+++ b/src/controls/replacebar.cpp
@@ -140,6 +140,7 @@ void ReplaceBar::replaceClose()
 {
     qDebug() << "replaceClose";
     searched = false;
+    m_replaceLine->setMatchCount(0, 0);
     hide();
     emit sigReplacebarClose();
     qDebug() << "replaceClose end";
@@ -149,6 +150,12 @@ void ReplaceBar::handleContentChanged()
 {
     qDebug() << "handleContentChanged";
     updateSearchKeyword(m_replaceFile, m_replaceLine->lineEdit()->text());
+}
+
+void ReplaceBar::slotUpdateMatchCount(int current, int total)
+{
+    qDebug() << "ReplaceBar slotUpdateMatchCount current:" << current << "total:" << total;
+    m_replaceLine->setMatchCount(current, total);
 }
 
 void ReplaceBar::handleReplaceNext()

--- a/src/controls/replacebar.h
+++ b/src/controls/replacebar.h
@@ -56,6 +56,7 @@ public Q_SLOTS:
     void handleReplaceNext();
     void handleReplaceRest();
     void handleSkip();
+    void slotUpdateMatchCount(int current, int total);
 
 protected:
     void hideEvent(QHideEvent *event);

--- a/src/editor/dtextedit.cpp
+++ b/src/editor/dtextedit.cpp
@@ -18,6 +18,7 @@
 #include "changemarkcommand.h"
 #include "endlineformatcommond.h"
 #include <QSet>
+#include <algorithm>
 
 #include <KSyntaxHighlighting/definition.h>
 #include <KSyntaxHighlighting/syntaxhighlighter.h>
@@ -190,6 +191,7 @@ TextEdit::TextEdit(QWidget *parent)
     // Don't blink the cursor when selecting text
     // Recover blink when not selecting text.
     connect(this, &TextEdit::selectionChanged, this, &TextEdit::slotSelectionChanged, Qt::QueuedConnection);
+    connect(this, &QPlainTextEdit::textChanged, this, &TextEdit::invalidateMatchCountCache);
     qDebug() << "TextEdit initialized";
 }
 
@@ -2361,6 +2363,7 @@ void TextEdit::updateCursorKeywordSelection(QString keyword, bool findNext,
         }
     }
     qDebug() << "Updating cursor keyword selection completed";
+    updateMatchCount(keyword, caseFlag);
 }
 
 void TextEdit::updateHighlightLineSelection()
@@ -2417,6 +2420,82 @@ bool TextEdit::updateKeywordSelections(QString keyword, QTextCharFormat charForm
 
     qDebug() << "Updating keyword selections with no keyword";
     return false;
+}
+
+QList<int> TextEdit::scanAllMatchPositions(const QString &keyword, Qt::CaseSensitivity caseFlag) const
+{
+    qDebug() << "Scanning all match positions for keyword:" << keyword;
+    QList<int> positions;
+
+    if (keyword.isEmpty()) {
+        qDebug() << "Empty keyword, return empty list";
+        return positions;
+    }
+
+    QTextCursor cursor(document());
+    QTextDocument::FindFlags flags;
+    if (Qt::CaseSensitive == caseFlag) {
+        flags |= QTextDocument::FindCaseSensitively;
+    }
+
+    cursor = document()->find(keyword, cursor, flags);
+    while (!cursor.isNull()) {
+        positions.append(cursor.selectionStart());
+        cursor = document()->find(keyword, cursor, flags);
+    }
+
+    qDebug() << "Scan completed, total positions:" << positions.size();
+    return positions;
+}
+
+int TextEdit::findCurrentMatchIndex() const
+{
+    qDebug() << "Finding current match index";
+    if (m_allMatchPositions.isEmpty()) {
+        qDebug() << "Empty cache, return 0";
+        return 0;
+    }
+
+    int cursorPos = m_findHighlightSelection.cursor.selectionStart();
+    auto it = std::lower_bound(m_allMatchPositions.begin(), m_allMatchPositions.end(), cursorPos);
+    if (it != m_allMatchPositions.end() && *it == cursorPos) {
+        int index = static_cast<int>(std::distance(m_allMatchPositions.begin(), it));
+        qDebug() << "Found at index" << index;
+        return index + 1;
+    }
+
+    qDebug() << "Not found in cache, return 0";
+    return 0;
+}
+
+void TextEdit::updateMatchCount(const QString &keyword, Qt::CaseSensitivity caseFlag)
+{
+    qDebug() << "updateMatchCount keyword:" << keyword << "case:" << caseFlag;
+
+    if (keyword.isEmpty()) {
+        qDebug() << "Empty keyword, emit (0, 0)";
+        emit findMatchCountChanged(0, 0);
+        return;
+    }
+
+    if (keyword != m_countedKeyword || caseFlag != m_countedCase) {
+        qDebug() << "Cache miss, rescan";
+        m_allMatchPositions = scanAllMatchPositions(keyword, caseFlag);
+        m_countedKeyword = keyword;
+        m_countedCase = caseFlag;
+    }
+
+    int total = m_allMatchPositions.size();
+    int current = findCurrentMatchIndex();
+    qDebug() << "Emit findMatchCountChanged current:" << current << "total:" << total;
+    emit findMatchCountChanged(current, total);
+}
+
+void TextEdit::invalidateMatchCountCache()
+{
+    qDebug() << "Invalidating match count cache";
+    m_countedKeyword.clear();
+    m_allMatchPositions.clear();
 }
 
 bool TextEdit::updateKeywordSelectionsInView(QString keyword, QTextCharFormat charFormat,

--- a/src/editor/dtextedit.h
+++ b/src/editor/dtextedit.h
@@ -210,6 +210,8 @@ public:
                                       Qt::CaseSensitivity caseFlag = Qt::CaseInsensitive);
     void updateHighlightLineSelection();
     bool updateKeywordSelections(QString keyword, QTextCharFormat charFormat, QList<QTextEdit::ExtraSelection> &listSelection);
+    QList<int> scanAllMatchPositions(const QString &keyword, Qt::CaseSensitivity caseFlag = Qt::CaseInsensitive) const;
+    int findCurrentMatchIndex() const;
     bool updateKeywordSelectionsInView(QString keyword, QTextCharFormat charFormat, QList<QTextEdit::ExtraSelection> *listSelection,
                                        Qt::CaseSensitivity caseFlag = Qt::CaseInsensitive);
     bool searchKeywordSeletion(QString keyword, QTextCursor cursor, bool findNext,
@@ -481,6 +483,7 @@ signals:
     void popupNotify(QString notify, bool warning = false);
     void signal_readingPath();
     void signal_setTitleFocus();
+    void findMatchCountChanged(int current, int total);
 public slots:
     /**
      * @author liumaochuan ut000616
@@ -640,12 +643,17 @@ public:
 private:
     EditWrapper *m_wrapper;
     QPropertyAnimation *m_scrollAnimation {nullptr};
+    void updateMatchCount(const QString &keyword, Qt::CaseSensitivity caseFlag);
+    void invalidateMatchCountCache();
 
     QList<QTextEdit::ExtraSelection> m_findMatchSelections;///< “查找”的字符格式（所有查找的字符）
     QTextEdit::ExtraSelection m_beginBracketSelection;
     QTextEdit::ExtraSelection m_endBracketSelection;
     QTextEdit::ExtraSelection m_currentLineSelection;///< 光标所在当前行的样式
     QTextEdit::ExtraSelection m_findHighlightSelection;///< “查找”的字符格式（当前位置字符）
+    QList<int> m_allMatchPositions;///< 查找匹配位置缓存（升序）
+    QString m_countedKeyword;///< 已缓存的查找关键字
+    Qt::CaseSensitivity m_countedCase = Qt::CaseInsensitive;///< 已缓存的查找大小写设置
     // 不再使用
     //QTextEdit::ExtraSelection m_wordUnderCursorSelection;
     QList<QPair<QTextEdit::ExtraSelection, qint64>> m_wordMarkSelections;///< 记录标记的列表（分行记录）

--- a/src/widgets/window.cpp
+++ b/src/widgets/window.cpp
@@ -790,6 +790,10 @@ void Window::addTabWithWrapper(EditWrapper *wrapper, const QString &filepath, co
     connect(wrapper->textEditor(), &TextEdit::popupNotify, this, &Window::showNotify, Qt::QueuedConnection);
     connect(wrapper->textEditor(), &TextEdit::signal_setTitleFocus, this, &Window::slot_setTitleFocus, Qt::QueuedConnection);
 
+    connect(wrapper->textEditor(), &TextEdit::findMatchCountChanged,
+            m_findBar, &FindBar::slotUpdateMatchCount, Qt::QueuedConnection);
+    connect(wrapper->textEditor(), &TextEdit::findMatchCountChanged,
+            m_replaceBar, &ReplaceBar::slotUpdateMatchCount, Qt::QueuedConnection);
     qDebug() << "Reconnecting DBus signals for gesture events";
     switch (Utils::getSystemVersion()) {
     case Utils::V23:
@@ -1113,6 +1117,10 @@ EditWrapper *Window::createEditor()
     connect(wrapper->textEditor(), &TextEdit::clickJumpLineAction, this, &Window::popupJumpLineBar, Qt::QueuedConnection);
     connect(wrapper->textEditor(), &TextEdit::clickFullscreenAction, this, &Window::toggleFullscreen, Qt::QueuedConnection);
     connect(wrapper->textEditor(), &TextEdit::popupNotify, this, &Window::showNotify, Qt::QueuedConnection);
+    connect(wrapper->textEditor(), &TextEdit::findMatchCountChanged,
+            m_findBar, &FindBar::slotUpdateMatchCount, Qt::QueuedConnection);
+    connect(wrapper->textEditor(), &TextEdit::findMatchCountChanged,
+            m_replaceBar, &ReplaceBar::slotUpdateMatchCount, Qt::QueuedConnection);
     connect(wrapper->textEditor(), &TextEdit::textChanged, this, [ = ]() {
         updateJumpLineBar(wrapper->textEditor());
     }, Qt::QueuedConnection);
@@ -3462,6 +3470,8 @@ void Window::handleCurrentChanged(const int &index)
         qDebug() << "m_replaceBar is visible";
         m_replaceBar->hide();
     }
+    m_findBar->slotUpdateMatchCount(0, 0);
+    m_replaceBar->slotUpdateMatchCount(0, 0);
 
     if (m_jumpLineBar->isVisible()) {
         qDebug() << "m_jumpLineBar is visible";

--- a/tests/src/controls/ut_findbar.cpp
+++ b/tests/src/controls/ut_findbar.cpp
@@ -4,6 +4,7 @@
 
 #include "ut_findbar.h"
 #include "../../src/controls/findbar.h"
+#include <QApplication>
 #include <QFocusEvent>
 #include <QEvent>
 
@@ -217,6 +218,37 @@ TEST_F(test_findbar, getCurrentSearchText)
 
     findBar->m_editLine->lineEdit()->setText("searchkeyword");
     EXPECT_EQ(findBar->getCurrentSearchText(), QString("searchkeyword"));
+
+    findBar->deleteLater();
+}
+
+//slotUpdateMatchCount 转发到内部 m_editLine
+TEST_F(test_findbar, slotUpdateMatchCount_Forward)
+{
+    FindBar *findBar = new FindBar();
+    findBar->show();
+    qApp->processEvents();
+    findBar->m_editLine->m_matchCountLabel->hide();
+
+    findBar->slotUpdateMatchCount(3, 7);
+
+    EXPECT_EQ(findBar->m_editLine->m_matchCountLabel->text().toStdString(), "第3/7项");
+    EXPECT_TRUE(findBar->m_editLine->m_matchCountLabel->isVisible());
+
+    findBar->deleteLater();
+}
+
+//slotUpdateMatchCount (0,0) 隐藏
+TEST_F(test_findbar, slotUpdateMatchCount_ZeroHide)
+{
+    FindBar *findBar = new FindBar();
+    findBar->show();
+    qApp->processEvents();
+    findBar->slotUpdateMatchCount(3, 7);
+
+    findBar->slotUpdateMatchCount(0, 0);
+
+    EXPECT_FALSE(findBar->m_editLine->m_matchCountLabel->isVisible());
 
     findBar->deleteLater();
 }

--- a/tests/src/controls/ut_linebar.cpp
+++ b/tests/src/controls/ut_linebar.cpp
@@ -4,6 +4,7 @@
 
 #include "ut_linebar.h"
 #include "../../src/controls/linebar.h"
+#include <QApplication>
 #include <QFocusEvent>
 #include <QEvent>
 #include <DGuiApplicationHelper>
@@ -121,5 +122,106 @@ TEST_F(test_linebar, ConstructorSizeModeLambda)
     helper->setSizeMode(origMode); // restore
 
     EXPECT_NE(lineBar, nullptr);
+    lineBar->deleteLater();
+}
+
+//setMatchCount 显示文本和可见性
+TEST_F(test_linebar, setMatchCount_Display)
+{
+    LineBar *lineBar = new LineBar();
+    lineBar->show();
+    qApp->processEvents();
+
+    lineBar->setMatchCount(5, 10);
+
+    EXPECT_EQ(lineBar->m_matchCountLabel->text().toStdString(), "第5/10项");
+    EXPECT_TRUE(lineBar->m_matchCountLabel->isVisible());
+
+    lineBar->deleteLater();
+}
+
+//setMatchCount total==0 隐藏
+TEST_F(test_linebar, setMatchCount_HideOnZero)
+{
+    LineBar *lineBar = new LineBar();
+    lineBar->show();
+    qApp->processEvents();
+    lineBar->setMatchCount(5, 10);
+
+    lineBar->setMatchCount(0, 0);
+
+    EXPECT_FALSE(lineBar->m_matchCountLabel->isVisible());
+
+    lineBar->deleteLater();
+}
+
+//setMatchCount 0/N 场景
+TEST_F(test_linebar, setMatchCount_ZeroCurrent)
+{
+    LineBar *lineBar = new LineBar();
+    lineBar->show();
+    qApp->processEvents();
+
+    lineBar->setMatchCount(0, 5);
+
+    EXPECT_EQ(lineBar->m_matchCountLabel->text().toStdString(), "第0/5项");
+    EXPECT_TRUE(lineBar->m_matchCountLabel->isVisible());
+
+    lineBar->deleteLater();
+}
+
+//m_matchCountLabel 已无 stylesheet hack，验证不再包含 padding-left
+TEST_F(test_linebar, m_matchCountLabel_NoStyleSheetHack)
+{
+    LineBar *lineBar = new LineBar();
+
+    EXPECT_FALSE(lineBar->m_matchCountLabel->styleSheet().contains("padding-left"));
+
+    lineBar->deleteLater();
+}
+
+//自绘清除按钮：有文本时显示，无文本时隐藏
+TEST_F(test_linebar, clearButton_VisibilityWithText)
+{
+    LineBar *lineBar = new LineBar();
+    lineBar->show();
+    qApp->processEvents();
+
+    // 初始无文本，清除按钮应隐藏
+    lineBar->handleTextChanged("");
+    EXPECT_FALSE(lineBar->m_clearButton->isVisible());
+
+    // 有文本时清除按钮应显示
+    lineBar->handleTextChanged("hello");
+    EXPECT_TRUE(lineBar->m_clearButton->isVisible());
+
+    // 清空文本后清除按钮应再次隐藏
+    lineBar->handleTextChanged("");
+    EXPECT_FALSE(lineBar->m_clearButton->isVisible());
+
+    lineBar->deleteLater();
+}
+
+//setMatchCount label 文本与可见性（含 0/N 场景）
+TEST_F(test_linebar, setMatchCount_LabelTextAndVisibility)
+{
+    LineBar *lineBar = new LineBar();
+    lineBar->show();
+    qApp->processEvents();
+
+    // 正常计数
+    lineBar->setMatchCount(3, 10);
+    EXPECT_EQ(lineBar->m_matchCountLabel->text().toStdString(), "第3/10项");
+    EXPECT_TRUE(lineBar->m_matchCountLabel->isVisible());
+
+    // 0/N 场景
+    lineBar->setMatchCount(0, 5);
+    EXPECT_EQ(lineBar->m_matchCountLabel->text().toStdString(), "第0/5项");
+    EXPECT_TRUE(lineBar->m_matchCountLabel->isVisible());
+
+    // total==0 隐藏
+    lineBar->setMatchCount(0, 0);
+    EXPECT_FALSE(lineBar->m_matchCountLabel->isVisible());
+
     lineBar->deleteLater();
 }

--- a/tests/src/controls/ut_replacebar.cpp
+++ b/tests/src/controls/ut_replacebar.cpp
@@ -1,8 +1,9 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "ut_replacebar.h"
+#include <QApplication>
 #include <QKeyEvent>
 test_replacebar::test_replacebar()
 {
@@ -198,4 +199,37 @@ TEST_F(test_replacebar, keyPressEvent)
     rep->deleteLater();
 
     
+}
+
+//slotUpdateMatchCount 只更新 m_replaceLine，不更新 m_withLine
+TEST_F(test_replacebar, slotUpdateMatchCount_OnlyReplaceLine)
+{
+    ReplaceBar *replaceBar = new ReplaceBar();
+    replaceBar->show();
+    qApp->processEvents();
+    replaceBar->m_replaceLine->m_matchCountLabel->hide();
+    replaceBar->m_withLine->m_matchCountLabel->hide();
+
+    replaceBar->slotUpdateMatchCount(5, 10);
+
+    EXPECT_EQ(replaceBar->m_replaceLine->m_matchCountLabel->text().toStdString(), "第5/10项");
+    EXPECT_TRUE(replaceBar->m_replaceLine->m_matchCountLabel->isVisible());
+    EXPECT_FALSE(replaceBar->m_withLine->m_matchCountLabel->isVisible());
+
+    replaceBar->deleteLater();
+}
+
+//slotUpdateMatchCount (0,0) 隐藏 m_replaceLine
+TEST_F(test_replacebar, slotUpdateMatchCount_ZeroHide)
+{
+    ReplaceBar *replaceBar = new ReplaceBar();
+    replaceBar->show();
+    qApp->processEvents();
+    replaceBar->slotUpdateMatchCount(5, 10);
+
+    replaceBar->slotUpdateMatchCount(0, 0);
+
+    EXPECT_FALSE(replaceBar->m_replaceLine->m_matchCountLabel->isVisible());
+
+    replaceBar->deleteLater();
 }

--- a/tests/src/editor/ut_textedit.cpp
+++ b/tests/src/editor/ut_textedit.cpp
@@ -22,6 +22,7 @@
 #include <QContextMenuEvent>
 #include <QMouseEvent>
 #include <QApplication>
+#include <QSignalSpy>
 
 
 namespace texteditstub {
@@ -10843,4 +10844,183 @@ TEST(UT_Textedit_Uncovered, calcMarkReplaceList)
     }
     SUCCEED();
     win->deleteLater();
+}
+
+//scanAllMatchPositions 基础计数
+TEST(UT_test_textedit_scanAllMatchPositions, UT_test_textedit_scanAllMatchPositions_001)
+{
+    Window *pWindow = new Window();
+    pWindow->addBlankTab(QString());
+    QString strMsg("hello world\nhello world");
+    QTextCursor textCursor = pWindow->currentWrapper()->textEditor()->textCursor();
+    pWindow->currentWrapper()->textEditor()->insertTextEx(textCursor, strMsg);
+
+    QList<int> positions = pWindow->currentWrapper()->textEditor()->scanAllMatchPositions(QString("world"));
+
+    ASSERT_EQ(positions.size(), 2);
+    ASSERT_EQ(positions[0], 6);
+    ASSERT_EQ(positions[1], 18);
+    pWindow->deleteLater();
+}
+
+//scanAllMatchPositions 空关键字返回空列表
+TEST(UT_test_textedit_scanAllMatchPositions, UT_test_textedit_scanAllMatchPositions_Empty)
+{
+    Window *pWindow = new Window();
+    pWindow->addBlankTab(QString());
+    QString strMsg("hello world");
+    QTextCursor textCursor = pWindow->currentWrapper()->textEditor()->textCursor();
+    pWindow->currentWrapper()->textEditor()->insertTextEx(textCursor, strMsg);
+
+    QList<int> positions = pWindow->currentWrapper()->textEditor()->scanAllMatchPositions(QString());
+
+    ASSERT_TRUE(positions.isEmpty());
+    pWindow->deleteLater();
+}
+
+//scanAllMatchPositions 大小写敏感
+TEST(UT_test_textedit_scanAllMatchPositions, UT_test_textedit_scanAllMatchPositions_CaseSensitive)
+{
+    Window *pWindow = new Window();
+    pWindow->addBlankTab(QString());
+    QString strMsg("hello world\nHello world");
+    QTextCursor textCursor = pWindow->currentWrapper()->textEditor()->textCursor();
+    pWindow->currentWrapper()->textEditor()->insertTextEx(textCursor, strMsg);
+
+    QList<int> positionsCI = pWindow->currentWrapper()->textEditor()->scanAllMatchPositions(QString("Hello"), Qt::CaseInsensitive);
+    ASSERT_EQ(positionsCI.size(), 2);
+
+    QList<int> positionsCS = pWindow->currentWrapper()->textEditor()->scanAllMatchPositions(QString("Hello"), Qt::CaseSensitive);
+    ASSERT_EQ(positionsCS.size(), 1);
+    ASSERT_EQ(positionsCS[0], 12);
+    pWindow->deleteLater();
+}
+
+//scanAllMatchPositions 无匹配返回空列表
+TEST(UT_test_textedit_scanAllMatchPositions, UT_test_textedit_scanAllMatchPositions_NoMatch)
+{
+    Window *pWindow = new Window();
+    pWindow->addBlankTab(QString());
+    QString strMsg("hello world");
+    QTextCursor textCursor = pWindow->currentWrapper()->textEditor()->textCursor();
+    pWindow->currentWrapper()->textEditor()->insertTextEx(textCursor, strMsg);
+
+    QList<int> positions = pWindow->currentWrapper()->textEditor()->scanAllMatchPositions(QString("xyz"));
+
+    ASSERT_TRUE(positions.isEmpty());
+    pWindow->deleteLater();
+}
+
+//findCurrentMatchIndex 命中：缓存预置 + cursor 落在第 2 个位置
+TEST(UT_test_textedit_findCurrentMatchIndex, UT_test_textedit_findCurrentMatchIndex_Hit)
+{
+    Window *pWindow = new Window();
+    pWindow->addBlankTab(QString());
+    TextEdit *editor = pWindow->currentWrapper()->textEditor();
+    QString strMsg("hello world\nhello world");
+    QTextCursor textCursor = editor->textCursor();
+    editor->insertTextEx(textCursor, strMsg);
+
+    editor->m_allMatchPositions = editor->scanAllMatchPositions(QString("world"));
+    QTextCursor c = editor->textCursor();
+    c.setPosition(18);
+    editor->m_findHighlightSelection.cursor = c;
+
+    ASSERT_EQ(editor->findCurrentMatchIndex(), 2);
+    pWindow->deleteLater();
+}
+
+//findCurrentMatchIndex 未命中：cursor 位置不在列表
+TEST(UT_test_textedit_findCurrentMatchIndex, UT_test_textedit_findCurrentMatchIndex_Miss)
+{
+    Window *pWindow = new Window();
+    pWindow->addBlankTab(QString());
+    TextEdit *editor = pWindow->currentWrapper()->textEditor();
+    editor->insertPlainText("hello world\nhello world");
+
+    editor->m_allMatchPositions = editor->scanAllMatchPositions(QString("world"));
+    QTextCursor c = editor->textCursor();
+    c.setPosition(3);
+    editor->m_findHighlightSelection.cursor = c;
+
+    ASSERT_EQ(editor->findCurrentMatchIndex(), 0);
+    pWindow->deleteLater();
+}
+
+//findCurrentMatchIndex 空缓存返回 0
+TEST(UT_test_textedit_findCurrentMatchIndex, UT_test_textedit_findCurrentMatchIndex_EmptyCache)
+{
+    Window *pWindow = new Window();
+    pWindow->addBlankTab(QString());
+    TextEdit *editor = pWindow->currentWrapper()->textEditor();
+    editor->m_allMatchPositions.clear();
+
+    ASSERT_EQ(editor->findCurrentMatchIndex(), 0);
+    pWindow->deleteLater();
+}
+
+//invalidateMatchCountCache 清空缓存字段
+TEST(UT_test_textedit_invalidateMatchCountCache, UT_test_textedit_invalidateMatchCountCache_001)
+{
+    Window *pWindow = new Window();
+    pWindow->addBlankTab(QString());
+    TextEdit *editor = pWindow->currentWrapper()->textEditor();
+    editor->m_allMatchPositions.append(1);
+    editor->m_allMatchPositions.append(2);
+    editor->m_countedKeyword = "abc";
+
+    editor->invalidateMatchCountCache();
+
+    ASSERT_TRUE(editor->m_allMatchPositions.isEmpty());
+    ASSERT_TRUE(editor->m_countedKeyword.isEmpty());
+    pWindow->deleteLater();
+}
+
+//updateMatchCount emit 验证（缓存命中）
+TEST(UT_test_textedit_updateMatchCount, UT_test_textedit_updateMatchCount_Emit)
+{
+    Window *pWindow = new Window();
+    pWindow->addBlankTab(QString());
+    TextEdit *editor = pWindow->currentWrapper()->textEditor();
+    editor->insertPlainText("hello\nhello\nhello");
+
+    QSignalSpy spy(editor, &TextEdit::findMatchCountChanged);
+    editor->updateMatchCount(QString("hello"), Qt::CaseInsensitive);
+
+    ASSERT_EQ(spy.count(), 1);
+    QList<QVariant> args = spy.takeFirst();
+    ASSERT_EQ(args.at(1).toInt(), 3);
+    pWindow->deleteLater();
+}
+
+//updateMatchCount 空关键字 emit (0,0)
+TEST(UT_test_textedit_updateMatchCount, UT_test_textedit_updateMatchCount_Empty)
+{
+    Window *pWindow = new Window();
+    pWindow->addBlankTab(QString());
+    TextEdit *editor = pWindow->currentWrapper()->textEditor();
+
+    QSignalSpy spy(editor, &TextEdit::findMatchCountChanged);
+    editor->updateMatchCount(QString(), Qt::CaseInsensitive);
+
+    ASSERT_EQ(spy.count(), 1);
+    QList<QVariant> args = spy.takeFirst();
+    ASSERT_EQ(args.at(0).toInt(), 0);
+    ASSERT_EQ(args.at(1).toInt(), 0);
+    pWindow->deleteLater();
+}
+
+//updateMatchCount 无双重 emit：highlightKeyword 后只 emit 1 次
+TEST(UT_test_textedit_updateMatchCount, UT_test_textedit_updateMatchCount_NoDoubleEmit)
+{
+    Window *pWindow = new Window();
+    pWindow->addBlankTab(QString());
+    TextEdit *editor = pWindow->currentWrapper()->textEditor();
+    editor->insertPlainText("hello world\nhello world");
+
+    QSignalSpy spy(editor, &TextEdit::findMatchCountChanged);
+    editor->highlightKeyword(QString("world"), 0);
+
+    ASSERT_EQ(spy.count(), 1);
+    pWindow->deleteLater();
 }

--- a/translations/deepin-editor.ts
+++ b/translations/deepin-editor.ts
@@ -140,6 +140,14 @@
     </message>
 </context>
 <context>
+    <name>LineBar</name>
+    <message>
+        <location filename="../src/controls/linebar.cpp" line="117"/>
+        <source>第%1/%2项</source>
+        <translation>Match %1 of %2</translation>
+    </message>
+</context>
+<context>
     <name>MainWindow</name>
     <message>
         <location filename="../src/editorapplication.cpp" line="12"/>

--- a/translations/deepin-editor_zh_CN.ts
+++ b/translations/deepin-editor_zh_CN.ts
@@ -138,6 +138,14 @@
     </message>
 </context>
 <context>
+    <name>LineBar</name>
+    <message>
+        <location filename="../src/controls/linebar.cpp" line="117"/>
+        <source>第%1/%2项</source>
+        <translation>第%1/%2项</translation>
+    </message>
+</context>
+<context>
     <name>MainWindow</name>
     <message>
         <location filename="../src/editorapplication.cpp" line="12"/>

--- a/translations/deepin-editor_zh_HK.ts
+++ b/translations/deepin-editor_zh_HK.ts
@@ -138,6 +138,14 @@
     </message>
 </context>
 <context>
+    <name>LineBar</name>
+    <message>
+        <location filename="../src/controls/linebar.cpp" line="117"/>
+        <source>第%1/%2项</source>
+        <translation>第%1/%2項</translation>
+    </message>
+</context>
+<context>
     <name>MainWindow</name>
     <message>
         <location filename="../src/editorapplication.cpp" line="12"/>

--- a/translations/deepin-editor_zh_TW.ts
+++ b/translations/deepin-editor_zh_TW.ts
@@ -138,6 +138,14 @@
     </message>
 </context>
 <context>
+    <name>LineBar</name>
+    <message>
+        <location filename="../src/controls/linebar.cpp" line="117"/>
+        <source>第%1/%2项</source>
+        <translation>第%1/%2項</translation>
+    </message>
+</context>
+<context>
     <name>MainWindow</name>
     <message>
         <location filename="../src/editorapplication.cpp" line="12"/>


### PR DESCRIPTION
## Summary

Display current match index and total count (`第xx/xx项`) in the find input of FindBar/ReplaceBar, updating in real time during search and next/previous navigation.

## Changes

- **TextEdit** (`dtextedit.h/.cpp`): `scanAllMatchPositions` full-document scan, `findCurrentMatchIndex` binary-search index lookup, `updateMatchCount`/`invalidateMatchCountCache` orchestration, signal `findMatchCountChanged(int,int)`, textChanged cache invalidation
- **LineBar** (`linebar.h/.cpp`): self-drawn `DIconButton` clear button + count label with manual `setGeometry` layout, 70% opacity, T9 font size, `tr("第%1/%2项")` i18n
- **FindBar/ReplaceBar**: `slotUpdateMatchCount` slot forwarding + clear-on-close
- **Window** (`window.cpp`): per-wrapper signal forwarding + Tab switch clear
- **Tests**: 19+3 UT cases across TextEdit, LineBar, FindBar, ReplaceBar
- **Translations**: 4 `.ts` files with `LineBar` context `第%1/%2项` entries

## Test

All new and existing unit tests pass (excluding pre-existing baseline crashes `UT_Editwrapper`/`UT_Textedit_MoveText`).

## Summary by Sourcery

Add search match count display to the editor’s find and replace bars and wire it to live updates from the text editor.

New Features:
- Display current and total search match counts in the find and replace input bars using an inline label within LineBar.
- Emit a match count change signal from TextEdit based on full-document scanning and current cursor position, driving the UI counters.

Enhancements:
- Replace the built-in clear button in LineBar with a custom inline clear icon to accommodate the new match count label layout and improve visual integration.
- Reset match count displays when closing find/replace bars or switching tabs to avoid stale results.
- Add internationalized text for the match count label across supported locales.

Tests:
- Extend unit test coverage for TextEdit match counting logic, LineBar match count and clear button behavior, and FindBar/ReplaceBar match count propagation.