### PR TITLE
fix(editor): remove redundant audio device disabled toast on each tab

### DIFF
--- a/src/editor/dtextedit.cpp
+++ b/src/editor/dtextedit.cpp
@@ -139,12 +139,6 @@ TextEdit::TextEdit(QWidget *parent)
             break;
     }
     
-    // 连接音频设备状态变化信号
-    dbus.sessionBus().connect("com.deepin.daemon.Audio",
-                            "/com/deepin/daemon/Audio", "com.deepin.daemon.Audio",
-                            "PortEnabledChanged",
-                            this, SLOT(onAudioPortEnabledChanged(quint32, QString, bool)));
-
     //初始化右键菜单
     initRightClickedMenu();
 
@@ -8275,35 +8269,4 @@ bool TextEdit::checkAudioInputDevice()
     }
 
     return false;
-}
-
-void TextEdit::onAudioPortEnabledChanged(quint32 cardId, const QString &portName, bool enabled)
-{
-    Q_UNUSED(cardId)
-    Q_UNUSED(portName)
-    
-    // 只处理设备被禁用的情况
-    if (!enabled) {
-        // 检查是否还有可用的输出设备和输入设备
-        bool hasOutputDevice = checkAudioOutputDevice();
-        bool hasInputDevice = checkAudioInputDevice();
-        
-        // 如果所有输出设备都被禁用，显示输出设备提示
-        if (!hasOutputDevice) {
-#ifdef DTKWIDGET_CLASS_DSizeMode
-            Utils::sendFloatMessageFixedFont(this, QIcon(":/images/warning.svg"), tr("No audio output device was detected. Please ensure your speakers or headphones are properly connected and try again."));
-#else
-            DMessageManager::instance()->sendMessage(this, QIcon(":/images/warning.svg"), tr("No audio output device was detected. Please ensure your speakers or headphones are properly connected and try again."));
-#endif
-        }
-        
-        // 如果所有输入设备都被禁用，显示输入设备提示
-        if (!hasInputDevice) {
-#ifdef DTKWIDGET_CLASS_DSizeMode
-            Utils::sendFloatMessageFixedFont(this, QIcon(":/images/warning.svg"), tr("No audio input device was detected. Please ensure your speakers or headphones are properly connected and try again."));
-#else
-            DMessageManager::instance()->sendMessage(this, QIcon(":/images/warning.svg"), tr("No audio input device was detected. Please ensure your speakers or headphones are properly connected and try again."));
-#endif
-        }
-    }
 }

--- a/src/editor/dtextedit.h
+++ b/src/editor/dtextedit.h
@@ -532,9 +532,7 @@ public slots:
     // 音频设备检测方法
     bool checkAudioOutputDevice();
     bool checkAudioInputDevice();
-    
-    // 音频设备状态监听槽函数
-    void onAudioPortEnabledChanged(quint32 cardId, const QString &portName, bool enabled);
+
     void slotColumnEditAction(bool checked = false);
     void slotPreBookMarkAction(bool checked = false);
     void slotNextBookMarkAction(bool checked = false);


### PR DESCRIPTION
## 根因分析

每个标签页对应的 `TextEdit` 在构造函数（`src/editor/dtextedit.cpp:143-146`）中订阅了音频守护进程 `com.deepin.daemon.Audio` 的 `PortEnabledChanged` 信号，并在回调 `onAudioPortEnabledChanged`（`dtextedit.cpp:8280-8316`）中于设备被禁用时主动向自身弹浮窗提示。N 个标签页 = N 个订阅者，因此控制中心禁用设备时每个标签页各弹一次"未检测到音频输出/输入设备"提示，与 bug 现象"多标签页均提示"一致。该逻辑由提交 `c0461e00`（Task 378245）引入，后续 `04a5e042`（Bug 323813）仅改按需路径，未触及本路径，`release/eagle` HEAD 仍存在。

## 修复方案

移除"主动监听并弹窗"的路径，保留"用户主动点击语音功能时的按需检查"：
1. 删除 `dtextedit.cpp` 构造函数中对 `PortEnabledChanged` 的 DBus 订阅。
2. 删除 `onAudioPortEnabledChanged` 槽函数实现及其在头文件的声明。
3. 保留 `checkAudioOutputDevice()`/`checkAudioInputDevice()` 及其在 `slotVoiceReadingAction`/`slotdictationAction` 中的按需调用——用户主动点击语音朗读/听写时仍会给出"无设备"提示。

按需路径与主动弹窗路径完全独立：`checkAudio*Device()` 是同步 DBus 方法调用，不依赖被删除的信号；`onAudioPortEnabledChanged` 回调体内不含任何 `dbus-send`/`QProcess`/`TextToSpeech` 调用，从不启动或控制朗读。

## 改动安全评估

低风险。`onAudioPortEnabledChanged` 仅被本类构造函数内部的 DBus 订阅使用，全仓库无第三个引用点（`reference_count=2`，均为本次删除对象）。删除订阅与删除声明成对进行，内部自洽，无外部调用者受影响。不修改任何函数签名，不触碰保留的按需检查与语音朗读/听写执行链路。

PMS: BUG-373361

## Summary by Sourcery

Remove automatic audio device state monitoring in the editor to avoid duplicate device-disabled toasts across multiple tabs while preserving on-demand checks when users trigger voice features.

Bug Fixes:
- Eliminate redundant audio device disabled notifications by removing per-tab subscriptions to the audio daemon’s PortEnabledChanged signal.

Enhancements:
- Simplify TextEdit audio handling by deleting the unused audio port state change slot and relying solely on existing on-demand device checks.