### PR TITLE
fix(editor): add hover and press states to color mark icons

### DIFF
--- a/src/widgets/ColorSelectWdg.cpp
+++ b/src/widgets/ColorSelectWdg.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2019 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2019-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -6,6 +6,7 @@
 #include "../common/utils.h"
 #include "../common/settings.h"
 #include <QPainter>
+#include <QEvent>
 #include <DSettingsOption>
 #include <DFontSizeManager>
 
@@ -39,44 +40,97 @@ void ColorLabel::paintEvent(QPaintEvent *event)
     Q_UNUSED(event)
 
     int distance = 2;
-
     QRect r = rect();
 
     QPainter painter(this);
-    painter.setRenderHints(QPainter::Antialiasing |QPainter::SmoothPixmapTransform | QPainter::Qt4CompatiblePainting);
+    painter.setRenderHints(QPainter::Antialiasing | QPainter::SmoothPixmapTransform | QPainter::Qt4CompatiblePainting);
 
+    if (m_bPressed) {
+        // press: 内圆微缩 + 颜色加深，模拟按压
+        QRectF pressedRect = r.adjusted(distance, distance, -distance, -distance);
+        QPainterPath pressedPath;
+        pressedPath.addEllipse(pressedRect);
+        painter.fillPath(pressedPath, m_color.darker(130));
+        if (m_bSelected) {
+            QPainterPath ring;
+            ring.addEllipse(r.adjusted(distance / 2, distance / 2, -distance / 2, -distance / 2));
+            QPainterPath outerPath;
+            outerPath.addEllipse(r);
+            ring = outerPath - ring;
+            painter.fillPath(ring, m_color);
+        }
+    } else if (m_bHover) {
+        // hover: 外圈光晕，圆略微放大
+        QRectF hoverRect = r.adjusted(distance, distance, -distance, -distance);
+        QPainterPath hoverPath;
+        hoverPath.addEllipse(hoverRect);
+        painter.fillPath(hoverPath, m_color);
+        if (m_bSelected) {
+            QPainterPath ring;
+            ring.addEllipse(r.adjusted(distance, distance, -distance, -distance));
+            QPainterPath outerPath;
+            outerPath.addEllipse(r);
+            ring = outerPath - ring;
+            painter.fillPath(ring, m_color);
+        }
+    } else {
+        // normal: 原有逻辑
+        QPainterPath bigCircle;
+        bigCircle.addEllipse(r);
 
-    QPainterPath bigCircle;
-    bigCircle.addEllipse(r);
+        QPainterPath smallCircle;
+        smallCircle.addEllipse(r.adjusted(2 * distance, 2 * distance, -2 * distance, -2 * distance));
 
-    QPainterPath smallCircle;
-    smallCircle.addEllipse(r.adjusted(2*distance,2*distance,-2*distance,-2*distance));
+        // 先画小圆
+        painter.fillPath(smallCircle, m_color);
 
-    //先画小圆
-    painter.fillPath(smallCircle,m_color);
-
-
-    //如果点击选择画　圆环
-    if(m_bSelected){
-        r = rect();
-        QPainterPath sencondCircle;
-        sencondCircle.addEllipse(r.adjusted(distance,distance,-distance,-distance));
-        //大圆减小圆等于圆环
-        QPainterPath path = bigCircle - sencondCircle;
-        painter.fillPath(path,m_color);
+        // 如果点击选择画圆环
+        if (m_bSelected) {
+            r = rect();
+            QPainterPath sencondCircle;
+            sencondCircle.addEllipse(r.adjusted(distance, distance, -distance, -distance));
+            // 大圆减小圆等于圆环
+            QPainterPath path = bigCircle - sencondCircle;
+            painter.fillPath(path, m_color);
+        }
     }
 
     painter.end();
 }
 
+void ColorLabel::enterEvent(QEvent *event)
+{
+    DWidget::enterEvent(event);
+    m_bHover = true;
+    update();
+}
+
+void ColorLabel::leaveEvent(QEvent *event)
+{
+    DWidget::leaveEvent(event);
+    m_bHover = false;
+    m_bPressed = false;
+    update();
+}
+
 void ColorLabel::mousePressEvent(QMouseEvent *e)
 {
-    //没有选择点击有效
-    if(e->button() == Qt::LeftButton){
-       m_bSelected = true;
-       update();
-       emit sigColorClicked(m_bSelected,m_color);
+    if (e->button() == Qt::LeftButton) {
+        m_bPressed = true;
+        update();
     }
+    DWidget::mousePressEvent(e);
+}
+
+void ColorLabel::mouseReleaseEvent(QMouseEvent *e)
+{
+    if (e->button() == Qt::LeftButton && m_bPressed) {
+        m_bPressed = false;
+        m_bSelected = true;
+        update();
+        emit sigColorClicked(m_bSelected, m_color);
+    }
+    DWidget::mouseReleaseEvent(e);
 }
 
 ColorSelectWdg::ColorSelectWdg(QString text,QWidget *parent):DWidget (parent),m_text(text)

--- a/src/widgets/ColorSelectWdg.h
+++ b/src/widgets/ColorSelectWdg.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2019 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2019-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -37,12 +37,17 @@ public:
 signals:
     void sigColorClicked(bool bSelect,QColor color);
 protected:
-    void paintEvent(QPaintEvent *event);
-    void mousePressEvent(QMouseEvent *e);
+    void paintEvent(QPaintEvent *event) override;
+    void enterEvent(QEvent *event) override;
+    void leaveEvent(QEvent *event) override;
+    void mousePressEvent(QMouseEvent *e) override;
+    void mouseReleaseEvent(QMouseEvent *e) override;
 private:
     //颜色选择标记
 
     bool m_bSelected = false;
+    bool m_bHover = false;
+    bool m_bPressed = false;
     QColor m_color;
 };
 


### PR DESCRIPTION
## 根因分析

颜色标记图标 `ColorLabel`（`src/widgets/ColorSelectWdg.h:53-63`）仅实现 `m_bSelected` 一个状态，缺失 hover 和 press 交互状态：
- 构造函数虽调用了 `setMouseTracking(true)`，但未重写 `enterEvent()`/`leaveEvent()`
- `mousePressEvent()` 直接选中，无 press 过渡反馈
- `paintEvent()` 只绘制默认圆/选中圆环两态

## 修复方案

为 `ColorLabel` 增加 `m_bHover`/`m_bPressed` 状态变量，重写 `enterEvent()`/`leaveEvent()`/`mousePressEvent()`/`mouseReleaseEvent()`。`paintEvent()` 三分支渲染：press 态颜色加深+微缩，hover 态外扩，normal 保持原有逻辑。选中信号改为 release 触发（与 Qt 按钮标准行为一致）。

## 改动安全评估

低风险。`ColorLabel` 是 `ColorSelectWdg` 中的私有控件，无外部引用。新增 hover/press 属纯叠加性视觉增强，`sigColorClicked` 信号语义不变（仅触发时机从 press 改为 release），不破坏 `ColorSelectWdg` 的互斥选中逻辑。

PMS: BUG-196825

## Summary by Sourcery

Improve color mark interaction feedback and align selection behavior with standard button semantics.

New Features:
- Add hover and pressed visual states to color selection icons for clearer pointer interaction feedback.

Bug Fixes:
- Correct color selection activation to occur on left-button release rather than immediately on press.