### PR TITLE
fix(editor): handle Shift+Backspace as backspace in keyPressEvent

### DIFF
--- a/src/editor/dtextedit.cpp
+++ b/src/editor/dtextedit.cpp
@@ -8431,7 +8431,10 @@ void TextEdit::keyPressEvent(QKeyEvent *e)
         }
 
         //列编辑 删除撤销重做
-        if (modifiers == Qt::NoModifier && (e->key() == Qt::Key_Backspace)) {
+        // 修复 BUG-373675：输入法大写 A 状态下 Shift+Backspace 的 e->text() 非空，
+        // 会被下方 Shift 符号插入分支当作文本插入而产生乱码字符。
+        // 将 Shift+Backspace 纳入删除分支，使其与普通 Backspace 一致地删除前一个字符。
+        if ((modifiers == Qt::NoModifier || modifiers == Qt::ShiftModifier) && (e->key() == Qt::Key_Backspace)) {
             flushDeferredCursorUpdate();
             if (m_isSelectAll)
                 QPlainTextEdit::selectAll();


### PR DESCRIPTION
fix(editor): handle Shift+Backspace as backspace in keyPressEvent
Under input method uppercase-A mode, Shift+Backspace produces a
non-empty QKeyEvent::text(), which was captured by the Shift-symbol
insertion branch and inserted as a control character, causing garbled
output. Extend the backspace deletion branch condition to also match
Qt::ShiftModifier, so Shift+Backspace deletes the previous character
identically to Backspace, matching standard editor behavior.

修复输入法大写字母A状态下Shift+Backspace插入乱码字符的问题：
将退格删除分支的修饰键条件从NoModifier扩展为NoModifier或
ShiftModifier，使Shift+Backspace与普通Backspace一致地删除前一个
字符，避免被下方Shift符号插入分支当作文本插入。

Log: 修复输入法大写A状态下按Shift+Backspace插入乱码字符的问题，使其等同Backspace删除前一个字符
PMS: BUG-373675
Influence: 仅影响Shift+Backspace行为，普通Backspace及其他Shift组合键不受影响。