### PR TITLE
fix: persist and restore mark color highlights across sessions

### DIFF
--- a/src/editor/dtextedit.cpp
+++ b/src/editor/dtextedit.cpp
@@ -4768,6 +4768,37 @@ void TextEdit::setBookMarkList(QList<int> bookMarkList)
     m_listBookmark = bookMarkList;
 }
 
+QList<TextEdit::MarkReplaceInfo> TextEdit::getMarkColorInfo()
+{
+    // 将当前标记操作转换为含绝对位置的替换信息，作为持久化载体
+    return convertMarkToReplace(m_markOperations);
+}
+
+void TextEdit::setMarkColorList(const QList<MarkReplaceInfo> &markInfo)
+{
+    // 持久化数据仅含绝对位置，需用当前文档构造有效光标后再交由既有逻辑恢复
+    QList<QPair<MarkOperation, qint64>> markList;
+    const int docLen = document()->characterCount();
+    for (const auto &info : markInfo) {
+        MarkOperation markOpt;
+        markOpt.type = info.opt.type;
+        markOpt.color = info.opt.color;
+        markOpt.matchText = info.opt.matchText;
+
+        // 用当前文档构造有效光标，避免持久化数据中光标无文档导致恢复失败
+        markOpt.cursor = QTextCursor(document());
+        // 限制位置在当前文档范围内，文件被外部修改后不致越界
+        int start = qBound(0, static_cast<int>(info.start), docLen);
+        int end = qBound(0, static_cast<int>(info.end), docLen);
+        markOpt.cursor.setPosition(start);
+        markOpt.cursor.setPosition(end, QTextCursor::KeepAnchor);
+
+        markList.append(qMakePair(markOpt, info.time));
+    }
+
+    manualUpdateAllMark(markList);
+}
+
 void TextEdit::updateSaveIndex()
 {
     m_lastSaveIndex = m_pUndoStack->index();

--- a/src/editor/dtextedit.h
+++ b/src/editor/dtextedit.h
@@ -456,6 +456,18 @@ public:
     void setBookMarkList(QList<int> bookMarkList);
 
     /**
+     * @brief getMarkColorInfo 得到当前标记颜色信息（含绝对位置）
+     * @return 标记颜色信息列表
+     */
+    QList<MarkReplaceInfo> getMarkColorInfo();
+
+    /**
+     * @brief setMarkColorList 从持久化数据恢复标记颜色，重建内存标记并刷新显示
+     * @param markInfo 标记颜色信息列表（含绝对位置，光标无需有效）
+     */
+    void setMarkColorList(const QList<MarkReplaceInfo> &markInfo);
+
+    /**
      * 更新上次保存时的撤销回收栈的索引值
      */
     void updateSaveIndex();

--- a/src/editor/editwrapper.cpp
+++ b/src/editor/editwrapper.cpp
@@ -5,6 +5,7 @@
 #include "editwrapper.h"
 #include "leftareaoftextedit.h"
 #include "drecentmanager.h"
+#include "../startmanager.h"
 
 #include <unistd.h>
 
@@ -938,6 +939,11 @@ void EditWrapper::handleFileLoadFinished(const QByteArray &encode, const QByteAr
     }
 
     m_pTextEdit->setTextFinished();
+
+    // 文件内容加载完成后，恢复该文件的标记颜色（位置型数据需待内容就绪）
+    QString markLocalPath = m_pTextEdit->getTruePath();
+    QList<TextEdit::MarkReplaceInfo> markColorInfo = StartManager::instance()->findMarkColor(markLocalPath);
+    m_pTextEdit->setMarkColorList(markColorInfo);
 
     QStringList temFileList = Settings::instance()->settings->option("advance.editor.browsing_history_temfile")->value().toStringList();
 

--- a/src/resources/settings.json
+++ b/src/resources/settings.json
@@ -2133,6 +2133,12 @@
                             "hide": true,
                             "reset": false,
                             "default": ""
+                        },
+                        {
+                            "key": "markcolor",
+                            "hide": true,
+                            "reset": false,
+                            "default": ""
                         }
                     ]
                 },

--- a/src/startmanager.cpp
+++ b/src/startmanager.cpp
@@ -14,6 +14,7 @@
 #include <QPropertyAnimation>
 #include <DSettingsOption>
 #include <DAboutDialog>
+#include <QJsonArray>
 //#include <DSettings>
 
 DWIDGET_USE_NAMESPACE
@@ -26,6 +27,8 @@ enum BackupInterval {
 
 // 用于配置文件书签的标识
 static const QString s_bookMarkKey = "advance.editor.bookmark";
+// 用于配置文件标记颜色的标识
+static const QString s_markColorKey = "advance.editor.markcolor";
 
 StartManager *StartManager::m_instance = nullptr;
 
@@ -61,6 +64,8 @@ StartManager::StartManager(QObject *parent)
     m_qlistTemFile = Settings::instance()->settings->option("advance.editor.browsing_history_temfile")->value().toStringList();
     // 初始化书签信息记录表
     initBookmark();
+    // 初始化标记颜色信息记录表
+    initMarkColor();
 
     //按时间自动备份（5分钟）
     m_pTimer = new QTimer;
@@ -190,6 +195,10 @@ void StartManager::autoBackupFile()
                 m_bookmarkTable.remove(localPath);
             }
 
+            //记录标记颜色
+            QList<TextEdit::MarkReplaceInfo> markColorList = wrapper->textEditor()->getMarkColorInfo();
+            recordMarkColor(localPath, markColorList);
+
             //记录活动页
             if (m_windows.value(var)->isActiveWindow()) {
                 if (wrapper == m_windows.value(var)->currentWrapper()) {
@@ -223,6 +232,8 @@ void StartManager::autoBackupFile()
     Settings::instance()->settings->option("advance.editor.browsing_history_temfile")->setValue(m_qlistTemFile);
     // 备份书签信息
     saveBookmark();
+    // 备份标记颜色信息
+    saveMarkColor();
 }
 
 int StartManager::recoverFile(Window *window)
@@ -650,6 +661,8 @@ void StartManager::slotCloseWindow()
     if (m_windows.isEmpty()) {
         // 保存书签信息
         saveBookmark();
+        // 保存标记颜色信息
+        saveMarkColor();
 
         QDir path = QDir::currentPath();
         if (!path.exists()) {
@@ -830,6 +843,115 @@ void StartManager::recordBookmark(const QString &localPath, const QList<int> &bo
 QList<int> StartManager::findBookmark(const QString &localPath)
 {
     return m_bookmarkTable.value(localPath);
+}
+
+/**
+ * @brief 主动更新记录文件 \a localPath 的标记颜色信息，空列表会清除该文件的记录。
+ * @param localPath 文件路径
+ * @param markColor 标记颜色信息（含绝对位置）
+ */
+void StartManager::recordMarkColor(const QString &localPath, const QList<TextEdit::MarkReplaceInfo> &markColor)
+{
+    if (markColor.isEmpty()) {
+        // 无标记颜色，移除历史记录
+        m_markColorTable.remove(localPath);
+    } else {
+        m_markColorTable.insert(localPath, markColor);
+    }
+}
+
+/**
+ * @return 返回文件 \a localPath 的标记颜色记录
+ */
+QList<TextEdit::MarkReplaceInfo> StartManager::findMarkColor(const QString &localPath)
+{
+    return m_markColorTable.value(localPath);
+}
+
+/**
+ * @brief 从配置文件中获取全局的标记颜色信息，包括已关闭的所有文件标记颜色，
+ *      会遍历每条记录并判断文件是否存在，若文件被删除或移动，则不再记录对应信息。
+ */
+void StartManager::initMarkColor()
+{
+    // 遍历标记颜色信息列表
+    QStringList markColorInfoList = Settings::instance()->settings->value(s_markColorKey).toStringList();
+    for (const QString &markColorInfo : markColorInfoList) {
+        QJsonParseError readError;
+        QJsonDocument doc = QJsonDocument::fromJson(markColorInfo.toUtf8(), &readError);
+        if (QJsonParseError::NoError == readError.error
+                && !doc.isNull()) {
+            QJsonObject obj = doc.object();
+            QString filePath = obj.value("localPath").toString();
+
+            // 判断文件是否仍存在，若不存在，则不保留标记颜色信息
+            if (!filePath.isEmpty()
+                    && QFileInfo::exists(filePath)) {
+                QList<TextEdit::MarkReplaceInfo> markList;
+                QJsonArray marksArray = obj.value("marks").toArray();
+                for (const QJsonValue &markValue : marksArray) {
+                    QJsonObject markObj = markValue.toObject();
+                    TextEdit::MarkReplaceInfo info;
+                    info.opt.type = static_cast<TextEdit::MarkOperationType>(markObj.value("type").toInt());
+                    info.opt.color = markObj.value("color").toString();
+                    info.opt.matchText = markObj.value("matchText").toString();
+                    info.start = markObj.value("start").toInt();
+                    info.end = markObj.value("end").toInt();
+                    info.time = static_cast<qint64>(markObj.value("time").toDouble());
+                    markList.append(info);
+                }
+
+                if (!markList.isEmpty()) {
+                    // 文件存在且标记颜色非空，缓存标记颜色信息
+                    m_markColorTable.insert(filePath, markList);
+                }
+            }
+        }
+    }
+}
+
+/**
+ * @brief 将当前记录的所有文件的标记颜色信息转换为 Json 数据列表记录到配置信息中，
+ *      被删除或移动文件的标记颜色将被销毁。
+ */
+void StartManager::saveMarkColor()
+{
+    QStringList recordInfo;
+    // 遍历记录
+    for (auto itr = m_markColorTable.begin(); itr != m_markColorTable.end();) {
+        if (!QFileInfo::exists(itr.key())
+                || itr.value().isEmpty()) {
+            // 文件不存在或无标记颜色则销毁记录
+            itr = m_markColorTable.erase(itr);
+        } else {
+            QJsonObject obj;
+            obj.insert("localPath", itr.key());
+
+            // 遍历标记颜色信息并组合
+            QJsonArray marksArray;
+            const auto &markList = itr.value();
+            for (const TextEdit::MarkReplaceInfo &info : markList) {
+                QJsonObject markObj;
+                markObj.insert("type", static_cast<int>(info.opt.type));
+                markObj.insert("color", info.opt.color);
+                markObj.insert("matchText", info.opt.matchText);
+                markObj.insert("start", info.start);
+                markObj.insert("end", info.end);
+                // time 为 qint64，超过 int 范围时用 double 保证精度
+                markObj.insert("time", static_cast<double>(info.time));
+                marksArray.append(markObj);
+            }
+            obj.insert("marks", marksArray);
+
+            QJsonDocument doc(obj);
+            recordInfo.append(doc.toJson(QJsonDocument::Compact));
+
+            ++itr;
+        }
+    }
+
+    // 将标记颜色信息保存至配置文件
+    Settings::instance()->settings->option(s_markColorKey)->setValue(recordInfo);
 }
 
 void StartManager::initBlockShutdown()

--- a/src/startmanager.h
+++ b/src/startmanager.h
@@ -69,6 +69,11 @@ public:
     // 查找文件对应的书签记录
     QList<int> findBookmark(const QString &localPath);
 
+    // 主动更新记录标记颜色信息
+    void recordMarkColor(const QString &localPath, const QList<TextEdit::MarkReplaceInfo> &markColor);
+    // 查找文件对应的标记颜色记录
+    QList<TextEdit::MarkReplaceInfo> findMarkColor(const QString &localPath);
+
     // 延迟释放堆内存
     void delayMallocTrim();
 
@@ -105,6 +110,10 @@ private:
     void initBookmark();
     // 保存书签信息
     void saveBookmark();
+    // 初始化标记颜色信息
+    void initMarkColor();
+    // 保存标记颜色信息
+    void saveMarkColor();
 
 private:
     static StartManager *m_instance;
@@ -119,6 +128,7 @@ private:
     QScopedPointer<Entry> m_pEntry;
     QStringList m_qlistTemFile;                 ///< 备份信息列表
     QHash<QString, QList<int>> m_bookmarkTable; ///< 书签标记信息表
+    QHash<QString, QList<TextEdit::MarkReplaceInfo>> m_markColorTable; ///< 标记颜色信息表
     QTimer *m_pTimer;
     QBasicTimer m_DelayTimer;   ///< 延迟备份定时器
     QString m_blankFileDir;     ///< 新建文件目录

--- a/src/widgets/window.cpp
+++ b/src/widgets/window.cpp
@@ -815,6 +815,11 @@ bool Window::closeTab(const QString &filePath)
         StartManager::instance()->recordBookmark(localPath, bookmarkInfo);
     }
 
+    // 关闭标签页前，记录全局的标记颜色信息（空列表会清除历史记录）
+    QList<TextEdit::MarkReplaceInfo> markColorInfo = wrapper->textEditor()->getMarkColorInfo();
+    QString markLocalPath = wrapper->textEditor()->getTruePath();
+    StartManager::instance()->recordMarkColor(markLocalPath, markColorInfo);
+
     if (isDraftFile) {
         if (isModified) {
             DDialog *dialog = createDialog(tr("Do you want to save this file?"), "");


### PR DESCRIPTION
## 根因分析

PMS 328067「文本编辑器无法保存标记颜色」——标记颜色功能在「数据模型 / 保存路径 / 恢复路径」三层均未接入持久化：

- 颜色仅存 `TextEdit` 内存容器 `m_markOperations`（`src/editor/dtextedit.h:641`）/`m_wordMarkSelections`（`dtextedit.h:639`），随对象销毁消失，无序列化出口；
- 保存路径 `TextFileSaver::saveToFile`（`src/common/text_file_saver.cpp:132`）经 `document->toPlainText()` 只落盘纯文本，丢弃所有 ExtraSelection 颜色；
- 会话 JSON（`src/startmanager.cpp:162-205`）与启动恢复（`startmanager.cpp:318-372`）均无标记颜色键，重开仅恢复书签与焦点；
- 同项目书签已完整持久化（`startmanager.cpp:28/822/862/894`）作为「可做而未做」的直接对照。

根因已通过独立复核（✅ 高置信）。

## 修复方案

仿书签持久化范式（方案 A）补全标记颜色的「序列化 / 保存触发 / 打开恢复」三层：

1. 新增隐藏配置项 `advance.editor.markcolor`，按文件路径持久化标记颜色（`{localPath, marks:[{start,end,color,type,matchText,time}]}`）。
2. `StartManager` 新增 `initMarkColor/saveMarkColor/recordMarkColor/findMarkColor` 与 `m_markColorTable`：启动读取、关窗/会话保存、变更缓存、按路径查找——与书签逐环节对应。
3. 保存触发：会话保存 `autoBackupFile` 与关闭标签页 `closeTab` 处记录当前标记颜色；`slotCloseWindow` 与 `autoBackupFile` 处落盘。
4. `TextEdit` 新增 `getMarkColorInfo`（复用既有 `convertMarkToReplace`）与 `setMarkColorList`（用当前文档光标重建选中区间后调既有 `manualUpdateAllMark` 恢复内存标记并 `renderAllSelections`）。
5. 打开恢复：`EditWrapper::handleFileLoadFinished` 文件内容加载完成后按路径 `findMarkColor` + `setMarkColorList` 恢复——位置型数据需待内容就绪，故不能像行号型书签那样在 `openFile` 后同步调用。

复用既有 `MarkReplaceInfo`/`convertMarkToReplace`/`manualUpdateAllMark` 模型，未修改任何既有函数签名或函数体，纯新增。

## 改动安全评估

低风险。纯新增 192 行、0 删除，不修改任何函数签名/公开成员，不触碰既有函数体；被复用的 `manualUpdateAllMark`/`convertMarkToReplace` 仅作只读入口调用，既有撤销/重做调用方（`changemarkcommand.cpp`）零影响；`setMarkColorList` 用 `qBound` 夹紧位置避免文件被外部修改后越界。详见 `change-safety.md`。

## 测试建议

1. 打开文本文件 → 选中文字 → 右键「标记」选色 → 保存 → 关闭 → 重开：颜色应恢复。
2. 整行标记 / 全文标记 / 关键字标记（MarkAllMatch）各类型分别验证保存重开恢复。
3. 清空所有标记后关闭重开：不应残留旧标记。
4. 文件被外部编辑器修改后重开：标记不致越界崩溃（位置被夹紧，不适配者被丢弃）。

## 关联

- PMS: https://pms.uniontech.com/bug-view-328067.html
- 基线：release/eagle @ `7458207c3bbb08c92fe9cf0902c7b8c0d3767263`

## Summary by Sourcery

Persist and restore file-specific text mark color highlights across saves, closures, and application restarts.

New Features:
- Persist text mark colors per file and restore them when the file is reopened.

Bug Fixes:
- Prevent saved mark highlights from being lost across application sessions and tab closures.

Enhancements:
- Restore highlights after document loading and safely handle stale positions or removed files.