### PR TITLE
feat(build): add WebEngine build infra for markdown render

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,8 +3,8 @@ if (NOT (${CMAKE_BUILD_TYPE} MATCHES "Debug"))
 endif ()
 
 # Sources files
-file(GLOB HEADERS "${CMAKE_CURRENT_SOURCE_DIR}/*.h"  "encodes/*.h" "common/*.h" "controls/*.h" "editor/*.h"  "thememodule/*.h" "widgets/*.h" "basepub/*.h")
-file(GLOB SRCS "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp" "encodes/*.cpp" "common/*.cpp" "controls/*.cpp" "editor/*.cpp"  "thememodule/*.cpp" "widgets/*.cpp" "basepub/*.c")
+file(GLOB HEADERS "${CMAKE_CURRENT_SOURCE_DIR}/*.h"  "encodes/*.h" "common/*.h" "controls/*.h" "editor/*.h" "editor/markdown/*.h"  "thememodule/*.h" "widgets/*.h" "basepub/*.h")
+file(GLOB SRCS "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp" "encodes/*.cpp" "common/*.cpp" "controls/*.cpp" "editor/*.cpp" "editor/markdown/*.cpp"  "thememodule/*.cpp" "widgets/*.cpp" "basepub/*.c")
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/encodes)
@@ -39,7 +39,7 @@ configure_file(
 # Find the library
 find_package(PkgConfig REQUIRED)
 
-set(qt_required_components Gui Widgets DBus Concurrent PrintSupport Svg Xml)
+set(qt_required_components Gui Widgets DBus Concurrent PrintSupport Svg Xml WebEngineWidgets WebChannel)
 if (QT_DESIRED_VERSION MATCHES 6)
     list(APPEND qt_required_components Core5Compat)
 endif()
@@ -56,6 +56,8 @@ set(LINK_LIBS
     Qt${QT_VERSION_MAJOR}::Concurrent
     Qt${QT_VERSION_MAJOR}::PrintSupport
     Qt${QT_VERSION_MAJOR}::DBus
+    Qt${QT_VERSION_MAJOR}::WebEngineWidgets
+    Qt${QT_VERSION_MAJOR}::WebChannel
     Dtk${DTK_VERSION_MAJOR}::Widget
     Dtk${DTK_VERSION_MAJOR}::Core
     KF${KF_VERSION_MAJOR}::Codecs

--- a/src/deepin-editor.qrc
+++ b/src/deepin-editor.qrc
@@ -32,5 +32,9 @@
         <file>encodes/encodes1.ini</file>
         <file>images/arrow_dark.svg</file>
         <file>images/arrow_light.svg</file>
+        <file>editor/markdown/web/milkdown.html</file>
+        <file>editor/markdown/web/qwebchannel.js</file>
+        <file>editor/markdown/web/build/main.bundle.js</file>
+        <file>editor/markdown/web/build/style.css</file>
     </qresource>
 </RCC>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -41,7 +41,10 @@ int main(int argc, char *argv[])
     }
     qDebug() << "XDG_CURRENT_DESKTOP set to:" << qgetenv("XDG_CURRENT_DESKTOP");
     QCoreApplication::setAttribute(Qt::AA_UseOpenGLES);
-    qDebug() << "Qt::AA_UseOpenGLES attribute set";
+    // QWebEngineView 硬性前提：共享 GL 上下文必须在 QApplication 构造前设置，
+    // 否则 Markdown 渲染视图无法创建共享上下文导致白屏（Qt6 文档要求）
+    QCoreApplication::setAttribute(Qt::AA_ShareOpenGLContexts);
+    qDebug() << "Qt::AA_UseOpenGLES / AA_ShareOpenGLContexts attributes set";
 
     EditorApplication app(argc, argv);
     qInfo() << "Application instance created, version:" << app.applicationVersion();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -24,7 +24,7 @@ set(APP_QRC "../src/deepin-editor.qrc")
 find_package(PkgConfig REQUIRED)
 
 
-set(qt_required_components Gui Widgets DBus Concurrent PrintSupport Svg Xml Test)
+set(qt_required_components Gui Widgets DBus Concurrent PrintSupport Svg Xml Test WebEngineWidgets WebChannel)
 if (QT_DESIRED_VERSION MATCHES 6)
     list(APPEND qt_required_components Core5Compat)
 endif()
@@ -42,6 +42,8 @@ set(LINK_LIBS
     Qt${QT_VERSION_MAJOR}::PrintSupport
     Qt${QT_VERSION_MAJOR}::DBus
     Qt${QT_VERSION_MAJOR}::Test
+    Qt${QT_VERSION_MAJOR}::WebEngineWidgets
+    Qt${QT_VERSION_MAJOR}::WebChannel
     Dtk${DTK_VERSION_MAJOR}::Widget
     Dtk${DTK_VERSION_MAJOR}::Core
     KF${KF_VERSION_MAJOR}::Codecs
@@ -58,6 +60,8 @@ find_package(GTest REQUIRED)
 find_package(ICU COMPONENTS i18n uc REQUIRED)
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/src)
+include_directories(${CMAKE_CURRENT_LIST_DIR}/../src/editor)
+include_directories(${CMAKE_CURRENT_LIST_DIR}/../src/editor/markdown)
 include_directories(${GTEST_INCLUDE_DIRS})
 include_directories(src)
 link_libraries(uchardet)

--- a/tests/src/ut_main.cpp
+++ b/tests/src/ut_main.cpp
@@ -25,6 +25,8 @@ int main(int argc, char *argv[])
 {
     qputenv("QT_QPA_PLATFORM","offscreen");
     qputenv("QT_LOGGING_RULES", "*.debug=false;*.info=false");
+    // 与生产 main.cpp 一致：WebEngine 渲染视图需要共享 GL 上下文（须在 QApplication 前设置）
+    QCoreApplication::setAttribute(Qt::AA_ShareOpenGLContexts);
     DApplication app(argc, argv);
 
     testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
Add WebEngineWidgets and WebChannel components to src and tests CMake, register markdown web resources in qrc, and set AA_ShareOpenGLContexts before QApplication in main and test main (WebEngine hard requirement).

src 与 tests 的 CMake 增加 WebEngineWidgets/WebChannel 组件与链接， qrc 注册 markdown web 资源，main 与测试 main 在 QApplication 前设置 AA_ShareOpenGLContexts（WebEngine 渲染进程硬性前提，防白屏）。

Log: 打通 Markdown 渲染的 WebEngine 构建链路
PMS: TASK-393979
Influence: 构建引入 Qt WebEngine 依赖；渲染区白屏问题在入口统一规避。

## Summary by Sourcery

Enable the Qt WebEngine build and runtime infrastructure required for Markdown rendering.

Bug Fixes:
- Prevent blank Markdown rendering views by enabling shared OpenGL contexts before application initialization.

Enhancements:
- Integrate Qt WebEngineWidgets and WebChannel dependencies into the application and test builds.
- Include Markdown editor sources and expose their include paths to the test build.
- Register Markdown web resources with the application resource bundle.

Build:
- Extend the source and test CMake configurations to discover and link the Qt WebEngine components.

Tests:
- Update the test application initialization to configure shared OpenGL contexts for WebEngine rendering.