### PR TITLE
feat(markdown): add pure logic layer for view mode and render

### DIFF
--- a/src/editor/markdown/imarkdownrenderer.h
+++ b/src/editor/markdown/imarkdownrenderer.h
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef IMARKDOWNRENDERER_H
+#define IMARKDOWNRENDERER_H
+
+#include "viewmode.h"
+
+#include <QString>
+#include <QVariantMap>
+
+//
+// IMarkdownRenderer —— Markdown 渲染器接口（供 EditWrapper 依赖接口编程 / 测试用 Mock 替换）
+//
+// 业务层（EditWrapper）不直接依赖 MarkdownView（QWebEngineView 子类），而依赖此接口，
+// 便于在完全不启动 WebEngine 的前提下用 GMock 替身验证编排逻辑（见 §5'.4）。
+//
+class IMarkdownRenderer
+{
+public:
+    virtual ~IMarkdownRenderer() = default;
+
+    // 渲染内核是否就绪（Milkdown 创建完成）。未就绪时 setMarkdown 会被缓存。
+    virtual bool isReady() const = 0;
+
+    // 单向（本期）：把 markdown 源码推给渲染内核。
+    virtual void setMarkdown(const QString &md) = 0;
+    // 切换只读/可编辑。本期固定 ReadOnly（Editable 为阶段二预留）。
+    // mode 取 MarkdownView::Mode（ReadOnly=0/Editable=1），用 int 避免循环 include。
+    virtual void setMode(int mode) = 0;
+    // 注入深浅色与配色。
+    virtual void applyTheme(const QVariantMap &themeMap) = 0;
+    // 内容区布局：maxContentWidth=0 表示不限最大宽（实时阅览半幅），>0 表示居中约束（查看视图 800）。
+    virtual void setLayout(int maxContentWidth, bool center) = 0;
+    // 滚动同步：ratio ∈ [0,1]，由左侧 TextEdit 滚动驱动。
+    virtual void scrollToRatio(double ratio) = 0;
+};
+
+#endif // IMARKDOWNRENDERER_H

--- a/src/editor/markdown/markdownbridge.cpp
+++ b/src/editor/markdown/markdownbridge.cpp
@@ -1,0 +1,5 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "markdownbridge.h"

--- a/src/editor/markdown/markdownbridge.h
+++ b/src/editor/markdown/markdownbridge.h
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef MARKDOWNBRIDGE_H
+#define MARKDOWNBRIDGE_H
+
+#include <QObject>
+
+//
+// MarkdownBridge —— 暴露给 JS 的 WebChannel 桥接对象
+//
+// 协议（与 web/bridge.js 一一对应）：
+//   JS → C++（槽）:onReady / onContentChanged / onScrollRatio / onOpenLink
+//   C++ → JS（信号）:setMarkdownRequested / setModeRequested /
+//                    applyThemeRequested / setLayoutRequested / scrollToRatioRequested
+//
+// 阶段一（只读预览）：仅 onReady / setMarkdownRequested / applyThemeRequested /
+//                    setLayoutRequested / scrollToRatioRequested 实际使用；
+//                    onContentChanged / onScrollRatio / setModeRequested 接口先到位，
+//                    阶段二（WYSIWYG 编辑）启用，本期实现为转发信号但上层不连接。
+//                    onOpenLink 由 JS 点击拦截调用（外部链接转系统浏览器）。
+//
+class MarkdownBridge : public QObject
+{
+    Q_OBJECT
+public:
+    explicit MarkdownBridge(QObject *parent = nullptr) : QObject(parent) {}
+
+public slots:
+    // JS → C++
+    void onReady() { emit ready(); }
+    void onContentChanged(const QString &md) { emit contentChanged(md); }
+    void onScrollRatio(double ratio) { emit scrollRatioChanged(ratio); }
+    void onOpenLink(const QString &url) { emit openLinkRequested(url); }
+
+signals:
+    // C++ → JS（JS 端 bridge.{signal}.connect(function(...){...}) 接收）
+    void ready();
+    void contentChanged(const QString &md);
+    void scrollRatioChanged(double ratio);
+    void openLinkRequested(const QString &url);
+
+    void setMarkdownRequested(const QString &md);
+    void setModeRequested(bool editable);
+    void applyThemeRequested(const QString &jsonColors, bool isDark);
+    void setLayoutRequested(int maxW, bool center);
+    void scrollToRatioRequested(double ratio);
+};
+
+#endif // MARKDOWNBRIDGE_H

--- a/src/editor/markdown/markdownlogic.h
+++ b/src/editor/markdown/markdownlogic.h
@@ -1,0 +1,88 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef MARKDOWNLOGIC_H
+#define MARKDOWNLOGIC_H
+
+#include <QString>
+#include <QDir>
+#include <QUrl>
+#include <QRegularExpression>
+
+//
+// MarkdownLogic —— Markdown 识别（纯函数，无 QWidget 依赖，可 100% 单测覆盖）
+//
+// 识别规则（与 KSyntaxHighlighting definition 体系对齐）：
+//   1. definition 名为 "Markdown"（精确匹配，大小写敏感）→ 是
+//   2. 文件扩展名 .md/.markdown/.mdown（不区分大小写）→ 是
+//   3. 综合：definition 优先，其次扩展名
+//
+// §4.4 模式判定使用 isMarkdown() 的结果决定 ReadView/LivePreview 是否可用。
+//
+class MarkdownLogic
+{
+public:
+    // 按 KSyntaxHighlighting definition 名判定（dtextedit.cpp:618 同类用法）
+    static bool isMarkdownByDefinitionName(const QString &definitionName)
+    {
+        return definitionName == QStringLiteral("Markdown");
+    }
+
+    // 按文件扩展名判定（.md/.markdown/.mdown，不区分大小写）
+    static bool isMarkdownByFileName(const QString &fileName)
+    {
+        if (fileName.isEmpty()) return false;
+        const auto lower = fileName.toLower();
+        return lower.endsWith(QStringLiteral(".md"))
+            || lower.endsWith(QStringLiteral(".markdown"))
+            || lower.endsWith(QStringLiteral(".mdown"));
+    }
+
+    // 综合：definition 优先，其次扩展名
+    static bool isMarkdown(const QString &fileName, const QString &definitionName)
+    {
+        if (isMarkdownByDefinitionName(definitionName)) return true;
+        return isMarkdownByFileName(fileName);
+    }
+
+    // 图片路径改写（供渲染）：渲染页从 qrc:/ 加载，Chromium 硬禁 qrc 页面访问 file://
+    // 子资源（Not allowed to load local resource），相对路径也会被错误解析到 qrc 内。
+    // 推送渲染前把非网络图片路径按 md 文件所在目录改写为 mdimg:// 绝对 URL
+    // （自定义 scheme + QWebEngineUrlSchemeHandler 在 Qt 侧供给本地文件内容）。
+    // 纯函数：md 为源文本，baseDir 为 md 文件绝对目录；http/https/data/mdimg 原样保留。
+    static QString resolveImagePaths(const QString &md, const QString &baseDir)
+    {
+        if (md.isEmpty() || baseDir.isEmpty())
+            return md;
+
+        static const QRegularExpression rx(
+            QStringLiteral("!\\[([^\\]]*)\\]\\(([^)]+?)(\\s+\"[^\"]*\")?\\)"));
+        QString result;
+        qsizetype last = 0;
+        auto it = rx.globalMatch(md);
+        while (it.hasNext()) {
+            const auto m = it.next();
+            result += QStringView(md).mid(last, m.capturedStart() - last);
+            const QString path = m.captured(2);
+            const QString title = m.captured(3);   // 可选 "title"，重建时原样保留
+            QString resolved = path;
+            if (!path.startsWith(QStringLiteral("http:"), Qt::CaseInsensitive)
+                    && !path.startsWith(QStringLiteral("https:"), Qt::CaseInsensitive)
+                    && !path.startsWith(QStringLiteral("data:"), Qt::CaseInsensitive)
+                    && !path.startsWith(QStringLiteral("mdimg:"), Qt::CaseInsensitive)) {
+                const QString abs = QDir(baseDir).absoluteFilePath(QString(path).trimmed());
+                // 手工构造 mdimg:///<编码路径>（abs 自带首斜杠，拼出恰三个斜杠）：不依赖 QUrl 对自定义 scheme 的 authority 推断
+                resolved = QStringLiteral("mdimg://")
+                           + QString::fromUtf8(QUrl::toPercentEncoding(abs, "/"));
+            }
+            result += QStringLiteral("![") + m.captured(1) + QStringLiteral("](")
+                      + resolved + title + QStringLiteral(")");
+            last = m.capturedEnd();
+        }
+        result += QStringView(md).mid(last);
+        return result;
+    }
+};
+
+#endif // MARKDOWNLOGIC_H

--- a/src/editor/markdown/renderthrottle.cpp
+++ b/src/editor/markdown/renderthrottle.cpp
@@ -1,0 +1,5 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "renderthrottle.h"

--- a/src/editor/markdown/renderthrottle.h
+++ b/src/editor/markdown/renderthrottle.h
@@ -1,0 +1,100 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef RENDERTHROTTLE_H
+#define RENDERTHROTTLE_H
+
+#include <QObject>
+#include <QTimer>
+#include <QString>
+
+//
+// RenderThrottle —— Markdown 内容渲染节流/缓存策略（纯逻辑，§5'.3）
+//
+// 职责：
+//   - 300ms 节流（前沿 + 后沿）：冷却期外的首次变更立即渲染（前沿）；冷却期内累积的
+//     变更在定时器到期时补发最新内容（后沿）并进入下一周期——连续输入期间每 300ms
+//     渲染一次，任何变更的可见延迟 ≤ 300ms（满足需求"300ms 内增量刷新"，2026-08-19
+//     修订：原纯尾沿去抖在连续输入下无限推迟渲染）
+//   - 首切立即触发：flushNow() 跳过冷却
+//   - 相同内容跳过：md == lastEmitted 不重复渲染
+//   - ready 前缓存：renderer 未就绪时缓存 pending，ready 后 flush
+//
+// 上层（EditWrapper）把 textChanged 转发给 noteContent()，渲染由 renderRequested 驱动。
+//
+class RenderThrottle : public QObject
+{
+    Q_OBJECT
+public:
+    explicit RenderThrottle(QObject *parent = nullptr)
+        : QObject(parent)
+    {
+        m_timer.setSingleShot(true);
+        m_timer.setInterval(300);
+        connect(&m_timer, &QTimer::timeout, this, &RenderThrottle::onTimeout);
+    }
+
+    int interval() const { return m_timer.interval(); }
+    void setInterval(int ms) { m_timer.setInterval(ms); }
+
+    bool isReady() const { return m_ready; }
+    void setReady(bool ready)
+    {
+        m_ready = ready;
+        if (m_ready) flushPending();
+    }
+
+    // 记录一次输入（节流：前沿立即 + 后沿补发）：
+    // 冷却期外的首次变更立即渲染并进入 300ms 冷却；冷却期内的变更累积到 pending，
+    // 定时器到期时补发最新内容——连续输入期间每 300ms 渲染一次，延迟有上界
+    void noteContent(const QString &md)
+    {
+        if (md == m_lastEmitted) return;   // 相同跳过
+        m_pending = md;
+        if (m_timer.interval() <= 0) {
+            // interval=0 表示首切立即
+            flushPending();
+            return;
+        }
+        if (!m_timer.isActive() && flushPending())
+            m_timer.start();               // 前沿已渲染，进入冷却；冷却期内变更由后沿补
+    }
+
+    // 首切立即触发（跳过去抖，但受 ready 约束）
+    void flushNow() { flushPending(); }
+
+signals:
+    void renderRequested(const QString &md);
+
+private:
+    // 渲染 pending（受 ready 约束与相同内容跳过约束）；返回是否实际发出。
+    // 定时器生命周期由调用方管理（noteContent 前沿启动 / onTimeout 后沿续期）
+    bool flushPending()
+    {
+        if (!m_ready) return false;       // 未 ready，缓存
+        if (m_pending.isEmpty() && m_lastEmitted.isEmpty()) {
+            // 首次空内容也允许（清空场景），但 pending 与 lastEmitted 都空时不发
+            return false;
+        }
+        if (m_pending == m_lastEmitted) return false;
+        m_lastEmitted = m_pending;
+        emit renderRequested(m_pending);
+        return true;
+    }
+
+    // 后沿：渲染冷却期内累积的最新内容；内容仍在变化则继续下一节流周期，
+    // 本周期无新内容则定时器自然停止（不再续期）
+    void onTimeout()
+    {
+        if (m_pending != m_lastEmitted && flushPending())
+            m_timer.start();
+    }
+
+    QTimer m_timer;
+    QString m_pending;
+    QString m_lastEmitted;
+    bool m_ready = false;
+};
+
+#endif // RENDERTHROTTLE_H

--- a/src/editor/markdown/scrollsync.h
+++ b/src/editor/markdown/scrollsync.h
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2026 UnionCTechnology Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef SCROLLSYNC_H
+#define SCROLLSYNC_H
+
+//
+// ScrollSync —— 滚动比例计算/钳制（纯函数，§4.6 / §5'.3）
+//
+// 实时阅览下由左侧 TextEdit 滚动驱动右侧 MarkdownView：
+//   ratio = (value - min) / (max - min)，钳制到 [0,1]，max<=0 返回 0（除零保护）
+//
+class ScrollSync
+{
+public:
+    // 由 QScrollBar 的 value/min/max 计算 ratio，钳制 [0,1]
+    static double ratioFromScrollBar(int value, int min, int max)
+    {
+        if (max <= min) return 0.0;
+        double r = double(value - min) / double(max - min);
+        return clampRatio(r);
+    }
+
+    // 钳制到 [0,1]
+    static double clampRatio(double ratio)
+    {
+        if (ratio < 0.0) return 0.0;
+        if (ratio > 1.0) return 1.0;
+        return ratio;
+    }
+};
+
+#endif // SCROLLSYNC_H

--- a/src/editor/markdown/themeserializer.h
+++ b/src/editor/markdown/themeserializer.h
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: 2026 UnionCTechnology Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef THEMESERIALIZER_H
+#define THEMESERIALIZER_H
+
+#include <QColor>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QString>
+#include <QVariantMap>
+
+//
+// ThemeSerializer —— 主题序列化（纯函数，§4.7 / §5'.3）
+//
+// 把 Utils::getThemeMapFromName 返回的 QVariantMap themeMap 派生为：
+//   1. 深浅色判定（背景色 lightness < 128 → 深色）
+//   2. CSS 变量 JSON（注入到渲染区 :root，供 theme.css 引用）
+//
+class ThemeSerializer
+{
+public:
+    // 深浅色判定：themeMap["editor-colors"]["background-color"] 的 lightness < 128 → true
+    static bool isDark(const QVariantMap &themeMap)
+    {
+        QColor bg = backgroundColor(themeMap);
+        if (!bg.isValid()) return false;
+        return bg.lightness() < 128;
+    }
+
+    // 序列化为 CSS 变量 JSON，供 JS applyTheme 注入到 document.documentElement.style
+    static QString serialize(const QVariantMap &themeMap)
+    {
+        QColor bg = backgroundColor(themeMap);
+        QColor fg = foregroundColor(themeMap);
+
+        QJsonObject obj;
+        obj["--bg"] = bg.isValid() ? bg.name() : QStringLiteral("#ffffff");
+        obj["--fg"] = fg.isValid() ? fg.name() : QStringLiteral("#1f1f1f");
+        obj["--fg-secondary"] = fg.isValid() ? fg.darker(180).name() : QStringLiteral("#595959");
+        // 代码块前景：跟随正文前景色（缺省时 theme.css 的浅色默认值会在深色主题下不可读）
+        obj["--code-fg"] = fg.isValid() ? fg.name() : QStringLiteral("#1f1f1f");
+        // 代码块背景：略深于正文背景
+        obj["--code-bg"] = bg.isValid() ? bg.darker(110).name() : QStringLiteral("#f5f5f5");
+        obj["--border"] = bg.isValid() ? bg.darker(130).name() : QStringLiteral("#e0e0e0");
+
+        return QString::fromUtf8(QJsonDocument(obj).toJson(QJsonDocument::Compact));
+    }
+
+private:
+    static QColor backgroundColor(const QVariantMap &themeMap)
+    {
+        auto ec = themeMap.value(QStringLiteral("editor-colors")).toMap();
+        return QColor(ec.value(QStringLiteral("background-color")).toString());
+    }
+    static QColor foregroundColor(const QVariantMap &themeMap)
+    {
+        auto ec = themeMap.value(QStringLiteral("editor-colors")).toMap();
+        return QColor(ec.value(QStringLiteral("text-color")).toString());
+    }
+};
+
+#endif // THEMESERIALIZER_H

--- a/src/editor/markdown/viewmode.h
+++ b/src/editor/markdown/viewmode.h
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef VIEWMODE_H
+#define VIEWMODE_H
+
+#include <QMetaType>
+
+//
+// ViewMode —— 编辑器视图模式枚举
+//
+// 阶段一（本期）实际使用：Edit / ReadView / LivePreview
+// Wysiwyg 为阶段二（WYSIWYG 富文本编辑）预留，本期不可达（ViewModeFsm 拒绝切换）。
+//
+enum class ViewMode {
+    Edit,         // 编辑视图（纯文本源码，现状）
+    ReadView,     // 查看视图（md：Milkdown 只读渲染；非 md：TextEdit 只读）
+    LivePreview,  // 实时阅览（左源码 + 右只读渲染，md 专属）
+    Wysiwyg       // 【预留】阶段二单面板所见即所得编辑
+};
+
+Q_DECLARE_METATYPE(ViewMode)
+
+#endif // VIEWMODE_H

--- a/src/editor/markdown/viewmodefsm.h
+++ b/src/editor/markdown/viewmodefsm.h
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef VIEWMODEFSM_H
+#define VIEWMODEFSM_H
+
+#include "viewmode.h"
+
+//
+// ViewModeFsm —— 视图模式判定/切换合法性/置灰规则（纯函数，无 QWidget 依赖，100% 可测）
+//
+// 落地需求（§4.4 模式判定规则，2026-08-04 细化）：
+//   - 入口始终显示（含新建 .txt）
+//   - 非 md 文件下仅「实时预览」置灰，「编辑模式」「查看视图」可用
+//   - md 文件默认 LivePreview；其他默认 Edit
+//   - 语言切为 Markdown 时 Edit 自动跃迁 LivePreview（2026-08-19，对齐 md 默认视图）；
+//     语言切走时 LivePreview 回退 Edit（对称）
+//   - 「查看视图」在非 md 下走纯文本只读（沿用原只读模式语义），md 下走 Milkdown 渲染
+//   - Wysiwyg 为阶段二预留，本期不可达
+//
+class ViewModeFsm
+{
+public:
+    // 默认视图：md → LivePreview，非 md → Edit
+    static ViewMode resolveDefaultMode(bool isMarkdown)
+    {
+        return isMarkdown ? ViewMode::LivePreview : ViewMode::Edit;
+    }
+
+    // 入口可用性（置灰规则）
+    static bool isLivePreviewAvailable(bool isMarkdown) { return isMarkdown; }
+    static bool isEditViewAvailable(bool) { return true; }
+    static bool isReadViewAvailable(bool) { return true; }
+
+    // 切换合法性：任意文件可切 Edit/ReadView；仅 md 可切 LivePreview；Wysiwyg 阶段二不可达
+    static bool canSwitchTo(ViewMode target, bool isMarkdown)
+    {
+        switch (target) {
+        case ViewMode::Edit:
+        case ViewMode::ReadView:
+            return true;
+        case ViewMode::LivePreview:
+            return isMarkdown;
+        case ViewMode::Wysiwyg:
+            return false;   // 阶段二预留
+        }
+        return false;
+    }
+
+    // 语言切走（md → 非 md）时的回退：LivePreview 退回 Edit，ReadView/Edit 保持
+    static ViewMode fallbackWhenMarkdownLost(ViewMode current)
+    {
+        if (current == ViewMode::LivePreview) return ViewMode::Edit;
+        return current;   // Edit/ReadView 不受影响（ReadView 对非 md 是纯文本只读）
+    }
+
+    // 语言切到（非 md → md）时的跃迁：Edit 自动切入 LivePreview（对齐「md 默认实时预览」，
+    // 2026-08-19 需求：新建文件手动切语言为 Markdown 即入实时预览）；
+    // ReadView/LivePreview 保持（ReadView 仅切换实现：渲染页 ↔ 纯文本只读）
+    static ViewMode elevateWhenMarkdownGained(ViewMode current)
+    {
+        if (current == ViewMode::Edit) return ViewMode::LivePreview;
+        return current;
+    }
+
+    // 「查看视图」是否走纯文本只读（ReadView + 非 md）：是则 EditWrapper 仅置 TextEdit 只读，不进渲染页
+    static bool isReadOnlyTextMode(ViewMode mode, bool isMarkdown)
+    {
+        return mode == ViewMode::ReadView && !isMarkdown;
+    }
+};
+
+#endif // VIEWMODEFSM_H


### PR DESCRIPTION
Add QWidget-free logic units: ViewModeFsm for mode transition rules, MarkdownLogic for recognition and mdimg image path rewrite, RenderThrottle for 300ms leading-plus-trailing content throttle, ScrollSync for ratio clamp, ThemeSerializer for CSS variable mapping. Add MarkdownBridge WebChannel protocol object and IMarkdownRenderer interface for DI tests.

新增无 QWidget 依赖的纯逻辑层：ViewModeFsm 视图模式状态规则、
MarkdownLogic 识别与 mdimg 图片路径改写、RenderThrottle 300ms 节流 （前沿立即+后沿补发）、ScrollSync 比例钳制、ThemeSerializer 主题变量
序列化；MarkdownBridge 通信协议对象与 IMarkdownRenderer 注入接口。

Log: 新增 Markdown 渲染纯逻辑层与桥接协议
PMS: TASK-393979
Influence: 为三视图编排/渲染服务层提供可单测的判定与同步逻辑。

## Summary by Sourcery

Introduce a testable pure-logic layer and bridge interfaces for Markdown view-mode orchestration and rendering.

New Features:
- Add QWidget-free Markdown decision, rendering, synchronization, and theme logic that can be unit tested independently.
- Add a WebChannel bridge protocol and renderer abstraction for Markdown view integration and dependency-injection testing.

Enhancements:
- Define view-mode availability and transition rules for Markdown and non-Markdown documents, including reserved WYSIWYG behavior.
- Support Markdown recognition, local image URL rewriting, bounded scroll synchronization, theme CSS-variable serialization, and leading-plus-trailing render throttling.

Tests:
- Provide pure logic components and an injectable renderer interface to enable tests without starting WebEngine or QWidget-based views.