### PR TITLE
chore(debian): add qt6-webengine-dev to build dependencies

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -13,6 +13,7 @@ Build-Depends:
  qt6-tools-dev,
  qt6-base-private-dev,
  qt6-svg-dev,
+ qt6-webengine-dev,
  libdtk6widget-dev,
  libdtk6gui-dev,
  libdtk6core-dev,


### PR DESCRIPTION
The markdown render feature requires WebEngineWidgets and WebChannel Qt components (find_package REQUIRED in src and tests CMake), which are provided by qt6-webengine-dev; without it deb builds fail at configure stage.

Markdown 渲染功能依赖 WebEngineWidgets 与 WebChannel Qt 组件 （src/tests 的 CMake 中 find_package REQUIRED），由 qt6-webengine-dev 提供；缺失时 deb 构建在 configure 阶段失败。

Log: 补充 deb 构建依赖 qt6-webengine-dev
PMS: TASK-393979
Influence: deb 构建可正常配置；运行期 webengine 由 shlibs 自动依赖。

## Summary by Sourcery

Add the missing Qt WebEngine development dependency to Debian packaging so markdown rendering builds configure successfully.

Bug Fixes:
- Ensure Debian packages can configure and build successfully by declaring the Qt WebEngine development dependency required by the markdown rendering components.

Build:
- Add qt6-webengine-dev to the Debian build dependencies.