### PR TITLE
feat(markdown): add milkdown web renderer source

### DIFF
--- a/src/editor/markdown/web/bridge.js
+++ b/src/editor/markdown/web/bridge.js
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// bridge.js —— QWebChannel 双向通信胶水
+//
+// 协议（与 C++ MarkdownBridge 一一对应）：
+//   C++ → JS：bridge.{signal}.connect(fn)
+//   JS → C++：bridge.onReady/onContentChanged/onScrollRatio/onOpenLink(...)
+//
+// 提供 setupBridge(handlers) 供 main.js 调用，在 QWebChannel 就绪后连接信号。
+
+let bridgeReady = false;
+let pendingHandlers = null;
+
+function initChannel() {
+    if (typeof QWebChannel === "undefined") {
+        // WebChannel 未注入（非 QWebEngine 宿主，如本地浏览器调试），降级
+        console.warn("QWebChannel unavailable; running in standalone mode");
+        if (pendingHandlers) pendingHandlers.standalone && pendingHandlers.standalone();
+        return;
+    }
+    // eslint-disable-next-line no-undef
+    new QWebChannel(qt.webChannelTransport, function (channel) {
+        window.bridge = channel.objects.bridge;
+        bridgeReady = true;
+        if (pendingHandlers) wireSignals(pendingHandlers);
+    });
+}
+
+function wireSignals(h) {
+    const b = window.bridge;
+    if (!b) return;
+    b.setMarkdownRequested.connect(function (md) { h.onSetMarkdown(md); });
+    b.setModeRequested.connect(function (editable) { h.onSetMode(editable); });
+    b.applyThemeRequested.connect(function (json, isDark) { h.onApplyTheme(json, isDark); });
+    b.setLayoutRequested.connect(function (maxW, center) { h.onSetLayout(maxW, center); });
+    b.scrollToRatioRequested.connect(function (ratio) { h.onScrollToRatio(ratio); });
+}
+
+// 供 main.js 调用：注册 C++→JS 信号处理器
+export function setupBridge(handlers) {
+    pendingHandlers = handlers;
+    if (bridgeReady) wireSignals(handlers);
+}
+
+initChannel();

--- a/src/editor/markdown/web/main.js
+++ b/src/editor/markdown/web/main.js
@@ -1,0 +1,177 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// main.js —— Milkdown 实例装配（移植自 uos-ai MarkdownEditor.tsx，去 Vue 包装，裸挂载）
+//
+// 插件链顺序与 uos-ai 一致：
+//   commonmark → gfm → history → indent → listener → clipboard → mathPlugins
+// 本期固定 editable:false（只读预览）。阶段二切 editable:true 即得 WYSIWYG。
+
+import { Editor, rootCtx, defaultValueCtx, editorViewOptionsCtx } from "@milkdown/kit/core";
+import { commonmark } from "@milkdown/kit/preset/commonmark";
+import { gfm } from "@milkdown/kit/preset/gfm";
+import { history } from "@milkdown/kit/plugin/history";
+import { indent } from "@milkdown/kit/plugin/indent";
+import { listener, listenerCtx } from "@milkdown/kit/plugin/listener";
+import { clipboard } from "@milkdown/kit/plugin/clipboard";
+import { replaceAll } from "@milkdown/kit/utils";
+import { mathPlugins, normalizeMathDelimiters } from "./milkdownMathPlugins.js";
+import { setupBridge } from "./bridge.js";
+import { enhance } from "./renderEnhancer.js";
+
+import "katex/dist/katex.min.css";
+import "./theme.css";
+
+const ROOT_ID = "app";
+let editor = null;
+let lastValue = "";
+
+// —— C++ → JS 处理器 ——
+let lastRequestedRatio = 0;   // 最近一次 C++ 请求的滚动比例；重渲染后重放（§4.6 初始对齐）
+
+function renderMarkdown(md) {
+    if (!editor) return;
+    const normalized = normalizeMathDelimiters(md == null ? "" : String(md));
+    if (normalized === lastValue) return;
+    lastValue = normalized;
+    editor.action(replaceAll(normalized));
+    // 重渲染后做静态后处理（表格包裹等）并重放滚动比例：
+    // 首次渲染完成前 scrollToRatio 因 max=0 被跳过，此处对齐左右初始位置
+    const rootEl = document.getElementById(ROOT_ID);
+    setTimeout(() => {
+        enhance(rootEl);
+        reapplyScroll();
+    }, 0);
+}
+
+function reapplyScroll() {
+    const max = document.documentElement.scrollHeight - window.innerHeight;
+    if (max > 0) {
+        __programmaticScroll = true;
+        window.scrollTo(0, lastRequestedRatio * max);
+        setTimeout(() => { __programmaticScroll = false; }, 0);
+    }
+}
+
+function applyTheme(jsonColors, isDark) {
+    try {
+        const colors = JSON.parse(jsonColors || "{}");
+        const root = document.documentElement;
+        for (const [k, v] of Object.entries(colors)) {
+            root.style.setProperty(k, v);
+        }
+        root.setAttribute("data-theme", isDark ? "dark" : "light");
+    } catch (e) {
+        console.error("applyTheme failed:", e);
+    }
+}
+
+function applyLayout(maxContentWidth, center) {
+    const root = document.documentElement;
+    root.style.setProperty("--content-max-width", maxContentWidth > 0 ? maxContentWidth + "px" : "none");
+    root.style.setProperty("--content-center", center ? "1" : "0");
+}
+
+function scrollToRatio(ratio) {
+    // §4.6 滚动到比例（0~1）
+    // 根因修复：ProseMirror 元素本身不可滚动（无 overflow:auto），页面滚动在 window/documentElement。
+    ratio = Math.max(0, Math.min(1, ratio));
+    lastRequestedRatio = ratio;
+    const max = document.documentElement.scrollHeight - window.innerHeight;
+    console.log("[md] scrollToRatio", ratio, "max", max);
+    if (max > 0) {
+        // 标记来自 C++ 的程序触发，window scroll 事件里跳过反向通知
+        __programmaticScroll = true;
+        window.scrollTo(0, ratio * max);
+        setTimeout(() => { __programmaticScroll = false; }, 0);
+    }
+}
+
+// 右栏用户滚动 → 通知 C++（反向同步）
+let __programmaticScroll = false;
+let __lastNotifiedRatio = -1;
+window.addEventListener("scroll", () => {
+    if (__programmaticScroll) return;
+    const max = document.documentElement.scrollHeight - window.innerHeight;
+    if (max <= 0) return;
+    const ratio = Math.max(0, Math.min(1, window.scrollY / max));
+    // 钳制微小抖动
+    if (Math.abs(ratio - __lastNotifiedRatio) < 0.001) return;
+    __lastNotifiedRatio = ratio;
+    if (window.bridge && typeof window.bridge.onScrollRatio === "function") {
+        window.bridge.onScrollRatio(ratio);
+    }
+}, { passive: true });
+
+// 外部链接拦截：http/https 链接不在预览内导航，经 bridge.onOpenLink → C++ QDesktopServices
+// 转系统浏览器打开（捕获阶段先行，preventDefault 阻止 Chromium 导航；页内锚点 # 不受影响）
+document.addEventListener("click", (event) => {
+    const target = event.target;
+    const anchor = target && target.closest ? target.closest("a[href]") : null;
+    if (!anchor) return;
+    const href = anchor.href || "";
+    if (!/^https?:\/\//i.test(href)) return;
+    event.preventDefault();
+    event.stopPropagation();
+    if (window.bridge && typeof window.bridge.onOpenLink === "function") {
+        window.bridge.onOpenLink(href);
+    } else {
+        console.warn("[md] bridge unavailable, external link not opened:", href);
+    }
+}, true);
+
+// 启动 Milkdown
+async function boot() {
+    const rootEl = document.getElementById(ROOT_ID);
+    editor = await Editor.make()
+        .config((ctx) => {
+            ctx.set(rootCtx, rootEl);
+            ctx.set(defaultValueCtx, "");
+            ctx.update(editorViewOptionsCtx, (prev) => ({
+                ...prev,
+                editable: () => false,
+                attributes: { class: "milkdown-read-only" },
+            }));
+            ctx.get(listenerCtx).markdownUpdated((_ctx, markdown) => {
+                // 预留：阶段二编辑模式回写源码
+                if (window.bridge && typeof window.bridge.onContentChanged === "function") {
+                    window.bridge.onContentChanged(markdown);
+                }
+            });
+        })
+        .use(commonmark)
+        .use(gfm)
+        .use(history)
+        .use(indent)
+        .use(listener)
+        .use(clipboard)
+        .use(mathPlugins)
+        .create();
+
+    setupBridge({
+        onSetMarkdown: renderMarkdown,
+        onSetMode: () => { /* 阶段二 */ },
+        onApplyTheme: applyTheme,
+        onSetLayout: applyLayout,
+        onScrollToRatio: scrollToRatio,
+    });
+
+    console.log("[md] boot done, bridge=", typeof window.bridge, "onReady=", window.bridge ? typeof window.bridge.onReady : "n/a");
+    if (window.bridge && typeof window.bridge.onReady === "function") {
+        window.bridge.onReady();
+    } else {
+        // bridge 尚未就绪（QWebChannel 回调竞态），延迟重试
+        const retry = () => {
+            if (window.bridge && typeof window.bridge.onReady === "function") {
+                window.bridge.onReady();
+                console.log("[md] ready notified (after retry)");
+            } else {
+                setTimeout(retry, 50);
+            }
+        };
+        setTimeout(retry, 50);
+    }
+}
+
+boot().catch((e) => console.error("Milkdown boot failed:", e));

--- a/src/editor/markdown/web/milkdown.html
+++ b/src/editor/markdown/web/milkdown.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<!--
+  SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+  SPDX-License-Identifier: GPL-3.0-or-later
+-->
+<html lang="zh-CN">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Markdown Preview</title>
+    <link rel="stylesheet" href="./build/style.css">
+    <script src="./qwebchannel.js"></script>
+</head>
+<body>
+    <div id="app"></div>
+    <script src="./build/main.bundle.js"></script>
+</body>
+</html>

--- a/src/editor/markdown/web/milkdownMathPlugins.js
+++ b/src/editor/markdown/web/milkdownMathPlugins.js
@@ -1,0 +1,115 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// milkdownMathPlugins.js —— Milkdown 数学公式插件
+//
+// 移植自 uos-ai milkdownMathPlugins.ts，去除 TypeScript 类型注解。
+// 基于 remark-math + KaTeX 实现行内公式（$...$）和块级公式（$$...$$）。
+// 提供 normalizeMathDelimiters() 将 LLM 常见的 \(...\)/\[...\] 转为 $...$/$$...$$。
+
+import katex from "katex";
+import remarkMath from "remark-math";
+import { $remark, $nodeSchema, $inputRule } from "@milkdown/kit/utils";
+import { nodeRule } from "@milkdown/kit/prose";
+import { InputRule } from "@milkdown/kit/prose/inputrules";
+
+/* ==================== LaTeX 定界符规范化 ==================== */
+export function normalizeMathDelimiters(markdown) {
+    let result = markdown.replace(/\\\[([\s\S]*?)\\\]/g, (_m, content) => `$$${content}$$`);
+    result = result.replace(/\\\((.+?)\\\)/g, (_m, content) => `$${content}$`);
+    return result;
+}
+
+/* ==================== remark-math 解析插件 ==================== */
+const remarkMathPlugin = $remark("remarkMath", () => remarkMath);
+
+/* ==================== 行内公式 $...$ ==================== */
+const MATH_INLINE_ID = "math_inline";
+const mathInlineSchema = $nodeSchema(MATH_INLINE_ID, () => ({
+    group: "inline",
+    inline: true,
+    atom: true,
+    attrs: { value: { default: "" } },
+    parseDOM: [{
+        tag: `span[data-type="${MATH_INLINE_ID}"]`,
+        getAttrs: (dom) => ({ value: dom.dataset.value ?? "" }),
+    }],
+    toDOM: (node) => {
+        const code = node.attrs.value;
+        const dom = document.createElement("span");
+        dom.dataset.type = MATH_INLINE_ID;
+        dom.dataset.value = code;
+        dom.classList.add("math-inline");
+        try { katex.render(code, dom, { throwOnError: false }); }
+        catch { dom.textContent = code; }
+        return dom;
+    },
+    parseMarkdown: {
+        match: (node) => node.type === "inlineMath",
+        runner: (state, node, type) => { state.addNode(type, { value: node.value }); },
+    },
+    toMarkdown: {
+        match: (node) => node.type.name === MATH_INLINE_ID,
+        runner: (state, node) => { state.addNode("inlineMath", undefined, node.attrs.value); },
+    },
+}));
+const mathInlineInputRule = $inputRule((ctx) =>
+    nodeRule(/(?<!\$)\$([^$\n]+)\$(?!\$)$/, mathInlineSchema.type(ctx), {
+        getAttr: (m) => ({ value: m[1] ?? "" }),
+    }),
+);
+
+/* ==================== 块级公式 $$...$$ ==================== */
+const MATH_BLOCK_ID = "math_block";
+const mathBlockSchema = $nodeSchema(MATH_BLOCK_ID, () => ({
+    group: "block",
+    atom: true,
+    attrs: { value: { default: "" } },
+    parseDOM: [{
+        tag: `div[data-type="${MATH_BLOCK_ID}"]`,
+        getAttrs: (dom) => ({ value: dom.dataset.value ?? "" }),
+    }],
+    toDOM: (node) => {
+        const code = node.attrs.value || "";
+        const wrapper = document.createElement("div");
+        wrapper.dataset.type = MATH_BLOCK_ID;
+        wrapper.dataset.value = code;
+        wrapper.classList.add("math-block");
+        if (code.trim()) {
+            const preview = document.createElement("div");
+            preview.classList.add("math-block__preview");
+            try { katex.render(code, preview, { throwOnError: false, displayMode: true }); }
+            catch { preview.textContent = code; }
+            wrapper.appendChild(preview);
+        }
+        return wrapper;
+    },
+    parseMarkdown: {
+        match: (node) => node.type === "math",
+        runner: (state, node, type) => { state.addNode(type, { value: (node.value) || "" }); },
+    },
+    toMarkdown: {
+        match: (node) => node.type.name === MATH_BLOCK_ID,
+        runner: (state, node) => { state.addNode("math", undefined, (node.attrs.value) || ""); },
+    },
+}));
+const mathBlockInputRule = $inputRule((ctx) =>
+    new InputRule(/^\$\$((?:[^$\n]|\$(?!\$))+)\$\$$/, (state, match, start, end) => {
+        const value = (match[1] ?? "").trim();
+        if (!value) return null;
+        const type = mathBlockSchema.type(ctx);
+        const $from = state.doc.resolve(start);
+        const blockFrom = $from.before($from.depth);
+        const blockTo = $from.after($from.depth);
+        return state.tr.replaceWith(blockFrom, blockTo, type.create({ value }));
+    }),
+);
+
+export const mathPlugins = [
+    ...remarkMathPlugin,
+    ...mathInlineSchema,
+    ...mathBlockSchema,
+    mathInlineInputRule,
+    mathBlockInputRule,
+];

--- a/src/editor/markdown/web/package.json
+++ b/src/editor/markdown/web/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "deepin-editor-markdown-web",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Markdown rendering kernel (Milkdown) for deepin-editor, embedded via QWebEngine",
+  "scripts": {
+    "build": "vite build",
+    "dev": "vite build --watch"
+  },
+  "dependencies": {
+    "@milkdown/kit": "~7.20.0",
+    "katex": "~0.16.0",
+    "remark-math": "~6.0.0",
+    "highlight.js": "~11.11.1"
+  },
+  "devDependencies": {
+    "vite": "~5.4.0"
+  }
+}

--- a/src/editor/markdown/web/renderEnhancer.js
+++ b/src/editor/markdown/web/renderEnhancer.js
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: 2026 UnionCTechnology Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// renderEnhancer.js —— 渲染后处理（静态部分）
+//
+// §4.8.8：在 Milkdown 默认 DOM 之上做无副作用的幂等加工，为 CSS 容器查询提供挂载点。
+// 交互部分（粘性表头/复制按钮/图片右键菜单）阶段 3.5 启用。
+
+const TABLE_WRAPPER_CLASS = "table-wrapper";
+
+// 把每个 <table> 包裹进 .table-wrapper（横向滚动容器 + 容器查询锚点）
+// 幂等：已包裹的表格跳过
+export function wrapTables(root) {
+    if (!root) return;
+    const tables = root.querySelectorAll("table");
+    tables.forEach((table) => {
+        if (table.parentElement && table.parentElement.classList.contains(TABLE_WRAPPER_CLASS)) return;
+        const wrapper = document.createElement("div");
+        wrapper.className = TABLE_WRAPPER_CLASS;
+        table.parentNode.insertBefore(wrapper, table);
+        wrapper.appendChild(table);
+    });
+}
+
+// 统一入口：每次 Milkdown 重渲染后执行一次
+export function enhance(root) {
+    wrapTables(root);
+}

--- a/src/editor/markdown/web/theme.css
+++ b/src/editor/markdown/web/theme.css
@@ -1,0 +1,142 @@
+/* SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd. */
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+
+/* theme.css —— Milkdown 渲染区主题（§4.8 视觉规范） */
+
+:root {
+    --bg: #ffffff;
+    --fg: #1f1f1f;
+    --fg-secondary: #595959;
+    --code-bg: #f5f5f5;
+    --code-fg: #1f1f1f;
+    --border: #e0e0e0;
+    --content-max-width: 800px;
+    --content-center: 1;
+}
+
+html, body {
+    margin: 0;
+    padding: 0;
+    background: var(--bg);
+    color: var(--fg);
+    font-family: "Noto Sans CJK SC", "PingFang SC", "Microsoft YaHei", sans-serif;
+    font-size: 14px;
+    line-height: 1.6;
+}
+
+/* §4.8.1 内容区布局：800px 居中 + 20px 边距 */
+/* 居中由 max-width + margin:auto 完成；padding 用固定 20px。
+   不可写 max(20px, calc((100% - 800px)/2))：百分比 padding 相对包含块（视口）解析，
+   与元素自身 max-width 叠加会把内容宽压成负值（最大化时内容被挤压成极窄列） */
+#app {
+    max-width: var(--content-max-width);
+    margin: 0 auto;
+    padding-left: 20px;
+    padding-right: 20px;
+    box-sizing: border-box;
+}
+
+/* §4.8.2 字号字重 */
+.milkdown h1 { font-size: 26px; font-weight: 700; margin: 1em 0 0.5em; }
+.milkdown h2 { font-size: 22px; font-weight: 700; margin: 1em 0 0.5em; }
+.milkdown h3 { font-size: 18px; font-weight: 700; margin: 1em 0 0.5em; }
+.milkdown h4 { font-size: 16px; font-weight: 700; margin: 1em 0 0.5em; }
+.milkdown h5 { font-size: 14px; font-weight: 700; margin: 1em 0 0.5em; }
+.milkdown h6 { font-size: 13px; font-weight: 700; margin: 1em 0 0.5em; }
+
+/* 正文 14px normal，继承 body */
+.milkdown p, .milkdown li, .milkdown td, .milkdown th { font-size: 14px; font-weight: 400; }
+
+/* §4.8.3 说明文字 12px / normal / opacity 0.7 */
+.milkdown blockquote,
+.milkdown figcaption,
+.milkdown .footnote,
+.milkdown .image-caption {
+    font-size: 12px;
+    font-weight: 400;
+    opacity: 0.7;
+}
+
+/* 深色主题下用 fg-secondary 替代纯 opacity，保证可读性 */
+[data-theme="dark"] .milkdown blockquote,
+[data-theme="dark"] .milkdown figcaption,
+[data-theme="dark"] .milkdown .footnote,
+[data-theme="dark"] .milkdown .image-caption {
+    opacity: 1;
+    color: var(--fg-secondary);
+}
+
+/* blockquote 引用样式 */
+.milkdown blockquote {
+    border-left: 3px solid var(--border);
+    padding: 0.5em 1em;
+    margin: 1em 0;
+    background: transparent;
+}
+
+/* §4.8.5 表格 */
+.table-wrapper { container-type: inline-size; overflow-x: auto; }
+.table-wrapper table { width: 100%; border-collapse: collapse; margin: 1em 0; }
+.table-wrapper td, .table-wrapper th {
+    min-width: 100px;
+    max-width: 240px;
+    height: 46px;
+    padding: 0 20px;
+    text-align: left;
+    vertical-align: middle;
+    word-break: break-word;
+    white-space: normal;
+    border: 1px solid var(--border);
+    box-sizing: border-box;
+}
+.table-wrapper th { font-weight: 700; }
+@container (max-width: 600px) {
+    .table-wrapper td, .table-wrapper th { max-width: 180px; }
+}
+
+/* §4.8.6 代码块 */
+.milkdown pre {
+    background: var(--code-bg);
+    color: var(--code-fg);
+    border-radius: 6px;
+    padding: 12px 16px;
+    overflow-x: auto;
+    font-family: "Noto Sans Mono", "DejaVu Sans Mono", "Courier New", monospace;
+    font-size: 13px;
+    line-height: 1.5;
+    margin: 1em 0;
+}
+.milkdown pre code { background: transparent; padding: 0; }
+.milkdown :not(pre) > code {
+    background: var(--code-bg);
+    padding: 2px 6px;
+    border-radius: 3px;
+    font-family: "Noto Sans Mono", "DejaVu Sans Mono", "Courier New", monospace;
+    font-size: 0.9em;
+}
+
+/* §4.8.7 图片 */
+.milkdown img {
+    display: block;
+    max-width: 258px;
+    max-height: 400px;
+    border-radius: 10px;
+    background: rgba(255, 255, 255, 0.3);
+    object-fit: contain;
+    margin: 1em 0;
+}
+
+/* 链接 */
+.milkdown a { color: #1a73e8; text-decoration: none; }
+.milkdown a:hover { text-decoration: underline; }
+
+/* 分割线 */
+.milkdown hr { border: none; border-top: 1px solid var(--border); margin: 2em 0; }
+
+/* 任务列表 */
+.milkdown ul:has(input[type="checkbox"]), .milkdown ol:has(input[type="checkbox"]) { list-style: none; padding-left: 1.5em; }
+.milkdown li:has(input[type="checkbox"]) { display: flex; align-items: center; gap: 8px; }
+
+/* 只读模式去除编辑光标 */
+.milkdown .ProseMirror { outline: none; caret-color: transparent; }
+.milkdown-read-only .ProseMirror { cursor: default; }

--- a/src/editor/markdown/web/vite.config.js
+++ b/src/editor/markdown/web/vite.config.js
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// vite.config.js —— 打包 Milkdown 为 IIFE 单文件，供 QWebEngine qrc 加载
+import { defineConfig } from "vite";
+import { resolve } from "path";
+
+export default defineConfig({
+    build: {
+        lib: {
+            entry: resolve(__dirname, "main.js"),
+            name: "DeepinMarkdownRenderer",
+            fileName: () => "main.bundle.js",
+            formats: ["iife"],
+        },
+        outDir: "build",
+        emptyOutDir: true,
+        minify: false,
+        rollupOptions: {
+            output: {
+                inlineDynamicImports: true,
+            },
+        },
+    },
+});


### PR DESCRIPTION
Add hand-written web kernel sources: milkdown.html host page, main.js assembling Milkdown 7.x read-only editor with commonmark/gfm/math chain, bridge.js QWebChannel glue, theme.css with CSS variable theming, math plugins ported from uos-ai, renderEnhancer post-processing and vite config to bundle the kernel into a single IIFE for qrc embedding.

新增手写 web 内核源码：milkdown.html 宿主页、main.js 装配 Milkdown 7.x 只读编辑器（commonmark/gfm/数学公式插件链）、bridge.js 通道胶水、
theme.css 变量主题、移植自 uos-ai 的数学插件、renderEnhancer 渲染后 处理与 vite 打包配置（产出 qrc 内嵌的单文件 IIFE bundle）。

Log: 新增 Milkdown 渲染 web 内核手写源码
PMS: TASK-393979
Influence: 渲染区语法支持（表格/代码高亮/任务列表/公式）由本层提供。

## Summary by Sourcery

Introduce an embeddable Milkdown web kernel for rendering feature-rich Markdown previews in the editor.

New Features:
- Add a Milkdown-based read-only Markdown web renderer with CommonMark, GFM, task list, code, and mathematical expression support.
- Add QWebChannel integration for Markdown updates, theming, layout, scroll synchronization, readiness notifications, and external link handling.

Enhancements:
- Add configurable CSS-variable theming and responsive content, table, code block, image, and typography styling.
- Add post-render table wrapping and LaTeX delimiter normalization for the preview output.

Build:
- Add Vite configuration and package metadata to bundle the renderer as a single IIFE for QWebEngine resource embedding.