### PR TITLE
feat(markdown): add view-mode entries in context menu and bottom bar

### DIFF
--- a/src/editor/dtextedit.cpp
+++ b/src/editor/dtextedit.cpp
@@ -18,6 +18,7 @@
 #include "changemarkcommand.h"
 #include "endlineformatcommond.h"
 #include <QSet>
+#include <QActionGroup>
 #include <algorithm>
 
 #include <KSyntaxHighlighting/definition.h>
@@ -404,10 +405,13 @@ void TextEdit::initRightClickedMenu()
     m_replaceAction->setObjectName("Replace");
     m_jumpLineAction = new QAction(tr("Go to Line"), this);
     m_jumpLineAction->setObjectName("GoToLine");
-    m_enableReadOnlyModeAction = new QAction(tr("Turn on Read-Only mode"), this);
-    m_enableReadOnlyModeAction->setObjectName("EnableReadOnly");
-    m_disableReadOnlyModeAction = new QAction(tr("Turn off Read-Only mode"), this);
-    m_disableReadOnlyModeAction->setObjectName("DisableReadOnly");
+    // 右键菜单「视图模式」二级菜单（§8.1，替换原只读模式互斥项；原语义并入「查看视图」）
+    m_actEditView = new QAction(tr("Edit Mode"), this);
+    m_actEditView->setObjectName("EditView");
+    m_actReadView = new QAction(tr("Read View"), this);
+    m_actReadView->setObjectName("ReadView");
+    m_actLivePreview = new QAction(tr("Live Preview"), this);
+    m_actLivePreview->setObjectName("LivePreview");
     m_fullscreenAction = new QAction(tr("Fullscreen"), this);
     m_fullscreenAction->setObjectName("Fullscreen");
     m_exitFullscreenAction = new QAction(tr("Exit fullscreen"), this);
@@ -506,8 +510,6 @@ void TextEdit::initRightClickedMenu()
     connect(m_jumpLineAction, &QAction::triggered, this, &TextEdit::clickJumpLineAction);
     connect(m_fullscreenAction, &QAction::triggered, this, &TextEdit::clickFullscreenAction);
     connect(m_exitFullscreenAction, &QAction::triggered, this, &TextEdit::clickFullscreenAction);
-    connect(m_enableReadOnlyModeAction, &QAction::triggered, this, &TextEdit::toggleReadOnlyMode);
-    connect(m_disableReadOnlyModeAction, &QAction::triggered, this, &TextEdit::toggleReadOnlyMode);
     connect(m_openInFileManagerAction, &QAction::triggered, this, &TextEdit::slotOpenInFileManagerAction);
     connect(m_addComment, &QAction::triggered, this, &TextEdit::slotAddComment);
     connect(m_cancelComment, &QAction::triggered, this, &TextEdit::slotCancelComment);
@@ -536,6 +538,25 @@ void TextEdit::initRightClickedMenu()
     m_convertCaseMenu->addAction(m_upcaseAction);
     m_convertCaseMenu->addAction(m_downcaseAction);
     m_convertCaseMenu->addAction(m_capitalizeAction);
+
+    // Init view mode sub menu（§8.1：三子项互斥可选；默认「编辑模式」选中、「实时预览」置灰）
+    m_viewModeMenu = new DMenu(tr("View Mode"), this);
+    QActionGroup *pViewModeGroup = new QActionGroup(this);
+    m_actEditView->setCheckable(true);
+    m_actReadView->setCheckable(true);
+    m_actLivePreview->setCheckable(true);
+    m_actEditView->setData(static_cast<int>(ViewMode::Edit));
+    m_actReadView->setData(static_cast<int>(ViewMode::ReadView));
+    m_actLivePreview->setData(static_cast<int>(ViewMode::LivePreview));
+    pViewModeGroup->addAction(m_actEditView);
+    pViewModeGroup->addAction(m_actReadView);
+    pViewModeGroup->addAction(m_actLivePreview);
+    m_viewModeMenu->addActions(pViewModeGroup->actions());
+    m_actEditView->setChecked(true);
+    m_actLivePreview->setEnabled(false);   // 初始非 md：仅「实时预览」置灰
+    connect(m_actEditView, &QAction::triggered, this, [this]() { emit viewModeRequested(ViewMode::Edit); });
+    connect(m_actReadView, &QAction::triggered, this, [this]() { emit viewModeRequested(ViewMode::ReadView); });
+    connect(m_actLivePreview, &QAction::triggered, this, [this]() { emit viewModeRequested(ViewMode::LivePreview); });
 
     connect(m_upcaseAction, &QAction::triggered, this, &TextEdit::upcaseWord);
     connect(m_downcaseAction, &QAction::triggered, this, &TextEdit::downcaseWord);
@@ -672,16 +693,8 @@ void TextEdit::popRightMenu(QPoint pos)
     }
 
     m_rightMenu->addSeparator();
-    if (m_bReadOnlyPermission == false) {
-        qDebug() << "Adding read only mode action";
-        if (m_readOnlyMode) {
-            qDebug() << "Adding disable read only mode action";
-            m_rightMenu->addAction(m_disableReadOnlyModeAction);
-        } else {
-            qDebug() << "Adding enable read only mode action";
-            m_rightMenu->addAction(m_enableReadOnlyModeAction);
-        }
-    }
+    // 视图模式二级菜单（§8.1）：入口始终显示；原只读模式互斥项移除（语义并入「查看视图」）
+    m_rightMenu->addMenu(m_viewModeMenu);
 
     m_rightMenu->addAction(m_openInFileManagerAction);
     m_rightMenu->addSeparator();
@@ -5057,6 +5070,29 @@ void TextEdit::setReadOnlyPermission(bool permission)
     }
     SendtoggleReadOnlyMode();
     qDebug() << "Set read only permission completed";
+}
+
+// 右键菜单「视图模式」入口（§8.1）：由 EditWrapper 在 viewModeChanged/markdownAvailabilityChanged 时回写
+void TextEdit::updateViewModeActions(ViewMode mode, bool isMarkdown)
+{
+    QAction *action = nullptr;
+    switch (mode) {
+    case ViewMode::ReadView:
+        action = m_actReadView;
+        break;
+    case ViewMode::LivePreview:
+        action = m_actLivePreview;
+        break;
+    case ViewMode::Edit:
+    case ViewMode::Wysiwyg:
+    default:
+        action = m_actEditView;
+        break;
+    }
+    if (action && !action->isChecked())
+        action->setChecked(true);
+    // 置灰规则（§4.4）：非 md 文件仅「实时预览」置灰，编辑/查看始终可用
+    m_actLivePreview->setEnabled(isMarkdown);
 }
 
 void TextEdit::SendtoggleReadmessage()

--- a/src/editor/dtextedit.h
+++ b/src/editor/dtextedit.h
@@ -16,6 +16,7 @@
 #include "inserttextundocommand.h"
 #include "deletetextundocommand.h"
 #include "../widgets/bottombar.h"
+#include "markdown/viewmode.h"
 #include <QUndoStack>
 
 #include <KSyntaxHighlighting/Definition>
@@ -263,6 +264,11 @@ public:
     void setReadOnlyPermission(bool permission);
     bool getReadOnlyPermission();
     bool getReadOnlyMode();
+    // 右键菜单「视图模式」入口（§8.1）：刷新子项选中态与非 md 置灰规则
+    void updateViewModeActions(ViewMode mode, bool isMarkdown);
+    // 视图模式动作组（编辑/查看/实时预览），供渲染视图右键菜单等复用同一份状态（§8.1）
+    QList<QAction *> viewModeActions() const
+    { return QList<QAction *>() << m_actEditView << m_actReadView << m_actLivePreview; }
     void hideRightMenu();
     void flodOrUnflodAllLevel(bool isFlod);
     void flodOrUnflodCurrentLevel(bool isFlod);
@@ -484,6 +490,8 @@ signals:
     void signal_readingPath();
     void signal_setTitleFocus();
     void findMatchCountChanged(int current, int total);
+    // 右键菜单「视图模式」请求切换（EditWrapper 校验后经 viewModeChanged 回写状态，§8.1）
+    void viewModeRequested(ViewMode mode);
 public slots:
     /**
      * @author liumaochuan ut000616
@@ -687,8 +695,11 @@ private:
     QAction *m_findAction;
     QAction *m_replaceAction;
     QAction *m_jumpLineAction;
-    QAction *m_enableReadOnlyModeAction;
-    QAction *m_disableReadOnlyModeAction;
+    // —— 右键菜单「视图模式」二级菜单（§8.1，替换原只读模式互斥项）——
+    DMenu *m_viewModeMenu = nullptr;
+    QAction *m_actEditView = nullptr;
+    QAction *m_actReadView = nullptr;
+    QAction *m_actLivePreview = nullptr;
     QAction *m_fullscreenAction;
     QAction *m_exitFullscreenAction;
     QAction *m_openInFileManagerAction;

--- a/src/widgets/bottombar.cpp
+++ b/src/widgets/bottombar.cpp
@@ -12,6 +12,7 @@
 #include "bottombar.h"
 #include "../common/utils.h"
 #include "../editor/editwrapper.h"
+#include "../editor/markdown/viewmode.h"
 #include "../widgets/window.h"
 #include "../editor/replaceallcommond.h"
 
@@ -24,7 +25,6 @@ BottomBar::BottomBar(QWidget *parent)
       m_pWrapper(static_cast<EditWrapper *>(parent)),
       m_pPositionLabel(new DLabel),
       m_pCharCountLabel(new DLabel),
-      m_pCursorStatus(new DLabel),
       m_pEncodeMenu(DDropdownMenu::createEncodeMenu()),
       m_pHighlightMenu(DDropdownMenu::createHighLightMenu()),
       m_rowStr(tr("Row")),
@@ -40,8 +40,6 @@ BottomBar::BottomBar(QWidget *parent)
     m_pPositionLabel->setAccessibleName("PositionLabel");
     m_pCharCountLabel->setFont(font);
     m_pCharCountLabel->setAccessibleName("CharCountLabel");
-    m_pCursorStatus->setFont(font);
-    m_pCursorStatus->setAccessibleName("CursorStatus");
     m_scaleLabel->setFont(font);
     m_scaleLabel->setAccessibleName("ScaleLabel");
     m_progressLabel->setFont(font);
@@ -58,7 +56,6 @@ BottomBar::BottomBar(QWidget *parent)
 
     DFontSizeManager::instance()->bind(m_pPositionLabel, DFontSizeManager::T9);
     DFontSizeManager::instance()->bind(m_pCharCountLabel, DFontSizeManager::T9);
-    DFontSizeManager::instance()->bind(m_pCursorStatus, DFontSizeManager::T9);
     DFontSizeManager::instance()->bind(m_scaleLabel, DFontSizeManager::T9);
     DFontSizeManager::instance()->bind(m_progressLabel, DFontSizeManager::T9);
 
@@ -67,6 +64,32 @@ BottomBar::BottomBar(QWidget *parent)
 #endif
 
     initFormatMenu();
+
+    // —— Markdown 视图模式 combobox（§8.2，与编码格式菜单同型）——
+    m_pViewModeMenu = new DDropdownMenu();
+    m_pViewModeMenu->setAccessibleName("ViewModeMenu");
+    DMenu *pViewModeDMenu = new DMenu(m_pViewModeMenu);
+    QActionGroup *pViewModeGroup = new QActionGroup(m_pViewModeMenu);
+    m_actEditView = pViewModeDMenu->addAction(tr("Edit Mode"));
+    m_actReadView = pViewModeDMenu->addAction(tr("Read View"));
+    m_actLivePreview = pViewModeDMenu->addAction(tr("Live Preview"));
+    m_actEditView->setCheckable(true);
+    m_actReadView->setCheckable(true);
+    m_actLivePreview->setCheckable(true);
+    m_actEditView->setData(static_cast<int>(ViewMode::Edit));
+    m_actReadView->setData(static_cast<int>(ViewMode::ReadView));
+    m_actLivePreview->setData(static_cast<int>(ViewMode::LivePreview));
+    m_actEditView->setChecked(true);
+    pViewModeGroup->addAction(m_actEditView);
+    pViewModeGroup->addAction(m_actReadView);
+    pViewModeGroup->addAction(m_actLivePreview);
+    // 默认非 md（含新建标签）：仅「实时预览」置灰（§4.4 置灰规则）
+    m_actLivePreview->setEnabled(false);
+    connect(pViewModeDMenu, &DMenu::triggered, this, [this](QAction *action) {
+        emit viewModeRequested(static_cast<ViewMode>(action->data().toInt()));
+    });
+    m_pViewModeMenu->setCurrentTextOnly(tr("Edit Mode"));
+    m_pViewModeMenu->setMenu(pViewModeDMenu);
 
     QHBoxLayout *layout = new QHBoxLayout(this);
     layout->setContentsMargins(29, 1, 10, 0);
@@ -81,7 +104,6 @@ BottomBar::BottomBar(QWidget *parent)
     m_progressBar->hide();
     m_progressLabel->hide();
 
-    m_pCursorStatus->setText(qApp->translate("EditWrapper", "INSERT"));
     m_pPositionLabel->setText(QString("%1 %2  %3 %4").arg(m_rowStr, "1",m_columnStr, "1"));
 
     m_pCharCountLabel->setText(m_chrCountStr.arg("0"));
@@ -98,7 +120,7 @@ BottomBar::BottomBar(QWidget *parent)
     layout->addStretch();
     layout->addWidget(m_scaleLabel);
     layout->addStretch();
-    layout->addWidget(m_pCursorStatus);
+    layout->addWidget(m_pViewModeMenu);
     layout->addSpacing(10);
     layout->addWidget(pVerticalLine1);
     layout->addWidget(m_pEncodeMenu);
@@ -175,33 +197,28 @@ void BottomBar::setEncodeName(const QString &name)
     m_pEncodeMenu->setCurrentTextOnly(name);
 }
 
-void BottomBar::setCursorStatus(const QString &text)
-{
-    m_pCursorStatus->setText(text);
-}
-
 void BottomBar::setPalette(const QPalette &palette)
 {
     DPalette paPositionLabel  = DGuiApplicationHelper::instance()->applicationPalette();
     DPalette paCharCountLabel = DGuiApplicationHelper::instance()->applicationPalette();
-    DPalette paCursorStatus = DGuiApplicationHelper::instance()->applicationPalette();
     DPalette paEncodeMenu = DGuiApplicationHelper::instance()->applicationPalette();
     DPalette paHighlightMenu = DGuiApplicationHelper::instance()->applicationPalette();
+    DPalette paViewModeMenu = DGuiApplicationHelper::instance()->applicationPalette();
 
     QColor colorFont = paPositionLabel.textTips().color();
 
     paPositionLabel.setColor(DPalette::WindowText, colorFont);
     paCharCountLabel.setColor(DPalette::WindowText, colorFont);
-    paCursorStatus.setColor(DPalette::WindowText, colorFont);
     paEncodeMenu.setColor(DPalette::WindowText, colorFont);
     paHighlightMenu.setColor(DPalette::WindowText, colorFont);
+    paViewModeMenu.setColor(DPalette::WindowText, colorFont);
 
 
     m_pPositionLabel->setPalette(paPositionLabel);
     m_pCharCountLabel->setPalette(paCharCountLabel);
-    m_pCursorStatus->setPalette(paCursorStatus);
     m_pEncodeMenu->getButton()->setPalette(paEncodeMenu);
     m_pHighlightMenu->getButton()->setPalette(paHighlightMenu);
+    m_pViewModeMenu->getButton()->setPalette(paViewModeMenu);
     m_scaleLabel->setPalette(paPositionLabel);
     m_formatMenu->getButton()->setPalette(paEncodeMenu);
 
@@ -209,6 +226,7 @@ void BottomBar::setPalette(const QPalette &palette)
     m_pEncodeMenu->setTheme(theme);
     m_pHighlightMenu->setTheme(theme);
     m_formatMenu->setTheme(theme);
+    m_pViewModeMenu->setTheme(theme);
 
     QWidget::setPalette(palette);
 }
@@ -298,7 +316,6 @@ bool BottomBar::eventFilter(QObject *watched, QEvent *event)
         QFont font = qApp->font();
         m_pPositionLabel->setFont(font);
         m_pCharCountLabel->setFont(font);
-        m_pCursorStatus->setFont(font);
         m_scaleLabel->setFont(font);
         m_progressLabel->setFont(font);
         return false;
@@ -459,4 +476,36 @@ int BottomBar::defaultHeight()
 #else
     return s_BottomBarHeight;
 #endif
+}
+
+// —— Markdown 视图模式入口（§8.2）——
+void BottomBar::setViewMode(ViewMode mode)
+{
+    QAction *action = nullptr;
+    QString name;
+    switch (mode) {
+    case ViewMode::ReadView:
+        action = m_actReadView;
+        name = tr("Read View");
+        break;
+    case ViewMode::LivePreview:
+        action = m_actLivePreview;
+        name = tr("Live Preview");
+        break;
+    case ViewMode::Edit:
+    case ViewMode::Wysiwyg:
+    default:
+        action = m_actEditView;
+        name = tr("Edit Mode");
+        break;
+    }
+    if (action && !action->isChecked())
+        action->setChecked(true);
+    m_pViewModeMenu->setCurrentTextOnly(name);
+}
+
+void BottomBar::setMarkdownAvailable(bool ok)
+{
+    // 非 md 文件：仅「实时预览」置灰（§4.4 置灰规则）
+    m_actLivePreview->setEnabled(ok);
 }

--- a/src/widgets/bottombar.h
+++ b/src/widgets/bottombar.h
@@ -17,6 +17,8 @@
 #define FormatActionType "format-action-type"
 
 class EditWrapper;
+enum class ViewMode;
+
 class BottomBar : public QWidget
 {
     Q_OBJECT
@@ -35,7 +37,6 @@ public:
     void updatePosition(int row, int column);
     void updateWordCount(int charactorCount);
     void setEncodeName(const QString &name);
-    void setCursorStatus(const QString &text);
     void setPalette(const QPalette &palette);
     void updateSize(int size, bool bIsFindOrReplace);
     void setChildEnabled(bool enabled);
@@ -43,6 +44,10 @@ public:
     void setChildrenFocus(bool ok,QWidget* preOrderWidget = nullptr);
     void setScaleLabelText(qreal fontSize);
     void setProgress(int progress);
+
+    // —— Markdown 视图模式入口（§8.2）：折叠态显示当前视图名；非 md 仅置灰「实时预览」 ——
+    void setViewMode(ViewMode mode);
+    void setMarkdownAvailable(bool ok);
 
     DDropdownMenu* getEncodeMenu();
     DDropdownMenu* getHighlightMenu();
@@ -55,6 +60,10 @@ protected:
     void paintEvent(QPaintEvent *);
     bool eventFilter(QObject *, QEvent *) override;
 
+signals:
+    // 用户经 combobox 请求切换视图模式（EditWrapper 校验后经 viewModeChanged 回写状态）
+    void viewModeRequested(ViewMode mode);
+
 private:
     void initFormatMenu();
     Q_SLOT void onFormatMenuTrigged(QAction* action);
@@ -64,7 +73,6 @@ private:
     EditWrapper *m_pWrapper {nullptr};
     DLabel *m_pPositionLabel {nullptr};
     DLabel *m_pCharCountLabel {nullptr};
-    DLabel *m_pCursorStatus {nullptr};
     DDropdownMenu *m_pEncodeMenu {nullptr};
     DDropdownMenu *m_pHighlightMenu {nullptr};
     QString m_rowStr {QString()};
@@ -78,6 +86,12 @@ private:
     EndlineFormat m_endlineFormat = EndlineFormat::Unix;
     QAction* m_unixAction = nullptr;
     QAction* m_windowsAction = nullptr;
+
+    // —— Markdown 视图模式 combobox（§8.2，与编码格式菜单同型）——
+    DDropdownMenu *m_pViewModeMenu {nullptr};
+    QAction *m_actEditView {nullptr};
+    QAction *m_actReadView {nullptr};
+    QAction *m_actLivePreview {nullptr};
 
 
 public slots:

--- a/src/widgets/window.cpp
+++ b/src/widgets/window.cpp
@@ -801,7 +801,6 @@ void Window::addTabWithWrapper(EditWrapper *wrapper, const QString &filepath, co
     wrapper->textEditor()->disconnect();
 
     qDebug() << "Connecting signals to text editor";
-    connect(wrapper->textEditor(), &TextEdit::cursorModeChanged, wrapper, &EditWrapper::handleCursorModeChanged);
     connect(wrapper->textEditor(), &TextEdit::clickFindAction, this, &Window::popupFindBar, Qt::QueuedConnection);
     connect(wrapper->textEditor(), &TextEdit::clickReplaceAction, this, &Window::popupReplaceBar, Qt::QueuedConnection);
     connect(wrapper->textEditor(), &TextEdit::clickJumpLineAction, this, &Window::popupJumpLineBar, Qt::QueuedConnection);

--- a/test/at/spi/expected_names.yaml
+++ b/test/at/spi/expected_names.yaml
@@ -214,11 +214,6 @@ elements:
     role: "label"
     description: "字符计数"
 
-  - id: "CursorStatus"
-    name: "CursorStatus"
-    role: "label"
-    description: "光标状态(INSERT/OVERWRITE)"
-
   - id: "ScaleLabel"
     name: "ScaleLabel"
     role: "label"
@@ -396,15 +391,20 @@ elements:
     role: "menu item"
     description: "转到行"
 
-  - id: "EnableReadOnly"
-    name: "EnableReadOnly"
+  - id: "EditView"
+    name: "EditView"
     role: "menu item"
-    description: "开启只读模式"
+    description: "编辑模式"
 
-  - id: "DisableReadOnly"
-    name: "DisableReadOnly"
+  - id: "ReadView"
+    name: "ReadView"
     role: "menu item"
-    description: "关闭只读模式"
+    description: "查看视图"
+
+  - id: "LivePreview"
+    name: "LivePreview"
+    role: "menu item"
+    description: "实时预览"
 
   - id: "Fullscreen"
     name: "Fullscreen"


### PR DESCRIPTION
Replace read-only toggle actions with a view-mode submenu in the editor context menu (edit/read/live-preview, shared action group also reused by the render-view context menu), add a DDropdownMenu view-mode combobox to the bottom bar showing the current view name with live-preview greyed out for non-markdown files, and remove the obsolete INSERT/OVERWRITE cursor status label. Update AT-SPI expected names accordingly.

右键菜单的只读互斥项替换为「视图模式」二级菜单（编辑/查看/实时
预览，动作组同时供渲染视图右键复用）；底部状态栏新增视图模式
combobox，折叠态显示当前视图名，非 md 文件仅置灰「实时预览」；
移除原 INSERT/OVERWRITE 光标状态标签；同步更新 AT-SPI 期望名。

Log: 新增右键菜单与状态栏的视图模式入口
PMS: TASK-393979
Influence: 三处入口状态同步；状态栏不再显示光标模式（Insert 键功能不变）。

## Summary by Sourcery

Add synchronized view-mode entry points to editor menus and the bottom bar, while removing the obsolete cursor-status display.

New Features:
- Add Edit Mode, Read View, and Live Preview controls to the editor context menu and bottom bar, with synchronized view state and Markdown availability handling.

Enhancements:
- Replace the read-only context-menu actions with a mutually exclusive view-mode submenu that can be reused by other views.
- Remove the INSERT/OVERWRITE cursor-status indicator while preserving Insert key behavior.
- Update AT-SPI accessibility expectations for the new view-mode actions and removed cursor-status label.