### PR TITLE
test(markdown): add unit tests for pure logic layer

### DIFF
--- a/tests/src/editor/markdown/ut_markdownlogic.cpp
+++ b/tests/src/editor/markdown/ut_markdownlogic.cpp
@@ -1,0 +1,121 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "ut_markdownlogic.h"
+#include "markdownlogic.h"
+
+UT_MarkdownLogic::UT_MarkdownLogic()
+{
+}
+
+// definition 名为 "Markdown" → 是 markdown
+TEST_F(UT_MarkdownLogic, IsMarkdown_DefinitionNameMarkdown_True)
+{
+    EXPECT_TRUE(MarkdownLogic::isMarkdownByDefinitionName(QStringLiteral("Markdown")));
+}
+
+// definition 名大小写敏感（KSyntaxHighlighting 规范名为 "Markdown"）
+TEST_F(UT_MarkdownLogic, IsMarkdown_DefinitionNameLowercase_False)
+{
+    EXPECT_FALSE(MarkdownLogic::isMarkdownByDefinitionName(QStringLiteral("markdown")));
+}
+
+// definition 名为空 → false
+TEST_F(UT_MarkdownLogic, IsMarkdown_EmptyDefinitionName_False)
+{
+    EXPECT_FALSE(MarkdownLogic::isMarkdownByDefinitionName(QStringLiteral("")));
+}
+
+// definition 名为其他语言 → false
+TEST_F(UT_MarkdownLogic, IsMarkdown_OtherLanguage_False)
+{
+    EXPECT_FALSE(MarkdownLogic::isMarkdownByDefinitionName(QStringLiteral("C++")));
+}
+
+// 扩展名 .md → markdown
+TEST_F(UT_MarkdownLogic, IsMarkdown_DotMd_True)
+{
+    EXPECT_TRUE(MarkdownLogic::isMarkdownByFileName(QStringLiteral("readme.md")));
+    EXPECT_TRUE(MarkdownLogic::isMarkdownByFileName(QStringLiteral("README.MD")));
+}
+
+// 扩展名 .markdown → markdown
+TEST_F(UT_MarkdownLogic, IsMarkdown_DotMarkdown_True)
+{
+    EXPECT_TRUE(MarkdownLogic::isMarkdownByFileName(QStringLiteral("notes.markdown")));
+}
+
+// 扩展名 .mdown → markdown
+TEST_F(UT_MarkdownLogic, IsMarkdown_DotMdown_True)
+{
+    EXPECT_TRUE(MarkdownLogic::isMarkdownByFileName(QStringLiteral("doc.mdown")));
+}
+
+// 扩展名 .txt → 不是 markdown
+TEST_F(UT_MarkdownLogic, IsMarkdown_DotTxt_False)
+{
+    EXPECT_FALSE(MarkdownLogic::isMarkdownByFileName(QStringLiteral("notes.txt")));
+}
+
+// 扩展名 .cpp → 不是 markdown
+TEST_F(UT_MarkdownLogic, IsMarkdown_DotCpp_False)
+{
+    EXPECT_FALSE(MarkdownLogic::isMarkdownByFileName(QStringLiteral("main.cpp")));
+}
+
+// 无扩展名 → false
+TEST_F(UT_MarkdownLogic, IsMarkdown_NoExtension_False)
+{
+    EXPECT_FALSE(MarkdownLogic::isMarkdownByFileName(QStringLiteral("Makefile")));
+}
+
+// 综合判定：definition 优先，其次扩展名
+TEST_F(UT_MarkdownLogic, IsMarkdown_Combined_DefinitionFirst)
+{
+    // definition 名为 Markdown，即使文件名无扩展名也判为 true
+    EXPECT_TRUE(MarkdownLogic::isMarkdown(QStringLiteral("Makefile"), QStringLiteral("Markdown")));
+    // definition 名为空，扩展名 .md → true
+    EXPECT_TRUE(MarkdownLogic::isMarkdown(QStringLiteral("x.md"), QStringLiteral("")));
+    // 都不匹配 → false
+    EXPECT_FALSE(MarkdownLogic::isMarkdown(QStringLiteral("x.txt"), QStringLiteral("Plain Text")));
+}
+
+// 新建 .txt 不应识别为 markdown（需求：新建 txt 不触发渲染）
+TEST_F(UT_MarkdownLogic, IsMarkdown_NewTxt_False)
+{
+    EXPECT_FALSE(MarkdownLogic::isMarkdown(QStringLiteral("untitled.txt"), QStringLiteral("Plain Text")));
+}
+
+// —— 图片路径解析（渲染页从 qrc:/ 加载，相对路径会错误解析到 qrc，须改写为 file:// 绝对 URL）——
+
+// 相对路径 → baseDir 下的 file:// 绝对 URL
+TEST_F(UT_MarkdownLogic, ResolveImagePaths_RelativeToBaseDir)
+{
+    const QString md = QStringLiteral("![alt](sample.png)");
+    const QString out = MarkdownLogic::resolveImagePaths(md, QStringLiteral("/tmp/demo"));
+    EXPECT_EQ(out, QStringLiteral("![alt](mdimg:///tmp/demo/sample.png)"));
+}
+
+// 绝对本地路径 → file:// URL（含中文/空格需百分号编码）
+TEST_F(UT_MarkdownLogic, ResolveImagePaths_AbsoluteLocalPath)
+{
+    const QString out = MarkdownLogic::resolveImagePaths(
+        QStringLiteral("![x](/home/uos/我的 图片/a.png)"), QStringLiteral("/tmp"));
+    EXPECT_EQ(out, QStringLiteral("![x](mdimg:///home/uos/%E6%88%91%E7%9A%84%20%E5%9B%BE%E7%89%87/a.png)"));
+}
+
+// 网络与 data URI 原样保留
+TEST_F(UT_MarkdownLogic, ResolveImagePaths_RemoteAndDataUnchanged)
+{
+    const QString md = QStringLiteral("![a](https://x.org/i.png) ![b](http://y.org/j.png) ![c](data:image/png;base64,AAAA)");
+    EXPECT_EQ(MarkdownLogic::resolveImagePaths(md, QStringLiteral("/tmp")), md);
+}
+
+// 非 image 的普通链接不改动；带标题的图片语法保留标题
+TEST_F(UT_MarkdownLogic, ResolveImagePaths_NonImageLinkAndTitle)
+{
+    const QString md = QStringLiteral("[link](sample.png) ![t](pic.png \"title\")");
+    const QString out = MarkdownLogic::resolveImagePaths(md, QStringLiteral("/d"));
+    EXPECT_EQ(out, QStringLiteral("[link](sample.png) ![t](mdimg:///d/pic.png \"title\")"));
+}

--- a/tests/src/editor/markdown/ut_markdownlogic.h
+++ b/tests/src/editor/markdown/ut_markdownlogic.h
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef UT_MARKDOWNLOGIC_H
+#define UT_MARKDOWNLOGIC_H
+
+#include "gtest/gtest.h"
+#include <QObject>
+
+class UT_MarkdownLogic : public QObject, public ::testing::Test
+{
+    Q_OBJECT
+public:
+    UT_MarkdownLogic();
+};
+
+#endif // UT_MARKDOWNLOGIC_H

--- a/tests/src/editor/markdown/ut_renderthrottle.cpp
+++ b/tests/src/editor/markdown/ut_renderthrottle.cpp
@@ -1,0 +1,177 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "ut_renderthrottle.h"
+#include "renderthrottle.h"
+
+#include <QSignalSpy>
+#include <QTest>
+
+UT_RenderThrottle::UT_RenderThrottle()
+{
+}
+
+// 默认去抖间隔 300ms
+TEST_F(UT_RenderThrottle, DefaultInterval_300ms)
+{
+    RenderThrottle t;
+    EXPECT_EQ(t.interval(), 300);
+}
+
+// ready 默认 false
+TEST_F(UT_RenderThrottle, DefaultNotReady)
+{
+    RenderThrottle t;
+    EXPECT_FALSE(t.isReady());
+}
+
+// 300ms 内多次输入：前沿渲染首个内容 + 后沿渲染最新内容（共 2 次，各自延迟 ≤300ms）
+TEST_F(UT_RenderThrottle, MultipleInputs_Within300ms_LeadingAndTrailing)
+{
+    RenderThrottle t;
+    t.setReady(true);
+    QSignalSpy spy(&t, &RenderThrottle::renderRequested);
+
+    t.noteContent(QStringLiteral("a"));
+    QTest::qWait(100);
+    t.noteContent(QStringLiteral("b"));
+    QTest::qWait(100);
+    t.noteContent(QStringLiteral("c"));
+    QTest::qWait(350);   // 等后沿补发完成
+
+    ASSERT_EQ(spy.count(), 2);                       // 前沿 "a" + 后沿 "c"
+    EXPECT_EQ(spy.takeFirst().at(0).toString(), QStringLiteral("a"));
+    EXPECT_EQ(spy.takeFirst().at(0).toString(), QStringLiteral("c"));
+}
+
+// 冷却期外的首次变更立即渲染（前沿），不等 300ms
+TEST_F(UT_RenderThrottle, ReadyAndNote_EmitsImmediately_LeadingEdge)
+{
+    RenderThrottle t;
+    t.setReady(true);
+    QSignalSpy spy(&t, &RenderThrottle::renderRequested);
+
+    t.noteContent(QStringLiteral("hello"));
+    EXPECT_EQ(spy.count(), 1);   // 前沿：立即发出
+    EXPECT_EQ(spy.takeFirst().at(0).toString(), QStringLiteral("hello"));
+}
+
+// 连续输入期间每 300ms 渲染一次（不停顿也能实时刷新，2026-08-19 修订的节流语义）
+TEST_F(UT_RenderThrottle, ContinuousInput_RendersPeriodically)
+{
+    RenderThrottle t;
+    t.setReady(true);
+    QSignalSpy spy(&t, &RenderThrottle::renderRequested);
+
+    // 每 50ms 输入一次，持续约 700ms（模拟连续击键）
+    for (int i = 0; i <= 14; ++i) {
+        t.noteContent(QStringLiteral("v%1").arg(i));
+        QTest::qWait(50);
+    }
+    QTest::qWait(350);   // 等最后一次后沿补发
+
+    // 700ms 连续输入 + 节流 300ms：至少 3 次渲染（前沿 + 每 300ms 后沿）
+    EXPECT_GE(spy.count(), 3);
+    // 最后发出的应为最新内容 v14
+    EXPECT_EQ(spy.takeLast().at(0).toString(), QStringLiteral("v14"));
+}
+
+// 输入停止后：最后一个周期无新内容，定时器自然停止，不再多发
+TEST_F(UT_RenderThrottle, InputStops_NoExtraEmitAfterTrailing)
+{
+    RenderThrottle t;
+    t.setReady(true);
+    QSignalSpy spy(&t, &RenderThrottle::renderRequested);
+
+    t.noteContent(QStringLiteral("a"));
+    QTest::qWait(50);
+    t.noteContent(QStringLiteral("b"));
+    QTest::qWait(400);   // 前沿 "a" + 后沿 "b"，共 2 次
+    ASSERT_EQ(spy.count(), 2);
+    spy.clear();
+
+    QTest::qWait(600);   // 之后无输入：不再有任何渲染
+    EXPECT_EQ(spy.count(), 0);
+}
+
+// 相同内容跳过（md == lastEmitted 不 emit）
+TEST_F(UT_RenderThrottle, SameContent_Skipped)
+{
+    RenderThrottle t;
+    t.setReady(true);
+    QSignalSpy spy(&t, &RenderThrottle::renderRequested);
+
+    t.noteContent(QStringLiteral("same"));
+    QTest::qWait(350);
+    ASSERT_EQ(spy.count(), 1);
+    spy.clear();
+
+    t.noteContent(QStringLiteral("same"));   // 相同
+    QTest::qWait(350);
+    EXPECT_EQ(spy.count(), 0);
+}
+
+// ready 前缓存：noteContent 后 timer 到期不 emit（因为 not ready）
+TEST_F(UT_RenderThrottle, NotReady_NoteContent_CachedNoEmit)
+{
+    RenderThrottle t;
+    t.setReady(false);
+    QSignalSpy spy(&t, &RenderThrottle::renderRequested);
+
+    t.noteContent(QStringLiteral("pending"));
+    QTest::qWait(350);
+    EXPECT_EQ(spy.count(), 0);   // 未 ready，缓存不发出
+}
+
+// ready 前缓存的内容，setReady(true) 后立即 flush
+TEST_F(UT_RenderThrottle, PendingContent_FlushedOnReady)
+{
+    RenderThrottle t;
+    t.setReady(false);
+    QSignalSpy spy(&t, &RenderThrottle::renderRequested);
+
+    t.noteContent(QStringLiteral("pending"));
+    QTest::qWait(350);
+    ASSERT_EQ(spy.count(), 0);
+
+    t.setReady(true);   // flush
+    ASSERT_EQ(spy.count(), 1);
+    EXPECT_EQ(spy.takeFirst().at(0).toString(), QStringLiteral("pending"));
+}
+
+// 首切立即触发：flushNow 跳过去抖，立即 emit
+TEST_F(UT_RenderThrottle, FlushNow_EmitsImmediately)
+{
+    RenderThrottle t;
+    t.setReady(true);
+    QSignalSpy spy(&t, &RenderThrottle::renderRequested);
+
+    t.noteContent(QStringLiteral("first"));
+    t.flushNow();   // 不等 300ms
+    ASSERT_EQ(spy.count(), 1);
+    EXPECT_EQ(spy.takeFirst().at(0).toString(), QStringLiteral("first"));
+}
+
+// flushNow 未 ready 时缓存（不 emit，等 ready）
+TEST_F(UT_RenderThrottle, FlushNow_NotReady_CachedOnly)
+{
+    RenderThrottle t;
+    t.setReady(false);
+    QSignalSpy spy(&t, &RenderThrottle::renderRequested);
+
+    t.noteContent(QStringLiteral("x"));
+    t.flushNow();
+    EXPECT_EQ(spy.count(), 0);   // 未 ready 不 emit
+}
+
+// setReady(true) 但无 pending 内容，不 emit
+TEST_F(UT_RenderThrottle, SetReady_NoPending_NoEmit)
+{
+    RenderThrottle t;
+    t.setReady(false);
+    QSignalSpy spy(&t, &RenderThrottle::renderRequested);
+
+    t.setReady(true);
+    EXPECT_EQ(spy.count(), 0);
+}

--- a/tests/src/editor/markdown/ut_renderthrottle.h
+++ b/tests/src/editor/markdown/ut_renderthrottle.h
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef UT_RENDERTHROTTLE_H
+#define UT_RENDERTHROTTLE_H
+
+#include "gtest/gtest.h"
+#include <QObject>
+
+class UT_RenderThrottle : public QObject, public ::testing::Test
+{
+    Q_OBJECT
+public:
+    UT_RenderThrottle();
+};
+
+#endif // UT_RENDERTHROTTLE_H

--- a/tests/src/editor/markdown/ut_scrollsync.cpp
+++ b/tests/src/editor/markdown/ut_scrollsync.cpp
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: 2026 UnionCTechnology Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "ut_scrollsync.h"
+#include "scrollsync.h"
+
+UT_ScrollSync::UT_ScrollSync()
+{
+}
+
+// value=min → ratio=0
+TEST_F(UT_ScrollSync, RatioFromBar_AtMin_Zero)
+{
+    EXPECT_DOUBLE_EQ(ScrollSync::ratioFromScrollBar(0, 0, 100), 0.0);
+}
+
+// value=max → ratio=1
+TEST_F(UT_ScrollSync, RatioFromBar_AtMax_One)
+{
+    EXPECT_DOUBLE_EQ(ScrollSync::ratioFromScrollBar(100, 0, 100), 1.0);
+}
+
+// value=mid → ratio=0.5
+TEST_F(UT_ScrollSync, RatioFromBar_MidPoint_Half)
+{
+    EXPECT_DOUBLE_EQ(ScrollSync::ratioFromScrollBar(50, 0, 100), 0.5);
+}
+
+// max=0（无滚动范围）→ ratio=0（除零保护）
+TEST_F(UT_ScrollSync, RatioFromBar_MaxZero_NoDivByZero)
+{
+    EXPECT_DOUBLE_EQ(ScrollSync::ratioFromScrollBar(0, 0, 0), 0.0);
+}
+
+// value < min → 钳制 0
+TEST_F(UT_ScrollSync, RatioFromBar_BelowMin_ClampedZero)
+{
+    EXPECT_DOUBLE_EQ(ScrollSync::ratioFromScrollBar(-10, 0, 100), 0.0);
+}
+
+// value > max → 钳制 1
+TEST_F(UT_ScrollSync, RatioFromBar_AboveMax_ClampedOne)
+{
+    EXPECT_DOUBLE_EQ(ScrollSync::ratioFromScrollBar(150, 0, 100), 1.0);
+}
+
+// 非 0 起点 min：ratio 按 (value-min)/(max-min) 计算
+TEST_F(UT_ScrollSync, RatioFromBar_NonZeroMin_Normalized)
+{
+    EXPECT_DOUBLE_EQ(ScrollSync::ratioFromScrollBar(60, 10, 110), 0.5);
+}
+
+// clampRatio：越界值钳制 [0,1]
+TEST_F(UT_ScrollSync, ClampRatio_OutOfRange_Clamped)
+{
+    EXPECT_DOUBLE_EQ(ScrollSync::clampRatio(-0.5), 0.0);
+    EXPECT_DOUBLE_EQ(ScrollSync::clampRatio(1.5), 1.0);
+    EXPECT_DOUBLE_EQ(ScrollSync::clampRatio(0.3), 0.3);
+    EXPECT_DOUBLE_EQ(ScrollSync::clampRatio(0.0), 0.0);
+    EXPECT_DOUBLE_EQ(ScrollSync::clampRatio(1.0), 1.0);
+}

--- a/tests/src/editor/markdown/ut_scrollsync.h
+++ b/tests/src/editor/markdown/ut_scrollsync.h
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2026 UnionCTechnology Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef UT_SCROLLSYNC_H
+#define UT_SCROLLSYNC_H
+
+#include "gtest/gtest.h"
+#include <QObject>
+
+class UT_ScrollSync : public QObject, public ::testing::Test
+{
+    Q_OBJECT
+public:
+    UT_ScrollSync();
+};
+
+#endif // UT_SCROLLSYNC_H

--- a/tests/src/editor/markdown/ut_themeserializer.cpp
+++ b/tests/src/editor/markdown/ut_themeserializer.cpp
@@ -1,0 +1,104 @@
+// SPDX-FileCopyrightText: 2026 UnionCTechnology Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "ut_themeserializer.h"
+#include "themeserializer.h"
+
+#include <QJsonDocument>
+#include <QJsonObject>
+
+UT_ThemeSerializer::UT_ThemeSerializer()
+{
+}
+
+// 浅色背景 lightness >= 128 → isDark=false
+TEST_F(UT_ThemeSerializer, IsDark_LightBackground_False)
+{
+    QVariantMap theme;
+    QVariantMap editorColors;
+    editorColors.insert("background-color", "#ffffff");   // lightness=255
+    theme.insert("editor-colors", editorColors);
+
+    EXPECT_FALSE(ThemeSerializer::isDark(theme));
+}
+
+// 深色背景 lightness < 128 → isDark=true
+TEST_F(UT_ThemeSerializer, IsDark_DarkBackground_True)
+{
+    QVariantMap theme;
+    QVariantMap editorColors;
+    editorColors.insert("background-color", "#1f1f1f");   // lightness≈31
+    theme.insert("editor-colors", editorColors);
+
+    EXPECT_TRUE(ThemeSerializer::isDark(theme));
+}
+
+// 空主题不崩溃，默认 false（浅色）
+TEST_F(UT_ThemeSerializer, IsDark_EmptyTheme_False)
+{
+    QVariantMap empty;
+    EXPECT_FALSE(ThemeSerializer::isDark(empty));
+}
+
+// 空背景色不崩溃
+TEST_F(UT_ThemeSerializer, IsDark_EmptyBackground_False)
+{
+    QVariantMap theme;
+    QVariantMap editorColors;
+    editorColors.insert("background-color", "");
+    theme.insert("editor-colors", editorColors);
+    EXPECT_FALSE(ThemeSerializer::isDark(theme));
+}
+
+// 非 hex 颜色不崩溃（QColor 解析失败返回 invalid，lightness=0 → 判深色，不崩）
+TEST_F(UT_ThemeSerializer, IsDark_InvalidColor_NoCrash)
+{
+    QVariantMap theme;
+    QVariantMap editorColors;
+    editorColors.insert("background-color", "not-a-color");
+    theme.insert("editor-colors", editorColors);
+    // 不崩即可，具体值不强制（invalid QColor lightness=-1 < 128 → true）
+    EXPECT_NO_FATAL_FAILURE(ThemeSerializer::isDark(theme));
+}
+
+// serializeToJson：输出包含从背景色派生的 --bg / --fg 变量
+TEST_F(UT_ThemeSerializer, Serialize_ContainsCssVars)
+{
+    QVariantMap theme;
+    QVariantMap editorColors;
+    editorColors.insert("background-color", "#ffffff");
+    editorColors.insert("text-color", "#000000");
+    theme.insert("editor-colors", editorColors);
+
+    const QString json = ThemeSerializer::serialize(theme);
+    ASSERT_FALSE(json.isEmpty());
+
+    auto doc = QJsonDocument::fromJson(json.toUtf8());
+    ASSERT_TRUE(doc.isObject());
+    auto obj = doc.object();
+    EXPECT_TRUE(obj.contains("--bg"));
+    EXPECT_TRUE(obj.contains("--fg"));
+}
+
+// serializeToJson：空主题输出合法 JSON（不崩）
+TEST_F(UT_ThemeSerializer, Serialize_EmptyTheme_ValidJson)
+{
+    QVariantMap empty;
+    const QString json = ThemeSerializer::serialize(empty);
+    auto doc = QJsonDocument::fromJson(json.toUtf8());
+    EXPECT_TRUE(doc.isObject());
+}
+
+// §4.7：序列化须包含 --code-fg（否则深色主题下代码块深字深底不可读）
+TEST_F(UT_ThemeSerializer, Serialize_IncludesCodeFg)
+{
+    QVariantMap themeMap;
+    themeMap["editor-colors"] = QVariantMap{
+        {"background-color", "#1e1e1e"},
+        {"text-color", "#d8d8d8"},
+    };
+    const QString json = ThemeSerializer::serialize(themeMap);
+    const auto doc = QJsonDocument::fromJson(json.toUtf8());
+    ASSERT_TRUE(doc.object().contains("--code-fg"));
+    EXPECT_EQ(doc.object().value("--code-fg").toString(), QString("#d8d8d8"));
+}

--- a/tests/src/editor/markdown/ut_themeserializer.h
+++ b/tests/src/editor/markdown/ut_themeserializer.h
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2026 UnionCTechnology Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef UT_THEMESERIALIZER_H
+#define UT_THEMESERIALIZER_H
+
+#include "gtest/gtest.h"
+#include <QObject>
+
+class UT_ThemeSerializer : public QObject, public ::testing::Test
+{
+    Q_OBJECT
+public:
+    UT_ThemeSerializer();
+};
+
+#endif // UT_THEMESERIALIZER_H

--- a/tests/src/editor/markdown/ut_viewmodefsm.cpp
+++ b/tests/src/editor/markdown/ut_viewmodefsm.cpp
@@ -1,0 +1,122 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "ut_viewmodefsm.h"
+#include "viewmodefsm.h"
+
+UT_ViewModeFsm::UT_ViewModeFsm()
+{
+}
+
+// 打开 .md → 默认 LivePreview
+TEST_F(UT_ViewModeFsm, DefaultMode_MarkdownFile_LivePreview)
+{
+    EXPECT_EQ(ViewModeFsm::resolveDefaultMode(true), ViewMode::LivePreview);
+}
+
+// 打开非 md → 默认 Edit
+TEST_F(UT_ViewModeFsm, DefaultMode_NonMarkdownFile_Edit)
+{
+    EXPECT_EQ(ViewModeFsm::resolveDefaultMode(false), ViewMode::Edit);
+}
+
+// 「实时预览」入口可用性：仅 md 文件可用
+TEST_F(UT_ViewModeFsm, LivePreviewAvailable_Markdown_True)
+{
+    EXPECT_TRUE(ViewModeFsm::isLivePreviewAvailable(true));
+}
+TEST_F(UT_ViewModeFsm, LivePreviewAvailable_NonMarkdown_False)
+{
+    EXPECT_FALSE(ViewModeFsm::isLivePreviewAvailable(false));
+}
+
+// 「编辑模式」「查看视图」始终可用（需求：入口始终显示，非 md 仅 LivePreview 置灰）
+TEST_F(UT_ViewModeFsm, EditViewAvailable_AlwaysTrue)
+{
+    EXPECT_TRUE(ViewModeFsm::isEditViewAvailable(true));
+    EXPECT_TRUE(ViewModeFsm::isEditViewAvailable(false));
+}
+TEST_F(UT_ViewModeFsm, ReadViewAvailable_AlwaysTrue)
+{
+    EXPECT_TRUE(ViewModeFsm::isReadViewAvailable(true));
+    EXPECT_TRUE(ViewModeFsm::isReadViewAvailable(false));
+}
+
+// 切换合法性：md 文件可切到任意三个视图
+TEST_F(UT_ViewModeFsm, CanSwitch_Markdown_AllThreeViews)
+{
+    EXPECT_TRUE(ViewModeFsm::canSwitchTo(ViewMode::Edit, true));
+    EXPECT_TRUE(ViewModeFsm::canSwitchTo(ViewMode::ReadView, true));
+    EXPECT_TRUE(ViewModeFsm::canSwitchTo(ViewMode::LivePreview, true));
+}
+
+// 切换合法性：非 md 文件不能切到 LivePreview
+TEST_F(UT_ViewModeFsm, CanSwitch_NonMarkdown_LivePreviewFalse)
+{
+    EXPECT_FALSE(ViewModeFsm::canSwitchTo(ViewMode::LivePreview, false));
+}
+
+// 切换合法性：非 md 文件可切到 Edit / ReadView
+TEST_F(UT_ViewModeFsm, CanSwitch_NonMarkdown_EditAndReadViewTrue)
+{
+    EXPECT_TRUE(ViewModeFsm::canSwitchTo(ViewMode::Edit, false));
+    EXPECT_TRUE(ViewModeFsm::canSwitchTo(ViewMode::ReadView, false));
+}
+
+// Wysiwyg 阶段二不可达（本期 ReadOnly）
+TEST_F(UT_ViewModeFsm, CanSwitch_Wysiwyg_AlwaysFalse)
+{
+    EXPECT_FALSE(ViewModeFsm::canSwitchTo(ViewMode::Wysiwyg, true));
+    EXPECT_FALSE(ViewModeFsm::canSwitchTo(ViewMode::Wysiwyg, false));
+}
+
+// 语言切走导致的回退：非 md 在 LivePreview 时退回 Edit
+TEST_F(UT_ViewModeFsm, Fallback_NonMarkdownFromLivePreview_Edit)
+{
+    EXPECT_EQ(ViewModeFsm::fallbackWhenMarkdownLost(ViewMode::LivePreview), ViewMode::Edit);
+}
+
+// 语言切走：非 md 在 ReadView 时保持 ReadView（查看视图对非 md 有效，纯文本只读）
+TEST_F(UT_ViewModeFsm, Fallback_NonMarkdownFromReadView_StayReadView)
+{
+    EXPECT_EQ(ViewModeFsm::fallbackWhenMarkdownLost(ViewMode::ReadView), ViewMode::ReadView);
+}
+
+// 语言切走：在 Edit 时保持 Edit
+TEST_F(UT_ViewModeFsm, Fallback_FromEdit_StayEdit)
+{
+    EXPECT_EQ(ViewModeFsm::fallbackWhenMarkdownLost(ViewMode::Edit), ViewMode::Edit);
+}
+
+// 语言切到（非 md → md）的跃迁：Edit → LivePreview（对齐 md 默认视图，2026-08-19）
+TEST_F(UT_ViewModeFsm, Elevate_MarkdownGainedFromEdit_LivePreview)
+{
+    EXPECT_EQ(ViewModeFsm::elevateWhenMarkdownGained(ViewMode::Edit), ViewMode::LivePreview);
+}
+
+// 语言切到：ReadView / LivePreview 保持（ReadView 仅切换实现，模式不变）
+TEST_F(UT_ViewModeFsm, Elevate_MarkdownGainedFromReadOrLive_Stay)
+{
+    EXPECT_EQ(ViewModeFsm::elevateWhenMarkdownGained(ViewMode::ReadView), ViewMode::ReadView);
+    EXPECT_EQ(ViewModeFsm::elevateWhenMarkdownGained(ViewMode::LivePreview), ViewMode::LivePreview);
+}
+
+// 「查看视图」在非 md 文件下走纯文本只读（非 Milkdown 渲染）
+TEST_F(UT_ViewModeFsm, ReadOnlyTextMode_ReadViewNonMarkdown_True)
+{
+    EXPECT_TRUE(ViewModeFsm::isReadOnlyTextMode(ViewMode::ReadView, false));
+}
+
+// 「查看视图」在 md 文件下走 Milkdown 渲染
+TEST_F(UT_ViewModeFsm, ReadOnlyTextMode_ReadViewMarkdown_False)
+{
+    EXPECT_FALSE(ViewModeFsm::isReadOnlyTextMode(ViewMode::ReadView, true));
+}
+
+// 其他视图不是纯文本只读
+TEST_F(UT_ViewModeFsm, ReadOnlyTextMode_EditOrLive_False)
+{
+    EXPECT_FALSE(ViewModeFsm::isReadOnlyTextMode(ViewMode::Edit, true));
+    EXPECT_FALSE(ViewModeFsm::isReadOnlyTextMode(ViewMode::LivePreview, true));
+}

--- a/tests/src/editor/markdown/ut_viewmodefsm.h
+++ b/tests/src/editor/markdown/ut_viewmodefsm.h
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef UT_VIEWMODEFSM_H
+#define UT_VIEWMODEFSM_H
+
+#include "gtest/gtest.h"
+#include <QObject>
+
+class UT_ViewModeFsm : public QObject, public ::testing::Test
+{
+    Q_OBJECT
+public:
+    UT_ViewModeFsm();
+};
+
+#endif // UT_VIEWMODEFSM_H


### PR DESCRIPTION
Add gtest suites for the QWidget-free logic units: ViewModeFsm default mode, availability, switch validity and fallback/elevate transitions; MarkdownLogic recognition rules and mdimg image path rewrite including chinese/space paths; RenderThrottle leading-plus-trailing throttle, same-content skip and pre-ready cache; ScrollSync ratio clamp and divide-by-zero guard; ThemeSerializer dark detection and CSS variables.

为纯逻辑层新增 gtest 套件：ViewModeFsm 默认视图/可用性/切换合法性/
回退与跃迁；MarkdownLogic 识别规则与 mdimg 图片路径改写（含中文、
空格路径）；RenderThrottle 前沿+后沿节流、相同内容跳过、ready 前
缓存；ScrollSync 比例钳制与除零保护；ThemeSerializer 深浅色判定与
CSS 变量序列化。

Log: 新增 Markdown 纯逻辑层单元测试
PMS: TASK-393979
Influence: 逻辑层规则全部有回归防护，改动有单测兜底。

## Summary by Sourcery

Add regression tests for the QWidget-free Markdown editor logic layer.

Enhancements:
- Add GoogleTest coverage for Markdown editor pure logic, including view-mode transitions, Markdown recognition and image URL rewriting, render throttling, scroll synchronization, and theme serialization.

Tests:
- Cover edge cases such as non-Markdown files, remote and encoded image paths, throttle readiness and duplicate content, scroll bounds and zero ranges, and empty or invalid themes.