### PR TITLE
test(markdown): add tests for bridge, view and webengine smoke

### DIFF
--- a/tests/src/editor/markdown/it_markdownview_smoke.cpp
+++ b/tests/src/editor/markdown/it_markdownview_smoke.cpp
@@ -1,0 +1,163 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// it_markdownview_smoke —— 真实 WebEngine 集成冒烟（§9.1）
+// 验证：qrc 页面 + file:// 本地图片 + 主题变量注入端到端可用。
+// 运行需真实渲染进程：QT_QPA_PLATFORM=offscreen 下可跑，必要时
+//   QTWEBENGINE_CHROMIUM_FLAGS="--no-sandbox --disable-gpu"
+
+#include "markdown/markdownview.h"
+#include "markdown/markdownbridge.h"
+#include "markdown/markdownlogic.h"
+
+#include <gtest/gtest.h>
+#include <QSignalSpy>
+#include <QTest>
+#include <QApplication>
+#include <QDebug>
+#include <QFileInfo>
+#include <QElapsedTimer>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QWebEnginePage>
+#include <functional>
+
+namespace {
+// 抓取 Chromium console 输出，定位资源加载被拒的确切原因
+class SpyPage : public QWebEnginePage
+{
+public:
+    using QWebEnginePage::QWebEnginePage;
+protected:
+    void javaScriptConsoleMessage(JavaScriptConsoleMessageLevel level, const QString &message,
+                                  int lineNumber, const QString &sourceID) override
+    {
+        fprintf(stderr, "[console] %s (%s:%d)\n", qPrintable(message), qPrintable(sourceID), lineNumber);
+    }
+};
+
+// 等待条件成立（事件循环驱动），超时返回 false
+bool waitFor(std::function<bool()> cond, int timeoutMs)
+{
+    QElapsedTimer t;
+    t.start();
+    while (t.elapsed() < timeoutMs) {
+        if (cond()) return true;
+        QApplication::processEvents(QEventLoop::AllEvents, 50);
+        QTest::qWait(10);
+    }
+    return cond();
+}
+}
+
+// 端到端：ready → setMarkdown（含 file:// 图片）→ 图片实际解码加载
+TEST(IT_MarkdownViewSmoke, DISABLED_RenderLocalImage_EndToEnd)
+{
+    const QString imgDir = QStringLiteral("/home/uos/work/deepin-editor/docs/markdown-demo");
+    if (!QFileInfo::exists(imgDir + QStringLiteral("/sample.png"))) {
+        GTEST_SKIP() << "sample.png not present, skip";
+    }
+
+    MarkdownView v;
+    SpyPage *page = new SpyPage(&v);   // 接管 page 以抓 console
+    v.setPage(page);
+    v.init();
+    QSignalSpy readySpy(v.bridge(), &MarkdownBridge::ready);
+    ASSERT_TRUE(waitFor([&readySpy]() { return readySpy.count() > 0; }, 15000))
+            << "WebEngine page not ready in 15s";
+
+    // 模拟 EditWrapper 完整链路：相对路径经 resolveImagePaths 改写为 mdimg://（自定义 scheme 供给本地文件）
+    const QString md = MarkdownLogic::resolveImagePaths(
+        QStringLiteral("# 标题\n\n![渐变图](sample.png)\n\n正文。"), imgDir);
+    qInfo() << "[smoke] rewritten md:" << md;
+    v.setMarkdown(md);
+    // 等渲染 + 图片子资源加载
+    QTest::qWait(3000);
+
+    QString json;
+    bool ok = false;
+    v.page()->runJavaScript(
+        QStringLiteral("JSON.stringify(Array.from(document.images).map(i=>"
+                       "({src:i.src, complete:i.complete, w:i.naturalWidth, h:i.naturalHeight})))"),
+        [&json, &ok](const QVariant &result) { json = result.toString(); ok = true; });
+    ASSERT_TRUE(waitFor([&ok]() { return ok; }, 5000));
+    qInfo() << "[smoke] images:" << json;
+
+    EXPECT_TRUE(json.contains(QStringLiteral("\"w\":400")))      // 真实解码出原始宽度
+            << "image not decoded/rendered: " << json.toStdString();
+}
+
+// 端到端：外部链接点击不在预览内导航，经 bridge 上抛 openLinkRequested（JS 拦截主路径）
+TEST(IT_MarkdownViewSmoke, DISABLED_ExternalLinkClick_DelegatedToBrowser)
+{
+    MarkdownView v;
+    SpyPage *page = new SpyPage(&v);
+    v.setPage(page);
+    v.init();
+    QSignalSpy readySpy(v.bridge(), &MarkdownBridge::ready);
+    ASSERT_TRUE(waitFor([&readySpy]() { return readySpy.count() > 0; }, 15000))
+            << "WebEngine page not ready in 15s";
+
+    v.setMarkdown(QStringLiteral("# 链接测试\n\n[deepin 官网](https://www.deepin.org/index.shtml)\n"));
+    QTest::qWait(1500);
+
+    // 模拟点击渲染出的 <a>：JS 捕获拦截 → preventDefault → bridge.onOpenLink 上抛
+    QSignalSpy linkSpy(v.bridge(), &MarkdownBridge::openLinkRequested);
+    bool anchorFound = false;
+    v.page()->runJavaScript(
+        QStringLiteral("(function(){const a=document.querySelector('a[href]');"
+                       "if(!a) return 'no-anchor'; a.click(); return 'clicked';})()"),
+        [&anchorFound](const QVariant &result) {
+            anchorFound = result.toString() != QLatin1String("no-anchor");
+        });
+    ASSERT_TRUE(waitFor([&anchorFound]() { return anchorFound; }, 5000)) << "anchor not rendered";
+
+    ASSERT_TRUE(waitFor([&linkSpy]() { return linkSpy.count() > 0; }, 5000))
+            << "openLinkRequested not emitted (click interception broken)";
+    EXPECT_EQ(linkSpy.takeFirst().at(0).toString(),
+              QStringLiteral("https://www.deepin.org/index.shtml"));
+}
+
+// 端到端时序复现（初始对齐）：ready 之前发出的 scrollToRatio 不得丢失，
+// 页面 ready + 首次渲染完成后应应用该比例（生产：恢复光标后左栏非顶部 → setViewMode 发真实比例）
+TEST(IT_MarkdownViewSmoke, DISABLED_ScrollRatioBeforeReady_AppliedAfterRender)
+{
+    const QString imgDir = QStringLiteral("/home/uos/work/deepin-editor/docs/markdown-demo");
+
+    MarkdownView v;
+    SpyPage *page = new SpyPage(&v);
+    v.setPage(page);
+    v.init();
+
+    // —— 不等 ready，模拟生产时序：内容 + 滚动比例先到 ——
+    QString longMd = QStringLiteral("# t\n\n");
+    for (int i = 0; i < 200; ++i)
+        longMd += QStringLiteral("段落 %1 一些内容文本。\n\n").arg(i);
+    v.setMarkdown(longMd);
+    v.scrollToRatio(0.5);          // 左栏恢复光标后在中间
+
+    QSignalSpy readySpy(v.bridge(), &MarkdownBridge::ready);
+    ASSERT_TRUE(waitFor([&readySpy]() { return readySpy.count() > 0; }, 15000))
+            << "WebEngine page not ready in 15s";
+
+    // 等首次渲染 + reapplyScroll 生效
+    QTest::qWait(2500);
+
+    QString json;
+    bool ok = false;
+    v.page()->runJavaScript(
+        QStringLiteral("(function(){const m=document.documentElement.scrollHeight-window.innerHeight;"
+                       "return JSON.stringify({y:window.scrollY,max:m});})()"),
+        [&json, &ok](const QVariant &result) { json = result.toString(); ok = true; });
+    ASSERT_TRUE(waitFor([&ok]() { return ok; }, 5000));
+    qInfo() << "[smoke] scroll:" << json;
+
+    // 解析并断言实际滚动比例 ≈ 0.5（允许 ±0.1 容差）
+    const auto doc = QJsonDocument::fromJson(json.toUtf8());
+    const double y = doc.object().value("y").toDouble();
+    const double max = doc.object().value("max").toDouble();
+    ASSERT_GT(max, 0);
+    EXPECT_NEAR(y / max, 0.5, 0.1)
+            << "initial scroll ratio lost: " << json.toStdString();
+}

--- a/tests/src/editor/markdown/ut_markdownbridge.cpp
+++ b/tests/src/editor/markdown/ut_markdownbridge.cpp
@@ -1,0 +1,124 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "ut_markdownbridge.h"
+#include "markdownbridge.h"
+
+#include <QSignalSpy>
+
+UT_MarkdownBridge::UT_MarkdownBridge()
+{
+}
+
+// onReady 应触发 ready 信号（JS 侧 Milkdown 创建完成后调用）
+TEST_F(UT_MarkdownBridge, OnReady_EmitsReadySignal)
+{
+    MarkdownBridge bridge;
+    QSignalSpy spy(&bridge, &MarkdownBridge::ready);
+    ASSERT_TRUE(spy.isValid());
+
+    bridge.onReady();
+
+    EXPECT_EQ(spy.count(), 1);
+}
+
+// onContentChanged 应转发 contentChanged 信号并原样携带 md（阶段二启用，接口先到位）
+TEST_F(UT_MarkdownBridge, OnContentChanged_EmitsContentChangedWithPayload)
+{
+    MarkdownBridge bridge;
+    QSignalSpy spy(&bridge, &MarkdownBridge::contentChanged);
+
+    bridge.onContentChanged(QStringLiteral("# hello"));
+
+    ASSERT_EQ(spy.count(), 1);
+    EXPECT_EQ(spy.takeFirst().at(0).toString(), QStringLiteral("# hello"));
+}
+
+// onScrollRatio 应转发 scrollRatioChanged 信号并携带 ratio
+TEST_F(UT_MarkdownBridge, OnScrollRatio_EmitsScrollRatioChangedWithPayload)
+{
+    MarkdownBridge bridge;
+    QSignalSpy spy(&bridge, &MarkdownBridge::scrollRatioChanged);
+
+    bridge.onScrollRatio(0.5);
+
+    ASSERT_EQ(spy.count(), 1);
+    EXPECT_DOUBLE_EQ(spy.takeFirst().at(0).toDouble(), 0.5);
+}
+
+// onOpenLink 应转发 openLinkRequested 信号并原样携带 url（JS 点击拦截外部链接 → 系统浏览器）
+TEST_F(UT_MarkdownBridge, OnOpenLink_EmitsOpenLinkRequestedWithPayload)
+{
+    MarkdownBridge bridge;
+    QSignalSpy spy(&bridge, &MarkdownBridge::openLinkRequested);
+
+    bridge.onOpenLink(QStringLiteral("https://www.deepin.org/index.shtml"));
+
+    ASSERT_EQ(spy.count(), 1);
+    EXPECT_EQ(spy.takeFirst().at(0).toString(), QStringLiteral("https://www.deepin.org/index.shtml"));
+}
+
+// C++ → JS 信号：setMarkdownRequested 应可被 QSignalSpy 捕获（验证信号存在且可连接）
+TEST_F(UT_MarkdownBridge, SetMarkdownRequested_IsEmitable)
+{
+    MarkdownBridge bridge;
+    QSignalSpy spy(&bridge, &MarkdownBridge::setMarkdownRequested);
+
+    emit bridge.setMarkdownRequested(QStringLiteral("body"));
+
+    ASSERT_EQ(spy.count(), 1);
+    EXPECT_EQ(spy.takeFirst().at(0).toString(), QStringLiteral("body"));
+}
+
+// applyThemeRequested 信号存在性 + 双参数载荷（jsonColors / isDark）
+TEST_F(UT_MarkdownBridge, ApplyThemeRequested_IsEmitableWithTwoArgs)
+{
+    MarkdownBridge bridge;
+    QSignalSpy spy(&bridge, &MarkdownBridge::applyThemeRequested);
+
+    emit bridge.applyThemeRequested(QStringLiteral("{\"--bg\":\"#fff\"}"), true);
+
+    ASSERT_EQ(spy.count(), 1);
+    QList<QVariant> args = spy.takeFirst();
+    EXPECT_EQ(args.at(0).toString(), QStringLiteral("{\"--bg\":\"#fff\"}"));
+    EXPECT_TRUE(args.at(1).toBool());
+}
+
+// setModeRequested 信号载荷（editable 开关）
+TEST_F(UT_MarkdownBridge, SetModeRequested_IsEmitable)
+{
+    MarkdownBridge bridge;
+    QSignalSpy spy(&bridge, &MarkdownBridge::setModeRequested);
+
+    emit bridge.setModeRequested(true);
+
+    ASSERT_EQ(spy.count(), 1);
+    EXPECT_TRUE(spy.takeFirst().at(0).toBool());
+}
+
+// setLayoutRequested 信号载荷（maxW / center）
+TEST_F(UT_MarkdownBridge, SetLayoutRequested_IsEmitableWithTwoArgs)
+{
+    MarkdownBridge bridge;
+    QSignalSpy spy(&bridge, &MarkdownBridge::setLayoutRequested);
+
+    emit bridge.setLayoutRequested(800, true);
+
+    ASSERT_EQ(spy.count(), 1);
+    QList<QVariant> args = spy.takeFirst();
+    EXPECT_EQ(args.at(0).toInt(), 800);
+    EXPECT_TRUE(args.at(1).toBool());
+}
+
+// scrollToRatioRequested 信号载荷
+TEST_F(UT_MarkdownBridge, ScrollToRatioRequested_IsEmitable)
+{
+    MarkdownBridge bridge;
+    QSignalSpy spy(&bridge, &MarkdownBridge::scrollToRatioRequested);
+
+    emit bridge.scrollToRatioRequested(0.25);
+
+    ASSERT_EQ(spy.count(), 1);
+    EXPECT_DOUBLE_EQ(spy.takeFirst().at(0).toDouble(), 0.25);
+}

--- a/tests/src/editor/markdown/ut_markdownbridge.h
+++ b/tests/src/editor/markdown/ut_markdownbridge.h
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef UT_MARKDOWNBRIDGE_H
+#define UT_MARKDOWNBRIDGE_H
+
+#include "gtest/gtest.h"
+#include <QObject>
+
+class UT_MarkdownBridge : public QObject, public ::testing::Test
+{
+    Q_OBJECT
+public:
+    UT_MarkdownBridge();
+};
+
+#endif // UT_MARKDOWNBRIDGE_H

--- a/tests/src/editor/markdown/ut_markdownview.cpp
+++ b/tests/src/editor/markdown/ut_markdownview.cpp
@@ -1,0 +1,169 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "ut_markdownview.h"
+#include "markdownview.h"
+#include "markdownbridge.h"
+
+#include <QSignalSpy>
+
+UT_MarkdownView::UT_MarkdownView()
+{
+}
+
+// 构造后（未 init/load）默认未就绪
+TEST_F(UT_MarkdownView, Construct_NotReadyByDefault)
+{
+    MarkdownView v;
+    EXPECT_FALSE(v.isReady());
+}
+
+// setMarkdown 应转发为 bridge 的 setMarkdownRequested（经 MarkdownView 内部 bridge）
+// 这里不监听内部 bridge，而是通过暴露的 bridge 访问器验证转发链路。
+TEST_F(UT_MarkdownView, SetMarkdown_ForwardsToBridge)
+{
+    MarkdownView v;
+    QSignalSpy spy(v.bridge(), &MarkdownBridge::setMarkdownRequested);
+
+    v.setMarkdown(QStringLiteral("# title"));
+
+    ASSERT_EQ(spy.count(), 1);
+    EXPECT_EQ(spy.takeFirst().at(0).toString(), QStringLiteral("# title"));
+}
+
+// setMode(ReadOnly) 应转发 setModeRequested(false)
+TEST_F(UT_MarkdownView, SetMode_ReadOnly_ForwardsFalse)
+{
+    MarkdownView v;
+    QSignalSpy spy(v.bridge(), &MarkdownBridge::setModeRequested);
+
+    v.setMode(static_cast<int>(MarkdownView::Mode::ReadOnly));
+
+    ASSERT_EQ(spy.count(), 1);
+    EXPECT_FALSE(spy.takeFirst().at(0).toBool());
+}
+
+// setMode(Editable) 应转发 setModeRequested(true)（阶段二用，本期接口先到位）
+TEST_F(UT_MarkdownView, SetMode_Editable_ForwardsTrue)
+{
+    MarkdownView v;
+    QSignalSpy spy(v.bridge(), &MarkdownBridge::setModeRequested);
+
+    v.setMode(static_cast<int>(MarkdownView::Mode::Editable));
+
+    ASSERT_EQ(spy.count(), 1);
+    EXPECT_TRUE(spy.takeFirst().at(0).toBool());
+}
+
+// setLayout 应转发 maxContentWidth / center
+TEST_F(UT_MarkdownView, SetLayout_ForwardsArgs)
+{
+    MarkdownView v;
+    QSignalSpy spy(v.bridge(), &MarkdownBridge::setLayoutRequested);
+
+    v.setLayout(800, true);
+
+    ASSERT_EQ(spy.count(), 1);
+    QList<QVariant> args = spy.takeFirst();
+    EXPECT_EQ(args.at(0).toInt(), 800);
+    EXPECT_TRUE(args.at(1).toBool());
+}
+
+// setLayout(maxContentWidth=0) 表示不限最大宽（实时阅览半幅场景）
+TEST_F(UT_MarkdownView, SetLayout_ZeroMaxWidth_ForwardsZero)
+{
+    MarkdownView v;
+    QSignalSpy spy(v.bridge(), &MarkdownBridge::setLayoutRequested);
+
+    v.setLayout(0, false);
+
+    ASSERT_EQ(spy.count(), 1);
+    QList<QVariant> args = spy.takeFirst();
+    EXPECT_EQ(args.at(0).toInt(), 0);
+    EXPECT_FALSE(args.at(1).toBool());
+}
+
+// scrollToRatio 应转发 ratio
+TEST_F(UT_MarkdownView, ScrollToRatio_ForwardsRatio)
+{
+    MarkdownView v;
+    QSignalSpy spy(v.bridge(), &MarkdownBridge::scrollToRatioRequested);
+
+    v.scrollToRatio(0.75);
+
+    ASSERT_EQ(spy.count(), 1);
+    EXPECT_DOUBLE_EQ(spy.takeFirst().at(0).toDouble(), 0.75);
+}
+
+// bridge.onReady() → MarkdownView 内部置 ready 标志 + 发 ready 信号
+TEST_F(UT_MarkdownView, BridgeReady_SetsReadyAndEmitsSignal)
+{
+    MarkdownView v;
+    QSignalSpy spy(&v, &MarkdownView::ready);
+    ASSERT_FALSE(v.isReady());
+
+    v.bridge()->onReady();
+
+    EXPECT_TRUE(v.isReady());
+    EXPECT_EQ(spy.count(), 1);
+}
+
+// bridge 的 scrollRatioChanged 应穿透为 MarkdownView::scrollRatioChanged（预留，本期不连上层）
+TEST_F(UT_MarkdownView, BridgeScrollRatio_PassesThrough)
+{
+    MarkdownView v;
+    QSignalSpy spy(&v, &MarkdownView::scrollRatioChanged);
+
+    v.bridge()->onScrollRatio(0.4);
+
+    ASSERT_EQ(spy.count(), 1);
+    EXPECT_DOUBLE_EQ(spy.takeFirst().at(0).toDouble(), 0.4);
+}
+
+// bridge 的 contentChanged 应穿透为 MarkdownView::contentChanged（预留，本期不连上层）
+TEST_F(UT_MarkdownView, BridgeContentChanged_PassesThrough)
+{
+    MarkdownView v;
+    QSignalSpy spy(&v, &MarkdownView::contentChanged);
+
+    v.bridge()->onContentChanged(QStringLiteral("body"));
+
+    ASSERT_EQ(spy.count(), 1);
+    EXPECT_EQ(spy.takeFirst().at(0).toString(), QStringLiteral("body"));
+}
+
+// §4.7/§5.3：页面加载是异步的，ready 前 applyTheme 的主题须缓存，ready 后自动补发
+TEST_F(UT_MarkdownView, ApplyTheme_BeforeReady_ReemittedAfterReady)
+{
+    MarkdownView v;
+    QVariantMap themeMap;
+    themeMap["editor-colors"] = QVariantMap{
+        {"background-color", "#1e1e1e"},
+        {"text-color", "#d8d8d8"},
+    };
+    QSignalSpy spy(v.bridge(), &MarkdownBridge::applyThemeRequested);
+
+    v.applyTheme(themeMap);          // 页面未 ready：直发一次（若 JS 未接线则丢失）
+    ASSERT_EQ(spy.count(), 1);
+
+    v.bridge()->onReady();           // 页面就绪：应补发缓存主题
+    ASSERT_EQ(spy.count(), 2);
+    const auto args = spy.takeLast();
+    EXPECT_EQ(args.at(1).toBool(), true);   // 深色背景 → isDark=true
+}
+
+// ready 之后的 applyTheme 不重复补发
+TEST_F(UT_MarkdownView, ApplyTheme_AfterReady_NoReemit)
+{
+    MarkdownView v;
+    v.bridge()->onReady();
+    QVariantMap themeMap;
+    themeMap["editor-colors"] = QVariantMap{
+        {"background-color", "#ffffff"},
+        {"text-color", "#1f1f1f"},
+    };
+    QSignalSpy spy(v.bridge(), &MarkdownBridge::applyThemeRequested);
+    v.applyTheme(themeMap);
+    EXPECT_EQ(spy.count(), 1);
+}

--- a/tests/src/editor/markdown/ut_markdownview.h
+++ b/tests/src/editor/markdown/ut_markdownview.h
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef UT_MARKDOWNVIEW_H
+#define UT_MARKDOWNVIEW_H
+
+#include "gtest/gtest.h"
+#include <QObject>
+
+class UT_MarkdownView : public QObject, public ::testing::Test
+{
+    Q_OBJECT
+public:
+    UT_MarkdownView();
+};
+
+#endif // UT_MARKDOWNVIEW_H


### PR DESCRIPTION
Add QSignalSpy suites covering MarkdownBridge signal payloads (incl. openLinkRequested) and MarkdownView protocol-cache replay verified via mock bridge without starting WebEngine; add DISABLED_ integration smoke tests running a real render process: local image naturalWidth decode, pre-ready scroll ratio replay and external link click delegation, with javaScriptConsoleMessage capture for diagnostics.

新增 QSignalSpy 套件覆盖 MarkdownBridge 信号载荷（含 openLink
Requested）与经 mock bridge 验证的 MarkdownView 协议缓存补发（不启 WebEngine）；新增 DISABLED_ 前缀的真实渲染冒烟：本地图片 naturalWidth 解码、ready 前滚动比例重放、外部链接点击转交，附带 console 抓取诊断。

Log: 新增桥接/渲染服务测试与真实 WebEngine 冒烟
PMS: TASK-393979
Influence: 渲染链路改动可按维护检查单跑冒烟验证，防"单测全绿实机白屏"。

## Summary by Sourcery

Expand Markdown rendering test coverage across bridge protocols, view state replay, and real WebEngine behavior.

Enhancements:
- Add unit coverage for MarkdownBridge signal payloads and MarkdownView command forwarding, readiness, pass-through signals, and theme replay.
- Add disabled end-to-end WebEngine smoke coverage for local image decoding, pre-ready scroll restoration, and external link delegation with console diagnostics.

Tests:
- Introduce QSignalSpy-based MarkdownBridge and MarkdownView test suites, plus disabled real-WebEngine integration smoke tests.