### PR TITLE
fix(editor): add hover and press states to color mark icons

### DIFF
--- a/src/widgets/ColorSelectWdg.cpp
+++ b/src/widgets/ColorSelectWdg.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2019 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2019-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -45,8 +45,7 @@ void ColorLabel::paintEvent(QPaintEvent *event)
 {
     Q_UNUSED(event)
 
-    int distance = 2;
-
+    const int distance = 2;
     QRect r = rect();
 
     QPainter painter(this);
@@ -56,41 +55,95 @@ void ColorLabel::paintEvent(QPaintEvent *event)
 #endif
     );
 
+    if (m_bPressed) {
+        // press: 内圆微缩 + 颜色加深，模拟按压
+        QPainterPath pressedPath;
+        pressedPath.addEllipse(r.adjusted(distance, distance, -distance, -distance));
+        painter.fillPath(pressedPath, m_color.darker(130));
 
-    QPainterPath bigCircle;
-    bigCircle.addEllipse(r);
+        if (m_bSelected) {
+            QPainterPath outerPath;
+            outerPath.addEllipse(r);
+            QPainterPath innerPath;
+            innerPath.addEllipse(r.adjusted(distance / 2, distance / 2,
+                                             -distance / 2, -distance / 2));
+            painter.fillPath(outerPath - innerPath, m_color);
+        }
+    } else if (m_bHover) {
+        // hover: 圆略微放大
+        QPainterPath hoverPath;
+        hoverPath.addEllipse(r.adjusted(distance, distance, -distance, -distance));
+        painter.fillPath(hoverPath, m_color);
 
-    QPainterPath smallCircle;
-    smallCircle.addEllipse(r.adjusted(2*distance,2*distance,-2*distance,-2*distance));
+        if (m_bSelected) {
+            QPainterPath outerPath;
+            outerPath.addEllipse(r);
+            QPainterPath innerPath;
+            innerPath.addEllipse(r.adjusted(distance, distance, -distance, -distance));
+            painter.fillPath(outerPath - innerPath, m_color);
+        }
+    } else {
+        // normal: 原有逻辑
+        QPainterPath outerPath;
+        outerPath.addEllipse(r);
+        QPainterPath innerPath;
+        innerPath.addEllipse(r.adjusted(2 * distance, 2 * distance,
+                                        -2 * distance, -2 * distance));
+        painter.fillPath(innerPath, m_color);
 
-    //先画小圆
-    painter.fillPath(smallCircle,m_color);
-
-
-    //如果点击选择画　圆环
-    if(m_bSelected){
-        r = rect();
-        QPainterPath sencondCircle;
-        sencondCircle.addEllipse(r.adjusted(distance,distance,-distance,-distance));
-        //大圆减小圆等于圆环
-        QPainterPath path = bigCircle - sencondCircle;
-        painter.fillPath(path,m_color);
+        if (m_bSelected) {
+            QPainterPath selectedInnerPath;
+            selectedInnerPath.addEllipse(r.adjusted(distance, distance,
+                                                     -distance, -distance));
+            painter.fillPath(outerPath - selectedInnerPath, m_color);
+        }
     }
 
     painter.end();
 }
 
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+void ColorLabel::enterEvent(QEvent *event)
+#else
+void ColorLabel::enterEvent(QEnterEvent *event)
+#endif
+{
+    DWidget::enterEvent(event);
+    m_bHover = true;
+    update();
+}
+
+void ColorLabel::leaveEvent(QEvent *event)
+{
+    DWidget::leaveEvent(event);
+    m_bHover = false;
+    m_bPressed = false;
+    update();
+}
+
 void ColorLabel::mousePressEvent(QMouseEvent *e)
 {
     qDebug() << "ColorLabel mouse press event";
-    //没有选择点击有效
-    if(e->button() == Qt::LeftButton){
-       m_bSelected = true;
-       update();
-       emit sigColorClicked(m_bSelected,m_color);
-       qDebug() << "ColorLabel mouse press event, color selected state updated to:" << m_bSelected;
+    if (e->button() == Qt::LeftButton) {
+        m_bPressed = true;
+        update();
     }
+    DWidget::mousePressEvent(e);
     qDebug() << "ColorLabel mouse press event end";
+}
+
+void ColorLabel::mouseReleaseEvent(QMouseEvent *e)
+{
+    qDebug() << "ColorLabel mouse release event";
+    if (e->button() == Qt::LeftButton && m_bPressed) {
+        m_bPressed = false;
+        m_bSelected = true;
+        update();
+        emit sigColorClicked(m_bSelected, m_color);
+        qDebug() << "ColorLabel mouse release event, color selected state updated to:" << m_bSelected;
+    }
+    DWidget::mouseReleaseEvent(e);
+    qDebug() << "ColorLabel mouse release event end";
 }
 
 ColorSelectWdg::ColorSelectWdg(QString text,QWidget *parent):DWidget (parent),m_text(text)

--- a/src/widgets/ColorSelectWdg.h
+++ b/src/widgets/ColorSelectWdg.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2019 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2019-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -37,12 +37,21 @@ public:
 signals:
     void sigColorClicked(bool bSelect,QColor color);
 protected:
-    void paintEvent(QPaintEvent *event);
-    void mousePressEvent(QMouseEvent *e);
+    void paintEvent(QPaintEvent *event) override;
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+    void enterEvent(QEvent *event) override;
+#else
+    void enterEvent(QEnterEvent *event) override;
+#endif
+    void leaveEvent(QEvent *event) override;
+    void mousePressEvent(QMouseEvent *e) override;
+    void mouseReleaseEvent(QMouseEvent *e) override;
 private:
     //颜色选择标记
 
     bool m_bSelected = false;
+    bool m_bHover = false;
+    bool m_bPressed = false;
     QColor m_color;
 };
 

--- a/tests/src/widgets/ut_bottombar.cpp
+++ b/tests/src/widgets/ut_bottombar.cpp
@@ -242,15 +242,15 @@ TEST_F(TestBottomBar, checkViewModeMenu_SetViewMode)
     ASSERT_NE(bottomBar->m_pViewModeMenu, nullptr);
 
     bottomBar->setViewMode(ViewMode::LivePreview);
-    EXPECT_EQ(bottomBar->m_pViewModeMenu->getCurrentText(), QString("实时预览"));
+    EXPECT_EQ(bottomBar->m_pViewModeMenu->getCurrentText(), bottomBar->m_actLivePreview->text());
     EXPECT_TRUE(bottomBar->m_actLivePreview->isChecked());
 
     bottomBar->setViewMode(ViewMode::ReadView);
-    EXPECT_EQ(bottomBar->m_pViewModeMenu->getCurrentText(), QString("查看视图"));
+    EXPECT_EQ(bottomBar->m_pViewModeMenu->getCurrentText(), bottomBar->m_actReadView->text());
     EXPECT_TRUE(bottomBar->m_actReadView->isChecked());
 
     bottomBar->setViewMode(ViewMode::Edit);
-    EXPECT_EQ(bottomBar->m_pViewModeMenu->getCurrentText(), QString("编辑模式"));
+    EXPECT_EQ(bottomBar->m_pViewModeMenu->getCurrentText(), bottomBar->m_actEditView->text());
     EXPECT_TRUE(bottomBar->m_actEditView->isChecked());
 
     bottomBar->deleteLater();

--- a/tests/src/widgets/ut_colorselectwidget.cpp
+++ b/tests/src/widgets/ut_colorselectwidget.cpp
@@ -56,7 +56,6 @@ TEST_F(test_colorlabel, checkGetColor)
 // 测试函数 ColorLabel::paintEvent
 TEST_F(test_colorlabel, checkPaintEvent)
 {
-
     auto colorLabel = new ColorLabel(QColor("#FF0000"));
     colorLabel->setColorSelected(true);
     QPaintEvent event(colorLabel->rect());
@@ -64,15 +63,18 @@ TEST_F(test_colorlabel, checkPaintEvent)
     EXPECT_NE(colorLabel,nullptr);
     colorLabel->deleteLater();
 
-
-
     colorLabel = new ColorLabel(QColor("#FF0000"));
     colorLabel->setColorSelected(false);
     QPaintEvent event2(colorLabel->rect());
     colorLabel->paintEvent(&event2);
     EXPECT_NE(colorLabel,nullptr);
-    colorLabel->deleteLater();
 
+    colorLabel->m_bHover = true;
+    colorLabel->paintEvent(&event2);
+    colorLabel->m_bHover = false;
+    colorLabel->m_bPressed = true;
+    colorLabel->paintEvent(&event2);
+    colorLabel->deleteLater();
 }
 
 // 测试函数 ColorLabel::mousePressEvent
@@ -82,31 +84,58 @@ TEST_F(test_colorlabel, checkMousePressEvent)
     // 场景1: LeftButtonPress
     auto colorLabel = new ColorLabel(QColor("#FF0000"));
     QSignalSpy spy(colorLabel, &ColorLabel::sigColorClicked);
-    QMouseEvent *event = new QMouseEvent(QEvent::MouseButtonPress, QPointF(), QPointF(),
-                                         Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
-    colorLabel->mousePressEvent(event);
+    QMouseEvent pressEvent(QEvent::MouseButtonPress, QPointF(), QPointF(),
+                           Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+    colorLabel->mousePressEvent(&pressEvent);
+    EXPECT_TRUE(colorLabel->m_bPressed);
+    EXPECT_EQ(spy.count(), 0);
+
+    QMouseEvent releaseEvent(QEvent::MouseButtonRelease, QPointF(), QPointF(),
+                             Qt::LeftButton, Qt::NoButton, Qt::NoModifier);
+    colorLabel->mouseReleaseEvent(&releaseEvent);
+    EXPECT_FALSE(colorLabel->m_bPressed);
+    EXPECT_TRUE(colorLabel->isSelected());
     EXPECT_EQ(spy.count(), 1);
 
     EXPECT_NE(colorLabel,nullptr);
     colorLabel->deleteLater();
-    EXPECT_NE(event,nullptr);
-    delete event;event=nullptr;
 
 
 
     // 场景2: 非LeftButtonPress
     colorLabel = new ColorLabel(QColor("#FF0000"));
     QSignalSpy spy2(colorLabel, &ColorLabel::sigColorClicked);
-    event = new QMouseEvent(QEvent::MouseButtonPress, QPointF(), QPointF(),
-                            Qt::RightButton, Qt::RightButton, Qt::NoModifier);
-    colorLabel->mousePressEvent(event);
+    QMouseEvent rightPressEvent(QEvent::MouseButtonPress, QPointF(), QPointF(),
+                                Qt::RightButton, Qt::RightButton, Qt::NoModifier);
+    colorLabel->mousePressEvent(&rightPressEvent);
+    EXPECT_FALSE(colorLabel->m_bPressed);
     EXPECT_EQ(spy2.count(), 0);
 
     EXPECT_NE(colorLabel,nullptr);
     colorLabel->deleteLater();
-    EXPECT_NE(event,nullptr);
-    delete event;event=nullptr;
 
+}
+
+// 测试函数 ColorLabel::enterEvent/leaveEvent
+TEST_F(test_colorlabel, checkHoverState)
+{
+    auto colorLabel = new ColorLabel(QColor("#FF0000"));
+
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+    QEvent enterEvent(QEvent::Enter);
+#else
+    QEnterEvent enterEvent(QPointF{}, QPointF{}, QPointF{});
+#endif
+    colorLabel->enterEvent(&enterEvent);
+    EXPECT_TRUE(colorLabel->m_bHover);
+
+    colorLabel->m_bPressed = true;
+    QEvent leaveEvent(QEvent::Leave);
+    colorLabel->leaveEvent(&leaveEvent);
+    EXPECT_FALSE(colorLabel->m_bHover);
+    EXPECT_FALSE(colorLabel->m_bPressed);
+
+    colorLabel->deleteLater();
 }
 
 // 测试函数 ColorSelectWdg::initWidget
@@ -223,16 +252,20 @@ TEST_F(test_colorselectwidget, checkColorLabelClickedLambda)
 
     QSignalSpy spy(colorSelctWidget, &ColorSelectWdg::sigColorSelected);
 
-    // 点击第二个颜色标签(非默认选中)，触发其 mousePressEvent 发出 sigColorClicked，
+    // 点击第二个颜色标签(非默认选中)，按下时显示反馈，释放时发出 sigColorClicked，
     // 进而调用 ColorSelectWdg 中 connect 注册的 lambda
     ColorLabel *label = colorSelctWidget->m_colorLabels.at(1);
-    QMouseEvent *event = new QMouseEvent(QEvent::MouseButtonPress, QPointF(), QPointF(),
-                                         Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
-    label->mousePressEvent(event);
+    QMouseEvent pressEvent(QEvent::MouseButtonPress, QPointF(), QPointF(),
+                           Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+    label->mousePressEvent(&pressEvent);
+    EXPECT_EQ(spy.count(), 0);
+
+    QMouseEvent releaseEvent(QEvent::MouseButtonRelease, QPointF(), QPointF(),
+                             Qt::LeftButton, Qt::NoButton, Qt::NoModifier);
+    label->mouseReleaseEvent(&releaseEvent);
     // 默认选中的第一个标签应被取消选中
     EXPECT_FALSE(colorSelctWidget->m_colorLabels.at(0)->isSelected());
     EXPECT_EQ(spy.count(), 1);
 
-    delete event;
     colorSelctWidget->deleteLater();
 }


### PR DESCRIPTION
Log: 增加颜色标记图标悬停与按压状态
Bug: https://pms.uniontech.com/bug-view-196825.html
Influence: 右键菜单颜色标记增加悬停和按压反馈，兼容 Qt5/Qt6。

## Summary by Sourcery

Add interactive hover and press states to color mark icons while preserving selection behavior across supported Qt versions.

New Features:
- Add hover and press visual feedback to color mark icons in the context menu.

Enhancements:
- Support the color mark interaction states across both Qt5 and Qt6 event APIs.

Tests:
- Expand color mark widget tests to cover hover, press, release, and selection behavior.
- Make bottom bar view-mode tests compare against action labels instead of hard-coded text.