### PR TITLE
feat(markdown): add code block and table header with i18n

### DIFF
--- a/src/editor/markdown/markdownbridge.h
+++ b/src/editor/markdown/markdownbridge.h
@@ -24,8 +24,22 @@
 class MarkdownBridge : public QObject
 {
     Q_OBJECT
+    // JS 侧 UI 文案（QWebChannel 会把 Q_PROPERTY 同步到 bridge.<name>）：
+    // 翻译走 Qt linguist，语言切换后经 retranslate 槽更新（JS 侧收到 propertyChanged 信号）
+    Q_PROPERTY(QString collapseTooltip READ collapseTooltip NOTIFY retranslated)
+    Q_PROPERTY(QString expandTooltip READ expandTooltip NOTIFY retranslated)
+    Q_PROPERTY(QString copyTooltip READ copyTooltip NOTIFY retranslated)
+    Q_PROPERTY(QString expandText READ expandText NOTIFY retranslated)
+    Q_PROPERTY(QString collapsedLinesText READ collapsedLinesText NOTIFY retranslated)
 public:
     explicit MarkdownBridge(QObject *parent = nullptr) : QObject(parent) {}
+
+    QString collapseTooltip() const { return tr("Collapse code block"); }
+    QString expandTooltip() const { return tr("Expand code block"); }
+    QString copyTooltip() const { return tr("Copy code"); }
+    QString expandText() const { return tr("Expand"); }
+    // %1 为行数；JS 侧 String.prototype.replace("%1", n) 填充
+    QString collapsedLinesText() const { return tr("%1 line(s) of code collapsed"); }
 
 public slots:
     // JS → C++
@@ -34,12 +48,16 @@ public slots:
     void onScrollRatio(double ratio) { emit scrollRatioChanged(ratio); }
     void onOpenLink(const QString &url) { emit openLinkRequested(url); }
 
+    // 语言切换后由宿主调用：NOTIFY 信号触发 JS 侧全部属性重取
+    void retranslate() { emit retranslated(); }
+
 signals:
     // C++ → JS（JS 端 bridge.{signal}.connect(function(...){...}) 接收）
     void ready();
     void contentChanged(const QString &md);
     void scrollRatioChanged(double ratio);
     void openLinkRequested(const QString &url);
+    void retranslated();
 
     void setMarkdownRequested(const QString &md);
     void setModeRequested(bool editable);

--- a/src/editor/markdown/web/bridge.js
+++ b/src/editor/markdown/web/bridge.js
@@ -36,6 +36,10 @@ function wireSignals(h) {
     b.applyThemeRequested.connect(function (json, isDark) { h.onApplyTheme(json, isDark); });
     b.setLayoutRequested.connect(function (maxW, center) { h.onSetLayout(maxW, center); });
     b.scrollToRatioRequested.connect(function (ratio) { h.onScrollToRatio(ratio); });
+    // 语言切换：C++ 侧 Q_PROPERTY 文案更新后触发，重刷已渲染 DOM
+    if (h.onRetranslate && b.retranslated) {
+        b.retranslated.connect(function () { h.onRetranslate(); });
+    }
 }
 
 // 供 main.js 调用：注册 C++→JS 信号处理器

--- a/src/editor/markdown/web/build/main.bundle.js
+++ b/src/editor/markdown/web/build/main.bundle.js
@@ -45303,6 +45303,11 @@ var __privateSet = (obj, member, value, setter) => (__accessCheck(obj, member, "
     b.scrollToRatioRequested.connect(function(ratio) {
       h.onScrollToRatio(ratio);
     });
+    if (h.onRetranslate && b.retranslated) {
+      b.retranslated.connect(function() {
+        h.onRetranslate();
+      });
+    }
   }
   function setupBridge(handlers2) {
     pendingHandlers = handlers2;
@@ -45310,19 +45315,151 @@ var __privateSet = (obj, member, value, setter) => (__accessCheck(obj, member, "
   }
   initChannel();
   const TABLE_WRAPPER_CLASS = "table-wrapper";
+  const CODE_BLOCK_CLASS = "code-block";
+  const ARROW_UP_SVG = '<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"><path d="M1 7 L5 3 L9 7"/></svg>';
+  const ARROW_DOWN_SVG = '<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"><path d="M1 3 L5 7 L9 3"/></svg>';
+  const COPY_ICON_SVG = '<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"><rect x="4.5" y="4.5" width="8" height="8" rx="1.5"/><path d="M9.5 4.5 V3 a1.5 1.5 0 0 0 -1.5 -1.5 H3 a1.5 1.5 0 0 0 -1.5 1.5 V8 a1.5 1.5 0 0 0 1.5 1.5 H4.5"/></svg>';
+  const CHECK_ICON_SVG = '<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M2.5 7.5 L5.5 10.5 L11.5 3.5"/></svg>';
+  const COPY_FEEDBACK_MS = 2e3;
+  const FALLBACK_TEXTS = {
+    collapseTooltip: "Collapse code block",
+    expandTooltip: "Expand code block",
+    copyTooltip: "Copy code",
+    expandText: "Expand",
+    collapsedLinesText: "%1 line(s) of code collapsed"
+  };
+  function uiText(key2) {
+    const b = window.bridge;
+    return b && typeof b[key2] === "string" && b[key2].length > 0 ? b[key2] : FALLBACK_TEXTS[key2];
+  }
+  function retranslateCodeBlocks(root2) {
+    if (!root2) return;
+    root2.querySelectorAll("." + CODE_BLOCK_CLASS).forEach((wrapper) => {
+      const pre = wrapper.querySelector("pre");
+      const lineCount = pre ? countCodeLines(pre.textContent) : 0;
+      wrapper.querySelector(".code-block-collapsed > span:first-child").textContent = uiText("collapsedLinesText").replace("%1", lineCount);
+      wrapper.querySelector(".code-block-expand").textContent = uiText("expandText");
+      const collapsed = wrapper.classList.contains("collapsed");
+      const toggle = wrapper.querySelector(".code-block-toggle");
+      toggle.setAttribute("aria-label", collapsed ? uiText("expandTooltip") : uiText("collapseTooltip"));
+      const copy2 = wrapper.querySelector(".code-block-copy");
+      copy2.title = uiText("copyTooltip");
+      copy2.setAttribute("aria-label", uiText("copyTooltip"));
+    });
+  }
   function wrapTables(root2) {
     if (!root2) return;
     const tables = root2.querySelectorAll("table");
     tables.forEach((table) => {
-      if (table.parentElement && table.parentElement.classList.contains(TABLE_WRAPPER_CLASS)) return;
+      if (table.closest("." + TABLE_WRAPPER_CLASS)) return;
+      const block = document.createElement("div");
+      block.className = "table-block";
+      const header = document.createElement("div");
+      header.className = "table-block-header";
       const wrapper = document.createElement("div");
       wrapper.className = TABLE_WRAPPER_CLASS;
-      table.parentNode.insertBefore(wrapper, table);
+      table.parentNode.insertBefore(block, table);
+      block.appendChild(header);
+      block.appendChild(wrapper);
       wrapper.appendChild(table);
+    });
+  }
+  function countCodeLines(text2) {
+    const lines = String(text2 || "").split("\n");
+    while (lines.length && lines[lines.length - 1].trim() === "") lines.pop();
+    return lines.length;
+  }
+  function detectLanguage(pre) {
+    const lang = pre.getAttribute("data-language");
+    if (lang && lang.length > 0) return lang;
+    const code2 = pre.querySelector("code");
+    if (code2) {
+      const m = code2.className.match(/(?:^|\s)language-([\w#+-]+)/);
+      if (m) return m[1];
+    }
+    return "";
+  }
+  function copyTextToClipboard(text2) {
+    const ta = document.createElement("textarea");
+    ta.value = text2;
+    ta.setAttribute("readonly", "");
+    ta.style.position = "fixed";
+    ta.style.opacity = "0";
+    document.body.appendChild(ta);
+    ta.select();
+    let ok2 = false;
+    try {
+      ok2 = document.execCommand("copy");
+    } catch (e) {
+      ok2 = false;
+    }
+    document.body.removeChild(ta);
+    return ok2;
+  }
+  function setCollapsed(wrapper, toggleBtn, collapsed) {
+    wrapper.classList.toggle("collapsed", collapsed);
+    toggleBtn.innerHTML = collapsed ? ARROW_DOWN_SVG : ARROW_UP_SVG;
+    toggleBtn.setAttribute("aria-label", collapsed ? uiText("expandTooltip") : uiText("collapseTooltip"));
+  }
+  function enhanceCodeBlocks(root2) {
+    if (!root2) return;
+    root2.querySelectorAll("pre").forEach((pre) => {
+      if (pre.closest("." + CODE_BLOCK_CLASS)) return;
+      const lang = detectLanguage(pre);
+      const codeEl = pre.querySelector("code");
+      const lineCount = countCodeLines(codeEl ? codeEl.textContent : pre.textContent);
+      const wrapper = document.createElement("div");
+      wrapper.className = CODE_BLOCK_CLASS;
+      const header = document.createElement("div");
+      header.className = "code-block-header";
+      const toggleBtn = document.createElement("button");
+      toggleBtn.type = "button";
+      toggleBtn.className = "code-block-toggle";
+      toggleBtn.innerHTML = ARROW_UP_SVG;
+      toggleBtn.setAttribute("aria-label", uiText("collapseTooltip"));
+      const langLabel = document.createElement("span");
+      langLabel.className = "code-block-lang";
+      langLabel.textContent = lang;
+      const copyBtn = document.createElement("button");
+      copyBtn.type = "button";
+      copyBtn.className = "code-block-copy";
+      copyBtn.innerHTML = COPY_ICON_SVG;
+      copyBtn.title = uiText("copyTooltip");
+      copyBtn.setAttribute("aria-label", uiText("copyTooltip"));
+      header.appendChild(toggleBtn);
+      header.appendChild(langLabel);
+      header.appendChild(copyBtn);
+      const hint = document.createElement("div");
+      hint.className = "code-block-collapsed";
+      const hintText = document.createElement("span");
+      hintText.textContent = uiText("collapsedLinesText").replace("%1", lineCount);
+      const expandBtn = document.createElement("span");
+      expandBtn.className = "code-block-expand";
+      expandBtn.textContent = uiText("expandText");
+      hint.appendChild(hintText);
+      hint.appendChild(expandBtn);
+      pre.parentNode.insertBefore(wrapper, pre);
+      wrapper.appendChild(header);
+      wrapper.appendChild(hint);
+      wrapper.appendChild(pre);
+      toggleBtn.addEventListener("click", () => {
+        setCollapsed(wrapper, toggleBtn, !wrapper.classList.contains("collapsed"));
+      });
+      expandBtn.addEventListener("click", () => {
+        setCollapsed(wrapper, toggleBtn, false);
+      });
+      copyBtn.addEventListener("click", () => {
+        const ok2 = copyTextToClipboard(codeEl ? codeEl.textContent : pre.textContent);
+        copyBtn.innerHTML = ok2 ? CHECK_ICON_SVG : COPY_ICON_SVG;
+        setTimeout(() => {
+          copyBtn.innerHTML = COPY_ICON_SVG;
+        }, COPY_FEEDBACK_MS);
+      });
     });
   }
   function enhance(root2) {
     wrapTables(root2);
+    enhanceCodeBlocks(root2);
   }
   const ROOT_ID = "app";
   let editor = null;
@@ -45429,7 +45566,8 @@ var __privateSet = (obj, member, value, setter) => (__accessCheck(obj, member, "
       },
       onApplyTheme: applyTheme,
       onSetLayout: applyLayout,
-      onScrollToRatio: scrollToRatio
+      onScrollToRatio: scrollToRatio,
+      onRetranslate: () => retranslateCodeBlocks(document.getElementById(ROOT_ID))
     });
     console.log("[md] boot done, bridge=", typeof window.bridge, "onReady=", window.bridge ? typeof window.bridge.onReady : "n/a");
     if (window.bridge && typeof window.bridge.onReady === "function") {

--- a/src/editor/markdown/web/build/style.css
+++ b/src/editor/markdown/web/build/style.css
@@ -72,9 +72,31 @@ html, body {
     background: transparent;
 }
 
-/* §4.8.5 表格 */
-.table-wrapper { container-type: inline-size; overflow-x: auto; }
+/* §4.8.5 表格：.table-block（空表头条 + 表格容器）
+   表头：36px 高 / 圆角 12px 12px 0 0 / rgba(0,0,0,0.05) 底，无内容
+   高度用 min-height：内容随行数增高（固定高度会截断表格） */
+.table-block {
+    width: 502px;
+    max-width: 100%;
+    min-height: 222px;
+    box-sizing: border-box;
+    border: 1px solid rgba(229, 229, 229, 1);
+    border-radius: 12px;
+    background-color: rgba(255, 255, 255, 0.3);
+    margin: 1em 0;
+}
+.table-block-header {
+    height: 36px;
+    border-radius: 12px 12px 0 0;
+    background-color: rgba(0, 0, 0, 0.05);
+}
+.table-block .table-wrapper {
+    container-type: inline-size;
+    overflow-x: auto;
+    border-radius: 0 0 12px 12px;
+}
 .table-wrapper table { width: 100%; border-collapse: collapse; margin: 1em 0; }
+.table-block .table-wrapper table { margin: 0; }
 .table-wrapper td, .table-wrapper th {
     min-width: 100px;
     max-width: 240px;
@@ -92,17 +114,85 @@ html, body {
     .table-wrapper td, .table-wrapper th { max-width: 180px; }
 }
 
-/* §4.8.6 代码块 */
+/* §4.8.6 代码块：782px 宽 / 208px 高 / 圆角 10px / 半透明底
+   高度用 min-height：内容须能随行数增高超出视口，表头吸顶才有意义（固定高度会截断内容） */
+.code-block {
+    width: 782px;
+    max-width: 100%;
+    min-height: 208px;
+    box-sizing: border-box;
+    display: flex;
+    flex-direction: column;
+    margin: 1em 0;
+    border: 1px solid rgba(0, 0, 0, 0.08);
+    border-radius: 10px;
+    background-color: rgba(255, 255, 255, 0.3);
+}
+
+/* 操作表头：折叠箭头 + 语言标签 + 复制按钮；块内容超出视口滚动时吸顶保持可见 */
+.code-block-header {
+    position: sticky;
+    top: 0;
+    z-index: 10;
+    flex: 0 0 auto;
+    height: 32px;
+    box-sizing: border-box;
+    display: flex;
+    align-items: center;
+    padding: 0 10px 0 6px;
+    border-radius: 10px 10px 0 0;
+    /* 半透明蒙层叠在不透明底色上：静止时等效 rgba(0,0,0,0.05)，吸顶时能遮住下方滚过的代码 */
+    background-color: var(--bg);
+    background-image: linear-gradient(rgba(0, 0, 0, 0.05), rgba(0, 0, 0, 0.05));
+}
+
+/* 折叠按钮：无背景，两段折线箭头（SVG currentColor 随此颜色） */
+.code-block-toggle {
+    border: none;
+    background: none;
+    padding: 4px 6px;
+    line-height: 0;
+    color: #000;
+    cursor: pointer;
+}
+.code-block-toggle svg { display: block; }
+
+/* 语言标签：黑色 14px */
+.code-block-lang {
+    color: #000;
+    font-size: 14px;
+    font-weight: 400;
+}
+
+.code-block-copy {
+    margin-left: auto;
+    border: none;
+    background: none;
+    padding: 4px 8px;
+    line-height: 0;
+    color: rgba(0, 0, 0, 0.7);
+    cursor: pointer;
+}
+.code-block-copy svg { display: block; }
+.code-block-copy:hover { color: rgba(0, 0, 0, 1); }
+
 .milkdown pre {
     background: var(--code-bg);
     color: var(--code-fg);
-    border-radius: 6px;
+    border-radius: 10px;
     padding: 12px 16px;
     overflow-x: auto;
     font-family: "Noto Sans Mono", "DejaVu Sans Mono", "Courier New", monospace;
     font-size: 13px;
     line-height: 1.5;
     margin: 1em 0;
+}
+/* 包裹进 .code-block 后：背景/圆角/外边距由 wrapper 承担 */
+.code-block pre {
+    flex: 1 1 auto;
+    margin: 0;
+    background: transparent;
+    border-radius: 0 0 10px 10px;
 }
 .milkdown pre code { background: transparent; padding: 0; }
 .milkdown :not(pre) > code {
@@ -111,6 +201,43 @@ html, body {
     border-radius: 3px;
     font-family: "Noto Sans Mono", "DejaVu Sans Mono", "Courier New", monospace;
     font-size: 0.9em;
+}
+
+/* 折叠态：隐藏代码区，块区显示“已折叠xx行代码  展开”提示行（不在表头内） */
+.code-block.collapsed { min-height: 0; }
+.code-block.collapsed pre { display: none; }
+.code-block-collapsed {
+    display: none;
+    align-items: center;
+    gap: 4px;
+    padding: 10px 16px;
+    font-size: 12px;
+    color: rgba(0, 0, 0, 0.5);
+    border-radius: 0 0 10px 10px;
+}
+.code-block.collapsed .code-block-collapsed { display: flex; }
+.code-block-expand { color: rgba(0, 0, 0, 0.7); cursor: pointer; }
+.code-block-expand:hover { color: rgba(0, 0, 0, 1); }
+
+/* 深色主题：黑系颜色按同透明度镜像为白系 */
+[data-theme="dark"] .code-block {
+    border-color: rgba(255, 255, 255, 0.08);
+    background-color: rgba(255, 255, 255, 0.1);
+}
+[data-theme="dark"] .code-block-header {
+    background-image: linear-gradient(rgba(255, 255, 255, 0.05), rgba(255, 255, 255, 0.05));
+}
+[data-theme="dark"] .code-block-toggle,
+[data-theme="dark"] .code-block-lang { color: #fff; }
+[data-theme="dark"] .code-block-copy { color: rgba(255, 255, 255, 0.7); }
+[data-theme="dark"] .code-block-copy:hover { color: rgba(255, 255, 255, 1); }
+[data-theme="dark"] .code-block-collapsed { color: rgba(255, 255, 255, 0.5); }
+[data-theme="dark"] .code-block-expand { color: rgba(255, 255, 255, 0.7); }
+[data-theme="dark"] .code-block-expand:hover { color: rgba(255, 255, 255, 1); }
+[data-theme="dark"] .table-block-header { background-color: rgba(255, 255, 255, 0.05); }
+[data-theme="dark"] .table-block {
+    border-color: var(--border);
+    background-color: rgba(255, 255, 255, 0.1);
 }
 
 /* §4.8.7 图片 */

--- a/src/editor/markdown/web/main.js
+++ b/src/editor/markdown/web/main.js
@@ -18,7 +18,7 @@ import { clipboard } from "@milkdown/kit/plugin/clipboard";
 import { replaceAll } from "@milkdown/kit/utils";
 import { mathPlugins, normalizeMathDelimiters } from "./milkdownMathPlugins.js";
 import { setupBridge } from "./bridge.js";
-import { enhance } from "./renderEnhancer.js";
+import { enhance, retranslateCodeBlocks } from "./renderEnhancer.js";
 
 import "katex/dist/katex.min.css";
 import "./theme.css";
@@ -155,6 +155,7 @@ async function boot() {
         onApplyTheme: applyTheme,
         onSetLayout: applyLayout,
         onScrollToRatio: scrollToRatio,
+        onRetranslate: () => retranslateCodeBlocks(document.getElementById(ROOT_ID)),
     });
 
     console.log("[md] boot done, bridge=", typeof window.bridge, "onReady=", window.bridge ? typeof window.bridge.onReady : "n/a");

--- a/src/editor/markdown/web/renderEnhancer.js
+++ b/src/editor/markdown/web/renderEnhancer.js
@@ -2,28 +2,190 @@
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-// renderEnhancer.js —— 渲染后处理（静态部分）
+// renderEnhancer.js —— 渲染后处理
 //
-// §4.8.8：在 Milkdown 默认 DOM 之上做无副作用的幂等加工，为 CSS 容器查询提供挂载点。
-// 交互部分（粘性表头/复制按钮/图片右键菜单）阶段 3.5 启用。
+// §4.8.8：在 Milkdown 默认 DOM 之上做无副作用的幂等加工。
+// wrapTables：表格包裹（横向滚动 + 容器查询锚点）。
+// enhanceCodeBlocks：代码块操作表头（折叠按钮 + 语言标签 + 复制按钮）与折叠提示行。
 
 const TABLE_WRAPPER_CLASS = "table-wrapper";
+const CODE_BLOCK_CLASS = "code-block";
 
-// 把每个 <table> 包裹进 .table-wrapper（横向滚动容器 + 容器查询锚点）
+// 折叠箭头 SVG：两段折线的上/下箭头（stroke 线条，非实心三角）
+const ARROW_UP_SVG = '<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"><path d="M1 7 L5 3 L9 7"/></svg>';
+const ARROW_DOWN_SVG = '<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"><path d="M1 3 L5 7 L9 3"/></svg>';
+
+// 复制按钮 SVG：两张交叠圆角纸（复制）/ 对勾（成功，2s 后恢复，与应用其他复制位置一致）
+const COPY_ICON_SVG = '<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"><rect x="4.5" y="4.5" width="8" height="8" rx="1.5"/><path d="M9.5 4.5 V3 a1.5 1.5 0 0 0 -1.5 -1.5 H3 a1.5 1.5 0 0 0 -1.5 1.5 V8 a1.5 1.5 0 0 0 1.5 1.5 H4.5"/></svg>';
+const CHECK_ICON_SVG = '<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M2.5 7.5 L5.5 10.5 L11.5 3.5"/></svg>';
+const COPY_FEEDBACK_MS = 2000;
+
+// UI 文案：来自 C++ MarkdownBridge 的 Q_PROPERTY（Qt 翻译体系），
+// 无 bridge（本地浏览器调试）时用英文兜底；语言切换时经 retranslated 信号刷新
+const FALLBACK_TEXTS = {
+    collapseTooltip: "Collapse code block",
+    expandTooltip: "Expand code block",
+    copyTooltip: "Copy code",
+    expandText: "Expand",
+    collapsedLinesText: "%1 line(s) of code collapsed",
+};
+
+function uiText(key) {
+    const b = window.bridge;
+    return (b && typeof b[key] === "string" && b[key].length > 0) ? b[key] : FALLBACK_TEXTS[key];
+}
+
+// 语言切换后重刷已渲染代码块上的动态文案（静态文案由 enhance() 重建时带上）
+export function retranslateCodeBlocks(root) {
+    if (!root) return;
+    root.querySelectorAll("." + CODE_BLOCK_CLASS).forEach((wrapper) => {
+        const pre = wrapper.querySelector("pre");
+        const lineCount = pre ? countCodeLines(pre.textContent) : 0;
+        wrapper.querySelector(".code-block-collapsed > span:first-child").textContent =
+            uiText("collapsedLinesText").replace("%1", lineCount);
+        wrapper.querySelector(".code-block-expand").textContent = uiText("expandText");
+        const collapsed = wrapper.classList.contains("collapsed");
+        const toggle = wrapper.querySelector(".code-block-toggle");
+        toggle.setAttribute("aria-label", collapsed ? uiText("expandTooltip") : uiText("collapseTooltip"));
+        const copy = wrapper.querySelector(".code-block-copy");
+        copy.title = uiText("copyTooltip");
+        copy.setAttribute("aria-label", uiText("copyTooltip"));
+    });
+}
+
+// 把每个 <table> 包裹为 .table-block > (.table-block-header + .table-wrapper > table)
+// .table-wrapper：横向滚动容器 + 容器查询锚点；.table-block-header：空表头装饰条
 // 幂等：已包裹的表格跳过
 export function wrapTables(root) {
     if (!root) return;
     const tables = root.querySelectorAll("table");
     tables.forEach((table) => {
-        if (table.parentElement && table.parentElement.classList.contains(TABLE_WRAPPER_CLASS)) return;
+        if (table.closest("." + TABLE_WRAPPER_CLASS)) return;
+        const block = document.createElement("div");
+        block.className = "table-block";
+        const header = document.createElement("div");
+        header.className = "table-block-header";
         const wrapper = document.createElement("div");
         wrapper.className = TABLE_WRAPPER_CLASS;
-        table.parentNode.insertBefore(wrapper, table);
+        table.parentNode.insertBefore(block, table);
+        block.appendChild(header);
+        block.appendChild(wrapper);
         wrapper.appendChild(table);
+    });
+}
+
+// 统计代码行数（忽略末尾空行）
+function countCodeLines(text) {
+    const lines = String(text || "").split("\n");
+    while (lines.length && lines[lines.length - 1].trim() === "") lines.pop();
+    return lines.length;
+}
+
+// 语言名：Milkdown 7.x 渲染在 pre[data-language]；兼容旧式 code.language-xxx class
+function detectLanguage(pre) {
+    const lang = pre.getAttribute("data-language");
+    if (lang && lang.length > 0) return lang;
+    const code = pre.querySelector("code");
+    if (code) {
+        const m = code.className.match(/(?:^|\s)language-([\w#+-]+)/);
+        if (m) return m[1];
+    }
+    return "";
+}
+
+function copyTextToClipboard(text) {
+    const ta = document.createElement("textarea");
+    ta.value = text;
+    ta.setAttribute("readonly", "");
+    ta.style.position = "fixed";
+    ta.style.opacity = "0";
+    document.body.appendChild(ta);
+    ta.select();
+    let ok = false;
+    try { ok = document.execCommand("copy"); } catch (e) { ok = false; }
+    document.body.removeChild(ta);
+    return ok;
+}
+
+// 折叠/展开：折叠时隐藏 pre、显示“已折叠xx行代码”提示行，箭头方向切换
+function setCollapsed(wrapper, toggleBtn, collapsed) {
+    wrapper.classList.toggle("collapsed", collapsed);
+    toggleBtn.innerHTML = collapsed ? ARROW_DOWN_SVG : ARROW_UP_SVG;
+    toggleBtn.setAttribute("aria-label", collapsed ? uiText("expandTooltip") : uiText("collapseTooltip"));
+}
+
+// 代码块加工：包一层 .code-block（圆角半透明底 + 吸顶表头挂载点）
+// 表头结构：[折叠箭头][语言标签]……[复制按钮]；提示行在块区内、不在表头内
+// 幂等：已包裹的 pre 跳过
+export function enhanceCodeBlocks(root) {
+    if (!root) return;
+    root.querySelectorAll("pre").forEach((pre) => {
+        if (pre.closest("." + CODE_BLOCK_CLASS)) return;
+
+        const lang = detectLanguage(pre);
+        const codeEl = pre.querySelector("code");
+        const lineCount = countCodeLines(codeEl ? codeEl.textContent : pre.textContent);
+
+        const wrapper = document.createElement("div");
+        wrapper.className = CODE_BLOCK_CLASS;
+
+        const header = document.createElement("div");
+        header.className = "code-block-header";
+
+        const toggleBtn = document.createElement("button");
+        toggleBtn.type = "button";
+        toggleBtn.className = "code-block-toggle";
+        toggleBtn.innerHTML = ARROW_UP_SVG;
+        toggleBtn.setAttribute("aria-label", uiText("collapseTooltip"));
+
+        const langLabel = document.createElement("span");
+        langLabel.className = "code-block-lang";
+        langLabel.textContent = lang;
+
+        const copyBtn = document.createElement("button");
+        copyBtn.type = "button";
+        copyBtn.className = "code-block-copy";
+        copyBtn.innerHTML = COPY_ICON_SVG;
+        copyBtn.title = uiText("copyTooltip");
+        copyBtn.setAttribute("aria-label", uiText("copyTooltip"));
+
+        header.appendChild(toggleBtn);
+        header.appendChild(langLabel);
+        header.appendChild(copyBtn);
+
+        // 折叠提示行：“已折叠xx行代码  展开”，显示在代码块区域
+        const hint = document.createElement("div");
+        hint.className = "code-block-collapsed";
+        const hintText = document.createElement("span");
+        hintText.textContent = uiText("collapsedLinesText").replace("%1", lineCount);
+        const expandBtn = document.createElement("span");
+        expandBtn.className = "code-block-expand";
+        expandBtn.textContent = uiText("expandText");
+        hint.appendChild(hintText);
+        hint.appendChild(expandBtn);
+
+        pre.parentNode.insertBefore(wrapper, pre);
+        wrapper.appendChild(header);
+        wrapper.appendChild(hint);
+        wrapper.appendChild(pre);
+
+        toggleBtn.addEventListener("click", () => {
+            setCollapsed(wrapper, toggleBtn, !wrapper.classList.contains("collapsed"));
+        });
+        expandBtn.addEventListener("click", () => {
+            setCollapsed(wrapper, toggleBtn, false);
+        });
+        copyBtn.addEventListener("click", () => {
+            // 折叠态同样复制完整代码（表头常驻可见，pre 隐藏不影响取文本）
+            const ok = copyTextToClipboard(codeEl ? codeEl.textContent : pre.textContent);
+            copyBtn.innerHTML = ok ? CHECK_ICON_SVG : COPY_ICON_SVG;
+            setTimeout(() => { copyBtn.innerHTML = COPY_ICON_SVG; }, COPY_FEEDBACK_MS);
+        });
     });
 }
 
 // 统一入口：每次 Milkdown 重渲染后执行一次
 export function enhance(root) {
     wrapTables(root);
+    enhanceCodeBlocks(root);
 }

--- a/src/editor/markdown/web/theme.css
+++ b/src/editor/markdown/web/theme.css
@@ -71,9 +71,31 @@ html, body {
     background: transparent;
 }
 
-/* §4.8.5 表格 */
-.table-wrapper { container-type: inline-size; overflow-x: auto; }
+/* §4.8.5 表格：.table-block（空表头条 + 表格容器）
+   表头：36px 高 / 圆角 12px 12px 0 0 / rgba(0,0,0,0.05) 底，无内容
+   高度用 min-height：内容随行数增高（固定高度会截断表格） */
+.table-block {
+    width: 502px;
+    max-width: 100%;
+    min-height: 222px;
+    box-sizing: border-box;
+    border: 1px solid rgba(229, 229, 229, 1);
+    border-radius: 12px;
+    background-color: rgba(255, 255, 255, 0.3);
+    margin: 1em 0;
+}
+.table-block-header {
+    height: 36px;
+    border-radius: 12px 12px 0 0;
+    background-color: rgba(0, 0, 0, 0.05);
+}
+.table-block .table-wrapper {
+    container-type: inline-size;
+    overflow-x: auto;
+    border-radius: 0 0 12px 12px;
+}
 .table-wrapper table { width: 100%; border-collapse: collapse; margin: 1em 0; }
+.table-block .table-wrapper table { margin: 0; }
 .table-wrapper td, .table-wrapper th {
     min-width: 100px;
     max-width: 240px;
@@ -91,17 +113,85 @@ html, body {
     .table-wrapper td, .table-wrapper th { max-width: 180px; }
 }
 
-/* §4.8.6 代码块 */
+/* §4.8.6 代码块：782px 宽 / 208px 高 / 圆角 10px / 半透明底
+   高度用 min-height：内容须能随行数增高超出视口，表头吸顶才有意义（固定高度会截断内容） */
+.code-block {
+    width: 782px;
+    max-width: 100%;
+    min-height: 208px;
+    box-sizing: border-box;
+    display: flex;
+    flex-direction: column;
+    margin: 1em 0;
+    border: 1px solid rgba(0, 0, 0, 0.08);
+    border-radius: 10px;
+    background-color: rgba(255, 255, 255, 0.3);
+}
+
+/* 操作表头：折叠箭头 + 语言标签 + 复制按钮；块内容超出视口滚动时吸顶保持可见 */
+.code-block-header {
+    position: sticky;
+    top: 0;
+    z-index: 10;
+    flex: 0 0 auto;
+    height: 32px;
+    box-sizing: border-box;
+    display: flex;
+    align-items: center;
+    padding: 0 10px 0 6px;
+    border-radius: 10px 10px 0 0;
+    /* 半透明蒙层叠在不透明底色上：静止时等效 rgba(0,0,0,0.05)，吸顶时能遮住下方滚过的代码 */
+    background-color: var(--bg);
+    background-image: linear-gradient(rgba(0, 0, 0, 0.05), rgba(0, 0, 0, 0.05));
+}
+
+/* 折叠按钮：无背景，两段折线箭头（SVG currentColor 随此颜色） */
+.code-block-toggle {
+    border: none;
+    background: none;
+    padding: 4px 6px;
+    line-height: 0;
+    color: #000;
+    cursor: pointer;
+}
+.code-block-toggle svg { display: block; }
+
+/* 语言标签：黑色 14px */
+.code-block-lang {
+    color: #000;
+    font-size: 14px;
+    font-weight: 400;
+}
+
+.code-block-copy {
+    margin-left: auto;
+    border: none;
+    background: none;
+    padding: 4px 8px;
+    line-height: 0;
+    color: rgba(0, 0, 0, 0.7);
+    cursor: pointer;
+}
+.code-block-copy svg { display: block; }
+.code-block-copy:hover { color: rgba(0, 0, 0, 1); }
+
 .milkdown pre {
     background: var(--code-bg);
     color: var(--code-fg);
-    border-radius: 6px;
+    border-radius: 10px;
     padding: 12px 16px;
     overflow-x: auto;
     font-family: "Noto Sans Mono", "DejaVu Sans Mono", "Courier New", monospace;
     font-size: 13px;
     line-height: 1.5;
     margin: 1em 0;
+}
+/* 包裹进 .code-block 后：背景/圆角/外边距由 wrapper 承担 */
+.code-block pre {
+    flex: 1 1 auto;
+    margin: 0;
+    background: transparent;
+    border-radius: 0 0 10px 10px;
 }
 .milkdown pre code { background: transparent; padding: 0; }
 .milkdown :not(pre) > code {
@@ -110,6 +200,43 @@ html, body {
     border-radius: 3px;
     font-family: "Noto Sans Mono", "DejaVu Sans Mono", "Courier New", monospace;
     font-size: 0.9em;
+}
+
+/* 折叠态：隐藏代码区，块区显示“已折叠xx行代码  展开”提示行（不在表头内） */
+.code-block.collapsed { min-height: 0; }
+.code-block.collapsed pre { display: none; }
+.code-block-collapsed {
+    display: none;
+    align-items: center;
+    gap: 4px;
+    padding: 10px 16px;
+    font-size: 12px;
+    color: rgba(0, 0, 0, 0.5);
+    border-radius: 0 0 10px 10px;
+}
+.code-block.collapsed .code-block-collapsed { display: flex; }
+.code-block-expand { color: rgba(0, 0, 0, 0.7); cursor: pointer; }
+.code-block-expand:hover { color: rgba(0, 0, 0, 1); }
+
+/* 深色主题：黑系颜色按同透明度镜像为白系 */
+[data-theme="dark"] .code-block {
+    border-color: rgba(255, 255, 255, 0.08);
+    background-color: rgba(255, 255, 255, 0.1);
+}
+[data-theme="dark"] .code-block-header {
+    background-image: linear-gradient(rgba(255, 255, 255, 0.05), rgba(255, 255, 255, 0.05));
+}
+[data-theme="dark"] .code-block-toggle,
+[data-theme="dark"] .code-block-lang { color: #fff; }
+[data-theme="dark"] .code-block-copy { color: rgba(255, 255, 255, 0.7); }
+[data-theme="dark"] .code-block-copy:hover { color: rgba(255, 255, 255, 1); }
+[data-theme="dark"] .code-block-collapsed { color: rgba(255, 255, 255, 0.5); }
+[data-theme="dark"] .code-block-expand { color: rgba(255, 255, 255, 0.7); }
+[data-theme="dark"] .code-block-expand:hover { color: rgba(255, 255, 255, 1); }
+[data-theme="dark"] .table-block-header { background-color: rgba(255, 255, 255, 0.05); }
+[data-theme="dark"] .table-block {
+    border-color: var(--border);
+    background-color: rgba(255, 255, 255, 0.1);
 }
 
 /* §4.8.7 图片 */


### PR DESCRIPTION
Code block: sticky header with chevron collapse toggle, language label and copy button (check icon 2s feedback). Table: decorative header bar. UI texts come from bridge Q_PROPERTY via Qt tr().

代码块：吸顶表头（折线箭头折叠、语言标签、复制按钮，对勾反馈2s）。
表格：装饰表头条。界面文案经 bridge Q_PROPERTY 走 Qt tr() 翻译。

Log: markdown代码块/表格增加操作表头并支持国际化
Influence: markdown预览中代码块带可折叠吸顶表头与复制功能，表格
带表头条，界面文案可通过Qt linguist翻译，折叠态复制完整代码。

## Summary by Sourcery

Enhance Markdown previews with interactive, theme-aware code blocks and decorated tables while supporting runtime internationalization of code block controls.

New Features:
- Add interactive Markdown code block headers with collapse/expand controls, language labels, and code-copy actions with success feedback.
- Add decorative header bars and unified styling for rendered Markdown tables.

Enhancements:
- Support translated code block UI text through Qt bridge properties and refresh rendered labels when the application language changes.
- Provide light and dark theme styling for the new code block and table presentation.