### PR TITLE
fix(editor): fix flash window when opening markdown files

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -39,7 +39,7 @@ configure_file(
 # Find the library
 find_package(PkgConfig REQUIRED)
 
-set(qt_required_components Gui Widgets DBus Concurrent PrintSupport Svg Xml WebEngineWidgets WebChannel)
+set(qt_required_components Gui Widgets DBus Concurrent PrintSupport Svg Xml WebEngineWidgets WebChannel OpenGLWidgets)
 if (QT_DESIRED_VERSION MATCHES 6)
     list(APPEND qt_required_components Core5Compat)
 endif()
@@ -58,6 +58,7 @@ set(LINK_LIBS
     Qt${QT_VERSION_MAJOR}::DBus
     Qt${QT_VERSION_MAJOR}::WebEngineWidgets
     Qt${QT_VERSION_MAJOR}::WebChannel
+    Qt${QT_VERSION_MAJOR}::OpenGLWidgets
     Dtk${DTK_VERSION_MAJOR}::Widget
     Dtk${DTK_VERSION_MAJOR}::Core
     KF${KF_VERSION_MAJOR}::Codecs

--- a/src/editor/editwrapper.cpp
+++ b/src/editor/editwrapper.cpp
@@ -1959,6 +1959,12 @@ void EditWrapper::ensureMarkdownViewCreated()
     if (ViewModeFsm::isReadOnlyTextMode(m_viewMode, m_isMarkdown))
         return;
 
+    // A/B 验证补丁：Edit 模式渲染页无用途（仅 ReadView/LivePreview 挂载），
+    // 延迟到真正切换时创建，避免纯文本文件也拉起 QWebEngineView（触发顶层窗口
+    // raster→RHI 重建造成"闪现窗口"）
+    if (m_viewMode == ViewMode::Edit)
+        return;
+
     m_pMarkdownView = new MarkdownView(this);
     m_pMarkdownView->setMinimumWidth(200);   // 防止分栏右栏被压缩到不可见
 #if !defined(QT_TESTCASE_SOURCEDIR)

--- a/src/widgets/window.cpp
+++ b/src/widgets/window.cpp
@@ -28,6 +28,7 @@
 #include <DPrintPreviewDialog>
 #include <QGuiApplication>
 #include <QWindow>
+#include <QOpenGLWidget>
 #include <DWidgetUtil>
 #include <QTextDocumentFragment>
 #include <dprintpreviewwidget.h>
@@ -258,6 +259,15 @@ Window::Window(DMainWindow *parent)
     setWindowIcon(QIcon::fromTheme("deepin-editor"));
     setAccessibleName("MainWindow");
     setCentralWidget(m_centralWidget);
+
+    // RHI 预置控件：MarkdownView(QWebEngineView) 内含 QQuickWidget（RHI 控件），若在
+    // 窗口已显示后才构造进入窗口层级，Qt 会以 GL visual 销毁重建顶层原生窗口（X11 下
+    // 表现为先闪一个窗口再出现主界面）。预置一个隐藏的 QOpenGLWidget 即可使顶层窗口
+    // 自创建起走 RHI 合成（Qt 对 QOpenGLWidget/QQuickWidget 的判定在构造期即生效），
+    // 后续 MarkdownView 任意时刻进入均无需重建原生窗口。
+    QOpenGLWidget *rhiPrimer = new QOpenGLWidget(this);
+    rhiPrimer->setGeometry(0, 0, 0, 0);
+    rhiPrimer->hide();
 
     // Init titlebar.
     if (titlebar()) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -24,7 +24,7 @@ set(APP_QRC "../src/deepin-editor.qrc")
 find_package(PkgConfig REQUIRED)
 
 
-set(qt_required_components Gui Widgets DBus Concurrent PrintSupport Svg Xml Test WebEngineWidgets WebChannel)
+set(qt_required_components Gui Widgets DBus Concurrent PrintSupport Svg Xml Test WebEngineWidgets WebChannel OpenGLWidgets)
 if (QT_DESIRED_VERSION MATCHES 6)
     list(APPEND qt_required_components Core5Compat)
 endif()
@@ -44,6 +44,7 @@ set(LINK_LIBS
     Qt${QT_VERSION_MAJOR}::Test
     Qt${QT_VERSION_MAJOR}::WebEngineWidgets
     Qt${QT_VERSION_MAJOR}::WebChannel
+    Qt${QT_VERSION_MAJOR}::OpenGLWidgets
     Dtk${DTK_VERSION_MAJOR}::Widget
     Dtk${DTK_VERSION_MAJOR}::Core
     KF${KF_VERSION_MAJOR}::Codecs


### PR DESCRIPTION
Prime a hidden QOpenGLWidget in Window ctor so the top-level native window uses RHI compositing from creation; defer MarkdownView creation in Edit mode to avoid unnecessary WebEngine startup.

在 Window 构造中预置隐藏的 QOpenGLWidget，使顶层原生窗口自创建起
走 RHI 合成，避免后加入的 QWebEngineView 触发窗口销毁重建；Edit
模式下延迟创建 MarkdownView，纯文本文件不再拉起 WebEngine。

Log: 修复打开markdown文件时闪现窗口的问题
Influence: 解决冷启动打开md文件、会话恢复含md标签、运行中新开md
标签时窗口先闪现再显示主界面的问题；纯文本文件不再拉起WebEngine。

## Summary by Sourcery

Prevent window flashes during Markdown startup and reduce unnecessary WebEngine initialization for text editing.

Bug Fixes:
- Prevent flash-window behavior when opening Markdown files by initializing RHI compositing before the main window is displayed.

Enhancements:
- Defer Markdown view creation in Edit mode so plain-text files avoid unnecessary WebEngine startup.

Build:
- Add the Qt OpenGLWidgets component and link it into the application and test targets.