### PR TITLE
fix(markdown): remove blank padding of empty code block in render view

### DIFF
--- a/src/editor/markdown/web/build/main.bundle.js
+++ b/src/editor/markdown/web/build/main.bundle.js
@@ -45410,6 +45410,7 @@ var __privateSet = (obj, member, value, setter) => (__accessCheck(obj, member, "
       const lineCount = countCodeLines(codeEl ? codeEl.textContent : pre.textContent);
       const wrapper = document.createElement("div");
       wrapper.className = CODE_BLOCK_CLASS;
+      if (lineCount === 0) wrapper.classList.add("empty");
       const header = document.createElement("div");
       header.className = "code-block-header";
       const toggleBtn = document.createElement("button");

--- a/src/editor/markdown/web/build/style.css
+++ b/src/editor/markdown/web/build/style.css
@@ -206,6 +206,8 @@ html, body {
 /* 折叠态：隐藏代码区，块区显示“已折叠xx行代码  展开”提示行（不在表头内） */
 .code-block.collapsed { min-height: 0; }
 .code-block.collapsed pre { display: none; }
+/* 空代码块：撤销 208px 设计最小高度，表头下仅保留一行空白 */
+.code-block.empty { min-height: 0; }
 .code-block-collapsed {
     display: none;
     align-items: center;

--- a/src/editor/markdown/web/renderEnhancer.js
+++ b/src/editor/markdown/web/renderEnhancer.js
@@ -128,6 +128,9 @@ export function enhanceCodeBlocks(root) {
 
         const wrapper = document.createElement("div");
         wrapper.className = CODE_BLOCK_CLASS;
+        // 空代码块（0 行）：加 empty 类，CSS 撤销 min-height 208px 设计最小高度，
+        // 表头下仅保留 pre 自身的一行空白，避免大块空白
+        if (lineCount === 0) wrapper.classList.add("empty");
 
         const header = document.createElement("div");
         header.className = "code-block-header";

--- a/src/editor/markdown/web/theme.css
+++ b/src/editor/markdown/web/theme.css
@@ -205,6 +205,8 @@ html, body {
 /* 折叠态：隐藏代码区，块区显示“已折叠xx行代码  展开”提示行（不在表头内） */
 .code-block.collapsed { min-height: 0; }
 .code-block.collapsed pre { display: none; }
+/* 空代码块：撤销 208px 设计最小高度，表头下仅保留一行空白 */
+.code-block.empty { min-height: 0; }
 .code-block-collapsed {
     display: none;
     align-items: center;

--- a/tests/src/editor/markdown/it_markdownview_smoke.cpp
+++ b/tests/src/editor/markdown/it_markdownview_smoke.cpp
@@ -20,6 +20,7 @@
 #include <QElapsedTimer>
 #include <QJsonDocument>
 #include <QJsonObject>
+#include <QJsonArray>
 #include <QWebEnginePage>
 #include <functional>
 
@@ -117,6 +118,52 @@ TEST(IT_MarkdownViewSmoke, DISABLED_ExternalLinkClick_DelegatedToBrowser)
             << "openLinkRequested not emitted (click interception broken)";
     EXPECT_EQ(linkSpy.takeFirst().at(0).toString(),
               QStringLiteral("https://www.deepin.org/index.shtml"));
+}
+
+// 端到端：空代码块不得被 min-height 208px 撑出大空白（enhance 加 empty 类，
+// CSS 降 min-height），表头下仅保留一行空白；非空块仍保持设计最小高度
+TEST(IT_MarkdownViewSmoke, DISABLED_EmptyCodeBlock_NoMinHeightBlank)
+{
+    MarkdownView v;
+    SpyPage *page = new SpyPage(&v);
+    v.setPage(page);
+    v.init();
+    QSignalSpy readySpy(v.bridge(), &MarkdownBridge::ready);
+    ASSERT_TRUE(waitFor([&readySpy]() { return readySpy.count() > 0; }, 15000))
+            << "WebEngine page not ready in 15s";
+
+    // 空代码块 + 非空代码块各一个
+    v.setMarkdown(QStringLiteral("# t\n\n```cpp\n```\n\ntext\n\n```js\nlet a = 1;\n```\n"));
+    QTest::qWait(2000);   // 等渲染 + enhance 后处理（setTimeout(0)）
+
+    QString json;
+    bool ok = false;
+    v.page()->runJavaScript(
+        QStringLiteral("JSON.stringify(Array.from(document.querySelectorAll('.code-block')).map(w=>"
+                       "({cls:w.className, h:Math.round(w.getBoundingClientRect().height), "
+                       "preH:Math.round(w.querySelector('pre').getBoundingClientRect().height)})))"),
+        [&json, &ok](const QVariant &result) { json = result.toString(); ok = true; });
+    ASSERT_TRUE(waitFor([&ok]() { return ok; }, 5000));
+    qInfo() << "[smoke] code blocks:" << json;
+
+    const auto doc = QJsonDocument::fromJson(json.toUtf8());
+    ASSERT_TRUE(doc.isArray()) << "no .code-block rendered";
+    const auto blocks = doc.array();
+    ASSERT_EQ(blocks.size(), 2) << "expected empty + non-empty blocks";
+
+    // 空块：带 empty 类；总高 = 表头(32) + pre 一行(约44) < 100，无 208px 空白
+    const auto emptyBlock = blocks.at(0).toObject();
+    EXPECT_TRUE(emptyBlock.value(QStringLiteral("cls")).toString()
+                .contains(QLatin1String("empty")))
+            << "empty code block not marked with 'empty' class";
+    EXPECT_LT(emptyBlock.value(QStringLiteral("h")).toInt(), 100)
+            << "empty code block still padded to min-height";
+
+    // 非空块：无 empty 类，仍满足设计最小高度 208px
+    const auto filledBlock = blocks.at(1).toObject();
+    EXPECT_FALSE(filledBlock.value(QStringLiteral("cls")).toString()
+                 .contains(QLatin1String("empty")));
+    EXPECT_GE(filledBlock.value(QStringLiteral("h")).toInt(), 208);
 }
 
 // 端到端时序复现（初始对齐）：ready 之前发出的 scrollToRatio 不得丢失，


### PR DESCRIPTION
Mark code blocks with zero lines via an "empty" class in enhanceCodeBlocks and drop the 208px design min-height for them, so only one blank line remains under the block header.

在 enhanceCodeBlocks 中为零行代码块添加 empty 类，并对该类撤销
208px 设计最小高度，空代码块表头下仅保留一行空白。

Log: 修复空代码块渲染区域大空白的问题
Influence: 仅影响 Markdown 渲染视图中的空代码块显示，非空代码块
仍保持 208px 最小高度设计规格，其余渲染行为不变。

## Summary by Sourcery

Compact empty Markdown code blocks in the render view without changing the layout of non-empty blocks.

Bug Fixes:
- Remove excessive blank space below empty Markdown code blocks in the render view while preserving the existing minimum height for non-empty blocks.

Enhancements:
- Mark zero-line code blocks explicitly for differentiated rendering and styling.

Tests:
- Add an end-to-end smoke test verifying empty blocks are compact and non-empty blocks retain the 208px minimum height.