### PR TITLE
chore(i18n): update translations and complete zh_CN/zh_HK/zh_TW

### DIFF
--- a/translations/deepin-editor.ts
+++ b/translations/deepin-editor.ts
@@ -19,17 +19,36 @@
         <translation>Characters %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="44"/>
+        <location filename="../src/widgets/bottombar.cpp" line="47"/>
         <source>Loading:</source>
         <translation>Loading:</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="73"/>
+        <location filename="../src/widgets/bottombar.cpp" line="91"/>
+        <location filename="../src/widgets/bottombar.cpp" line="499"/>
+        <source>Edit Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="74"/>
+        <location filename="../src/widgets/bottombar.cpp" line="489"/>
+        <source>Read View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="75"/>
+        <location filename="../src/widgets/bottombar.cpp" line="493"/>
+        <source>Live Preview</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DDropdownMenu</name>
     <message>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="362"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="420"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="425"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="363"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="421"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="426"/>
         <source>None</source>
         <translation>None</translation>
     </message>
@@ -37,73 +56,57 @@
 <context>
     <name>EditWrapper</name>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="292"/>
-        <location filename="../src/editor/editwrapper.cpp" line="365"/>
-        <location filename="../src/editor/editwrapper.cpp" line="521"/>
-        <location filename="../src/editor/editwrapper.cpp" line="751"/>
+        <location filename="../src/editor/editwrapper.cpp" line="355"/>
+        <location filename="../src/editor/editwrapper.cpp" line="429"/>
+        <location filename="../src/editor/editwrapper.cpp" line="595"/>
+        <location filename="../src/editor/editwrapper.cpp" line="887"/>
         <source>Save</source>
         <translation>Save</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="516"/>
+        <location filename="../src/editor/editwrapper.cpp" line="590"/>
         <source>Do you want to save this file?</source>
         <translation>Do you want to save this file?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="363"/>
-        <location filename="../src/editor/editwrapper.cpp" line="519"/>
+        <location filename="../src/editor/editwrapper.cpp" line="427"/>
+        <location filename="../src/editor/editwrapper.cpp" line="593"/>
         <source>Cancel</source>
         <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="360"/>
+        <location filename="../src/editor/editwrapper.cpp" line="424"/>
         <source>Encoding changed. Do you want to save the file now?</source>
         <translation>Encoding changed. Do you want to save the file now?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="520"/>
+        <location filename="../src/editor/editwrapper.cpp" line="594"/>
         <source>Discard</source>
         <translation>Discard</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="274"/>
-        <location filename="../src/editor/editwrapper.cpp" line="620"/>
+        <location filename="../src/editor/editwrapper.cpp" line="337"/>
+        <location filename="../src/editor/editwrapper.cpp" line="705"/>
         <source>You do not have permission to save %1</source>
         <translation>You do not have permission to save %1</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="836"/>
+        <location filename="../src/editor/editwrapper.cpp" line="987"/>
         <source>File removed on the disk. Save it now?</source>
         <translation>File removed on the disk. Save it now?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="842"/>
+        <location filename="../src/editor/editwrapper.cpp" line="993"/>
         <source>File has changed on disk. Reload?</source>
         <translation>File has changed on disk. Reload?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="884"/>
-        <location filename="../src/widgets/bottombar.cpp" line="74"/>
-        <source>INSERT</source>
-        <translation>INSERT</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="888"/>
-        <source>OVERWRITE</source>
-        <translation>OVERWRITE</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="892"/>
-        <source>R/O</source>
-        <translation>R/O</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="1618"/>
+        <location filename="../src/editor/editwrapper.cpp" line="1806"/>
         <source>The file cannot be read, which may be too large or has been damaged!</source>
         <translation>The file cannot be read, which may be too large or has been damaged!</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="1020"/>
+        <location filename="../src/editor/editwrapper.cpp" line="1121"/>
         <source>The file contains invalid characters (NUL). Preview mode is read-only.</source>
         <translation>The file contains invalid characters (NUL). Preview mode is read-only.</translation>
     </message>
@@ -116,17 +119,17 @@
         <translation>Find</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="36"/>
+        <location filename="../src/controls/findbar.cpp" line="38"/>
         <source>Previous</source>
         <translation>Previous</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="37"/>
+        <location filename="../src/controls/findbar.cpp" line="40"/>
         <source>Next</source>
         <translation>Next</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="38"/>
+        <location filename="../src/controls/findbar.cpp" line="42"/>
         <source>Replace</source>
         <translation>Replace</translation>
     </message>
@@ -134,7 +137,7 @@
 <context>
     <name>JumpLineBar</name>
     <message>
-        <location filename="../src/controls/jumplinebar.cpp" line="45"/>
+        <location filename="../src/controls/jumplinebar.cpp" line="46"/>
         <source>Go to Line: </source>
         <translation>Go to Line: </translation>
     </message>
@@ -142,7 +145,7 @@
 <context>
     <name>LineBar</name>
     <message>
-        <location filename="../src/controls/linebar.cpp" line="117"/>
+        <location filename="../src/controls/linebar.cpp" line="144"/>
         <source>第%1/%2项</source>
         <translation>Match %1 of %2</translation>
     </message>
@@ -161,19 +164,47 @@
     </message>
 </context>
 <context>
+    <name>MarkdownBridge</name>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="37"/>
+        <source>Collapse code block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="38"/>
+        <source>Expand code block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="39"/>
+        <source>Copy code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="40"/>
+        <source>Expand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="42"/>
+        <source>%1 line(s) of code collapsed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PathSettingWgt</name>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="84"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="90"/>
         <source>Remember the last used path</source>
         <translation>Remember the last used path</translation>
     </message>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="85"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="91"/>
         <source>Same path as the current file</source>
         <translation>Same path as the current file</translation>
     </message>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="86"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="92"/>
         <source>Customize the default path</source>
         <translation>Customize the default path</translation>
     </message>
@@ -186,15 +217,20 @@
         <translation>Text Editor</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="294"/>
-        <location filename="../src/editor/editwrapper.cpp" line="761"/>
-        <location filename="../src/editor/editwrapper.cpp" line="776"/>
-        <location filename="../src/widgets/window.cpp" line="1362"/>
-        <location filename="../src/widgets/window.cpp" line="1390"/>
-        <location filename="../src/widgets/window.cpp" line="1531"/>
-        <location filename="../src/widgets/window.cpp" line="1548"/>
+        <location filename="../src/editor/editwrapper.cpp" line="357"/>
+        <location filename="../src/editor/editwrapper.cpp" line="897"/>
+        <location filename="../src/editor/editwrapper.cpp" line="912"/>
+        <location filename="../src/widgets/window.cpp" line="1528"/>
+        <location filename="../src/widgets/window.cpp" line="1556"/>
+        <location filename="../src/widgets/window.cpp" line="1715"/>
+        <location filename="../src/widgets/window.cpp" line="1732"/>
         <source>Encoding</source>
         <translation>Encoding</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="2001"/>
+        <source>视图模式</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="11"/>
@@ -230,7 +266,7 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="18"/>
         <location filename="../src/controls/settingsdialog.cpp" line="96"/>
-        <location filename="../src/widgets/window.cpp" line="2388"/>
+        <location filename="../src/widgets/window.cpp" line="2581"/>
         <source>Window</source>
         <translation>Window</translation>
     </message>
@@ -770,68 +806,68 @@
         <translation>Vietnamese</translation>
     </message>
     <message>
-        <location filename="../src/startmanager.cpp" line="971"/>
+        <location filename="../src/startmanager.cpp" line="1035"/>
         <source>File not saved</source>
         <translation>File not saved</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1532"/>
-        <location filename="../src/widgets/window.cpp" line="1549"/>
+        <location filename="../src/widgets/window.cpp" line="1716"/>
+        <location filename="../src/widgets/window.cpp" line="1733"/>
         <source>Line Endings</source>
         <translation>Line Endings</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="243"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="379"/>
         <source>Please install &apos;UOS AI&apos; from the App Store before using</source>
         <translation>Please install &apos;UOS AI&apos; from the App Store before using</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="245"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="381"/>
         <source>No audio input device detected. Please check and try again</source>
         <translation>No audio input device detected. Please check and try again</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="247"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="383"/>
         <source>No audio output device detected. Please check and try again</source>
         <translation>No audio output device detected. Please check and try again</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="69"/>
+        <location filename="../src/common/text_file_saver.cpp" line="74"/>
         <source>File path is empty</source>
         <translation>File path is empty</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="155"/>
+        <location filename="../src/common/text_file_saver.cpp" line="153"/>
         <source>Insufficient memory to load document content</source>
         <translation>Insufficient memory to load document content</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="177"/>
+        <location filename="../src/common/text_file_saver.cpp" line="178"/>
         <source>Insufficient memory for encoding conversion</source>
         <translation>Insufficient memory for encoding conversion</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="183"/>
+        <location filename="../src/common/text_file_saver.cpp" line="184"/>
         <source>Encoding conversion failed</source>
         <translation>Encoding conversion failed</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="189"/>
+        <location filename="../src/common/text_file_saver.cpp" line="190"/>
         <source>Converted content is empty</source>
         <translation>Converted content is empty</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="207"/>
+        <location filename="../src/common/text_file_saver.cpp" line="208"/>
         <source>Memory allocation failed</source>
         <translation>Memory allocation failed</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="211"/>
+        <location filename="../src/common/text_file_saver.cpp" line="212"/>
         <source>Error occurred: %1</source>
         <translation>Error occurred: %1</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="215"/>
+        <location filename="../src/common/text_file_saver.cpp" line="216"/>
         <source>Unknown error occurred</source>
         <translation>Unknown error occurred</translation>
     </message>
@@ -844,27 +880,27 @@
         <translation>Find</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="34"/>
+        <location filename="../src/controls/replacebar.cpp" line="36"/>
         <source>Replace With</source>
         <translation>Replace With</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="36"/>
+        <location filename="../src/controls/replacebar.cpp" line="40"/>
         <source>Replace</source>
         <translation>Replace</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="37"/>
+        <location filename="../src/controls/replacebar.cpp" line="42"/>
         <source>Skip</source>
         <translation>Skip</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="38"/>
+        <location filename="../src/controls/replacebar.cpp" line="44"/>
         <source>Replace Rest</source>
         <translation>Replace Rest</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="39"/>
+        <location filename="../src/controls/replacebar.cpp" line="46"/>
         <source>Replace All</source>
         <translation>Replace All</translation>
     </message>
@@ -906,34 +942,34 @@
         <translation>Fullscreen</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="484"/>
+        <location filename="../src/common/settings.cpp" line="491"/>
         <source>This shortcut conflicts with system shortcut %1</source>
         <translation>This shortcut conflicts with system shortcut %1</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="487"/>
+        <location filename="../src/common/settings.cpp" line="494"/>
         <source>This shortcut conflicts with %1, click on Replace to make this shortcut effective immediately</source>
         <translation>This shortcut conflicts with %1, click on Replace to make this shortcut effective immediately</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="682"/>
-        <location filename="../src/common/settings.cpp" line="695"/>
-        <location filename="../src/common/settings.cpp" line="704"/>
+        <location filename="../src/common/settings.cpp" line="689"/>
+        <location filename="../src/common/settings.cpp" line="702"/>
+        <location filename="../src/common/settings.cpp" line="711"/>
         <source>The shortcut %1 is invalid, please set another one.</source>
         <translation>The shortcut %1 is invalid, please set another one.</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="736"/>
+        <location filename="../src/common/settings.cpp" line="743"/>
         <source>Cancel</source>
         <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="737"/>
+        <location filename="../src/common/settings.cpp" line="744"/>
         <source>Replace</source>
         <translation>Replace</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="740"/>
+        <location filename="../src/common/settings.cpp" line="747"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
@@ -941,7 +977,7 @@
 <context>
     <name>StartManager</name>
     <message>
-        <location filename="../src/startmanager.cpp" line="411"/>
+        <location filename="../src/startmanager.cpp" line="425"/>
         <source>Untitled %1</source>
         <translation>Untitled %1</translation>
     </message>
@@ -949,32 +985,32 @@
 <context>
     <name>Tabbar</name>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="641"/>
+        <location filename="../src/controls/tabbar.cpp" line="678"/>
         <source>Close tab</source>
         <translation>Close tab</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="642"/>
+        <location filename="../src/controls/tabbar.cpp" line="680"/>
         <source>Close other tabs</source>
         <translation>Close other tabs</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="643"/>
+        <location filename="../src/controls/tabbar.cpp" line="682"/>
         <source>More options</source>
         <translation>More options</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="644"/>
+        <location filename="../src/controls/tabbar.cpp" line="684"/>
         <source>Close tabs to the left</source>
         <translation>Close tabs to the left</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="645"/>
+        <location filename="../src/controls/tabbar.cpp" line="686"/>
         <source>Close tabs to the right</source>
         <translation>Close tabs to the right</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="646"/>
+        <location filename="../src/controls/tabbar.cpp" line="688"/>
         <source>Close unmodified tabs</source>
         <translation>Close unmodified tabs</translation>
     </message>
@@ -982,263 +1018,280 @@
 <context>
     <name>TextEdit</name>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="305"/>
+        <location filename="../src/editor/dtextedit.cpp" line="388"/>
         <source>Undo</source>
         <translation>Undo</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="306"/>
+        <location filename="../src/editor/dtextedit.cpp" line="390"/>
         <source>Redo</source>
         <translation>Redo</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="307"/>
+        <location filename="../src/editor/dtextedit.cpp" line="392"/>
         <source>Cut</source>
         <translation>Cut</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="308"/>
+        <location filename="../src/editor/dtextedit.cpp" line="394"/>
         <source>Copy</source>
         <translation>Copy</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="309"/>
+        <location filename="../src/editor/dtextedit.cpp" line="396"/>
         <source>Paste</source>
         <translation>Paste</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="310"/>
+        <location filename="../src/editor/dtextedit.cpp" line="398"/>
         <source>Delete</source>
         <translation>Delete</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="311"/>
+        <location filename="../src/editor/dtextedit.cpp" line="400"/>
         <source>Select All</source>
         <translation>Select All</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="312"/>
-        <location filename="../src/widgets/window.cpp" line="535"/>
+        <location filename="../src/editor/dtextedit.cpp" line="402"/>
+        <location filename="../src/widgets/window.cpp" line="556"/>
         <source>Find</source>
         <translation>Find</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="313"/>
-        <location filename="../src/widgets/window.cpp" line="536"/>
+        <location filename="../src/editor/dtextedit.cpp" line="404"/>
+        <location filename="../src/widgets/window.cpp" line="558"/>
         <source>Replace</source>
         <translation>Replace</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="314"/>
+        <location filename="../src/editor/dtextedit.cpp" line="406"/>
         <source>Go to Line</source>
         <translation>Go to Line</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="315"/>
-        <source>Turn on Read-Only mode</source>
-        <translation>Turn on Read-Only mode</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="316"/>
-        <source>Turn off Read-Only mode</source>
-        <translation>Turn off Read-Only mode</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="317"/>
+        <location filename="../src/editor/dtextedit.cpp" line="415"/>
         <source>Fullscreen</source>
         <translation>Fullscreen</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="318"/>
+        <location filename="../src/editor/dtextedit.cpp" line="417"/>
         <source>Exit fullscreen</source>
         <translation>Exit fullscreen</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="319"/>
+        <location filename="../src/editor/dtextedit.cpp" line="419"/>
         <source>Display in file manager</source>
         <translation>Display in file manager</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="320"/>
-        <location filename="../src/editor/dtextedit.cpp" line="374"/>
+        <location filename="../src/editor/dtextedit.cpp" line="421"/>
+        <location filename="../src/editor/dtextedit.cpp" line="493"/>
         <source>Add Comment</source>
         <translation>Add Comment</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="321"/>
+        <location filename="../src/editor/dtextedit.cpp" line="423"/>
         <source>Text to Speech</source>
         <translation>Text to Speech</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="322"/>
-        <source>Stop reading</source>
-        <translation>Stop reading</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="323"/>
+        <location filename="../src/editor/dtextedit.cpp" line="425"/>
         <source>Speech to Text</source>
         <translation>Speech to Text</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="324"/>
+        <location filename="../src/editor/dtextedit.cpp" line="427"/>
         <source>Translate</source>
         <translation>Translate</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="325"/>
+        <location filename="../src/editor/dtextedit.cpp" line="429"/>
         <source>Column Mode</source>
         <translation>Column Mode</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="326"/>
+        <location filename="../src/editor/dtextedit.cpp" line="431"/>
         <source>Add bookmark</source>
         <translation>Add bookmark</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="327"/>
+        <location filename="../src/editor/dtextedit.cpp" line="433"/>
         <source>Remove Bookmark</source>
         <translation>Remove Bookmark</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="328"/>
+        <location filename="../src/editor/dtextedit.cpp" line="435"/>
         <source>Previous bookmark</source>
         <translation>Previous bookmark</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="329"/>
+        <location filename="../src/editor/dtextedit.cpp" line="437"/>
         <source>Next bookmark</source>
         <translation>Next bookmark</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="330"/>
+        <location filename="../src/editor/dtextedit.cpp" line="439"/>
         <source>Remove All Bookmarks</source>
         <translation>Remove All Bookmarks</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="331"/>
+        <location filename="../src/editor/dtextedit.cpp" line="441"/>
         <source>Fold All</source>
         <translation>Fold All</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="332"/>
+        <location filename="../src/editor/dtextedit.cpp" line="443"/>
         <source>Fold Current Level</source>
         <translation>Fold Current Level</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="333"/>
+        <location filename="../src/editor/dtextedit.cpp" line="445"/>
         <source>Unfold All</source>
         <translation>Unfold All</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="334"/>
+        <location filename="../src/editor/dtextedit.cpp" line="447"/>
         <source>Unfold Current Level</source>
         <translation>Unfold Current Level</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="339"/>
+        <location filename="../src/editor/dtextedit.cpp" line="453"/>
         <source>Color Mark</source>
         <translation>Color Mark</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="343"/>
+        <location filename="../src/editor/dtextedit.cpp" line="458"/>
         <source>Clear All Marks</source>
         <translation>Clear All Marks</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="344"/>
+        <location filename="../src/editor/dtextedit.cpp" line="460"/>
         <source>Clear Last Mark</source>
         <translation>Clear Last Mark</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="353"/>
+        <location filename="../src/editor/dtextedit.cpp" line="470"/>
         <source>Mark</source>
         <translation>Mark</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="366"/>
+        <location filename="../src/editor/dtextedit.cpp" line="484"/>
         <source>Mark All</source>
         <translation>Mark All</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="375"/>
+        <location filename="../src/editor/dtextedit.cpp" line="494"/>
         <source>Remove Comment</source>
         <translation>Remove Comment</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3208"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3211"/>
+        <location filename="../src/editor/dtextedit.cpp" line="543"/>
+        <source>View Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="3531"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3534"/>
         <source>Copy failed: not enough memory</source>
         <translation>Copy failed: not enough memory</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3333"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3335"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3656"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3658"/>
         <source>Press ALT and click lines to edit in column mode</source>
         <translation>Press ALT and click lines to edit in column mode</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="418"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9574"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9576"/>
+        <source>No audio output device was detected. Please ensure your speakers or headphones are properly connected and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="9583"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9585"/>
+        <source>No audio input device was detected. Please ensure your speakers or headphones are properly connected and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="534"/>
         <source>Change Case</source>
         <translation>Change Case</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="419"/>
+        <location filename="../src/editor/dtextedit.cpp" line="409"/>
+        <source>Edit Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="411"/>
+        <source>Read View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="413"/>
+        <source>Live Preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="535"/>
         <source>Upper Case</source>
         <translation>Upper Case</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="420"/>
+        <location filename="../src/editor/dtextedit.cpp" line="536"/>
         <source>Lower Case</source>
         <translation>Lower Case</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="421"/>
+        <location filename="../src/editor/dtextedit.cpp" line="537"/>
         <source>Capitalize</source>
         <translation>Capitalize</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="78"/>
+        <location filename="../src/widgets/bottombar.cpp" line="110"/>
         <source>None</source>
         <translation>None</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1363"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1490"/>
         <source>Selected line(s) copied</source>
         <translation>Selected line(s) copied</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1370"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1497"/>
         <source>Current line copied</source>
         <translation>Current line copied</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1400"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1527"/>
         <source>Selected line(s) clipped</source>
         <translation>Selected line(s) clipped</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1412"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1539"/>
         <source>Current line clipped</source>
         <translation>Current line clipped</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3227"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3230"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3550"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3553"/>
         <source>Paste failed: not enough memory</source>
         <translation>Paste failed: not enough memory</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="4548"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4873"/>
         <source>Read-Only mode is off</source>
         <translation>Read-Only mode is off</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="4560"/>
-        <location filename="../src/editor/dtextedit.cpp" line="4584"/>
-        <location filename="../src/editor/dtextedit.cpp" line="7896"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8007"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8015"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8026"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4885"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4909"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8236"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8347"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8355"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8366"/>
         <source>Read-Only mode is on</source>
         <translation>Read-Only mode is on</translation>
     </message>
@@ -1246,12 +1299,12 @@
 <context>
     <name>WarningNotices</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="24"/>
+        <location filename="../src/controls/warningnotices.cpp" line="25"/>
         <source>Reload</source>
         <translation>Reload</translation>
     </message>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="26"/>
+        <location filename="../src/controls/warningnotices.cpp" line="29"/>
         <source>Edit Anyway</source>
         <translation>Edit Anyway</translation>
     </message>
@@ -1259,160 +1312,162 @@
 <context>
     <name>Window</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="25"/>
-        <location filename="../src/widgets/window.cpp" line="531"/>
+        <location filename="../src/controls/warningnotices.cpp" line="27"/>
+        <location filename="../src/widgets/window.cpp" line="548"/>
         <source>Save as</source>
         <translation>Save as</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="527"/>
+        <location filename="../src/widgets/window.cpp" line="540"/>
         <source>New window</source>
         <translation>New window</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="528"/>
+        <location filename="../src/widgets/window.cpp" line="542"/>
         <source>New tab</source>
         <translation>New tab</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="529"/>
+        <location filename="../src/widgets/window.cpp" line="544"/>
         <source>Open file</source>
         <translation>Open file</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="530"/>
-        <location filename="../src/widgets/window.cpp" line="3545"/>
+        <location filename="../src/widgets/window.cpp" line="546"/>
+        <location filename="../src/widgets/window.cpp" line="3950"/>
         <source>Save</source>
         <translation>Save</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="532"/>
+        <location filename="../src/widgets/window.cpp" line="550"/>
         <source>Print</source>
         <translation>Print</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="533"/>
+        <location filename="../src/widgets/window.cpp" line="552"/>
         <source>Switch theme</source>
         <translation>Switch theme</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="534"/>
-        <location filename="../src/widgets/window.cpp" line="2448"/>
+        <location filename="../src/widgets/window.cpp" line="554"/>
+        <location filename="../src/widgets/window.cpp" line="2641"/>
         <source>Settings</source>
         <translation>Settings</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="666"/>
-        <location filename="../src/widgets/window.cpp" line="3845"/>
+        <location filename="../src/widgets/window.cpp" line="696"/>
+        <location filename="../src/widgets/window.cpp" line="4250"/>
         <source>Read-Only</source>
         <translation>Read-Only</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="687"/>
+        <location filename="../src/widgets/window.cpp" line="719"/>
         <source>You do not have permission to open %1</source>
         <translation>You do not have permission to open %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="738"/>
-        <location filename="../src/widgets/window.cpp" line="2963"/>
+        <location filename="../src/widgets/window.cpp" line="773"/>
+        <location filename="../src/widgets/window.cpp" line="3266"/>
         <source>Invalid file: %1</source>
         <translation>Invalid file: %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="903"/>
-        <location filename="../src/widgets/window.cpp" line="956"/>
+        <location filename="../src/widgets/window.cpp" line="957"/>
+        <location filename="../src/widgets/window.cpp" line="1050"/>
+        <location filename="../src/widgets/window.cpp" line="3217"/>
         <source>Do you want to save this file?</source>
         <translation>Do you want to save this file?</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1290"/>
+        <location filename="../src/widgets/window.cpp" line="1456"/>
         <source>You do not have permission to save %1</source>
         <translation>You do not have permission to save %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1312"/>
+        <location filename="../src/widgets/window.cpp" line="1428"/>
+        <location filename="../src/widgets/window.cpp" line="1478"/>
         <source>Saved successfully</source>
         <translation>Saved successfully</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1354"/>
-        <location filename="../src/widgets/window.cpp" line="1481"/>
-        <location filename="../src/widgets/window.cpp" line="1529"/>
+        <location filename="../src/widgets/window.cpp" line="1520"/>
+        <location filename="../src/widgets/window.cpp" line="1665"/>
+        <location filename="../src/widgets/window.cpp" line="1713"/>
         <source>Save File</source>
         <translation>Save File</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1483"/>
+        <location filename="../src/widgets/window.cpp" line="1667"/>
         <source>Encoding</source>
         <translation>Encoding</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1773"/>
+        <location filename="../src/widgets/window.cpp" line="1957"/>
         <source>Read-Only mode is on</source>
         <translation>Read-Only mode is on</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2322"/>
+        <location filename="../src/widgets/window.cpp" line="2511"/>
         <source>Current location remembered</source>
         <translation>Current location remembered</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2398"/>
+        <location filename="../src/widgets/window.cpp" line="2591"/>
         <source>Ctrl+&apos;=&apos;</source>
         <translation>Ctrl+&apos;=&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2401"/>
+        <location filename="../src/widgets/window.cpp" line="2594"/>
         <source>Ctrl+&apos;-&apos;</source>
         <translation>Ctrl+&apos;-&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2430"/>
+        <location filename="../src/widgets/window.cpp" line="2623"/>
         <source>Editor</source>
         <translation>Editor</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3061"/>
+        <location filename="../src/widgets/window.cpp" line="3436"/>
         <source>Untitled %1</source>
         <translation>Untitled %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3543"/>
+        <location filename="../src/widgets/window.cpp" line="3948"/>
         <source>Cancel</source>
         <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3544"/>
+        <location filename="../src/widgets/window.cpp" line="3949"/>
         <source>Discard</source>
         <translation>Discard</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1317"/>
-        <source>Invalid characters detected while saving "%1"</source>
-        <translation>Invalid characters detected while saving "%1"</translation>
+        <location filename="../src/widgets/window.cpp" line="1381"/>
+        <source>Invalid characters detected while saving &quot;%1&quot;</source>
+        <translation>Invalid characters detected while saving &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1318"/>
+        <location filename="../src/widgets/window.cpp" line="1382"/>
         <source>If you force save this file, it may cause file corruption. Still want to save?</source>
         <translation>If you force save this file, it may cause file corruption. Still want to save?</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1321"/>
+        <location filename="../src/widgets/window.cpp" line="1386"/>
         <source>Don&apos;t Save</source>
         <translation>Don&apos;t Save</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1322"/>
+        <location filename="../src/widgets/window.cpp" line="1387"/>
         <source>Save As</source>
         <translation>Save As</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1323"/>
+        <location filename="../src/widgets/window.cpp" line="1388"/>
         <source>Save Anyway</source>
         <translation>Save Anyway</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1521"/>
+        <location filename="../src/widgets/window.cpp" line="1569"/>
         <source>Cannot save as the original file in preview mode. Please choose a different path.</source>
         <translation>Cannot save as the original file in preview mode. Please choose a different path.</translation>
     </message>

--- a/translations/deepin-editor_am_ET.ts
+++ b/translations/deepin-editor_am_ET.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="am_ET">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="am_ET">
 <context>
     <name>BottomBar</name>
     <message>
@@ -17,17 +19,36 @@
         <translation>ባህሪዎች %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="44"/>
+        <location filename="../src/widgets/bottombar.cpp" line="47"/>
         <source>Loading:</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="73"/>
+        <location filename="../src/widgets/bottombar.cpp" line="91"/>
+        <location filename="../src/widgets/bottombar.cpp" line="499"/>
+        <source>Edit Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="74"/>
+        <location filename="../src/widgets/bottombar.cpp" line="489"/>
+        <source>Read View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="75"/>
+        <location filename="../src/widgets/bottombar.cpp" line="493"/>
+        <source>Live Preview</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DDropdownMenu</name>
     <message>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="362"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="420"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="425"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="363"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="421"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="426"/>
         <source>None</source>
         <translation>ምንም</translation>
     </message>
@@ -35,70 +56,59 @@
 <context>
     <name>EditWrapper</name>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="292"/>
-        <location filename="../src/editor/editwrapper.cpp" line="365"/>
-        <location filename="../src/editor/editwrapper.cpp" line="521"/>
-        <location filename="../src/editor/editwrapper.cpp" line="751"/>
+        <location filename="../src/editor/editwrapper.cpp" line="355"/>
+        <location filename="../src/editor/editwrapper.cpp" line="429"/>
+        <location filename="../src/editor/editwrapper.cpp" line="595"/>
+        <location filename="../src/editor/editwrapper.cpp" line="887"/>
         <source>Save</source>
         <translation>ማስቀመጫ</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="516"/>
+        <location filename="../src/editor/editwrapper.cpp" line="590"/>
         <source>Do you want to save this file?</source>
         <translation>እርስዎ ይህን ፋይሉን ማስቀመጥ ይፈልጋሎ?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="363"/>
-        <location filename="../src/editor/editwrapper.cpp" line="519"/>
+        <location filename="../src/editor/editwrapper.cpp" line="427"/>
+        <location filename="../src/editor/editwrapper.cpp" line="593"/>
         <source>Cancel</source>
         <translation>መሰረዣ</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="360"/>
+        <location filename="../src/editor/editwrapper.cpp" line="424"/>
         <source>Encoding changed. Do you want to save the file now?</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="520"/>
+        <location filename="../src/editor/editwrapper.cpp" line="594"/>
         <source>Discard</source>
         <translation>ማስወገጃ</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="274"/>
-        <location filename="../src/editor/editwrapper.cpp" line="620"/>
+        <location filename="../src/editor/editwrapper.cpp" line="1121"/>
+        <source>The file contains invalid characters (NUL). Preview mode is read-only.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="337"/>
+        <location filename="../src/editor/editwrapper.cpp" line="705"/>
         <source>You do not have permission to save %1</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="836"/>
+        <location filename="../src/editor/editwrapper.cpp" line="987"/>
         <source>File removed on the disk. Save it now?</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="842"/>
+        <location filename="../src/editor/editwrapper.cpp" line="993"/>
         <source>File has changed on disk. Reload?</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="884"/>
-        <location filename="../src/widgets/bottombar.cpp" line="74"/>
-        <source>INSERT</source>
-        <translation>ማስገቢያ</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="888"/>
-        <source>OVERWRITE</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="892"/>
-        <source>R/O</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="1618"/>
+        <location filename="../src/editor/editwrapper.cpp" line="1806"/>
         <source>The file cannot be read, which may be too large or has been damaged!</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -109,17 +119,17 @@
         <translation>መፈለጊያ</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="36"/>
-        <source>Previous</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/controls/findbar.cpp" line="37"/>
-        <source>Next</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
         <location filename="../src/controls/findbar.cpp" line="38"/>
+        <source>Previous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/controls/findbar.cpp" line="40"/>
+        <source>Next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/controls/findbar.cpp" line="42"/>
         <source>Replace</source>
         <translation>መቀየሪያ</translation>
     </message>
@@ -127,9 +137,17 @@
 <context>
     <name>JumpLineBar</name>
     <message>
-        <location filename="../src/controls/jumplinebar.cpp" line="45"/>
+        <location filename="../src/controls/jumplinebar.cpp" line="46"/>
         <source>Go to Line: </source>
         <translation>መሄጃ ወደ መስመር</translation>
+    </message>
+</context>
+<context>
+    <name>LineBar</name>
+    <message>
+        <location filename="../src/controls/linebar.cpp" line="144"/>
+        <source>第%1/%2项</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -137,30 +155,58 @@
     <message>
         <location filename="../src/editorapplication.cpp" line="12"/>
         <source>Text Editor is a powerful tool for viewing and editing text files.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/editorapplication.cpp" line="34"/>
         <source>Text Editor</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MarkdownBridge</name>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="37"/>
+        <source>Collapse code block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="38"/>
+        <source>Expand code block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="39"/>
+        <source>Copy code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="40"/>
+        <source>Expand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="42"/>
+        <source>%1 line(s) of code collapsed</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>PathSettingWgt</name>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="84"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="90"/>
         <source>Remember the last used path</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="85"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="91"/>
         <source>Same path as the current file</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="86"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="92"/>
         <source>Customize the default path</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -168,28 +214,33 @@
     <message>
         <location filename="../src/editorapplication.cpp" line="28"/>
         <source>Text Editor</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="294"/>
-        <location filename="../src/editor/editwrapper.cpp" line="761"/>
-        <location filename="../src/editor/editwrapper.cpp" line="776"/>
-        <location filename="../src/widgets/window.cpp" line="1362"/>
-        <location filename="../src/widgets/window.cpp" line="1390"/>
-        <location filename="../src/widgets/window.cpp" line="1531"/>
-        <location filename="../src/widgets/window.cpp" line="1548"/>
+        <location filename="../src/editor/editwrapper.cpp" line="357"/>
+        <location filename="../src/editor/editwrapper.cpp" line="897"/>
+        <location filename="../src/editor/editwrapper.cpp" line="912"/>
+        <location filename="../src/widgets/window.cpp" line="1528"/>
+        <location filename="../src/widgets/window.cpp" line="1556"/>
+        <location filename="../src/widgets/window.cpp" line="1715"/>
+        <location filename="../src/widgets/window.cpp" line="1732"/>
         <source>Encoding</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="2001"/>
+        <source>视图模式</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="11"/>
         <source>Basic</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="12"/>
         <source>Font Style</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="13"/>
@@ -199,35 +250,35 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="14"/>
         <source>Font Size</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="15"/>
         <source>Shortcuts</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="16"/>
         <location filename="../src/controls/settingsdialog.cpp" line="17"/>
         <source>Keymap</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="18"/>
         <location filename="../src/controls/settingsdialog.cpp" line="96"/>
-        <location filename="../src/widgets/window.cpp" line="2388"/>
+        <location filename="../src/widgets/window.cpp" line="2581"/>
         <source>Window</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="19"/>
         <source>New tab</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="20"/>
         <source>New window</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="21"/>
@@ -242,27 +293,27 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="23"/>
         <source>Next tab</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="24"/>
         <source>Previous tab</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="25"/>
         <source>Close tab</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="26"/>
         <source>Close other tabs</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="27"/>
         <source>Restore tab</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="28"/>
@@ -272,27 +323,27 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="29"/>
         <source>Increment font size</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="30"/>
         <source>Decrement font size</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="31"/>
         <source>Reset font size</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="32"/>
         <source>Help</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="33"/>
         <source>Toggle fullscreen</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="34"/>
@@ -302,12 +353,12 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="35"/>
         <source>Find Next</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="36"/>
         <source>Find Previous</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="37"/>
@@ -322,12 +373,12 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="39"/>
         <source>Save cursor position</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="40"/>
         <source>Reset cursor position</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="41"/>
@@ -337,7 +388,7 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="42"/>
         <source>Display shortcuts</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="43"/>
@@ -352,42 +403,42 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="45"/>
         <source>Increase indent</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="46"/>
         <source>Decrease indent</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="47"/>
         <source>Forward character</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="48"/>
         <source>Backward character</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="49"/>
         <source>Forward word</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="50"/>
         <source>Backward word</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="51"/>
         <source>Next line</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="52"/>
         <source>Previous line</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="53"/>
@@ -397,47 +448,47 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="54"/>
         <source>New line above</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="55"/>
         <source>New line below</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="56"/>
         <source>Duplicate line</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="57"/>
         <source>Delete to end of line</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="58"/>
         <source>Delete current line</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="59"/>
         <source>Swap line up</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="60"/>
         <source>Swap line down</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="61"/>
         <source>Scroll up one line</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="62"/>
         <source>Scroll down one line</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="63"/>
@@ -452,62 +503,62 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="65"/>
         <source>Move to end of line</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="66"/>
         <source>Move to start of line</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="67"/>
         <source>Move to end of text</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="68"/>
         <source>Move to start of text</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="69"/>
         <source>Move to line indentation</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="70"/>
         <source>Upper case</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="71"/>
         <source>Lower case</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="72"/>
         <source>Capitalize</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="73"/>
         <source>Delete backward word</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="74"/>
         <source>Delete forward word</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="75"/>
         <source>Forward over a pair</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="76"/>
         <source>Backward over a pair</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="77"/>
@@ -532,47 +583,47 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="81"/>
         <source>Transpose character</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="82"/>
         <source>Mark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="83"/>
         <source>Unmark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="84"/>
         <source>Copy line</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="85"/>
         <source>Cut line</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="86"/>
         <source>Merge lines</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="87"/>
         <source>Read-Only mode</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="88"/>
         <source>Add comment</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="89"/>
         <source>Remove comment</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="90"/>
@@ -587,238 +638,238 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="92"/>
         <source>Add/Remove bookmark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="93"/>
         <source>Move to previous bookmark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="94"/>
         <source>Move to next bookmark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="95"/>
         <source>Advanced</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="97"/>
         <source>Window size</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="98"/>
         <source>Tab width</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="99"/>
         <source>Paste by pressing a middle mouse button</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="101"/>
         <source>Startup</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="102"/>
         <source>Reopen last closed tabs</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="104"/>
         <source>Open/Save Settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="106"/>
         <source>Word wrap</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="107"/>
         <source>Code folding flag</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="108"/>
         <source>Show line numbers</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="109"/>
         <source>Show bookmarks icon</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="110"/>
         <source>Show whitespaces and tabs</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="111"/>
         <source>Highlight current line</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="112"/>
         <source>Color mark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="115"/>
         <source>Unicode</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="116"/>
         <source>WesternEuropean</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="117"/>
         <source>CentralEuropean</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="118"/>
         <source>Baltic</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="119"/>
         <source>Cyrillic</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="120"/>
         <source>Arabic</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="125"/>
         <source>Celtic</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="126"/>
         <source>SouthEasternEuropean</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="121"/>
         <source>Greek</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="122"/>
         <source>Hebrew</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="127"/>
         <source>ChineseSimplified</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="128"/>
         <source>ChineseTraditional</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="129"/>
         <source>Japanese</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="130"/>
         <source>Korean</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="124"/>
         <source>Thai</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="123"/>
         <source>Turkish</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="131"/>
         <source>Vietnamese</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/startmanager.cpp" line="971"/>
+        <location filename="../src/startmanager.cpp" line="1035"/>
         <source>File not saved</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1532"/>
-        <location filename="../src/widgets/window.cpp" line="1549"/>
+        <location filename="../src/widgets/window.cpp" line="1716"/>
+        <location filename="../src/widgets/window.cpp" line="1733"/>
         <source>Line Endings</source>
         <translation>የ መስመር መጨረሻ</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="243"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="379"/>
         <source>Please install &apos;UOS AI&apos; from the App Store before using</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="245"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="381"/>
         <source>No audio input device detected. Please check and try again</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="247"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="383"/>
         <source>No audio output device detected. Please check and try again</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="69"/>
+        <location filename="../src/common/text_file_saver.cpp" line="74"/>
         <source>File path is empty</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="155"/>
+        <location filename="../src/common/text_file_saver.cpp" line="153"/>
         <source>Insufficient memory to load document content</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="177"/>
+        <location filename="../src/common/text_file_saver.cpp" line="178"/>
         <source>Insufficient memory for encoding conversion</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="183"/>
+        <location filename="../src/common/text_file_saver.cpp" line="184"/>
         <source>Encoding conversion failed</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="189"/>
+        <location filename="../src/common/text_file_saver.cpp" line="190"/>
         <source>Converted content is empty</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="207"/>
+        <location filename="../src/common/text_file_saver.cpp" line="208"/>
         <source>Memory allocation failed</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="211"/>
+        <location filename="../src/common/text_file_saver.cpp" line="212"/>
         <source>Error occurred: %1</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="215"/>
+        <location filename="../src/common/text_file_saver.cpp" line="216"/>
         <source>Unknown error occurred</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -829,38 +880,38 @@
         <translation>መፈለጊያ</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="34"/>
+        <location filename="../src/controls/replacebar.cpp" line="36"/>
         <source>Replace With</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="36"/>
+        <location filename="../src/controls/replacebar.cpp" line="40"/>
         <source>Replace</source>
         <translation>መቀየሪያ</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="37"/>
+        <location filename="../src/controls/replacebar.cpp" line="42"/>
         <source>Skip</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="38"/>
+        <location filename="../src/controls/replacebar.cpp" line="44"/>
         <source>Replace Rest</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="39"/>
+        <location filename="../src/controls/replacebar.cpp" line="46"/>
         <source>Replace All</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>S:</name>
     <message>
         <location filename="../third/libiconv-1.16/src/iconv.c" line="103"/>
-        <source/>
+        <source></source>
         <comment>The first line of the short usage message.</comment>
-        <translation type="unfinished"/>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -868,501 +919,555 @@
     <message>
         <location filename="../src/common/settings.cpp" line="141"/>
         <source>Standard</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/common/settings.cpp" line="141"/>
         <source>Customize</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/common/settings.cpp" line="154"/>
         <source>Normal</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/common/settings.cpp" line="154"/>
         <source>Maximum</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/common/settings.cpp" line="154"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="484"/>
+        <location filename="../src/common/settings.cpp" line="491"/>
         <source>This shortcut conflicts with system shortcut %1</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="487"/>
+        <location filename="../src/common/settings.cpp" line="494"/>
         <source>This shortcut conflicts with %1, click on Replace to make this shortcut effective immediately</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="682"/>
-        <location filename="../src/common/settings.cpp" line="695"/>
-        <location filename="../src/common/settings.cpp" line="704"/>
+        <location filename="../src/common/settings.cpp" line="689"/>
+        <location filename="../src/common/settings.cpp" line="702"/>
+        <location filename="../src/common/settings.cpp" line="711"/>
         <source>The shortcut %1 is invalid, please set another one.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="736"/>
+        <location filename="../src/common/settings.cpp" line="743"/>
         <source>Cancel</source>
         <translation>መሰረዣ</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="737"/>
+        <location filename="../src/common/settings.cpp" line="744"/>
         <source>Replace</source>
         <translation>መቀየሪያ</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="740"/>
+        <location filename="../src/common/settings.cpp" line="747"/>
         <source>OK</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>StartManager</name>
     <message>
-        <location filename="../src/startmanager.cpp" line="411"/>
+        <location filename="../src/startmanager.cpp" line="425"/>
         <source>Untitled %1</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>Tabbar</name>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="641"/>
+        <location filename="../src/controls/tabbar.cpp" line="678"/>
         <source>Close tab</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="642"/>
+        <location filename="../src/controls/tabbar.cpp" line="680"/>
         <source>Close other tabs</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="643"/>
+        <location filename="../src/controls/tabbar.cpp" line="682"/>
         <source>More options</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="644"/>
+        <location filename="../src/controls/tabbar.cpp" line="684"/>
         <source>Close tabs to the left</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="645"/>
+        <location filename="../src/controls/tabbar.cpp" line="686"/>
         <source>Close tabs to the right</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="646"/>
+        <location filename="../src/controls/tabbar.cpp" line="688"/>
         <source>Close unmodified tabs</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>TextEdit</name>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="305"/>
+        <location filename="../src/editor/dtextedit.cpp" line="388"/>
         <source>Undo</source>
         <translation>መተው</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="306"/>
+        <location filename="../src/editor/dtextedit.cpp" line="390"/>
         <source>Redo</source>
         <translation>እንደገና መስሪያ</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="307"/>
+        <location filename="../src/editor/dtextedit.cpp" line="392"/>
         <source>Cut</source>
         <translation>መቁረጫ</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="308"/>
+        <location filename="../src/editor/dtextedit.cpp" line="394"/>
         <source>Copy</source>
         <translation>ኮፒ</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="309"/>
+        <location filename="../src/editor/dtextedit.cpp" line="396"/>
         <source>Paste</source>
         <translation>መለጠፊያ</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="310"/>
+        <location filename="../src/editor/dtextedit.cpp" line="398"/>
         <source>Delete</source>
         <translation>ማጥፊያ</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="311"/>
+        <location filename="../src/editor/dtextedit.cpp" line="400"/>
         <source>Select All</source>
         <translation>ሁሉንም መምረጫ</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="312"/>
-        <location filename="../src/widgets/window.cpp" line="535"/>
+        <location filename="../src/editor/dtextedit.cpp" line="402"/>
+        <location filename="../src/widgets/window.cpp" line="556"/>
         <source>Find</source>
         <translation>መፈለጊያ</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="313"/>
-        <location filename="../src/widgets/window.cpp" line="536"/>
+        <location filename="../src/editor/dtextedit.cpp" line="404"/>
+        <location filename="../src/widgets/window.cpp" line="558"/>
         <source>Replace</source>
         <translation>መቀየሪያ</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="314"/>
+        <location filename="../src/editor/dtextedit.cpp" line="406"/>
         <source>Go to Line</source>
         <translation>መሄጃ ወደ መስመር</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="315"/>
-        <source>Turn on Read-Only mode</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="316"/>
-        <source>Turn off Read-Only mode</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="317"/>
+        <location filename="../src/editor/dtextedit.cpp" line="415"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="318"/>
+        <location filename="../src/editor/dtextedit.cpp" line="417"/>
         <source>Exit fullscreen</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="319"/>
-        <source>Display in file manager</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="320"/>
-        <location filename="../src/editor/dtextedit.cpp" line="374"/>
-        <source>Add Comment</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="321"/>
-        <source>Text to Speech</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="322"/>
-        <source>Stop reading</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="323"/>
-        <source>Speech to Text</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="324"/>
-        <source>Translate</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="325"/>
-        <source>Column Mode</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="326"/>
-        <source>Add bookmark</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="327"/>
-        <source>Remove Bookmark</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="328"/>
-        <source>Previous bookmark</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="329"/>
-        <source>Next bookmark</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="330"/>
-        <source>Remove All Bookmarks</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="331"/>
-        <source>Fold All</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="332"/>
-        <source>Fold Current Level</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="333"/>
-        <source>Unfold All</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="334"/>
-        <source>Unfold Current Level</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="339"/>
-        <source>Color Mark</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="343"/>
-        <source>Clear All Marks</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="344"/>
-        <source>Clear Last Mark</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="353"/>
-        <source>Mark</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="366"/>
-        <source>Mark All</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="375"/>
-        <source>Remove Comment</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3208"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3211"/>
-        <source>Copy failed: not enough memory</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3333"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3335"/>
-        <source>Press ALT and click lines to edit in column mode</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="418"/>
-        <source>Change Case</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/editor/dtextedit.cpp" line="419"/>
-        <source>Upper Case</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="420"/>
-        <source>Lower Case</source>
-        <translation type="unfinished"/>
+        <source>Display in file manager</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/editor/dtextedit.cpp" line="421"/>
-        <source>Capitalize</source>
-        <translation type="unfinished"/>
+        <location filename="../src/editor/dtextedit.cpp" line="493"/>
+        <source>Add Comment</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="78"/>
+        <location filename="../src/editor/dtextedit.cpp" line="423"/>
+        <source>Text to Speech</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="425"/>
+        <source>Speech to Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="427"/>
+        <source>Translate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="429"/>
+        <source>Column Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="431"/>
+        <source>Add bookmark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="433"/>
+        <source>Remove Bookmark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="435"/>
+        <source>Previous bookmark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="437"/>
+        <source>Next bookmark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="439"/>
+        <source>Remove All Bookmarks</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="441"/>
+        <source>Fold All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="443"/>
+        <source>Fold Current Level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="445"/>
+        <source>Unfold All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="447"/>
+        <source>Unfold Current Level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="453"/>
+        <source>Color Mark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="458"/>
+        <source>Clear All Marks</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="460"/>
+        <source>Clear Last Mark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="470"/>
+        <source>Mark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="484"/>
+        <source>Mark All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="494"/>
+        <source>Remove Comment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="543"/>
+        <source>View Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="3531"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3534"/>
+        <source>Copy failed: not enough memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="3656"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3658"/>
+        <source>Press ALT and click lines to edit in column mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="9574"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9576"/>
+        <source>No audio output device was detected. Please ensure your speakers or headphones are properly connected and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="9583"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9585"/>
+        <source>No audio input device was detected. Please ensure your speakers or headphones are properly connected and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="534"/>
+        <source>Change Case</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="409"/>
+        <source>Edit Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="411"/>
+        <source>Read View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="413"/>
+        <source>Live Preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="535"/>
+        <source>Upper Case</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="536"/>
+        <source>Lower Case</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="537"/>
+        <source>Capitalize</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="110"/>
         <source>None</source>
         <translation>ምንም</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1363"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1490"/>
         <source>Selected line(s) copied</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1370"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1497"/>
         <source>Current line copied</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1400"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1527"/>
         <source>Selected line(s) clipped</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1412"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1539"/>
         <source>Current line clipped</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3227"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3230"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3550"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3553"/>
         <source>Paste failed: not enough memory</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="4548"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4873"/>
         <source>Read-Only mode is off</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="4560"/>
-        <location filename="../src/editor/dtextedit.cpp" line="4584"/>
-        <location filename="../src/editor/dtextedit.cpp" line="7896"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8007"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8015"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8026"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4885"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4909"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8236"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8347"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8355"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8366"/>
         <source>Read-Only mode is on</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>WarningNotices</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="24"/>
+        <location filename="../src/controls/warningnotices.cpp" line="25"/>
         <source>Reload</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/controls/warningnotices.cpp" line="29"/>
+        <source>Edit Anyway</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>Window</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="25"/>
-        <location filename="../src/widgets/window.cpp" line="531"/>
+        <location filename="../src/controls/warningnotices.cpp" line="27"/>
+        <location filename="../src/widgets/window.cpp" line="548"/>
         <source>Save as</source>
         <translation>ማስቀመጫ እንደ</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="527"/>
+        <location filename="../src/widgets/window.cpp" line="540"/>
         <source>New window</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="528"/>
+        <location filename="../src/widgets/window.cpp" line="542"/>
         <source>New tab</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="529"/>
+        <location filename="../src/widgets/window.cpp" line="544"/>
         <source>Open file</source>
         <translation>ፋይል መክፈቻ</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="530"/>
-        <location filename="../src/widgets/window.cpp" line="3545"/>
+        <location filename="../src/widgets/window.cpp" line="546"/>
+        <location filename="../src/widgets/window.cpp" line="3950"/>
         <source>Save</source>
         <translation>ማስቀመጫ</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="532"/>
+        <location filename="../src/widgets/window.cpp" line="550"/>
         <source>Print</source>
         <translation>ማተሚያ</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="533"/>
+        <location filename="../src/widgets/window.cpp" line="552"/>
         <source>Switch theme</source>
         <translation>ገጽታ መቀየሪያ</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="534"/>
-        <location filename="../src/widgets/window.cpp" line="2448"/>
+        <location filename="../src/widgets/window.cpp" line="554"/>
+        <location filename="../src/widgets/window.cpp" line="2641"/>
         <source>Settings</source>
         <translation>ማሰናጃ</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="666"/>
-        <location filename="../src/widgets/window.cpp" line="3845"/>
+        <location filename="../src/widgets/window.cpp" line="696"/>
+        <location filename="../src/widgets/window.cpp" line="4250"/>
         <source>Read-Only</source>
         <translation>ለማንበብ-ብቻ</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="687"/>
+        <location filename="../src/widgets/window.cpp" line="719"/>
         <source>You do not have permission to open %1</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="738"/>
-        <location filename="../src/widgets/window.cpp" line="2963"/>
+        <location filename="../src/widgets/window.cpp" line="773"/>
+        <location filename="../src/widgets/window.cpp" line="3266"/>
         <source>Invalid file: %1</source>
         <translation>ዋጋ የሌለው ፋይል: %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="903"/>
-        <location filename="../src/widgets/window.cpp" line="956"/>
+        <location filename="../src/widgets/window.cpp" line="957"/>
+        <location filename="../src/widgets/window.cpp" line="1050"/>
+        <location filename="../src/widgets/window.cpp" line="3217"/>
         <source>Do you want to save this file?</source>
         <translation>እርስዎ ይህን ፋይሉን ማስቀመጥ ይፈልጋሎ?</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1290"/>
-        <source>You do not have permission to save %1</source>
-        <translation type="unfinished"/>
+        <location filename="../src/widgets/window.cpp" line="1381"/>
+        <source>Invalid characters detected while saving &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1312"/>
+        <location filename="../src/widgets/window.cpp" line="1382"/>
+        <source>If you force save this file, it may cause file corruption. Still want to save?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1386"/>
+        <source>Don&apos;t Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1387"/>
+        <source>Save As</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1388"/>
+        <source>Save Anyway</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1456"/>
+        <source>You do not have permission to save %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1428"/>
+        <location filename="../src/widgets/window.cpp" line="1478"/>
         <source>Saved successfully</source>
         <translation>ተሳክቶ ተቀምጧል</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1354"/>
-        <location filename="../src/widgets/window.cpp" line="1481"/>
-        <location filename="../src/widgets/window.cpp" line="1529"/>
+        <location filename="../src/widgets/window.cpp" line="1520"/>
+        <location filename="../src/widgets/window.cpp" line="1665"/>
+        <location filename="../src/widgets/window.cpp" line="1713"/>
         <source>Save File</source>
         <translation>ፋይል ማስቀመጫ</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1483"/>
+        <location filename="../src/widgets/window.cpp" line="1569"/>
+        <source>Cannot save as the original file in preview mode. Please choose a different path.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1667"/>
         <source>Encoding</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1773"/>
+        <location filename="../src/widgets/window.cpp" line="1957"/>
         <source>Read-Only mode is on</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2322"/>
+        <location filename="../src/widgets/window.cpp" line="2511"/>
         <source>Current location remembered</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2398"/>
+        <location filename="../src/widgets/window.cpp" line="2591"/>
         <source>Ctrl+&apos;=&apos;</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2401"/>
+        <location filename="../src/widgets/window.cpp" line="2594"/>
         <source>Ctrl+&apos;-&apos;</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2430"/>
+        <location filename="../src/widgets/window.cpp" line="2623"/>
         <source>Editor</source>
         <translation>ማረሚያ</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3061"/>
+        <location filename="../src/widgets/window.cpp" line="3436"/>
         <source>Untitled %1</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3543"/>
+        <location filename="../src/widgets/window.cpp" line="3948"/>
         <source>Cancel</source>
         <translation>መሰረዣ</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3544"/>
+        <location filename="../src/widgets/window.cpp" line="3949"/>
         <source>Discard</source>
         <translation>ማስወገጃ</translation>
     </message>

--- a/translations/deepin-editor_ar.ts
+++ b/translations/deepin-editor_ar.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ar">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ar">
 <context>
     <name>BottomBar</name>
     <message>
@@ -17,17 +19,36 @@
         <translation>الحروف 1%</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="44"/>
+        <location filename="../src/widgets/bottombar.cpp" line="47"/>
         <source>Loading:</source>
         <translation>تحميل:</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="73"/>
+        <location filename="../src/widgets/bottombar.cpp" line="91"/>
+        <location filename="../src/widgets/bottombar.cpp" line="499"/>
+        <source>Edit Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="74"/>
+        <location filename="../src/widgets/bottombar.cpp" line="489"/>
+        <source>Read View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="75"/>
+        <location filename="../src/widgets/bottombar.cpp" line="493"/>
+        <source>Live Preview</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DDropdownMenu</name>
     <message>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="362"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="420"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="425"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="363"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="421"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="426"/>
         <source>None</source>
         <translation>لا شيء</translation>
     </message>
@@ -35,68 +56,57 @@
 <context>
     <name>EditWrapper</name>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="292"/>
-        <location filename="../src/editor/editwrapper.cpp" line="365"/>
-        <location filename="../src/editor/editwrapper.cpp" line="521"/>
-        <location filename="../src/editor/editwrapper.cpp" line="751"/>
+        <location filename="../src/editor/editwrapper.cpp" line="355"/>
+        <location filename="../src/editor/editwrapper.cpp" line="429"/>
+        <location filename="../src/editor/editwrapper.cpp" line="595"/>
+        <location filename="../src/editor/editwrapper.cpp" line="887"/>
         <source>Save</source>
         <translation>حفظ</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="516"/>
+        <location filename="../src/editor/editwrapper.cpp" line="590"/>
         <source>Do you want to save this file?</source>
         <translation>هل تريد حفظ هذا الملف؟</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="363"/>
-        <location filename="../src/editor/editwrapper.cpp" line="519"/>
+        <location filename="../src/editor/editwrapper.cpp" line="427"/>
+        <location filename="../src/editor/editwrapper.cpp" line="593"/>
         <source>Cancel</source>
         <translation>إلغاء</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="360"/>
+        <location filename="../src/editor/editwrapper.cpp" line="424"/>
         <source>Encoding changed. Do you want to save the file now?</source>
         <translation>تم تغيير الترميز. هل تريد حفظ الملف الآن؟</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="520"/>
+        <location filename="../src/editor/editwrapper.cpp" line="594"/>
         <source>Discard</source>
         <translation>إلغاء</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="274"/>
-        <location filename="../src/editor/editwrapper.cpp" line="620"/>
+        <location filename="../src/editor/editwrapper.cpp" line="1121"/>
+        <source>The file contains invalid characters (NUL). Preview mode is read-only.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="337"/>
+        <location filename="../src/editor/editwrapper.cpp" line="705"/>
         <source>You do not have permission to save %1</source>
         <translation>لا تملك الإذن لحفظ 1%</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="836"/>
+        <location filename="../src/editor/editwrapper.cpp" line="987"/>
         <source>File removed on the disk. Save it now?</source>
         <translation>الملف الذي في القرص قد حُذِف. أحفظه الآن؟</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="842"/>
+        <location filename="../src/editor/editwrapper.cpp" line="993"/>
         <source>File has changed on disk. Reload?</source>
         <translation>الملف الذي في القرص قد عُدِّل. أعيد التحميل؟</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="884"/>
-        <location filename="../src/widgets/bottombar.cpp" line="74"/>
-        <source>INSERT</source>
-        <translation>إدخال</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="888"/>
-        <source>OVERWRITE</source>
-        <translation>إعادة الكتابة</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="892"/>
-        <source>R/O</source>
-        <translation>قراءة</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="1618"/>
+        <location filename="../src/editor/editwrapper.cpp" line="1806"/>
         <source>The file cannot be read, which may be too large or has been damaged!</source>
         <translation>لا يمكن قراءة الملف ، وربما يكون كبيرًا جدًا أو تم تلفه!</translation>
     </message>
@@ -109,17 +119,17 @@
         <translation>بحث</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="36"/>
+        <location filename="../src/controls/findbar.cpp" line="38"/>
         <source>Previous</source>
         <translation>السابق</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="37"/>
+        <location filename="../src/controls/findbar.cpp" line="40"/>
         <source>Next</source>
         <translation>التالي</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="38"/>
+        <location filename="../src/controls/findbar.cpp" line="42"/>
         <source>Replace</source>
         <translation>استبدال</translation>
     </message>
@@ -127,9 +137,17 @@
 <context>
     <name>JumpLineBar</name>
     <message>
-        <location filename="../src/controls/jumplinebar.cpp" line="45"/>
+        <location filename="../src/controls/jumplinebar.cpp" line="46"/>
         <source>Go to Line: </source>
         <translation>انتقل إلى السطر:</translation>
+    </message>
+</context>
+<context>
+    <name>LineBar</name>
+    <message>
+        <location filename="../src/controls/linebar.cpp" line="144"/>
+        <source>第%1/%2项</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -146,19 +164,47 @@
     </message>
 </context>
 <context>
+    <name>MarkdownBridge</name>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="37"/>
+        <source>Collapse code block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="38"/>
+        <source>Expand code block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="39"/>
+        <source>Copy code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="40"/>
+        <source>Expand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="42"/>
+        <source>%1 line(s) of code collapsed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PathSettingWgt</name>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="84"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="90"/>
         <source>Remember the last used path</source>
         <translation>تذكر آخر مسار استخدم</translation>
     </message>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="85"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="91"/>
         <source>Same path as the current file</source>
         <translation>نفس المسار كملف الحالي</translation>
     </message>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="86"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="92"/>
         <source>Customize the default path</source>
         <translation>تخصيص المسار الافتراضي</translation>
     </message>
@@ -171,15 +217,20 @@
         <translation>محرر النصوص</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="294"/>
-        <location filename="../src/editor/editwrapper.cpp" line="761"/>
-        <location filename="../src/editor/editwrapper.cpp" line="776"/>
-        <location filename="../src/widgets/window.cpp" line="1362"/>
-        <location filename="../src/widgets/window.cpp" line="1390"/>
-        <location filename="../src/widgets/window.cpp" line="1531"/>
-        <location filename="../src/widgets/window.cpp" line="1548"/>
+        <location filename="../src/editor/editwrapper.cpp" line="357"/>
+        <location filename="../src/editor/editwrapper.cpp" line="897"/>
+        <location filename="../src/editor/editwrapper.cpp" line="912"/>
+        <location filename="../src/widgets/window.cpp" line="1528"/>
+        <location filename="../src/widgets/window.cpp" line="1556"/>
+        <location filename="../src/widgets/window.cpp" line="1715"/>
+        <location filename="../src/widgets/window.cpp" line="1732"/>
         <source>Encoding</source>
         <translation>الترميز</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="2001"/>
+        <source>视图模式</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="11"/>
@@ -215,7 +266,7 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="18"/>
         <location filename="../src/controls/settingsdialog.cpp" line="96"/>
-        <location filename="../src/widgets/window.cpp" line="2388"/>
+        <location filename="../src/widgets/window.cpp" line="2581"/>
         <source>Window</source>
         <translation>النافذة</translation>
     </message>
@@ -755,68 +806,68 @@
         <translation>الفيتنامية</translation>
     </message>
     <message>
-        <location filename="../src/startmanager.cpp" line="971"/>
+        <location filename="../src/startmanager.cpp" line="1035"/>
         <source>File not saved</source>
         <translation>لم يتم حفظ الملف</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1532"/>
-        <location filename="../src/widgets/window.cpp" line="1549"/>
+        <location filename="../src/widgets/window.cpp" line="1716"/>
+        <location filename="../src/widgets/window.cpp" line="1733"/>
         <source>Line Endings</source>
         <translation>نهايات السطور</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="243"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="379"/>
         <source>Please install &apos;UOS AI&apos; from the App Store before using</source>
         <translation>يرجى تثبيت &apos;UOS AI&apos; من متجر التطبيقات قبل الاستخدام</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="245"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="381"/>
         <source>No audio input device detected. Please check and try again</source>
         <translation>لم يتم الكشف على جهاز إدخال الصوت. يرجى التحقق والمحاولة مرة أخرى</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="247"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="383"/>
         <source>No audio output device detected. Please check and try again</source>
         <translation>لم يتم الكشف على جهاز إخراج الصوت. يرجى التحقق والمحاولة مرة أخرى</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="69"/>
+        <location filename="../src/common/text_file_saver.cpp" line="74"/>
         <source>File path is empty</source>
         <translation>مسار الملف فارغ</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="155"/>
+        <location filename="../src/common/text_file_saver.cpp" line="153"/>
         <source>Insufficient memory to load document content</source>
         <translation>ذاكرة غير كافية لتحميل محتوى المستند</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="177"/>
+        <location filename="../src/common/text_file_saver.cpp" line="178"/>
         <source>Insufficient memory for encoding conversion</source>
         <translation>ذاكرة غير كافية لتحويل الترميز</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="183"/>
+        <location filename="../src/common/text_file_saver.cpp" line="184"/>
         <source>Encoding conversion failed</source>
         <translation>فشل تحويل الترميز</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="189"/>
+        <location filename="../src/common/text_file_saver.cpp" line="190"/>
         <source>Converted content is empty</source>
         <translation>المحتوى المحول فارغ</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="207"/>
+        <location filename="../src/common/text_file_saver.cpp" line="208"/>
         <source>Memory allocation failed</source>
         <translation>فشل تخصيص الذاكرة</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="211"/>
+        <location filename="../src/common/text_file_saver.cpp" line="212"/>
         <source>Error occurred: %1</source>
         <translation>حدث خطأ: %1</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="215"/>
+        <location filename="../src/common/text_file_saver.cpp" line="216"/>
         <source>Unknown error occurred</source>
         <translation>حدث خطأ غير معروف</translation>
     </message>
@@ -829,27 +880,27 @@
         <translation>بحث</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="34"/>
+        <location filename="../src/controls/replacebar.cpp" line="36"/>
         <source>Replace With</source>
         <translation>استبدال بـ</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="36"/>
+        <location filename="../src/controls/replacebar.cpp" line="40"/>
         <source>Replace</source>
         <translation>استبدال</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="37"/>
+        <location filename="../src/controls/replacebar.cpp" line="42"/>
         <source>Skip</source>
         <translation>تخطي</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="38"/>
+        <location filename="../src/controls/replacebar.cpp" line="44"/>
         <source>Replace Rest</source>
         <translation>استبدال الباقي</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="39"/>
+        <location filename="../src/controls/replacebar.cpp" line="46"/>
         <source>Replace All</source>
         <translation>استبدال الكل</translation>
     </message>
@@ -858,9 +909,9 @@
     <name>S:</name>
     <message>
         <location filename="../third/libiconv-1.16/src/iconv.c" line="103"/>
-        <source/>
+        <source></source>
         <comment>The first line of the short usage message.</comment>
-        <translation type="unfinished"/>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -891,34 +942,34 @@
         <translation>ملء الشاشة</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="484"/>
+        <location filename="../src/common/settings.cpp" line="491"/>
         <source>This shortcut conflicts with system shortcut %1</source>
         <translation>هذا الاختصار يتعارث مع اختصار النظام %1</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="487"/>
+        <location filename="../src/common/settings.cpp" line="494"/>
         <source>This shortcut conflicts with %1, click on Replace to make this shortcut effective immediately</source>
         <translation>هذا الاختصار يتعارث مع %1, انقر فوق استبدال لجعل هذا الاختصار فعال على الفور</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="682"/>
-        <location filename="../src/common/settings.cpp" line="695"/>
-        <location filename="../src/common/settings.cpp" line="704"/>
+        <location filename="../src/common/settings.cpp" line="689"/>
+        <location filename="../src/common/settings.cpp" line="702"/>
+        <location filename="../src/common/settings.cpp" line="711"/>
         <source>The shortcut %1 is invalid, please set another one.</source>
         <translation>الاختصار %1 غير صالح, يرجى تعيين اختصار آخر.</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="736"/>
+        <location filename="../src/common/settings.cpp" line="743"/>
         <source>Cancel</source>
         <translation>إلغاء</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="737"/>
+        <location filename="../src/common/settings.cpp" line="744"/>
         <source>Replace</source>
         <translation>استبدال</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="740"/>
+        <location filename="../src/common/settings.cpp" line="747"/>
         <source>OK</source>
         <translation>موافق</translation>
     </message>
@@ -926,7 +977,7 @@
 <context>
     <name>StartManager</name>
     <message>
-        <location filename="../src/startmanager.cpp" line="411"/>
+        <location filename="../src/startmanager.cpp" line="425"/>
         <source>Untitled %1</source>
         <translation>بلا عنوان %1</translation>
     </message>
@@ -934,32 +985,32 @@
 <context>
     <name>Tabbar</name>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="641"/>
+        <location filename="../src/controls/tabbar.cpp" line="678"/>
         <source>Close tab</source>
         <translation>أغلق اللسان</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="642"/>
+        <location filename="../src/controls/tabbar.cpp" line="680"/>
         <source>Close other tabs</source>
         <translation>أغلق الألسنة الأخرى</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="643"/>
+        <location filename="../src/controls/tabbar.cpp" line="682"/>
         <source>More options</source>
         <translation>المزيد من الخيارات</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="644"/>
+        <location filename="../src/controls/tabbar.cpp" line="684"/>
         <source>Close tabs to the left</source>
         <translation>أغلق اللسنة اليسرى</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="645"/>
+        <location filename="../src/controls/tabbar.cpp" line="686"/>
         <source>Close tabs to the right</source>
         <translation>أغلق اللسنة اليمنى</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="646"/>
+        <location filename="../src/controls/tabbar.cpp" line="688"/>
         <source>Close unmodified tabs</source>
         <translation>أغلق اللسنات غير المعدلة</translation>
     </message>
@@ -967,263 +1018,280 @@
 <context>
     <name>TextEdit</name>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="305"/>
+        <location filename="../src/editor/dtextedit.cpp" line="388"/>
         <source>Undo</source>
         <translation>تراجع</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="306"/>
+        <location filename="../src/editor/dtextedit.cpp" line="390"/>
         <source>Redo</source>
         <translation>أعد</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="307"/>
+        <location filename="../src/editor/dtextedit.cpp" line="392"/>
         <source>Cut</source>
         <translation>قص</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="308"/>
+        <location filename="../src/editor/dtextedit.cpp" line="394"/>
         <source>Copy</source>
         <translation>نسخ</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="309"/>
+        <location filename="../src/editor/dtextedit.cpp" line="396"/>
         <source>Paste</source>
         <translation>لصق</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="310"/>
+        <location filename="../src/editor/dtextedit.cpp" line="398"/>
         <source>Delete</source>
         <translation>حذف</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="311"/>
+        <location filename="../src/editor/dtextedit.cpp" line="400"/>
         <source>Select All</source>
         <translation>اختر الكل</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="312"/>
-        <location filename="../src/widgets/window.cpp" line="535"/>
+        <location filename="../src/editor/dtextedit.cpp" line="402"/>
+        <location filename="../src/widgets/window.cpp" line="556"/>
         <source>Find</source>
         <translation>بحث</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="313"/>
-        <location filename="../src/widgets/window.cpp" line="536"/>
+        <location filename="../src/editor/dtextedit.cpp" line="404"/>
+        <location filename="../src/widgets/window.cpp" line="558"/>
         <source>Replace</source>
         <translation>استبدال</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="314"/>
+        <location filename="../src/editor/dtextedit.cpp" line="406"/>
         <source>Go to Line</source>
         <translation>انتقال إلى سطر</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="315"/>
-        <source>Turn on Read-Only mode</source>
-        <translation>تشغيل وضع القراءة فقط</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="316"/>
-        <source>Turn off Read-Only mode</source>
-        <translation>ايقاف وضع القراءة فقط</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="317"/>
+        <location filename="../src/editor/dtextedit.cpp" line="415"/>
         <source>Fullscreen</source>
         <translation>ملء الشاشة</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="318"/>
+        <location filename="../src/editor/dtextedit.cpp" line="417"/>
         <source>Exit fullscreen</source>
         <translation>الخروج من وضع ملء للشاشة</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="319"/>
+        <location filename="../src/editor/dtextedit.cpp" line="419"/>
         <source>Display in file manager</source>
         <translation>عرض في مدير الملفات</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="320"/>
-        <location filename="../src/editor/dtextedit.cpp" line="374"/>
+        <location filename="../src/editor/dtextedit.cpp" line="421"/>
+        <location filename="../src/editor/dtextedit.cpp" line="493"/>
         <source>Add Comment</source>
         <translation>إضافة التعليق</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="321"/>
+        <location filename="../src/editor/dtextedit.cpp" line="423"/>
         <source>Text to Speech</source>
         <translation>النص إلى الكلام</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="322"/>
-        <source>Stop reading</source>
-        <translation>إيقاف القراءة</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="323"/>
+        <location filename="../src/editor/dtextedit.cpp" line="425"/>
         <source>Speech to Text</source>
         <translation>الكلام إلى النص</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="324"/>
+        <location filename="../src/editor/dtextedit.cpp" line="427"/>
         <source>Translate</source>
         <translation>تَرجم</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="325"/>
+        <location filename="../src/editor/dtextedit.cpp" line="429"/>
         <source>Column Mode</source>
         <translation>وضع العمود</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="326"/>
+        <location filename="../src/editor/dtextedit.cpp" line="431"/>
         <source>Add bookmark</source>
         <translation>إضافة العلامة</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="327"/>
+        <location filename="../src/editor/dtextedit.cpp" line="433"/>
         <source>Remove Bookmark</source>
         <translation>إزالة العلامة</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="328"/>
+        <location filename="../src/editor/dtextedit.cpp" line="435"/>
         <source>Previous bookmark</source>
         <translation>العلامة السابقة</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="329"/>
+        <location filename="../src/editor/dtextedit.cpp" line="437"/>
         <source>Next bookmark</source>
         <translation>العلامة التالية</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="330"/>
+        <location filename="../src/editor/dtextedit.cpp" line="439"/>
         <source>Remove All Bookmarks</source>
         <translation>إزالة كل العلامات</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="331"/>
+        <location filename="../src/editor/dtextedit.cpp" line="441"/>
         <source>Fold All</source>
         <translation>إغلاق كل العلامات</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="332"/>
+        <location filename="../src/editor/dtextedit.cpp" line="443"/>
         <source>Fold Current Level</source>
         <translation>إغلاق المستوى الحالي</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="333"/>
+        <location filename="../src/editor/dtextedit.cpp" line="445"/>
         <source>Unfold All</source>
         <translation>فتح كل العلامات</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="334"/>
+        <location filename="../src/editor/dtextedit.cpp" line="447"/>
         <source>Unfold Current Level</source>
         <translation>فتح المستوى الحالي</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="339"/>
+        <location filename="../src/editor/dtextedit.cpp" line="453"/>
         <source>Color Mark</source>
         <translation>علامة اللون</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="343"/>
+        <location filename="../src/editor/dtextedit.cpp" line="458"/>
         <source>Clear All Marks</source>
         <translation>مسح كل العلامات</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="344"/>
+        <location filename="../src/editor/dtextedit.cpp" line="460"/>
         <source>Clear Last Mark</source>
         <translation>مسح العلامة الأخيرة</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="353"/>
+        <location filename="../src/editor/dtextedit.cpp" line="470"/>
         <source>Mark</source>
         <translation>وضع علامة</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="366"/>
+        <location filename="../src/editor/dtextedit.cpp" line="484"/>
         <source>Mark All</source>
         <translation>علامة كل العلامات</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="375"/>
+        <location filename="../src/editor/dtextedit.cpp" line="494"/>
         <source>Remove Comment</source>
         <translation>إزالة التعليق</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3208"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3211"/>
+        <location filename="../src/editor/dtextedit.cpp" line="543"/>
+        <source>View Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="3531"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3534"/>
         <source>Copy failed: not enough memory</source>
         <translation>فشل النسخ: ذاكرة غير كافية</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3333"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3335"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3656"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3658"/>
         <source>Press ALT and click lines to edit in column mode</source>
         <translation>اضغط على ALT وانقر على الخطوط لتحريرها في وضع العمود</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="418"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9574"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9576"/>
+        <source>No audio output device was detected. Please ensure your speakers or headphones are properly connected and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="9583"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9585"/>
+        <source>No audio input device was detected. Please ensure your speakers or headphones are properly connected and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="534"/>
         <source>Change Case</source>
         <translation>غيِّر الخانة</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="419"/>
+        <location filename="../src/editor/dtextedit.cpp" line="409"/>
+        <source>Edit Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="411"/>
+        <source>Read View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="413"/>
+        <source>Live Preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="535"/>
         <source>Upper Case</source>
         <translation>احرف الكبيرة</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="420"/>
+        <location filename="../src/editor/dtextedit.cpp" line="536"/>
         <source>Lower Case</source>
         <translation>أحرف صغيرة</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="421"/>
+        <location filename="../src/editor/dtextedit.cpp" line="537"/>
         <source>Capitalize</source>
         <translation>تحويل الحروف إلى حروف كبيرة</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="78"/>
+        <location filename="../src/widgets/bottombar.cpp" line="110"/>
         <source>None</source>
         <translation>لا شيء</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1363"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1490"/>
         <source>Selected line(s) copied</source>
         <translation>تم نسخ الخط (الخطوط) المحدد</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1370"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1497"/>
         <source>Current line copied</source>
         <translation>تم نسخ السطر الحالي</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1400"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1527"/>
         <source>Selected line(s) clipped</source>
         <translation>تم قص الخط (الخطوط) المحدد</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1412"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1539"/>
         <source>Current line clipped</source>
         <translation>تم قص الخط المحدد</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3227"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3230"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3550"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3553"/>
         <source>Paste failed: not enough memory</source>
         <translation>فشل اللصق: ذاكرة غير كافية</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="4548"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4873"/>
         <source>Read-Only mode is off</source>
         <translation>وضع القراءة فقط متوقف</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="4560"/>
-        <location filename="../src/editor/dtextedit.cpp" line="4584"/>
-        <location filename="../src/editor/dtextedit.cpp" line="7896"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8007"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8015"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8026"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4885"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4909"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8236"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8347"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8355"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8366"/>
         <source>Read-Only mode is on</source>
         <translation>وضع القراءة فقط قيد التشغيل</translation>
     </message>
@@ -1231,138 +1299,175 @@
 <context>
     <name>WarningNotices</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="24"/>
+        <location filename="../src/controls/warningnotices.cpp" line="25"/>
         <source>Reload</source>
         <translation>أعد التحميل</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/warningnotices.cpp" line="29"/>
+        <source>Edit Anyway</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>Window</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="25"/>
-        <location filename="../src/widgets/window.cpp" line="531"/>
+        <location filename="../src/controls/warningnotices.cpp" line="27"/>
+        <location filename="../src/widgets/window.cpp" line="548"/>
         <source>Save as</source>
         <translation>حفظ باسم</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="527"/>
+        <location filename="../src/widgets/window.cpp" line="540"/>
         <source>New window</source>
         <translation>نافذة جديدة</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="528"/>
+        <location filename="../src/widgets/window.cpp" line="542"/>
         <source>New tab</source>
         <translation>لسان جديد</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="529"/>
+        <location filename="../src/widgets/window.cpp" line="544"/>
         <source>Open file</source>
         <translation>فتح الملف</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="530"/>
-        <location filename="../src/widgets/window.cpp" line="3545"/>
+        <location filename="../src/widgets/window.cpp" line="546"/>
+        <location filename="../src/widgets/window.cpp" line="3950"/>
         <source>Save</source>
         <translation>حفظ</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="532"/>
+        <location filename="../src/widgets/window.cpp" line="550"/>
         <source>Print</source>
         <translation>طباعة</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="533"/>
+        <location filename="../src/widgets/window.cpp" line="552"/>
         <source>Switch theme</source>
         <translation>غيِّر السمة</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="534"/>
-        <location filename="../src/widgets/window.cpp" line="2448"/>
+        <location filename="../src/widgets/window.cpp" line="554"/>
+        <location filename="../src/widgets/window.cpp" line="2641"/>
         <source>Settings</source>
         <translation>إعدادات</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="666"/>
-        <location filename="../src/widgets/window.cpp" line="3845"/>
+        <location filename="../src/widgets/window.cpp" line="696"/>
+        <location filename="../src/widgets/window.cpp" line="4250"/>
         <source>Read-Only</source>
         <translation>للقراءة فقط</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="687"/>
+        <location filename="../src/widgets/window.cpp" line="719"/>
         <source>You do not have permission to open %1</source>
         <translation>لا تملك الإذن لفتح 1%</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="738"/>
-        <location filename="../src/widgets/window.cpp" line="2963"/>
+        <location filename="../src/widgets/window.cpp" line="773"/>
+        <location filename="../src/widgets/window.cpp" line="3266"/>
         <source>Invalid file: %1</source>
         <translation>ملف غير مدعوم: 1%</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="903"/>
-        <location filename="../src/widgets/window.cpp" line="956"/>
+        <location filename="../src/widgets/window.cpp" line="957"/>
+        <location filename="../src/widgets/window.cpp" line="1050"/>
+        <location filename="../src/widgets/window.cpp" line="3217"/>
         <source>Do you want to save this file?</source>
         <translation>هل تريد حفظ هذا الملف؟</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1290"/>
+        <location filename="../src/widgets/window.cpp" line="1381"/>
+        <source>Invalid characters detected while saving &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1382"/>
+        <source>If you force save this file, it may cause file corruption. Still want to save?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1386"/>
+        <source>Don&apos;t Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1387"/>
+        <source>Save As</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1388"/>
+        <source>Save Anyway</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1456"/>
         <source>You do not have permission to save %1</source>
         <translation>لا تملك الإذن لحفظ 1%</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1312"/>
+        <location filename="../src/widgets/window.cpp" line="1428"/>
+        <location filename="../src/widgets/window.cpp" line="1478"/>
         <source>Saved successfully</source>
         <translation>حُفِظ بنجاح</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1354"/>
-        <location filename="../src/widgets/window.cpp" line="1481"/>
-        <location filename="../src/widgets/window.cpp" line="1529"/>
+        <location filename="../src/widgets/window.cpp" line="1520"/>
+        <location filename="../src/widgets/window.cpp" line="1665"/>
+        <location filename="../src/widgets/window.cpp" line="1713"/>
         <source>Save File</source>
         <translation>حفظ الملف</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1483"/>
+        <location filename="../src/widgets/window.cpp" line="1569"/>
+        <source>Cannot save as the original file in preview mode. Please choose a different path.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1667"/>
         <source>Encoding</source>
         <translation>الترميز</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1773"/>
+        <location filename="../src/widgets/window.cpp" line="1957"/>
         <source>Read-Only mode is on</source>
         <translation>وضع القراءة فقط قيد التشغيل</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2322"/>
+        <location filename="../src/widgets/window.cpp" line="2511"/>
         <source>Current location remembered</source>
         <translation>تم تذكر المكان الحالي</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2398"/>
+        <location filename="../src/widgets/window.cpp" line="2591"/>
         <source>Ctrl+&apos;=&apos;</source>
         <translation>Ctrl+&apos;=&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2401"/>
+        <location filename="../src/widgets/window.cpp" line="2594"/>
         <source>Ctrl+&apos;-&apos;</source>
         <translation>Ctrl+&apos;-&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2430"/>
+        <location filename="../src/widgets/window.cpp" line="2623"/>
         <source>Editor</source>
         <translation>المحرر</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3061"/>
+        <location filename="../src/widgets/window.cpp" line="3436"/>
         <source>Untitled %1</source>
         <translation>بلا عنوان %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3543"/>
+        <location filename="../src/widgets/window.cpp" line="3948"/>
         <source>Cancel</source>
         <translation>إلغاء</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3544"/>
+        <location filename="../src/widgets/window.cpp" line="3949"/>
         <source>Discard</source>
         <translation>إلغاء</translation>
     </message>

--- a/translations/deepin-editor_az.ts
+++ b/translations/deepin-editor_az.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="az">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="az">
 <context>
     <name>BottomBar</name>
     <message>
@@ -17,17 +19,36 @@
         <translation>%1 simvol</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="44"/>
+        <location filename="../src/widgets/bottombar.cpp" line="47"/>
         <source>Loading:</source>
         <translation>Yüklənir:</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="73"/>
+        <location filename="../src/widgets/bottombar.cpp" line="91"/>
+        <location filename="../src/widgets/bottombar.cpp" line="499"/>
+        <source>Edit Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="74"/>
+        <location filename="../src/widgets/bottombar.cpp" line="489"/>
+        <source>Read View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="75"/>
+        <location filename="../src/widgets/bottombar.cpp" line="493"/>
+        <source>Live Preview</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DDropdownMenu</name>
     <message>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="362"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="420"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="425"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="363"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="421"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="426"/>
         <source>None</source>
         <translation>Heç biri</translation>
     </message>
@@ -35,68 +56,57 @@
 <context>
     <name>EditWrapper</name>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="292"/>
-        <location filename="../src/editor/editwrapper.cpp" line="365"/>
-        <location filename="../src/editor/editwrapper.cpp" line="521"/>
-        <location filename="../src/editor/editwrapper.cpp" line="751"/>
+        <location filename="../src/editor/editwrapper.cpp" line="355"/>
+        <location filename="../src/editor/editwrapper.cpp" line="429"/>
+        <location filename="../src/editor/editwrapper.cpp" line="595"/>
+        <location filename="../src/editor/editwrapper.cpp" line="887"/>
         <source>Save</source>
         <translation>Saxlamaq</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="516"/>
+        <location filename="../src/editor/editwrapper.cpp" line="590"/>
         <source>Do you want to save this file?</source>
         <translation>Bu faylı saxlamaq istəyirsiniz?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="363"/>
-        <location filename="../src/editor/editwrapper.cpp" line="519"/>
+        <location filename="../src/editor/editwrapper.cpp" line="427"/>
+        <location filename="../src/editor/editwrapper.cpp" line="593"/>
         <source>Cancel</source>
         <translation>İmtina</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="360"/>
+        <location filename="../src/editor/editwrapper.cpp" line="424"/>
         <source>Encoding changed. Do you want to save the file now?</source>
         <translation>Kodlaşma dəyişdirildi. Faylı indi saxlamaq istəyirsiniz?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="520"/>
+        <location filename="../src/editor/editwrapper.cpp" line="594"/>
         <source>Discard</source>
         <translation>Rədd etmək</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="274"/>
-        <location filename="../src/editor/editwrapper.cpp" line="620"/>
+        <location filename="../src/editor/editwrapper.cpp" line="1121"/>
+        <source>The file contains invalid characters (NUL). Preview mode is read-only.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="337"/>
+        <location filename="../src/editor/editwrapper.cpp" line="705"/>
         <source>You do not have permission to save %1</source>
         <translation>%1 saxlamaq üçün imtiyazınız yoxdur</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="836"/>
+        <location filename="../src/editor/editwrapper.cpp" line="987"/>
         <source>File removed on the disk. Save it now?</source>
         <translation>Diskdəki fayl silindi. O, indi saxlanılsın?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="842"/>
+        <location filename="../src/editor/editwrapper.cpp" line="993"/>
         <source>File has changed on disk. Reload?</source>
         <translation>Diskdəki fayl dəyişdirildi. Yenidən yüklənsin?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="884"/>
-        <location filename="../src/widgets/bottombar.cpp" line="74"/>
-        <source>INSERT</source>
-        <translation>DAXİL_ETMƏK</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="888"/>
-        <source>OVERWRITE</source>
-        <translation>ÜZƏRİNƏ_YAZMAQ</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="892"/>
-        <source>R/O</source>
-        <translation>Y/O</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="1618"/>
+        <location filename="../src/editor/editwrapper.cpp" line="1806"/>
         <source>The file cannot be read, which may be too large or has been damaged!</source>
         <translation>Fayl oxuna bilməz, ola bilsin ki, o, çox böyükdür və ya zədələnib!</translation>
     </message>
@@ -109,17 +119,17 @@
         <translation>Tapmaq</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="36"/>
+        <location filename="../src/controls/findbar.cpp" line="38"/>
         <source>Previous</source>
         <translation>Əvvəlki</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="37"/>
+        <location filename="../src/controls/findbar.cpp" line="40"/>
         <source>Next</source>
         <translation>Sonrakı</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="38"/>
+        <location filename="../src/controls/findbar.cpp" line="42"/>
         <source>Replace</source>
         <translation>Əvəzləmək</translation>
     </message>
@@ -127,9 +137,17 @@
 <context>
     <name>JumpLineBar</name>
     <message>
-        <location filename="../src/controls/jumplinebar.cpp" line="45"/>
+        <location filename="../src/controls/jumplinebar.cpp" line="46"/>
         <source>Go to Line: </source>
         <translation>Sətirə keçin:</translation>
+    </message>
+</context>
+<context>
+    <name>LineBar</name>
+    <message>
+        <location filename="../src/controls/linebar.cpp" line="144"/>
+        <source>第%1/%2项</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -146,19 +164,47 @@
     </message>
 </context>
 <context>
+    <name>MarkdownBridge</name>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="37"/>
+        <source>Collapse code block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="38"/>
+        <source>Expand code block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="39"/>
+        <source>Copy code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="40"/>
+        <source>Expand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="42"/>
+        <source>%1 line(s) of code collapsed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PathSettingWgt</name>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="84"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="90"/>
         <source>Remember the last used path</source>
         <translation>Sonuncu istifadə olunmuş yolu yadda saxlamaq</translation>
     </message>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="85"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="91"/>
         <source>Same path as the current file</source>
         <translation>Cari fayl ilə eyni yol</translation>
     </message>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="86"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="92"/>
         <source>Customize the default path</source>
         <translation>Satandart yolu dəyişdir</translation>
     </message>
@@ -171,15 +217,20 @@
         <translation>Mətn Redaktoru</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="294"/>
-        <location filename="../src/editor/editwrapper.cpp" line="761"/>
-        <location filename="../src/editor/editwrapper.cpp" line="776"/>
-        <location filename="../src/widgets/window.cpp" line="1362"/>
-        <location filename="../src/widgets/window.cpp" line="1390"/>
-        <location filename="../src/widgets/window.cpp" line="1531"/>
-        <location filename="../src/widgets/window.cpp" line="1548"/>
+        <location filename="../src/editor/editwrapper.cpp" line="357"/>
+        <location filename="../src/editor/editwrapper.cpp" line="897"/>
+        <location filename="../src/editor/editwrapper.cpp" line="912"/>
+        <location filename="../src/widgets/window.cpp" line="1528"/>
+        <location filename="../src/widgets/window.cpp" line="1556"/>
+        <location filename="../src/widgets/window.cpp" line="1715"/>
+        <location filename="../src/widgets/window.cpp" line="1732"/>
         <source>Encoding</source>
         <translation>Kodlaşma</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="2001"/>
+        <source>视图模式</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="11"/>
@@ -215,7 +266,7 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="18"/>
         <location filename="../src/controls/settingsdialog.cpp" line="96"/>
-        <location filename="../src/widgets/window.cpp" line="2388"/>
+        <location filename="../src/widgets/window.cpp" line="2581"/>
         <source>Window</source>
         <translation>Pəncərə</translation>
     </message>
@@ -755,68 +806,68 @@
         <translation>Vyetnam</translation>
     </message>
     <message>
-        <location filename="../src/startmanager.cpp" line="971"/>
+        <location filename="../src/startmanager.cpp" line="1035"/>
         <source>File not saved</source>
         <translation>Fayl saxlanılmadı</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1532"/>
-        <location filename="../src/widgets/window.cpp" line="1549"/>
+        <location filename="../src/widgets/window.cpp" line="1716"/>
+        <location filename="../src/widgets/window.cpp" line="1733"/>
         <source>Line Endings</source>
         <translation>Sətrin sonu</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="243"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="379"/>
         <source>Please install &apos;UOS AI&apos; from the App Store before using</source>
         <translation>Tətbiq mağazasından &apos;UOS AI&apos; təqdim edin, istifadə etməzdən əvvəl</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="245"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="381"/>
         <source>No audio input device detected. Please check and try again</source>
         <translation>Audio daxil edici cihaz aşkarlanmadı. Təkkləyin və ya təkrar cəhd edin</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="247"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="383"/>
         <source>No audio output device detected. Please check and try again</source>
         <translation>Audio çıxış cihazı aşkarlanmadı. Təkkləyin və ya təkrar cəhd edin</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="69"/>
+        <location filename="../src/common/text_file_saver.cpp" line="74"/>
         <source>File path is empty</source>
         <translation>Fayl yolunun boş olduğunu</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="155"/>
+        <location filename="../src/common/text_file_saver.cpp" line="153"/>
         <source>Insufficient memory to load document content</source>
         <translation>Dokument məzmunun yüklənməsi üçün yeterli yaddaş yoxdur</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="177"/>
+        <location filename="../src/common/text_file_saver.cpp" line="178"/>
         <source>Insufficient memory for encoding conversion</source>
         <translation>Kodlamadan keçirmək üçün yeterli yaddaş yoxdur</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="183"/>
+        <location filename="../src/common/text_file_saver.cpp" line="184"/>
         <source>Encoding conversion failed</source>
         <translation>Kodlama çevrilməsi uğursuz oldu</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="189"/>
+        <location filename="../src/common/text_file_saver.cpp" line="190"/>
         <source>Converted content is empty</source>
         <translation>Çevrilməmiş məzmun boşdur</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="207"/>
+        <location filename="../src/common/text_file_saver.cpp" line="208"/>
         <source>Memory allocation failed</source>
         <translation>Yaddaş təyinatı uğursuz oldu</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="211"/>
+        <location filename="../src/common/text_file_saver.cpp" line="212"/>
         <source>Error occurred: %1</source>
         <translation>&apos;Xəta baş verdi: %1&apos;</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="215"/>
+        <location filename="../src/common/text_file_saver.cpp" line="216"/>
         <source>Unknown error occurred</source>
         <translation>Məlum olmayan xəta baş verdi</translation>
     </message>
@@ -829,27 +880,27 @@
         <translation>Tapmaq</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="34"/>
+        <location filename="../src/controls/replacebar.cpp" line="36"/>
         <source>Replace With</source>
         <translation>Bununla əvəzləmək</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="36"/>
+        <location filename="../src/controls/replacebar.cpp" line="40"/>
         <source>Replace</source>
         <translation>Əvəzləmək</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="37"/>
+        <location filename="../src/controls/replacebar.cpp" line="42"/>
         <source>Skip</source>
         <translation>Ötürmək</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="38"/>
+        <location filename="../src/controls/replacebar.cpp" line="44"/>
         <source>Replace Rest</source>
         <translation>Başqalarını dəyişin</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="39"/>
+        <location filename="../src/controls/replacebar.cpp" line="46"/>
         <source>Replace All</source>
         <translation>Hamısını əvəzləmək</translation>
     </message>
@@ -858,9 +909,9 @@
     <name>S:</name>
     <message>
         <location filename="../third/libiconv-1.16/src/iconv.c" line="103"/>
-        <source/>
+        <source></source>
         <comment>The first line of the short usage message.</comment>
-        <translation type="unfinished"/>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -891,34 +942,34 @@
         <translation>Tam ekran</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="484"/>
+        <location filename="../src/common/settings.cpp" line="491"/>
         <source>This shortcut conflicts with system shortcut %1</source>
         <translation>Bu qısayol %1 sistem qısayolu ilə ziddiyyətlidir</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="487"/>
+        <location filename="../src/common/settings.cpp" line="494"/>
         <source>This shortcut conflicts with %1, click on Replace to make this shortcut effective immediately</source>
         <translation>Bu qısayol %1 ilə ziddiyyətlidir, bu qısayolu dərhal qüvvəyə mindirmək üçün Əvəzləmək düyməsinə vurun</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="682"/>
-        <location filename="../src/common/settings.cpp" line="695"/>
-        <location filename="../src/common/settings.cpp" line="704"/>
+        <location filename="../src/common/settings.cpp" line="689"/>
+        <location filename="../src/common/settings.cpp" line="702"/>
+        <location filename="../src/common/settings.cpp" line="711"/>
         <source>The shortcut %1 is invalid, please set another one.</source>
         <translation>%1 qısayolu işləmir, başqa birini təyin edin.</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="736"/>
+        <location filename="../src/common/settings.cpp" line="743"/>
         <source>Cancel</source>
         <translation>İmtina</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="737"/>
+        <location filename="../src/common/settings.cpp" line="744"/>
         <source>Replace</source>
         <translation>Əvəzləmək</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="740"/>
+        <location filename="../src/common/settings.cpp" line="747"/>
         <source>OK</source>
         <translation>OLDU</translation>
     </message>
@@ -926,7 +977,7 @@
 <context>
     <name>StartManager</name>
     <message>
-        <location filename="../src/startmanager.cpp" line="411"/>
+        <location filename="../src/startmanager.cpp" line="425"/>
         <source>Untitled %1</source>
         <translation>Başlıqsız %1</translation>
     </message>
@@ -934,32 +985,32 @@
 <context>
     <name>Tabbar</name>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="641"/>
+        <location filename="../src/controls/tabbar.cpp" line="678"/>
         <source>Close tab</source>
         <translation>Vərəqi bağlamaq</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="642"/>
+        <location filename="../src/controls/tabbar.cpp" line="680"/>
         <source>Close other tabs</source>
         <translation>Digər vərəqləri baölamaq</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="643"/>
+        <location filename="../src/controls/tabbar.cpp" line="682"/>
         <source>More options</source>
         <translation>Daha çox seçimlər</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="644"/>
+        <location filename="../src/controls/tabbar.cpp" line="684"/>
         <source>Close tabs to the left</source>
         <translation>Soldakı vərəqləri bağlamaq</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="645"/>
+        <location filename="../src/controls/tabbar.cpp" line="686"/>
         <source>Close tabs to the right</source>
         <translation>Saödakı vərəqləri bağlamaq</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="646"/>
+        <location filename="../src/controls/tabbar.cpp" line="688"/>
         <source>Close unmodified tabs</source>
         <translation>Dəyişdirilməmiş vərəqləri bağlamaq</translation>
     </message>
@@ -967,263 +1018,280 @@
 <context>
     <name>TextEdit</name>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="305"/>
+        <location filename="../src/editor/dtextedit.cpp" line="388"/>
         <source>Undo</source>
         <translation>Qaytarmaq</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="306"/>
+        <location filename="../src/editor/dtextedit.cpp" line="390"/>
         <source>Redo</source>
         <translation>Hazır</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="307"/>
+        <location filename="../src/editor/dtextedit.cpp" line="392"/>
         <source>Cut</source>
         <translation>Kəsmək</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="308"/>
+        <location filename="../src/editor/dtextedit.cpp" line="394"/>
         <source>Copy</source>
         <translation>Kopyalamaq</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="309"/>
+        <location filename="../src/editor/dtextedit.cpp" line="396"/>
         <source>Paste</source>
         <translation>Yerləşdirmək</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="310"/>
+        <location filename="../src/editor/dtextedit.cpp" line="398"/>
         <source>Delete</source>
         <translation>Silmək</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="311"/>
+        <location filename="../src/editor/dtextedit.cpp" line="400"/>
         <source>Select All</source>
         <translation>Hamısını seçmək</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="312"/>
-        <location filename="../src/widgets/window.cpp" line="535"/>
+        <location filename="../src/editor/dtextedit.cpp" line="402"/>
+        <location filename="../src/widgets/window.cpp" line="556"/>
         <source>Find</source>
         <translation>Tapmaq</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="313"/>
-        <location filename="../src/widgets/window.cpp" line="536"/>
+        <location filename="../src/editor/dtextedit.cpp" line="404"/>
+        <location filename="../src/widgets/window.cpp" line="558"/>
         <source>Replace</source>
         <translation>Əvəzləmək</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="314"/>
+        <location filename="../src/editor/dtextedit.cpp" line="406"/>
         <source>Go to Line</source>
         <translation>Sətirə keçin</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="315"/>
-        <source>Turn on Read-Only mode</source>
-        <translation>Yalnız-oxu, rejimini açmaq</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="316"/>
-        <source>Turn off Read-Only mode</source>
-        <translation>Yalnız-oxu, rejimini söndürmək</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="317"/>
+        <location filename="../src/editor/dtextedit.cpp" line="415"/>
         <source>Fullscreen</source>
         <translation>Tam ekran</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="318"/>
+        <location filename="../src/editor/dtextedit.cpp" line="417"/>
         <source>Exit fullscreen</source>
         <translation>Tam ekrandan çıxış</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="319"/>
+        <location filename="../src/editor/dtextedit.cpp" line="419"/>
         <source>Display in file manager</source>
         <translation>Fayl bələdçisində göstərmək</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="320"/>
-        <location filename="../src/editor/dtextedit.cpp" line="374"/>
+        <location filename="../src/editor/dtextedit.cpp" line="421"/>
+        <location filename="../src/editor/dtextedit.cpp" line="493"/>
         <source>Add Comment</source>
         <translation>Şərh əlavə edin</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="321"/>
+        <location filename="../src/editor/dtextedit.cpp" line="423"/>
         <source>Text to Speech</source>
         <translation>Mətndən_Nitqə</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="322"/>
-        <source>Stop reading</source>
-        <translation>Oxunuşu saxlamaq</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="323"/>
+        <location filename="../src/editor/dtextedit.cpp" line="425"/>
         <source>Speech to Text</source>
         <translation>Nitqdən_Mətnə</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="324"/>
+        <location filename="../src/editor/dtextedit.cpp" line="427"/>
         <source>Translate</source>
         <translation>Tərcümə</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="325"/>
+        <location filename="../src/editor/dtextedit.cpp" line="429"/>
         <source>Column Mode</source>
         <translation>Sütun rejimi</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="326"/>
+        <location filename="../src/editor/dtextedit.cpp" line="431"/>
         <source>Add bookmark</source>
         <translation>Əlfəcin əlavə etmək</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="327"/>
+        <location filename="../src/editor/dtextedit.cpp" line="433"/>
         <source>Remove Bookmark</source>
         <translation>Əlfəcini silmək</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="328"/>
+        <location filename="../src/editor/dtextedit.cpp" line="435"/>
         <source>Previous bookmark</source>
         <translation>Əvvəlki əlfəcin</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="329"/>
+        <location filename="../src/editor/dtextedit.cpp" line="437"/>
         <source>Next bookmark</source>
         <translation>Sonrakı əlfəcin</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="330"/>
+        <location filename="../src/editor/dtextedit.cpp" line="439"/>
         <source>Remove All Bookmarks</source>
         <translation>Bütün əlfəcinləri silmək</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="331"/>
+        <location filename="../src/editor/dtextedit.cpp" line="441"/>
         <source>Fold All</source>
         <translation>Hamısını bükmək</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="332"/>
+        <location filename="../src/editor/dtextedit.cpp" line="443"/>
         <source>Fold Current Level</source>
         <translation>Cari səviyyəni bükmək</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="333"/>
+        <location filename="../src/editor/dtextedit.cpp" line="445"/>
         <source>Unfold All</source>
         <translation>Hamısını açmaq</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="334"/>
+        <location filename="../src/editor/dtextedit.cpp" line="447"/>
         <source>Unfold Current Level</source>
         <translation>Cari səviyyəni açmaq</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="339"/>
+        <location filename="../src/editor/dtextedit.cpp" line="453"/>
         <source>Color Mark</source>
         <translation>Rəng markeri</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="343"/>
+        <location filename="../src/editor/dtextedit.cpp" line="458"/>
         <source>Clear All Marks</source>
         <translation>Bütün işarələri qaldırmaq</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="344"/>
+        <location filename="../src/editor/dtextedit.cpp" line="460"/>
         <source>Clear Last Mark</source>
         <translation>Sonuncu işarəni qaldırmaq</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="353"/>
+        <location filename="../src/editor/dtextedit.cpp" line="470"/>
         <source>Mark</source>
         <translation>İşarələmək</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="366"/>
+        <location filename="../src/editor/dtextedit.cpp" line="484"/>
         <source>Mark All</source>
         <translation>Hamısını işarələmək</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="375"/>
+        <location filename="../src/editor/dtextedit.cpp" line="494"/>
         <source>Remove Comment</source>
         <translation>Şərhi silmək</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3208"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3211"/>
+        <location filename="../src/editor/dtextedit.cpp" line="543"/>
+        <source>View Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="3531"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3534"/>
         <source>Copy failed: not enough memory</source>
         <translation>Kopyalanmadı: kifayət qədər yaddaş yoxdur</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3333"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3335"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3656"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3658"/>
         <source>Press ALT and click lines to edit in column mode</source>
         <translation>Sütun rejimində düzəliş etmək üçün ALT düyməsini basın və sətirə vurun</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="418"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9574"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9576"/>
+        <source>No audio output device was detected. Please ensure your speakers or headphones are properly connected and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="9583"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9585"/>
+        <source>No audio input device was detected. Please ensure your speakers or headphones are properly connected and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="534"/>
         <source>Change Case</source>
         <translation>Böyük-kiçik hərfi dəyişdirmək</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="419"/>
+        <location filename="../src/editor/dtextedit.cpp" line="409"/>
+        <source>Edit Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="411"/>
+        <source>Read View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="413"/>
+        <source>Live Preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="535"/>
         <source>Upper Case</source>
         <translation>Böyük hərf</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="420"/>
+        <location filename="../src/editor/dtextedit.cpp" line="536"/>
         <source>Lower Case</source>
         <translation>Kiçik hərf</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="421"/>
+        <location filename="../src/editor/dtextedit.cpp" line="537"/>
         <source>Capitalize</source>
         <translation>Baş hərflərlə</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="78"/>
+        <location filename="../src/widgets/bottombar.cpp" line="110"/>
         <source>None</source>
         <translation>Heç biri</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1363"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1490"/>
         <source>Selected line(s) copied</source>
         <translation>Seçilmiş sətir(lər) kopyalandı</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1370"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1497"/>
         <source>Current line copied</source>
         <translation>Cari sətir kopyalandı</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1400"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1527"/>
         <source>Selected line(s) clipped</source>
         <translation>Seçilmiş sətir(lər) kəsildi</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1412"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1539"/>
         <source>Current line clipped</source>
         <translation>Cari sətir kəsildi</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3227"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3230"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3550"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3553"/>
         <source>Paste failed: not enough memory</source>
         <translation>Yerləşdirilmədi: kifayət qədər yaddaş yoxdur</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="4548"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4873"/>
         <source>Read-Only mode is off</source>
         <translation>Yalnız-oxu, rejimi söndürülüb</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="4560"/>
-        <location filename="../src/editor/dtextedit.cpp" line="4584"/>
-        <location filename="../src/editor/dtextedit.cpp" line="7896"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8007"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8015"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8026"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4885"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4909"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8236"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8347"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8355"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8366"/>
         <source>Read-Only mode is on</source>
         <translation>Yalnız-ozu, rejimi aktivdir</translation>
     </message>
@@ -1231,138 +1299,175 @@
 <context>
     <name>WarningNotices</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="24"/>
+        <location filename="../src/controls/warningnotices.cpp" line="25"/>
         <source>Reload</source>
         <translation>Yenidən yükləmək</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/warningnotices.cpp" line="29"/>
+        <source>Edit Anyway</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>Window</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="25"/>
-        <location filename="../src/widgets/window.cpp" line="531"/>
+        <location filename="../src/controls/warningnotices.cpp" line="27"/>
+        <location filename="../src/widgets/window.cpp" line="548"/>
         <source>Save as</source>
         <translation>Belə saxlayın</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="527"/>
+        <location filename="../src/widgets/window.cpp" line="540"/>
         <source>New window</source>
         <translation>Yeni pəncərə</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="528"/>
+        <location filename="../src/widgets/window.cpp" line="542"/>
         <source>New tab</source>
         <translation>Yeni vərəq</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="529"/>
+        <location filename="../src/widgets/window.cpp" line="544"/>
         <source>Open file</source>
         <translation>Faylı açın</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="530"/>
-        <location filename="../src/widgets/window.cpp" line="3545"/>
+        <location filename="../src/widgets/window.cpp" line="546"/>
+        <location filename="../src/widgets/window.cpp" line="3950"/>
         <source>Save</source>
         <translation>Saxlamaq</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="532"/>
+        <location filename="../src/widgets/window.cpp" line="550"/>
         <source>Print</source>
         <translation>Çap</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="533"/>
+        <location filename="../src/widgets/window.cpp" line="552"/>
         <source>Switch theme</source>
         <translation>Mövzunu dəyişmək</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="534"/>
-        <location filename="../src/widgets/window.cpp" line="2448"/>
+        <location filename="../src/widgets/window.cpp" line="554"/>
+        <location filename="../src/widgets/window.cpp" line="2641"/>
         <source>Settings</source>
         <translation>Ayarlar</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="666"/>
-        <location filename="../src/widgets/window.cpp" line="3845"/>
+        <location filename="../src/widgets/window.cpp" line="696"/>
+        <location filename="../src/widgets/window.cpp" line="4250"/>
         <source>Read-Only</source>
         <translation>Yalnız-oxumaq</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="687"/>
+        <location filename="../src/widgets/window.cpp" line="719"/>
         <source>You do not have permission to open %1</source>
         <translation>%1 açmaq üçün imtiyazınız yoxdur</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="738"/>
-        <location filename="../src/widgets/window.cpp" line="2963"/>
+        <location filename="../src/widgets/window.cpp" line="773"/>
+        <location filename="../src/widgets/window.cpp" line="3266"/>
         <source>Invalid file: %1</source>
         <translation>Səhv fayl: %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="903"/>
-        <location filename="../src/widgets/window.cpp" line="956"/>
+        <location filename="../src/widgets/window.cpp" line="957"/>
+        <location filename="../src/widgets/window.cpp" line="1050"/>
+        <location filename="../src/widgets/window.cpp" line="3217"/>
         <source>Do you want to save this file?</source>
         <translation>Bu faylı saxlamaq istəyirsiniz?</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1290"/>
+        <location filename="../src/widgets/window.cpp" line="1381"/>
+        <source>Invalid characters detected while saving &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1382"/>
+        <source>If you force save this file, it may cause file corruption. Still want to save?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1386"/>
+        <source>Don&apos;t Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1387"/>
+        <source>Save As</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1388"/>
+        <source>Save Anyway</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1456"/>
         <source>You do not have permission to save %1</source>
         <translation>%1 saxlamaq üçün imtiyazınız yoxdur</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1312"/>
+        <location filename="../src/widgets/window.cpp" line="1428"/>
+        <location filename="../src/widgets/window.cpp" line="1478"/>
         <source>Saved successfully</source>
         <translation>Uğurla saxlanıldı</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1354"/>
-        <location filename="../src/widgets/window.cpp" line="1481"/>
-        <location filename="../src/widgets/window.cpp" line="1529"/>
+        <location filename="../src/widgets/window.cpp" line="1520"/>
+        <location filename="../src/widgets/window.cpp" line="1665"/>
+        <location filename="../src/widgets/window.cpp" line="1713"/>
         <source>Save File</source>
         <translation>Faylı saxlayın</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1483"/>
+        <location filename="../src/widgets/window.cpp" line="1569"/>
+        <source>Cannot save as the original file in preview mode. Please choose a different path.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1667"/>
         <source>Encoding</source>
         <translation>Kodlaşma</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1773"/>
+        <location filename="../src/widgets/window.cpp" line="1957"/>
         <source>Read-Only mode is on</source>
         <translation>Yalnız-ozu, rejimi aktivdir</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2322"/>
+        <location filename="../src/widgets/window.cpp" line="2511"/>
         <source>Current location remembered</source>
         <translation>Cari yer yadda saxlanıldı</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2398"/>
+        <location filename="../src/widgets/window.cpp" line="2591"/>
         <source>Ctrl+&apos;=&apos;</source>
         <translation>Ctrl+&apos;=&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2401"/>
+        <location filename="../src/widgets/window.cpp" line="2594"/>
         <source>Ctrl+&apos;-&apos;</source>
         <translation>Ctrl+&apos;-&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2430"/>
+        <location filename="../src/widgets/window.cpp" line="2623"/>
         <source>Editor</source>
         <translation>Redaktor</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3061"/>
+        <location filename="../src/widgets/window.cpp" line="3436"/>
         <source>Untitled %1</source>
         <translation>Başlıqsız %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3543"/>
+        <location filename="../src/widgets/window.cpp" line="3948"/>
         <source>Cancel</source>
         <translation>İmtina</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3544"/>
+        <location filename="../src/widgets/window.cpp" line="3949"/>
         <source>Discard</source>
         <translation>Rədd etmək</translation>
     </message>

--- a/translations/deepin-editor_bg.ts
+++ b/translations/deepin-editor_bg.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="bg">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="bg">
 <context>
     <name>BottomBar</name>
     <message>
@@ -17,17 +19,36 @@
         <translation>Знак %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="44"/>
+        <location filename="../src/widgets/bottombar.cpp" line="47"/>
         <source>Loading:</source>
         <translation>Зареждане:</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="73"/>
+        <location filename="../src/widgets/bottombar.cpp" line="91"/>
+        <location filename="../src/widgets/bottombar.cpp" line="499"/>
+        <source>Edit Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="74"/>
+        <location filename="../src/widgets/bottombar.cpp" line="489"/>
+        <source>Read View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="75"/>
+        <location filename="../src/widgets/bottombar.cpp" line="493"/>
+        <source>Live Preview</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DDropdownMenu</name>
     <message>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="362"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="420"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="425"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="363"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="421"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="426"/>
         <source>None</source>
         <translation>Нищо</translation>
     </message>
@@ -35,68 +56,57 @@
 <context>
     <name>EditWrapper</name>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="292"/>
-        <location filename="../src/editor/editwrapper.cpp" line="365"/>
-        <location filename="../src/editor/editwrapper.cpp" line="521"/>
-        <location filename="../src/editor/editwrapper.cpp" line="751"/>
+        <location filename="../src/editor/editwrapper.cpp" line="355"/>
+        <location filename="../src/editor/editwrapper.cpp" line="429"/>
+        <location filename="../src/editor/editwrapper.cpp" line="595"/>
+        <location filename="../src/editor/editwrapper.cpp" line="887"/>
         <source>Save</source>
         <translation>Запазване</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="516"/>
+        <location filename="../src/editor/editwrapper.cpp" line="590"/>
         <source>Do you want to save this file?</source>
         <translation>Искате ли да запазите този файл?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="363"/>
-        <location filename="../src/editor/editwrapper.cpp" line="519"/>
+        <location filename="../src/editor/editwrapper.cpp" line="427"/>
+        <location filename="../src/editor/editwrapper.cpp" line="593"/>
         <source>Cancel</source>
         <translation>Отказ</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="360"/>
+        <location filename="../src/editor/editwrapper.cpp" line="424"/>
         <source>Encoding changed. Do you want to save the file now?</source>
         <translation>Кодирането е променено. Желаете ли да запазите файла сега?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="520"/>
+        <location filename="../src/editor/editwrapper.cpp" line="594"/>
         <source>Discard</source>
         <translation>Отказ</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="274"/>
-        <location filename="../src/editor/editwrapper.cpp" line="620"/>
+        <location filename="../src/editor/editwrapper.cpp" line="1121"/>
+        <source>The file contains invalid characters (NUL). Preview mode is read-only.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="337"/>
+        <location filename="../src/editor/editwrapper.cpp" line="705"/>
         <source>You do not have permission to save %1</source>
         <translation>Нямате разрешение да запазите %1</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="836"/>
+        <location filename="../src/editor/editwrapper.cpp" line="987"/>
         <source>File removed on the disk. Save it now?</source>
         <translation>Файлът е премахнат на диска. Запазвате ли го?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="842"/>
+        <location filename="../src/editor/editwrapper.cpp" line="993"/>
         <source>File has changed on disk. Reload?</source>
         <translation>Файлът е променен на диска. Презареждане?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="884"/>
-        <location filename="../src/widgets/bottombar.cpp" line="74"/>
-        <source>INSERT</source>
-        <translation>ВМЪКВАНЕ</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="888"/>
-        <source>OVERWRITE</source>
-        <translation>ПРЕЗАПИСВАНЕ</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="892"/>
-        <source>R/O</source>
-        <translation>R/O</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="1618"/>
+        <location filename="../src/editor/editwrapper.cpp" line="1806"/>
         <source>The file cannot be read, which may be too large or has been damaged!</source>
         <translation>Файловете не може да се прочете, може да е прекалено голям или повреден!</translation>
     </message>
@@ -109,17 +119,17 @@
         <translation>Търсене</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="36"/>
+        <location filename="../src/controls/findbar.cpp" line="38"/>
         <source>Previous</source>
         <translation>Предишен</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="37"/>
+        <location filename="../src/controls/findbar.cpp" line="40"/>
         <source>Next</source>
         <translation>Следващ</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="38"/>
+        <location filename="../src/controls/findbar.cpp" line="42"/>
         <source>Replace</source>
         <translation>Замяна</translation>
     </message>
@@ -127,9 +137,17 @@
 <context>
     <name>JumpLineBar</name>
     <message>
-        <location filename="../src/controls/jumplinebar.cpp" line="45"/>
+        <location filename="../src/controls/jumplinebar.cpp" line="46"/>
         <source>Go to Line: </source>
         <translation>Отиди на ред:</translation>
+    </message>
+</context>
+<context>
+    <name>LineBar</name>
+    <message>
+        <location filename="../src/controls/linebar.cpp" line="144"/>
+        <source>第%1/%2项</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -146,19 +164,47 @@
     </message>
 </context>
 <context>
+    <name>MarkdownBridge</name>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="37"/>
+        <source>Collapse code block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="38"/>
+        <source>Expand code block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="39"/>
+        <source>Copy code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="40"/>
+        <source>Expand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="42"/>
+        <source>%1 line(s) of code collapsed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PathSettingWgt</name>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="84"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="90"/>
         <source>Remember the last used path</source>
         <translation>Запомнете последния използван път</translation>
     </message>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="85"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="91"/>
         <source>Same path as the current file</source>
         <translation>Същият път като текущия файл</translation>
     </message>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="86"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="92"/>
         <source>Customize the default path</source>
         <translation>Персонализирайте подразумевания път</translation>
     </message>
@@ -171,15 +217,20 @@
         <translation>Текстов редактор</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="294"/>
-        <location filename="../src/editor/editwrapper.cpp" line="761"/>
-        <location filename="../src/editor/editwrapper.cpp" line="776"/>
-        <location filename="../src/widgets/window.cpp" line="1362"/>
-        <location filename="../src/widgets/window.cpp" line="1390"/>
-        <location filename="../src/widgets/window.cpp" line="1531"/>
-        <location filename="../src/widgets/window.cpp" line="1548"/>
+        <location filename="../src/editor/editwrapper.cpp" line="357"/>
+        <location filename="../src/editor/editwrapper.cpp" line="897"/>
+        <location filename="../src/editor/editwrapper.cpp" line="912"/>
+        <location filename="../src/widgets/window.cpp" line="1528"/>
+        <location filename="../src/widgets/window.cpp" line="1556"/>
+        <location filename="../src/widgets/window.cpp" line="1715"/>
+        <location filename="../src/widgets/window.cpp" line="1732"/>
         <source>Encoding</source>
         <translation>Кодиране</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="2001"/>
+        <source>视图模式</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="11"/>
@@ -215,7 +266,7 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="18"/>
         <location filename="../src/controls/settingsdialog.cpp" line="96"/>
-        <location filename="../src/widgets/window.cpp" line="2388"/>
+        <location filename="../src/widgets/window.cpp" line="2581"/>
         <source>Window</source>
         <translation>Прозорец</translation>
     </message>
@@ -755,68 +806,68 @@
         <translation>Виетнамски</translation>
     </message>
     <message>
-        <location filename="../src/startmanager.cpp" line="971"/>
+        <location filename="../src/startmanager.cpp" line="1035"/>
         <source>File not saved</source>
         <translation>Файлът не е запазен</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1532"/>
-        <location filename="../src/widgets/window.cpp" line="1549"/>
+        <location filename="../src/widgets/window.cpp" line="1716"/>
+        <location filename="../src/widgets/window.cpp" line="1733"/>
         <source>Line Endings</source>
         <translation>Крайни линии</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="243"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="379"/>
         <source>Please install &apos;UOS AI&apos; from the App Store before using</source>
         <translation>Моля, инсталирайте &apos;UOS AI&apos; от App Store преди използване</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="245"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="381"/>
         <source>No audio input device detected. Please check and try again</source>
         <translation>Не е открит аудио въходен уред. Моля, проверете и опитайте отново</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="247"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="383"/>
         <source>No audio output device detected. Please check and try again</source>
         <translation>Не е открит аудио изходен уред. Моля, проверете и опитайте отново</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="69"/>
+        <location filename="../src/common/text_file_saver.cpp" line="74"/>
         <source>File path is empty</source>
         <translation>Пътят към файла е празен</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="155"/>
+        <location filename="../src/common/text_file_saver.cpp" line="153"/>
         <source>Insufficient memory to load document content</source>
         <translation>Недостатъчно памет за зареждане на съдържание на документа</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="177"/>
+        <location filename="../src/common/text_file_saver.cpp" line="178"/>
         <source>Insufficient memory for encoding conversion</source>
         <translation>Недостатъчно памет за конвертиране на кодирането</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="183"/>
+        <location filename="../src/common/text_file_saver.cpp" line="184"/>
         <source>Encoding conversion failed</source>
         <translation>Конвертирането на кодирането е сбъркано</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="189"/>
+        <location filename="../src/common/text_file_saver.cpp" line="190"/>
         <source>Converted content is empty</source>
         <translation>Конвертираното съдържание е празно</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="207"/>
+        <location filename="../src/common/text_file_saver.cpp" line="208"/>
         <source>Memory allocation failed</source>
         <translation>Паметта не е осигурена</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="211"/>
+        <location filename="../src/common/text_file_saver.cpp" line="212"/>
         <source>Error occurred: %1</source>
         <translation>Грешка: %1</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="215"/>
+        <location filename="../src/common/text_file_saver.cpp" line="216"/>
         <source>Unknown error occurred</source>
         <translation>Неизвестна грешка</translation>
     </message>
@@ -829,27 +880,27 @@
         <translation>Търсене</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="34"/>
+        <location filename="../src/controls/replacebar.cpp" line="36"/>
         <source>Replace With</source>
         <translation>Замени с</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="36"/>
+        <location filename="../src/controls/replacebar.cpp" line="40"/>
         <source>Replace</source>
         <translation>Рамени</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="37"/>
+        <location filename="../src/controls/replacebar.cpp" line="42"/>
         <source>Skip</source>
         <translation>Пропусни</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="38"/>
+        <location filename="../src/controls/replacebar.cpp" line="44"/>
         <source>Replace Rest</source>
         <translation>Замени останалото</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="39"/>
+        <location filename="../src/controls/replacebar.cpp" line="46"/>
         <source>Replace All</source>
         <translation>Замени всички:</translation>
     </message>
@@ -858,9 +909,9 @@
     <name>S:</name>
     <message>
         <location filename="../third/libiconv-1.16/src/iconv.c" line="103"/>
-        <source/>
+        <source></source>
         <comment>The first line of the short usage message.</comment>
-        <translation type="unfinished"/>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -891,34 +942,34 @@
         <translation>На цял екран</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="484"/>
+        <location filename="../src/common/settings.cpp" line="491"/>
         <source>This shortcut conflicts with system shortcut %1</source>
         <translation>Този кратък текст се конфликтува с системния кратък текст %1</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="487"/>
+        <location filename="../src/common/settings.cpp" line="494"/>
         <source>This shortcut conflicts with %1, click on Replace to make this shortcut effective immediately</source>
         <translation>Този кратък текст се конфликтува с %1, кликнете върху Замени, за да направите този кратък текст ефективен веднага</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="682"/>
-        <location filename="../src/common/settings.cpp" line="695"/>
-        <location filename="../src/common/settings.cpp" line="704"/>
+        <location filename="../src/common/settings.cpp" line="689"/>
+        <location filename="../src/common/settings.cpp" line="702"/>
+        <location filename="../src/common/settings.cpp" line="711"/>
         <source>The shortcut %1 is invalid, please set another one.</source>
         <translation>Кратката %1 е невалидна, моля, задайте друга.</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="736"/>
+        <location filename="../src/common/settings.cpp" line="743"/>
         <source>Cancel</source>
         <translation>Отказ</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="737"/>
+        <location filename="../src/common/settings.cpp" line="744"/>
         <source>Replace</source>
         <translation>Рамени</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="740"/>
+        <location filename="../src/common/settings.cpp" line="747"/>
         <source>OK</source>
         <translation>Добре</translation>
     </message>
@@ -926,7 +977,7 @@
 <context>
     <name>StartManager</name>
     <message>
-        <location filename="../src/startmanager.cpp" line="411"/>
+        <location filename="../src/startmanager.cpp" line="425"/>
         <source>Untitled %1</source>
         <translation>Без заглавие %1</translation>
     </message>
@@ -934,32 +985,32 @@
 <context>
     <name>Tabbar</name>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="641"/>
+        <location filename="../src/controls/tabbar.cpp" line="678"/>
         <source>Close tab</source>
         <translation>Затваряне на раздел</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="642"/>
+        <location filename="../src/controls/tabbar.cpp" line="680"/>
         <source>Close other tabs</source>
         <translation>Затвори другите раздели</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="643"/>
+        <location filename="../src/controls/tabbar.cpp" line="682"/>
         <source>More options</source>
         <translation>Повече опции</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="644"/>
+        <location filename="../src/controls/tabbar.cpp" line="684"/>
         <source>Close tabs to the left</source>
         <translation>Затвори вкладки от ляво</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="645"/>
+        <location filename="../src/controls/tabbar.cpp" line="686"/>
         <source>Close tabs to the right</source>
         <translation>Затвори вкладки от дясно</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="646"/>
+        <location filename="../src/controls/tabbar.cpp" line="688"/>
         <source>Close unmodified tabs</source>
         <translation>Затвори непроменени вкладки</translation>
     </message>
@@ -967,263 +1018,280 @@
 <context>
     <name>TextEdit</name>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="305"/>
+        <location filename="../src/editor/dtextedit.cpp" line="388"/>
         <source>Undo</source>
         <translation>Поправи</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="306"/>
+        <location filename="../src/editor/dtextedit.cpp" line="390"/>
         <source>Redo</source>
         <translation>Повторение</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="307"/>
+        <location filename="../src/editor/dtextedit.cpp" line="392"/>
         <source>Cut</source>
         <translation>Премести</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="308"/>
+        <location filename="../src/editor/dtextedit.cpp" line="394"/>
         <source>Copy</source>
         <translation>Копиране</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="309"/>
+        <location filename="../src/editor/dtextedit.cpp" line="396"/>
         <source>Paste</source>
         <translation>Прилагане</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="310"/>
+        <location filename="../src/editor/dtextedit.cpp" line="398"/>
         <source>Delete</source>
         <translation>Изтриване</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="311"/>
+        <location filename="../src/editor/dtextedit.cpp" line="400"/>
         <source>Select All</source>
         <translation>Избор на всичко</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="312"/>
-        <location filename="../src/widgets/window.cpp" line="535"/>
+        <location filename="../src/editor/dtextedit.cpp" line="402"/>
+        <location filename="../src/widgets/window.cpp" line="556"/>
         <source>Find</source>
         <translation>Търсене</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="313"/>
-        <location filename="../src/widgets/window.cpp" line="536"/>
+        <location filename="../src/editor/dtextedit.cpp" line="404"/>
+        <location filename="../src/widgets/window.cpp" line="558"/>
         <source>Replace</source>
         <translation>Рамени</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="314"/>
+        <location filename="../src/editor/dtextedit.cpp" line="406"/>
         <source>Go to Line</source>
         <translation>Отиди на ред</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="315"/>
-        <source>Turn on Read-Only mode</source>
-        <translation>Включване режим &quot;Само за четене&quot;</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="316"/>
-        <source>Turn off Read-Only mode</source>
-        <translation>Изключване режим &quot;Само за четене&quot;</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="317"/>
+        <location filename="../src/editor/dtextedit.cpp" line="415"/>
         <source>Fullscreen</source>
         <translation>На цял екран</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="318"/>
+        <location filename="../src/editor/dtextedit.cpp" line="417"/>
         <source>Exit fullscreen</source>
         <translation>Изход от цял екран</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="319"/>
+        <location filename="../src/editor/dtextedit.cpp" line="419"/>
         <source>Display in file manager</source>
         <translation>Отвори във файловия диспечер</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="320"/>
-        <location filename="../src/editor/dtextedit.cpp" line="374"/>
+        <location filename="../src/editor/dtextedit.cpp" line="421"/>
+        <location filename="../src/editor/dtextedit.cpp" line="493"/>
         <source>Add Comment</source>
         <translation>Добави коментар</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="321"/>
+        <location filename="../src/editor/dtextedit.cpp" line="423"/>
         <source>Text to Speech</source>
         <translation>Текст към глас</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="322"/>
-        <source>Stop reading</source>
-        <translation>Стопи четене</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="323"/>
+        <location filename="../src/editor/dtextedit.cpp" line="425"/>
         <source>Speech to Text</source>
         <translation>Глас към текст</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="324"/>
+        <location filename="../src/editor/dtextedit.cpp" line="427"/>
         <source>Translate</source>
         <translation>Преведи</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="325"/>
+        <location filename="../src/editor/dtextedit.cpp" line="429"/>
         <source>Column Mode</source>
         <translation>Колонен режим</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="326"/>
+        <location filename="../src/editor/dtextedit.cpp" line="431"/>
         <source>Add bookmark</source>
         <translation>Добави закладка</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="327"/>
+        <location filename="../src/editor/dtextedit.cpp" line="433"/>
         <source>Remove Bookmark</source>
         <translation>Премахни закладка</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="328"/>
+        <location filename="../src/editor/dtextedit.cpp" line="435"/>
         <source>Previous bookmark</source>
         <translation>Предишна закладка</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="329"/>
+        <location filename="../src/editor/dtextedit.cpp" line="437"/>
         <source>Next bookmark</source>
         <translation>Следваща закладка</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="330"/>
+        <location filename="../src/editor/dtextedit.cpp" line="439"/>
         <source>Remove All Bookmarks</source>
         <translation>Премахни всички закладки</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="331"/>
+        <location filename="../src/editor/dtextedit.cpp" line="441"/>
         <source>Fold All</source>
         <translation>Затвори всичко</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="332"/>
+        <location filename="../src/editor/dtextedit.cpp" line="443"/>
         <source>Fold Current Level</source>
         <translation>Затвори текущия ниво</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="333"/>
+        <location filename="../src/editor/dtextedit.cpp" line="445"/>
         <source>Unfold All</source>
         <translation>Разгъни всичко</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="334"/>
+        <location filename="../src/editor/dtextedit.cpp" line="447"/>
         <source>Unfold Current Level</source>
         <translation>Разгъни текущия ниво</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="339"/>
+        <location filename="../src/editor/dtextedit.cpp" line="453"/>
         <source>Color Mark</source>
         <translation>Цветен бележка</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="343"/>
+        <location filename="../src/editor/dtextedit.cpp" line="458"/>
         <source>Clear All Marks</source>
         <translation>Премахни всички бележки</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="344"/>
+        <location filename="../src/editor/dtextedit.cpp" line="460"/>
         <source>Clear Last Mark</source>
         <translation>Премахни последната бележка</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="353"/>
+        <location filename="../src/editor/dtextedit.cpp" line="470"/>
         <source>Mark</source>
         <translation>Маркиране</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="366"/>
+        <location filename="../src/editor/dtextedit.cpp" line="484"/>
         <source>Mark All</source>
         <translation>Маркирай всичко</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="375"/>
+        <location filename="../src/editor/dtextedit.cpp" line="494"/>
         <source>Remove Comment</source>
         <translation>Премахни коментар</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3208"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3211"/>
+        <location filename="../src/editor/dtextedit.cpp" line="543"/>
+        <source>View Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="3531"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3534"/>
         <source>Copy failed: not enough memory</source>
         <translation>Копиране неуспешно: недостатъчно памет</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3333"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3335"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3656"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3658"/>
         <source>Press ALT and click lines to edit in column mode</source>
         <translation>Натиснете ALT и кликнете върху редове, за да редактирате в колонен режим</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="418"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9574"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9576"/>
+        <source>No audio output device was detected. Please ensure your speakers or headphones are properly connected and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="9583"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9585"/>
+        <source>No audio input device was detected. Please ensure your speakers or headphones are properly connected and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="534"/>
         <source>Change Case</source>
         <translation>Смяна на големината</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="419"/>
+        <location filename="../src/editor/dtextedit.cpp" line="409"/>
+        <source>Edit Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="411"/>
+        <source>Read View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="413"/>
+        <source>Live Preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="535"/>
         <source>Upper Case</source>
         <translation>Големи букви</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="420"/>
+        <location filename="../src/editor/dtextedit.cpp" line="536"/>
         <source>Lower Case</source>
         <translation>Малки букви</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="421"/>
+        <location filename="../src/editor/dtextedit.cpp" line="537"/>
         <source>Capitalize</source>
         <translation>С големи букви</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="78"/>
+        <location filename="../src/widgets/bottombar.cpp" line="110"/>
         <source>None</source>
         <translation>Нищо</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1363"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1490"/>
         <source>Selected line(s) copied</source>
         <translation>Избран ред(а) е копиран</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1370"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1497"/>
         <source>Current line copied</source>
         <translation>Текстът на текущия ред е копиран</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1400"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1527"/>
         <source>Selected line(s) clipped</source>
         <translation>Избран ред(и) е изрязан</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1412"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1539"/>
         <source>Current line clipped</source>
         <translation>Текстът на текущия ред е изрязан</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3227"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3230"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3550"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3553"/>
         <source>Paste failed: not enough memory</source>
         <translation>Пастинг неуспешен: недостатъчно памет</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="4548"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4873"/>
         <source>Read-Only mode is off</source>
         <translation>Режим &quot;Само за четене&quot; е изключен</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="4560"/>
-        <location filename="../src/editor/dtextedit.cpp" line="4584"/>
-        <location filename="../src/editor/dtextedit.cpp" line="7896"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8007"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8015"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8026"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4885"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4909"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8236"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8347"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8355"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8366"/>
         <source>Read-Only mode is on</source>
         <translation>Режим &quot;Само за четене&quot; е включен</translation>
     </message>
@@ -1231,138 +1299,175 @@
 <context>
     <name>WarningNotices</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="24"/>
+        <location filename="../src/controls/warningnotices.cpp" line="25"/>
         <source>Reload</source>
         <translation>Презареди</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/warningnotices.cpp" line="29"/>
+        <source>Edit Anyway</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>Window</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="25"/>
-        <location filename="../src/widgets/window.cpp" line="531"/>
+        <location filename="../src/controls/warningnotices.cpp" line="27"/>
+        <location filename="../src/widgets/window.cpp" line="548"/>
         <source>Save as</source>
         <translation>Запази като</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="527"/>
+        <location filename="../src/widgets/window.cpp" line="540"/>
         <source>New window</source>
         <translation>Нов прозорец</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="528"/>
+        <location filename="../src/widgets/window.cpp" line="542"/>
         <source>New tab</source>
         <translation>Нов раздел</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="529"/>
+        <location filename="../src/widgets/window.cpp" line="544"/>
         <source>Open file</source>
         <translation>Отваряне на файл</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="530"/>
-        <location filename="../src/widgets/window.cpp" line="3545"/>
+        <location filename="../src/widgets/window.cpp" line="546"/>
+        <location filename="../src/widgets/window.cpp" line="3950"/>
         <source>Save</source>
         <translation>Запазване</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="532"/>
+        <location filename="../src/widgets/window.cpp" line="550"/>
         <source>Print</source>
         <translation>Принтиране</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="533"/>
+        <location filename="../src/widgets/window.cpp" line="552"/>
         <source>Switch theme</source>
         <translation>Смени тема</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="534"/>
-        <location filename="../src/widgets/window.cpp" line="2448"/>
+        <location filename="../src/widgets/window.cpp" line="554"/>
+        <location filename="../src/widgets/window.cpp" line="2641"/>
         <source>Settings</source>
         <translation>Настройки</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="666"/>
-        <location filename="../src/widgets/window.cpp" line="3845"/>
+        <location filename="../src/widgets/window.cpp" line="696"/>
+        <location filename="../src/widgets/window.cpp" line="4250"/>
         <source>Read-Only</source>
         <translation>Само за четене</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="687"/>
+        <location filename="../src/widgets/window.cpp" line="719"/>
         <source>You do not have permission to open %1</source>
         <translation>Нямате разрешение да отворите %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="738"/>
-        <location filename="../src/widgets/window.cpp" line="2963"/>
+        <location filename="../src/widgets/window.cpp" line="773"/>
+        <location filename="../src/widgets/window.cpp" line="3266"/>
         <source>Invalid file: %1</source>
         <translation>Невалиден файл: %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="903"/>
-        <location filename="../src/widgets/window.cpp" line="956"/>
+        <location filename="../src/widgets/window.cpp" line="957"/>
+        <location filename="../src/widgets/window.cpp" line="1050"/>
+        <location filename="../src/widgets/window.cpp" line="3217"/>
         <source>Do you want to save this file?</source>
         <translation>Искате ли да запазите този файл?</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1290"/>
+        <location filename="../src/widgets/window.cpp" line="1381"/>
+        <source>Invalid characters detected while saving &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1382"/>
+        <source>If you force save this file, it may cause file corruption. Still want to save?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1386"/>
+        <source>Don&apos;t Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1387"/>
+        <source>Save As</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1388"/>
+        <source>Save Anyway</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1456"/>
         <source>You do not have permission to save %1</source>
         <translation>Нямате разрешение да запазите %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1312"/>
+        <location filename="../src/widgets/window.cpp" line="1428"/>
+        <location filename="../src/widgets/window.cpp" line="1478"/>
         <source>Saved successfully</source>
         <translation>Успешно запазено</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1354"/>
-        <location filename="../src/widgets/window.cpp" line="1481"/>
-        <location filename="../src/widgets/window.cpp" line="1529"/>
+        <location filename="../src/widgets/window.cpp" line="1520"/>
+        <location filename="../src/widgets/window.cpp" line="1665"/>
+        <location filename="../src/widgets/window.cpp" line="1713"/>
         <source>Save File</source>
         <translation>Запази файла</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1483"/>
+        <location filename="../src/widgets/window.cpp" line="1569"/>
+        <source>Cannot save as the original file in preview mode. Please choose a different path.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1667"/>
         <source>Encoding</source>
         <translation>Кодиране</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1773"/>
+        <location filename="../src/widgets/window.cpp" line="1957"/>
         <source>Read-Only mode is on</source>
         <translation>Режим &quot;Само за четене&quot; е включен</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2322"/>
+        <location filename="../src/widgets/window.cpp" line="2511"/>
         <source>Current location remembered</source>
         <translation>Текущата позиция е запомнена</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2398"/>
+        <location filename="../src/widgets/window.cpp" line="2591"/>
         <source>Ctrl+&apos;=&apos;</source>
         <translation>Ctrl+=&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2401"/>
+        <location filename="../src/widgets/window.cpp" line="2594"/>
         <source>Ctrl+&apos;-&apos;</source>
         <translation>Ctrl=&apos;-</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2430"/>
+        <location filename="../src/widgets/window.cpp" line="2623"/>
         <source>Editor</source>
         <translation>Редактор</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3061"/>
+        <location filename="../src/widgets/window.cpp" line="3436"/>
         <source>Untitled %1</source>
         <translation>Без заглавие %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3543"/>
+        <location filename="../src/widgets/window.cpp" line="3948"/>
         <source>Cancel</source>
         <translation>Отказ</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3544"/>
+        <location filename="../src/widgets/window.cpp" line="3949"/>
         <source>Discard</source>
         <translation>Отказ</translation>
     </message>

--- a/translations/deepin-editor_bo.ts
+++ b/translations/deepin-editor_bo.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="bo">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="bo">
 <context>
     <name>BottomBar</name>
     <message>
@@ -17,17 +19,36 @@
         <translation>ཡིག་འབྲུ། %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="44"/>
+        <location filename="../src/widgets/bottombar.cpp" line="47"/>
         <source>Loading:</source>
         <translation>ཡིག་ཆ་སྣོན་འཇུག་བྱེད་བཞིན་པ།</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="73"/>
+        <location filename="../src/widgets/bottombar.cpp" line="91"/>
+        <location filename="../src/widgets/bottombar.cpp" line="499"/>
+        <source>Edit Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="74"/>
+        <location filename="../src/widgets/bottombar.cpp" line="489"/>
+        <source>Read View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="75"/>
+        <location filename="../src/widgets/bottombar.cpp" line="493"/>
+        <source>Live Preview</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DDropdownMenu</name>
     <message>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="362"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="420"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="425"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="363"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="421"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="426"/>
         <source>None</source>
         <translation>མེད།</translation>
     </message>
@@ -35,68 +56,57 @@
 <context>
     <name>EditWrapper</name>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="292"/>
-        <location filename="../src/editor/editwrapper.cpp" line="365"/>
-        <location filename="../src/editor/editwrapper.cpp" line="521"/>
-        <location filename="../src/editor/editwrapper.cpp" line="751"/>
+        <location filename="../src/editor/editwrapper.cpp" line="355"/>
+        <location filename="../src/editor/editwrapper.cpp" line="429"/>
+        <location filename="../src/editor/editwrapper.cpp" line="595"/>
+        <location filename="../src/editor/editwrapper.cpp" line="887"/>
         <source>Save</source>
         <translation>ཉར་ཚགས།</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="516"/>
+        <location filename="../src/editor/editwrapper.cpp" line="590"/>
         <source>Do you want to save this file?</source>
         <translation>ཁྱེད་ཀྱིས་ཡིག་ཆ་འདི་ཉར་ཚགས་བྱེད་དམ།</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="363"/>
-        <location filename="../src/editor/editwrapper.cpp" line="519"/>
+        <location filename="../src/editor/editwrapper.cpp" line="427"/>
+        <location filename="../src/editor/editwrapper.cpp" line="593"/>
         <source>Cancel</source>
         <translation>འདོར་བ།</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="360"/>
+        <location filename="../src/editor/editwrapper.cpp" line="424"/>
         <source>Encoding changed. Do you want to save the file now?</source>
         <translation>ཡིག་ཆའི་ཨང་སྒྲིག་བཟོ་བཅོས་བྱས་ཟིན་པས། སྔོན་ལ་ཉར་ཚགས་བྱེད་དམ།</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="520"/>
+        <location filename="../src/editor/editwrapper.cpp" line="594"/>
         <source>Discard</source>
         <translation>མི་ཉར།</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="274"/>
-        <location filename="../src/editor/editwrapper.cpp" line="620"/>
+        <location filename="../src/editor/editwrapper.cpp" line="1121"/>
+        <source>The file contains invalid characters (NUL). Preview mode is read-only.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="337"/>
+        <location filename="../src/editor/editwrapper.cpp" line="705"/>
         <source>You do not have permission to save %1</source>
         <translation>ཁྱེད་ལ་%1ཉར་བའི་དབང་ཚད་མེད།</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="836"/>
+        <location filename="../src/editor/editwrapper.cpp" line="987"/>
         <source>File removed on the disk. Save it now?</source>
         <translation>སྡུད་སྡེར་ནང་གི་ཐོག་མའི་ཡིག་ཆ་འབུད་ཟིན་པས། དེ་ཉར་རམ།</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="842"/>
+        <location filename="../src/editor/editwrapper.cpp" line="993"/>
         <source>File has changed on disk. Reload?</source>
         <translation>སྡུད་སྡེར་ནང་གི་ཐོག་མའི་ཡིག་ཆ་བཟོ་བཅོས་བྱས་ཟིན་པས། བསྐྱར་འཇུག་བྱེད་དམ།</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="884"/>
-        <location filename="../src/widgets/bottombar.cpp" line="74"/>
-        <source>INSERT</source>
-        <translation>ནང་འཇུག</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="888"/>
-        <source>OVERWRITE</source>
-        <translation>འགེབས་པ།</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="892"/>
-        <source>R/O</source>
-        <translation>ཀློག་ཙམ།</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="1618"/>
+        <location filename="../src/editor/editwrapper.cpp" line="1806"/>
         <source>The file cannot be read, which may be too large or has been damaged!</source>
         <translation>ཡིག་ཆ་འདི་ཉིད་ཀློག་ཐབས་བྲལ། ཡིག་ཆ་ཆེ་དྲགས་པ་དང་ཡང་ན་འཕྲོ་བརླག་ཕྱིན་ཡོད་སྲིད།</translation>
     </message>
@@ -109,17 +119,17 @@
         <translation>འཚོལ་བ།</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="36"/>
+        <location filename="../src/controls/findbar.cpp" line="38"/>
         <source>Previous</source>
         <translation>གོང་མ།</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="37"/>
+        <location filename="../src/controls/findbar.cpp" line="40"/>
         <source>Next</source>
         <translation>རྗེས་མ།</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="38"/>
+        <location filename="../src/controls/findbar.cpp" line="42"/>
         <source>Replace</source>
         <translation>བརྗེ་བ།</translation>
     </message>
@@ -127,9 +137,17 @@
 <context>
     <name>JumpLineBar</name>
     <message>
-        <location filename="../src/controls/jumplinebar.cpp" line="45"/>
+        <location filename="../src/controls/jumplinebar.cpp" line="46"/>
         <source>Go to Line: </source>
         <translation>འཕྲེད་སྟར་དུ་མཆོང་བ།</translation>
+    </message>
+</context>
+<context>
+    <name>LineBar</name>
+    <message>
+        <location filename="../src/controls/linebar.cpp" line="144"/>
+        <source>第%1/%2项</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -146,19 +164,47 @@
     </message>
 </context>
 <context>
+    <name>MarkdownBridge</name>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="37"/>
+        <source>Collapse code block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="38"/>
+        <source>Expand code block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="39"/>
+        <source>Copy code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="40"/>
+        <source>Expand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="42"/>
+        <source>%1 line(s) of code collapsed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PathSettingWgt</name>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="84"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="90"/>
         <source>Remember the last used path</source>
         <translation>མཐའ་མའི་བཀོལ་སྤྱོད་ལམ་བུ་ངེས་དགོས།</translation>
     </message>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="85"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="91"/>
         <source>Same path as the current file</source>
         <translation>མིག་སྔའི་ཡིག་ཆ་དང་གཅིག་མཐུན་བྱེད་པ།</translation>
     </message>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="86"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="92"/>
         <source>Customize the default path</source>
         <translation>རང་སྒྲུབ་བཀོལ་སྤྱོད་ལམ་བུ།</translation>
     </message>
@@ -171,15 +217,20 @@
         <translation>ཡིག་ཆ་རྩོམ་སྒྲུག་ཆས།</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="294"/>
-        <location filename="../src/editor/editwrapper.cpp" line="761"/>
-        <location filename="../src/editor/editwrapper.cpp" line="776"/>
-        <location filename="../src/widgets/window.cpp" line="1362"/>
-        <location filename="../src/widgets/window.cpp" line="1390"/>
-        <location filename="../src/widgets/window.cpp" line="1531"/>
-        <location filename="../src/widgets/window.cpp" line="1548"/>
+        <location filename="../src/editor/editwrapper.cpp" line="357"/>
+        <location filename="../src/editor/editwrapper.cpp" line="897"/>
+        <location filename="../src/editor/editwrapper.cpp" line="912"/>
+        <location filename="../src/widgets/window.cpp" line="1528"/>
+        <location filename="../src/widgets/window.cpp" line="1556"/>
+        <location filename="../src/widgets/window.cpp" line="1715"/>
+        <location filename="../src/widgets/window.cpp" line="1732"/>
         <source>Encoding</source>
         <translation>ཨང་སྒྲིག</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="2001"/>
+        <source>视图模式</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="11"/>
@@ -215,7 +266,7 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="18"/>
         <location filename="../src/controls/settingsdialog.cpp" line="96"/>
-        <location filename="../src/widgets/window.cpp" line="2388"/>
+        <location filename="../src/widgets/window.cpp" line="2581"/>
         <source>Window</source>
         <translation>སྒེའུ་ཁུང་།</translation>
     </message>
@@ -755,68 +806,68 @@
         <translation>ཝེ་ཐེ་ནམ་གྱི་སྐད།</translation>
     </message>
     <message>
-        <location filename="../src/startmanager.cpp" line="971"/>
+        <location filename="../src/startmanager.cpp" line="1035"/>
         <source>File not saved</source>
         <translation>ཡིག་ཆ་ཉར་ཚགས་བྱས་མེད།</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1532"/>
-        <location filename="../src/widgets/window.cpp" line="1549"/>
+        <location filename="../src/widgets/window.cpp" line="1716"/>
+        <location filename="../src/widgets/window.cpp" line="1733"/>
         <source>Line Endings</source>
         <translation>སྟར་བརྗེ་རྟགས།</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="243"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="379"/>
         <source>Please install &apos;UOS AI&apos; from the App Store before using</source>
         <translation>མནན་ནས་མ་ལག་གི་མྱུར་མཐེབ་འདི་དང་%1འགལ་ཟླ་ཡོད་པས། བརྗེ་པོ་མནན་ནས་མྱུར་མཐེབ་འདི་ལམ་སེང་སྤྱོད་གོ་ཆོད།</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="245"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="381"/>
         <source>No audio input device detected. Please check and try again</source>
         <translation>མིག་སྔའི་མཐོ་ཚད་གསལ་བ།</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="247"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="383"/>
         <source>No audio output device detected. Please check and try again</source>
         <translation>སྟོང་ཆའི་ཡིག་རྟགས།/རེའུ་མིག་བཟོ་རྟགས་གསལ་བ།</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="69"/>
+        <location filename="../src/common/text_file_saver.cpp" line="74"/>
         <source>File path is empty</source>
         <translation>ཡིག་ཆ་ཉར་ཚགས་བྱས་མེད།</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="155"/>
+        <location filename="../src/common/text_file_saver.cpp" line="153"/>
         <source>Insufficient memory to load document content</source>
         <translation>སྟོང་ཆའི་ཡིག་རྟགས།/རེའུ་མིག་བཟོ་རྟགས་གསལ་བ།</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="177"/>
+        <location filename="../src/common/text_file_saver.cpp" line="178"/>
         <source>Insufficient memory for encoding conversion</source>
         <translation>སྟོང་ཆའི་ཡིག་རྟགས།/རེའུ་མིག་བཟོ་རྟགས་གསལ་བ།</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="183"/>
+        <location filename="../src/common/text_file_saver.cpp" line="184"/>
         <source>Encoding conversion failed</source>
         <translation>སྟོང་ཆའི་ཡིག་རྟགས།/རེའུ་མིག་བཟོ་རྟགས་གསལ་བ།</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="189"/>
+        <location filename="../src/common/text_file_saver.cpp" line="190"/>
         <source>Converted content is empty</source>
         <translation>སྟོང་ཆའི་ཡིག་རྟགས།/རེའུ་མིག་བཟོ་རྟགས་གསལ་བ།</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="207"/>
+        <location filename="../src/common/text_file_saver.cpp" line="208"/>
         <source>Memory allocation failed</source>
         <translation>སྟོང་ཆའི་ཡིག་རྟགས།/རེའུ་མིག་བཟོ་རྟགས་གསལ་བ།</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="211"/>
+        <location filename="../src/common/text_file_saver.cpp" line="212"/>
         <source>Error occurred: %1</source>
         <translation>སྟོང་ཆའི་ཡིག་རྟགས།/རེའུ་མིག་བཟོ་རྟགས་གསལ་བ།</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="215"/>
+        <location filename="../src/common/text_file_saver.cpp" line="216"/>
         <source>Unknown error occurred</source>
         <translation>སྟོང་ཆའི་ཡིག་རྟགས།/རེའུ་མིག་བཟོ་རྟགས་གསལ་བ།</translation>
     </message>
@@ -829,27 +880,27 @@
         <translation>འཚོལ་བ།</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="34"/>
+        <location filename="../src/controls/replacebar.cpp" line="36"/>
         <source>Replace With</source>
         <translation>ལ་བརྗེ་བ།</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="36"/>
+        <location filename="../src/controls/replacebar.cpp" line="40"/>
         <source>Replace</source>
         <translation>བརྗེ་བ།</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="37"/>
+        <location filename="../src/controls/replacebar.cpp" line="42"/>
         <source>Skip</source>
         <translation>མཆོང་བ།</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="38"/>
+        <location filename="../src/controls/replacebar.cpp" line="44"/>
         <source>Replace Rest</source>
         <translation>ལྷག་མ་བརྗེ་བ། </translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="39"/>
+        <location filename="../src/controls/replacebar.cpp" line="46"/>
         <source>Replace All</source>
         <translation>ཚང་མ་བརྗེ་བ།</translation>
     </message>
@@ -858,9 +909,9 @@
     <name>S:</name>
     <message>
         <location filename="../third/libiconv-1.16/src/iconv.c" line="103"/>
-        <source/>
+        <source></source>
         <comment>The first line of the short usage message.</comment>
-        <translation type="unfinished"/>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -891,34 +942,34 @@
         <translation>ཡོལ་གང་།</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="484"/>
+        <location filename="../src/common/settings.cpp" line="491"/>
         <source>This shortcut conflicts with system shortcut %1</source>
         <translation>མྱུར་མཐེབ་འདི་དང་མ་ལག་གི་མྱུར་མཐེབ་%1འགལ་ཟླ་ཡོད།</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="487"/>
+        <location filename="../src/common/settings.cpp" line="494"/>
         <source>This shortcut conflicts with %1, click on Replace to make this shortcut effective immediately</source>
         <translation>མྱུར་མཐེབ་འདི་དང་%1འགལ་ཟླ་ཡོད་པས། བརྗེ་པོ་མནན་ནས་མྱུར་མཐེབ་འདི་ལམ་སེང་སྤྱོད་གོ་ཆོད།</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="682"/>
-        <location filename="../src/common/settings.cpp" line="695"/>
-        <location filename="../src/common/settings.cpp" line="704"/>
+        <location filename="../src/common/settings.cpp" line="689"/>
+        <location filename="../src/common/settings.cpp" line="702"/>
+        <location filename="../src/common/settings.cpp" line="711"/>
         <source>The shortcut %1 is invalid, please set another one.</source>
         <translation>%1ནི་ནུས་མེད་མྱུར་མཐེབ་ཡིན་པས། ཡང་བསྐྱར་སྒྲིག་བཀོད་གནང་རྒྱུ།</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="736"/>
+        <location filename="../src/common/settings.cpp" line="743"/>
         <source>Cancel</source>
         <translation>འདོར་བ།</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="737"/>
+        <location filename="../src/common/settings.cpp" line="744"/>
         <source>Replace</source>
         <translation>བརྗེ་བ།</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="740"/>
+        <location filename="../src/common/settings.cpp" line="747"/>
         <source>OK</source>
         <translation>གཏན་འཁེལ།</translation>
     </message>
@@ -926,7 +977,7 @@
 <context>
     <name>StartManager</name>
     <message>
-        <location filename="../src/startmanager.cpp" line="411"/>
+        <location filename="../src/startmanager.cpp" line="425"/>
         <source>Untitled %1</source>
         <translation>མིང་མེད་པའི་ཡིག་ཚགས་%1</translation>
     </message>
@@ -934,32 +985,32 @@
 <context>
     <name>Tabbar</name>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="641"/>
+        <location filename="../src/controls/tabbar.cpp" line="678"/>
         <source>Close tab</source>
         <translation>ཁ་བྱང་ངོས་ཁ་རྒྱག</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="642"/>
+        <location filename="../src/controls/tabbar.cpp" line="680"/>
         <source>Close other tabs</source>
         <translation>ཁ་བྱང་ངོས་གཞན་དག་ཁ་རྒྱག</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="643"/>
+        <location filename="../src/controls/tabbar.cpp" line="682"/>
         <source>More options</source>
         <translation>ཁ་རྒྱག་ཐབས་དེ་ལས་མང་།</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="644"/>
+        <location filename="../src/controls/tabbar.cpp" line="684"/>
         <source>Close tabs to the left</source>
         <translation>གཡོན་ཕྱོགས་ཀྱི་ཁ་བྱང་ངོས་ཚང་མ་ཁ་རྒྱག</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="645"/>
+        <location filename="../src/controls/tabbar.cpp" line="686"/>
         <source>Close tabs to the right</source>
         <translation>གཡས་ཕྱོགས་ཀྱི་ཁ་བྱང་ངོས་ཚང་མ་ཁ་རྒྱག</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="646"/>
+        <location filename="../src/controls/tabbar.cpp" line="688"/>
         <source>Close unmodified tabs</source>
         <translation>བཟོ་བཅོས་བྱས་མེད་པའི་ཁ་བྱང་ངོས་ཚང་མ་ཁ་རྒྱག</translation>
     </message>
@@ -967,263 +1018,280 @@
 <context>
     <name>TextEdit</name>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="305"/>
+        <location filename="../src/editor/dtextedit.cpp" line="388"/>
         <source>Undo</source>
         <translation>མི་བྱེད།</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="306"/>
+        <location filename="../src/editor/dtextedit.cpp" line="390"/>
         <source>Redo</source>
         <translation>བསྐྱར་བྱེད།</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="307"/>
+        <location filename="../src/editor/dtextedit.cpp" line="392"/>
         <source>Cut</source>
         <translation>དྲས་གཏུབ།</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="308"/>
+        <location filename="../src/editor/dtextedit.cpp" line="394"/>
         <source>Copy</source>
         <translation>པར་སློག</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="309"/>
+        <location filename="../src/editor/dtextedit.cpp" line="396"/>
         <source>Paste</source>
         <translation>སྦྱར་བ།</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="310"/>
+        <location filename="../src/editor/dtextedit.cpp" line="398"/>
         <source>Delete</source>
         <translation>སུབ་པ། </translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="311"/>
+        <location filename="../src/editor/dtextedit.cpp" line="400"/>
         <source>Select All</source>
         <translation>ཡོངས་འདེམས།</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="312"/>
-        <location filename="../src/widgets/window.cpp" line="535"/>
+        <location filename="../src/editor/dtextedit.cpp" line="402"/>
+        <location filename="../src/widgets/window.cpp" line="556"/>
         <source>Find</source>
         <translation>འཚོལ་བ།</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="313"/>
-        <location filename="../src/widgets/window.cpp" line="536"/>
+        <location filename="../src/editor/dtextedit.cpp" line="404"/>
+        <location filename="../src/widgets/window.cpp" line="558"/>
         <source>Replace</source>
         <translation>བརྗེ་བ།</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="314"/>
+        <location filename="../src/editor/dtextedit.cpp" line="406"/>
         <source>Go to Line</source>
         <translation>འཕྲེད་སྟར་དུ་མཆོང་བ།</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="315"/>
-        <source>Turn on Read-Only mode</source>
-        <translation>ཀློག་ཙམ་དཔེ་དབྱིབས་ཁ་ཕྱེ།</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="316"/>
-        <source>Turn off Read-Only mode</source>
-        <translation>ཀློག་ཙམ་དཔེ་དབྱིབས་ཁ་རྒྱག</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="317"/>
+        <location filename="../src/editor/dtextedit.cpp" line="415"/>
         <source>Fullscreen</source>
         <translation>ཡོལ་གང་།</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="318"/>
+        <location filename="../src/editor/dtextedit.cpp" line="417"/>
         <source>Exit fullscreen</source>
         <translation>ཡོལ་གང་ནས་ཕྱིར་འབུད་པ།</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="319"/>
+        <location filename="../src/editor/dtextedit.cpp" line="419"/>
         <source>Display in file manager</source>
         <translation>ཡིག་ཆ་དོ་དམ་ཆས་ཁྲོད་དུ་མངོན་པ།</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="320"/>
-        <location filename="../src/editor/dtextedit.cpp" line="374"/>
+        <location filename="../src/editor/dtextedit.cpp" line="421"/>
+        <location filename="../src/editor/dtextedit.cpp" line="493"/>
         <source>Add Comment</source>
         <translation>མཆན་སྣོན་པ།</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="321"/>
+        <location filename="../src/editor/dtextedit.cpp" line="423"/>
         <source>Text to Speech</source>
         <translation>ཀློག་འདོན་བྱ་རྒྱུ།</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="322"/>
-        <source>Stop reading</source>
-        <translation>ཀློག་མཚམས་འཇོག་པ།</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="323"/>
+        <location filename="../src/editor/dtextedit.cpp" line="425"/>
         <source>Speech to Text</source>
         <translation>སྐད་སྒྲའི་དཔོད་བྲིས།</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="324"/>
+        <location filename="../src/editor/dtextedit.cpp" line="427"/>
         <source>Translate</source>
         <translation>ཡིག་སྒྱུར།</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="325"/>
+        <location filename="../src/editor/dtextedit.cpp" line="429"/>
         <source>Column Mode</source>
         <translation>གཞུང་སྟར་རྩོམ་སྒྲིག་རྣམ་པ།</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="326"/>
+        <location filename="../src/editor/dtextedit.cpp" line="431"/>
         <source>Add bookmark</source>
         <translation>ཤོག་འཛར་སྣོན་པ།</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="327"/>
+        <location filename="../src/editor/dtextedit.cpp" line="433"/>
         <source>Remove Bookmark</source>
         <translation>ཤོག་འཛར་འདོར་བ།</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="328"/>
+        <location filename="../src/editor/dtextedit.cpp" line="435"/>
         <source>Previous bookmark</source>
         <translation>ཤོག་འཛར་གོང་མ།</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="329"/>
+        <location filename="../src/editor/dtextedit.cpp" line="437"/>
         <source>Next bookmark</source>
         <translation>ཤོག་འཛར་རྗེས་མ།</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="330"/>
+        <location filename="../src/editor/dtextedit.cpp" line="439"/>
         <source>Remove All Bookmarks</source>
         <translation>ཤོག་འཛར་ཚང་མ་འདོར་བ།</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="331"/>
+        <location filename="../src/editor/dtextedit.cpp" line="441"/>
         <source>Fold All</source>
         <translation>བང་རིམ་ཚང་མ་ལྟེབ་པ།</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="332"/>
+        <location filename="../src/editor/dtextedit.cpp" line="443"/>
         <source>Fold Current Level</source>
         <translation>མིག་སྔའི་བང་རིམ་ལྟེབ་པ།</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="333"/>
+        <location filename="../src/editor/dtextedit.cpp" line="445"/>
         <source>Unfold All</source>
         <translation>བང་རིམ་ཚང་མ་བཀྲམ་པ།</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="334"/>
+        <location filename="../src/editor/dtextedit.cpp" line="447"/>
         <source>Unfold Current Level</source>
         <translation>མིག་སྔའི་བང་རིམ་བཀྲམ་པ།</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="339"/>
+        <location filename="../src/editor/dtextedit.cpp" line="453"/>
         <source>Color Mark</source>
         <translation>ཚོས་གཞིའི་རྟགས།</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="343"/>
+        <location filename="../src/editor/dtextedit.cpp" line="458"/>
         <source>Clear All Marks</source>
         <translation>རྟགས་ཚང་མ་གཙང་སེལ།</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="344"/>
+        <location filename="../src/editor/dtextedit.cpp" line="460"/>
         <source>Clear Last Mark</source>
         <translation>གོང་གི་རྟགས་གཙང་སེལ།</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="353"/>
+        <location filename="../src/editor/dtextedit.cpp" line="470"/>
         <source>Mark</source>
         <translation>རྟགས་སྒྲིག་བཀོད།</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="366"/>
+        <location filename="../src/editor/dtextedit.cpp" line="484"/>
         <source>Mark All</source>
         <translation>རྟགས་ཚང་མ།</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="375"/>
+        <location filename="../src/editor/dtextedit.cpp" line="494"/>
         <source>Remove Comment</source>
         <translation>མཆན་འདོར་བ།</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3208"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3211"/>
+        <location filename="../src/editor/dtextedit.cpp" line="543"/>
+        <source>View Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="3531"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3534"/>
         <source>Copy failed: not enough memory</source>
         <translation>གཤོང་ཚད་མ་འདང་བས་པར་སློག་བྱེད་ཐབས་བྲལ།</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3333"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3335"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3656"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3658"/>
         <source>Press ALT and click lines to edit in column mode</source>
         <translation>ALT+ཙི་གུའི་འདེམས་པ་སྤྱད་ནས་གཞུང་སྟར་རྩོམ་སྒྲིག་རྣམ་པ་བརྗེ་རྒྱུ།</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="418"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9574"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9576"/>
+        <source>No audio output device was detected. Please ensure your speakers or headphones are properly connected and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="9583"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9585"/>
+        <source>No audio input device was detected. Please ensure your speakers or headphones are properly connected and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="534"/>
         <source>Change Case</source>
         <translation>ཆེ་བྲིས་ཆུང་བྲིས་བརྗེ་བ།</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="419"/>
+        <location filename="../src/editor/dtextedit.cpp" line="409"/>
+        <source>Edit Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="411"/>
+        <source>Read View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="413"/>
+        <source>Live Preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="535"/>
         <source>Upper Case</source>
         <translation>ཆེ་བྲིས།</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="420"/>
+        <location filename="../src/editor/dtextedit.cpp" line="536"/>
         <source>Lower Case</source>
         <translation>ཆུང་བྲིས།</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="421"/>
+        <location filename="../src/editor/dtextedit.cpp" line="537"/>
         <source>Capitalize</source>
         <translation>མགོ་ཡིག་ཆེ་བྲིས།</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="78"/>
+        <location filename="../src/widgets/bottombar.cpp" line="110"/>
         <source>None</source>
         <translation>མེད།</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1363"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1490"/>
         <source>Selected line(s) copied</source>
         <translation>བདམས་ཟིན་པའི་སྟར་པ(རུ་སྟར)འདི་དྲས་སྦྱར་པང་དུ་པར་སློག་བྱས་ཟིན།</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1370"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1497"/>
         <source>Current line copied</source>
         <translation>མིག་སྔའི་སྟར་པ་འདི་དྲས་སྦྱར་པང་དུ་པར་སློག་བྱས་ཟིན།</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1400"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1527"/>
         <source>Selected line(s) clipped</source>
         <translation>བདམས་ཟིན་པའི་སྟར་པ(རུ་སྟར)འདི་དྲས་སྦྱར་པང་དུ་དྲས་གཏུབ་བྱས་ཟིན།</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1412"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1539"/>
         <source>Current line clipped</source>
         <translation>མིག་སྔའི་སྟར་པ་འདི་དྲས་སྦྱར་པང་དུ་དྲས་གཏུབ་བྱས་ཟིན།</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3227"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3230"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3550"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3553"/>
         <source>Paste failed: not enough memory</source>
         <translation>ཤོང་ཚད་མི་འདང་བས་སྦྱར་མ་ཐུབ།</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="4548"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4873"/>
         <source>Read-Only mode is off</source>
         <translation>ཀློག་ཙམ་དཔེ་དབྱིབས་ཁ་བརྒྱབ་ཟིན།</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="4560"/>
-        <location filename="../src/editor/dtextedit.cpp" line="4584"/>
-        <location filename="../src/editor/dtextedit.cpp" line="7896"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8007"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8015"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8026"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4885"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4909"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8236"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8347"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8355"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8366"/>
         <source>Read-Only mode is on</source>
         <translation>ཀློག་ཙམ་དཔེ་དབྱིབས་ཁ་ཕྱེ་ཟིན།</translation>
     </message>
@@ -1231,138 +1299,175 @@
 <context>
     <name>WarningNotices</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="24"/>
+        <location filename="../src/controls/warningnotices.cpp" line="25"/>
         <source>Reload</source>
         <translation>བསྐྱར་འཇུག</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/warningnotices.cpp" line="29"/>
+        <source>Edit Anyway</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>Window</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="25"/>
-        <location filename="../src/widgets/window.cpp" line="531"/>
+        <location filename="../src/controls/warningnotices.cpp" line="27"/>
+        <location filename="../src/widgets/window.cpp" line="548"/>
         <source>Save as</source>
         <translation>གཞན་ཉར།</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="527"/>
+        <location filename="../src/widgets/window.cpp" line="540"/>
         <source>New window</source>
         <translation>སྒེའུ་ཁུང་གསར་པ།</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="528"/>
+        <location filename="../src/widgets/window.cpp" line="542"/>
         <source>New tab</source>
         <translation>ཁ་བྱང་ངོས་གསར།</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="529"/>
+        <location filename="../src/widgets/window.cpp" line="544"/>
         <source>Open file</source>
         <translation>ཡིག་ཆ་ཁ་ཕྱེ།</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="530"/>
-        <location filename="../src/widgets/window.cpp" line="3545"/>
+        <location filename="../src/widgets/window.cpp" line="546"/>
+        <location filename="../src/widgets/window.cpp" line="3950"/>
         <source>Save</source>
         <translation>ཉར་ཚགས།</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="532"/>
+        <location filename="../src/widgets/window.cpp" line="550"/>
         <source>Print</source>
         <translation>པར་འདེབས།</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="533"/>
+        <location filename="../src/widgets/window.cpp" line="552"/>
         <source>Switch theme</source>
         <translation>བརྗོད་བྱ་གཙོ་བོ་བརྗེ་བ།</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="534"/>
-        <location filename="../src/widgets/window.cpp" line="2448"/>
+        <location filename="../src/widgets/window.cpp" line="554"/>
+        <location filename="../src/widgets/window.cpp" line="2641"/>
         <source>Settings</source>
         <translation>སྒྲིག་བཀོད།</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="666"/>
-        <location filename="../src/widgets/window.cpp" line="3845"/>
+        <location filename="../src/widgets/window.cpp" line="696"/>
+        <location filename="../src/widgets/window.cpp" line="4250"/>
         <source>Read-Only</source>
         <translation>ཀློག་ཙམ།</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="687"/>
+        <location filename="../src/widgets/window.cpp" line="719"/>
         <source>You do not have permission to open %1</source>
         <translation>ཁྱེད་ལ་%1ཁ་ཕྱེ་བའི་དབང་ཚད་མེད།</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="738"/>
-        <location filename="../src/widgets/window.cpp" line="2963"/>
+        <location filename="../src/widgets/window.cpp" line="773"/>
+        <location filename="../src/widgets/window.cpp" line="3266"/>
         <source>Invalid file: %1</source>
         <translation>ཕན་མེད་ཡིག་ཆ། %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="903"/>
-        <location filename="../src/widgets/window.cpp" line="956"/>
+        <location filename="../src/widgets/window.cpp" line="957"/>
+        <location filename="../src/widgets/window.cpp" line="1050"/>
+        <location filename="../src/widgets/window.cpp" line="3217"/>
         <source>Do you want to save this file?</source>
         <translation>ཁྱེད་ཀྱིས་ཡིག་ཆ་འདི་ཉར་ཚགས་བྱེད་དམ།</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1290"/>
+        <location filename="../src/widgets/window.cpp" line="1381"/>
+        <source>Invalid characters detected while saving &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1382"/>
+        <source>If you force save this file, it may cause file corruption. Still want to save?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1386"/>
+        <source>Don&apos;t Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1387"/>
+        <source>Save As</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1388"/>
+        <source>Save Anyway</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1456"/>
         <source>You do not have permission to save %1</source>
         <translation>ཁྱེད་ལ་%1ཉར་བའི་དབང་ཚད་མེད།</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1312"/>
+        <location filename="../src/widgets/window.cpp" line="1428"/>
+        <location filename="../src/widgets/window.cpp" line="1478"/>
         <source>Saved successfully</source>
         <translation>ཡིག་ཆ་ཉར་ཟིན།</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1354"/>
-        <location filename="../src/widgets/window.cpp" line="1481"/>
-        <location filename="../src/widgets/window.cpp" line="1529"/>
+        <location filename="../src/widgets/window.cpp" line="1520"/>
+        <location filename="../src/widgets/window.cpp" line="1665"/>
+        <location filename="../src/widgets/window.cpp" line="1713"/>
         <source>Save File</source>
         <translation>ཉར་བ།</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1483"/>
+        <location filename="../src/widgets/window.cpp" line="1569"/>
+        <source>Cannot save as the original file in preview mode. Please choose a different path.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1667"/>
         <source>Encoding</source>
         <translation>ཨང་སྒྲིག</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1773"/>
+        <location filename="../src/widgets/window.cpp" line="1957"/>
         <source>Read-Only mode is on</source>
         <translation>ཀློག་ཙམ་དཔེ་དབྱིབས་ཁ་ཕྱེ་ཟིན།</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2322"/>
+        <location filename="../src/widgets/window.cpp" line="2511"/>
         <source>Current location remembered</source>
         <translation>མིག་སྔའི་གནས་ས་ངེས་ཟིན།</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2398"/>
+        <location filename="../src/widgets/window.cpp" line="2591"/>
         <source>Ctrl+&apos;=&apos;</source>
         <translation>Ctrl+&apos;=&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2401"/>
+        <location filename="../src/widgets/window.cpp" line="2594"/>
         <source>Ctrl+&apos;-&apos;</source>
         <translation>Ctrl+&apos;-&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2430"/>
+        <location filename="../src/widgets/window.cpp" line="2623"/>
         <source>Editor</source>
         <translation>རྩོམ་སྒྲིག</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3061"/>
+        <location filename="../src/widgets/window.cpp" line="3436"/>
         <source>Untitled %1</source>
         <translation>མིང་མེད་པའི་ཡིག་ཚགས་%1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3543"/>
+        <location filename="../src/widgets/window.cpp" line="3948"/>
         <source>Cancel</source>
         <translation>འདོར་བ།</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3544"/>
+        <location filename="../src/widgets/window.cpp" line="3949"/>
         <source>Discard</source>
         <translation>མི་ཉར།</translation>
     </message>

--- a/translations/deepin-editor_br.ts
+++ b/translations/deepin-editor_br.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="br">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="br">
 <context>
     <name>BottomBar</name>
     <message>
@@ -17,17 +19,36 @@
         <translation>Arouezioù %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="44"/>
+        <location filename="../src/widgets/bottombar.cpp" line="47"/>
         <source>Loading:</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="73"/>
+        <location filename="../src/widgets/bottombar.cpp" line="91"/>
+        <location filename="../src/widgets/bottombar.cpp" line="499"/>
+        <source>Edit Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="74"/>
+        <location filename="../src/widgets/bottombar.cpp" line="489"/>
+        <source>Read View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="75"/>
+        <location filename="../src/widgets/bottombar.cpp" line="493"/>
+        <source>Live Preview</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DDropdownMenu</name>
     <message>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="362"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="420"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="425"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="363"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="421"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="426"/>
         <source>None</source>
         <translation>Hini ebet</translation>
     </message>
@@ -35,70 +56,59 @@
 <context>
     <name>EditWrapper</name>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="292"/>
-        <location filename="../src/editor/editwrapper.cpp" line="365"/>
-        <location filename="../src/editor/editwrapper.cpp" line="521"/>
-        <location filename="../src/editor/editwrapper.cpp" line="751"/>
+        <location filename="../src/editor/editwrapper.cpp" line="355"/>
+        <location filename="../src/editor/editwrapper.cpp" line="429"/>
+        <location filename="../src/editor/editwrapper.cpp" line="595"/>
+        <location filename="../src/editor/editwrapper.cpp" line="887"/>
         <source>Save</source>
         <translation>Enrollañ</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="516"/>
+        <location filename="../src/editor/editwrapper.cpp" line="590"/>
         <source>Do you want to save this file?</source>
         <translation>Ha fellout a ra deoc&apos;h enrollañ ar restr-mañ?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="363"/>
-        <location filename="../src/editor/editwrapper.cpp" line="519"/>
+        <location filename="../src/editor/editwrapper.cpp" line="427"/>
+        <location filename="../src/editor/editwrapper.cpp" line="593"/>
         <source>Cancel</source>
         <translation>Nullañ</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="360"/>
+        <location filename="../src/editor/editwrapper.cpp" line="424"/>
         <source>Encoding changed. Do you want to save the file now?</source>
         <translation>An enkodañ a zo cheñchet anezhañ. Ha c&apos;hoant ho peus da enrollañ ar restr bremañ?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="520"/>
+        <location filename="../src/editor/editwrapper.cpp" line="594"/>
         <source>Discard</source>
         <translation>Na ober van</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="274"/>
-        <location filename="../src/editor/editwrapper.cpp" line="620"/>
+        <location filename="../src/editor/editwrapper.cpp" line="1121"/>
+        <source>The file contains invalid characters (NUL). Preview mode is read-only.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="337"/>
+        <location filename="../src/editor/editwrapper.cpp" line="705"/>
         <source>You do not have permission to save %1</source>
         <translation>N&apos;ho peus ket an aotre da enrollañ %1</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="836"/>
+        <location filename="../src/editor/editwrapper.cpp" line="987"/>
         <source>File removed on the disk. Save it now?</source>
         <translation>Restr dilammet diwar an disk. Enrollañ bremañ?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="842"/>
+        <location filename="../src/editor/editwrapper.cpp" line="993"/>
         <source>File has changed on disk. Reload?</source>
         <translation>Ar restr a zo bet kemmet war an disk. Adkargañ?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="884"/>
-        <location filename="../src/widgets/bottombar.cpp" line="74"/>
-        <source>INSERT</source>
-        <translation>ENLAKAAT</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="888"/>
-        <source>OVERWRITE</source>
-        <translation>FLASTRAÑ</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="892"/>
-        <source>R/O</source>
-        <translation>L/H</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="1618"/>
+        <location filename="../src/editor/editwrapper.cpp" line="1806"/>
         <source>The file cannot be read, which may be too large or has been damaged!</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -109,17 +119,17 @@
         <translation>Klask</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="36"/>
+        <location filename="../src/controls/findbar.cpp" line="38"/>
         <source>Previous</source>
         <translation>Kent</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="37"/>
+        <location filename="../src/controls/findbar.cpp" line="40"/>
         <source>Next</source>
         <translation>Da-heul</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="38"/>
+        <location filename="../src/controls/findbar.cpp" line="42"/>
         <source>Replace</source>
         <translation>Erlec&apos;hiañ</translation>
     </message>
@@ -127,9 +137,17 @@
 <context>
     <name>JumpLineBar</name>
     <message>
-        <location filename="../src/controls/jumplinebar.cpp" line="45"/>
+        <location filename="../src/controls/jumplinebar.cpp" line="46"/>
         <source>Go to Line: </source>
         <translation>Ouzhpennañ d&apos;al linenn:</translation>
+    </message>
+</context>
+<context>
+    <name>LineBar</name>
+    <message>
+        <location filename="../src/controls/linebar.cpp" line="144"/>
+        <source>第%1/%2项</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -146,21 +164,49 @@
     </message>
 </context>
 <context>
+    <name>MarkdownBridge</name>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="37"/>
+        <source>Collapse code block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="38"/>
+        <source>Expand code block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="39"/>
+        <source>Copy code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="40"/>
+        <source>Expand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="42"/>
+        <source>%1 line(s) of code collapsed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PathSettingWgt</name>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="84"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="90"/>
         <source>Remember the last used path</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="85"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="91"/>
         <source>Same path as the current file</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="86"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="92"/>
         <source>Customize the default path</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -171,15 +217,20 @@
         <translation>Aozer testennoù</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="294"/>
-        <location filename="../src/editor/editwrapper.cpp" line="761"/>
-        <location filename="../src/editor/editwrapper.cpp" line="776"/>
-        <location filename="../src/widgets/window.cpp" line="1362"/>
-        <location filename="../src/widgets/window.cpp" line="1390"/>
-        <location filename="../src/widgets/window.cpp" line="1531"/>
-        <location filename="../src/widgets/window.cpp" line="1548"/>
+        <location filename="../src/editor/editwrapper.cpp" line="357"/>
+        <location filename="../src/editor/editwrapper.cpp" line="897"/>
+        <location filename="../src/editor/editwrapper.cpp" line="912"/>
+        <location filename="../src/widgets/window.cpp" line="1528"/>
+        <location filename="../src/widgets/window.cpp" line="1556"/>
+        <location filename="../src/widgets/window.cpp" line="1715"/>
+        <location filename="../src/widgets/window.cpp" line="1732"/>
         <source>Encoding</source>
         <translation>Enkodañ</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="2001"/>
+        <source>视图模式</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="11"/>
@@ -215,7 +266,7 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="18"/>
         <location filename="../src/controls/settingsdialog.cpp" line="96"/>
-        <location filename="../src/widgets/window.cpp" line="2388"/>
+        <location filename="../src/widgets/window.cpp" line="2581"/>
         <source>Window</source>
         <translation>Prenestr</translation>
     </message>
@@ -272,12 +323,12 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="29"/>
         <source>Increment font size</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="30"/>
         <source>Decrement font size</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="31"/>
@@ -302,12 +353,12 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="35"/>
         <source>Find Next</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="36"/>
         <source>Find Previous</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="37"/>
@@ -567,12 +618,12 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="88"/>
         <source>Add comment</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="89"/>
         <source>Remove comment</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="90"/>
@@ -587,17 +638,17 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="92"/>
         <source>Add/Remove bookmark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="93"/>
         <source>Move to previous bookmark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="94"/>
         <source>Move to next bookmark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="95"/>
@@ -617,208 +668,208 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="99"/>
         <source>Paste by pressing a middle mouse button</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="101"/>
         <source>Startup</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="102"/>
         <source>Reopen last closed tabs</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="104"/>
         <source>Open/Save Settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="106"/>
         <source>Word wrap</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="107"/>
         <source>Code folding flag</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="108"/>
         <source>Show line numbers</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="109"/>
         <source>Show bookmarks icon</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="110"/>
         <source>Show whitespaces and tabs</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="111"/>
         <source>Highlight current line</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="112"/>
         <source>Color mark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="115"/>
         <source>Unicode</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="116"/>
         <source>WesternEuropean</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="117"/>
         <source>CentralEuropean</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="118"/>
         <source>Baltic</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="119"/>
         <source>Cyrillic</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="120"/>
         <source>Arabic</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="125"/>
         <source>Celtic</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="126"/>
         <source>SouthEasternEuropean</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="121"/>
         <source>Greek</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="122"/>
         <source>Hebrew</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="127"/>
         <source>ChineseSimplified</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="128"/>
         <source>ChineseTraditional</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="129"/>
         <source>Japanese</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="130"/>
         <source>Korean</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="124"/>
         <source>Thai</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="123"/>
         <source>Turkish</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="131"/>
         <source>Vietnamese</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/startmanager.cpp" line="971"/>
+        <location filename="../src/startmanager.cpp" line="1035"/>
         <source>File not saved</source>
         <translation>Restr nann-enrollet</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1532"/>
-        <location filename="../src/widgets/window.cpp" line="1549"/>
+        <location filename="../src/widgets/window.cpp" line="1716"/>
+        <location filename="../src/widgets/window.cpp" line="1733"/>
         <source>Line Endings</source>
         <translation>Fin al linenn</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="243"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="379"/>
         <source>Please install &apos;UOS AI&apos; from the App Store before using</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="245"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="381"/>
         <source>No audio input device detected. Please check and try again</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="247"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="383"/>
         <source>No audio output device detected. Please check and try again</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="69"/>
+        <location filename="../src/common/text_file_saver.cpp" line="74"/>
         <source>File path is empty</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="155"/>
+        <location filename="../src/common/text_file_saver.cpp" line="153"/>
         <source>Insufficient memory to load document content</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="177"/>
+        <location filename="../src/common/text_file_saver.cpp" line="178"/>
         <source>Insufficient memory for encoding conversion</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="183"/>
+        <location filename="../src/common/text_file_saver.cpp" line="184"/>
         <source>Encoding conversion failed</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="189"/>
+        <location filename="../src/common/text_file_saver.cpp" line="190"/>
         <source>Converted content is empty</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="207"/>
+        <location filename="../src/common/text_file_saver.cpp" line="208"/>
         <source>Memory allocation failed</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="211"/>
+        <location filename="../src/common/text_file_saver.cpp" line="212"/>
         <source>Error occurred: %1</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="215"/>
+        <location filename="../src/common/text_file_saver.cpp" line="216"/>
         <source>Unknown error occurred</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -829,27 +880,27 @@
         <translation>Klask</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="34"/>
+        <location filename="../src/controls/replacebar.cpp" line="36"/>
         <source>Replace With</source>
         <translation>Erlec&apos;hiañ gant</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="36"/>
+        <location filename="../src/controls/replacebar.cpp" line="40"/>
         <source>Replace</source>
         <translation>Erlec&apos;hiañ</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="37"/>
+        <location filename="../src/controls/replacebar.cpp" line="42"/>
         <source>Skip</source>
         <translation>Tremen</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="38"/>
+        <location filename="../src/controls/replacebar.cpp" line="44"/>
         <source>Replace Rest</source>
         <translation>Erlec&apos;hiañ ar peurrest</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="39"/>
+        <location filename="../src/controls/replacebar.cpp" line="46"/>
         <source>Replace All</source>
         <translation>Erlec&apos;hiañ pep-tra</translation>
     </message>
@@ -858,9 +909,9 @@
     <name>S:</name>
     <message>
         <location filename="../third/libiconv-1.16/src/iconv.c" line="103"/>
-        <source/>
+        <source></source>
         <comment>The first line of the short usage message.</comment>
-        <translation type="unfinished"/>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -891,42 +942,42 @@
         <translation>Skramm-leun</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="484"/>
+        <location filename="../src/common/settings.cpp" line="491"/>
         <source>This shortcut conflicts with system shortcut %1</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="487"/>
+        <location filename="../src/common/settings.cpp" line="494"/>
         <source>This shortcut conflicts with %1, click on Replace to make this shortcut effective immediately</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="682"/>
-        <location filename="../src/common/settings.cpp" line="695"/>
-        <location filename="../src/common/settings.cpp" line="704"/>
+        <location filename="../src/common/settings.cpp" line="689"/>
+        <location filename="../src/common/settings.cpp" line="702"/>
+        <location filename="../src/common/settings.cpp" line="711"/>
         <source>The shortcut %1 is invalid, please set another one.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="736"/>
+        <location filename="../src/common/settings.cpp" line="743"/>
         <source>Cancel</source>
         <translation>Nullañ</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="737"/>
+        <location filename="../src/common/settings.cpp" line="744"/>
         <source>Replace</source>
         <translation>Erlec&apos;hiañ</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="740"/>
+        <location filename="../src/common/settings.cpp" line="747"/>
         <source>OK</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>StartManager</name>
     <message>
-        <location filename="../src/startmanager.cpp" line="411"/>
+        <location filename="../src/startmanager.cpp" line="425"/>
         <source>Untitled %1</source>
         <translation>Hep titl %1</translation>
     </message>
@@ -934,296 +985,313 @@
 <context>
     <name>Tabbar</name>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="641"/>
+        <location filename="../src/controls/tabbar.cpp" line="678"/>
         <source>Close tab</source>
         <translation>Serriñ an ivinell</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="642"/>
+        <location filename="../src/controls/tabbar.cpp" line="680"/>
         <source>Close other tabs</source>
         <translation>Serriñ an ivinelloù all</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="643"/>
+        <location filename="../src/controls/tabbar.cpp" line="682"/>
         <source>More options</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="644"/>
+        <location filename="../src/controls/tabbar.cpp" line="684"/>
         <source>Close tabs to the left</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="645"/>
+        <location filename="../src/controls/tabbar.cpp" line="686"/>
         <source>Close tabs to the right</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="646"/>
+        <location filename="../src/controls/tabbar.cpp" line="688"/>
         <source>Close unmodified tabs</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>TextEdit</name>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="305"/>
+        <location filename="../src/editor/dtextedit.cpp" line="388"/>
         <source>Undo</source>
         <translation>Nullañ</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="306"/>
+        <location filename="../src/editor/dtextedit.cpp" line="390"/>
         <source>Redo</source>
         <translation>Adober</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="307"/>
+        <location filename="../src/editor/dtextedit.cpp" line="392"/>
         <source>Cut</source>
         <translation>Troc&apos;hañ</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="308"/>
+        <location filename="../src/editor/dtextedit.cpp" line="394"/>
         <source>Copy</source>
         <translation>Eilañ</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="309"/>
+        <location filename="../src/editor/dtextedit.cpp" line="396"/>
         <source>Paste</source>
         <translation>Pegañ</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="310"/>
+        <location filename="../src/editor/dtextedit.cpp" line="398"/>
         <source>Delete</source>
         <translation>Dilemel</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="311"/>
+        <location filename="../src/editor/dtextedit.cpp" line="400"/>
         <source>Select All</source>
         <translation>Diuzañ pep-tra</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="312"/>
-        <location filename="../src/widgets/window.cpp" line="535"/>
+        <location filename="../src/editor/dtextedit.cpp" line="402"/>
+        <location filename="../src/widgets/window.cpp" line="556"/>
         <source>Find</source>
         <translation>Klask</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="313"/>
-        <location filename="../src/widgets/window.cpp" line="536"/>
+        <location filename="../src/editor/dtextedit.cpp" line="404"/>
+        <location filename="../src/widgets/window.cpp" line="558"/>
         <source>Replace</source>
         <translation>Erlec&apos;hiañ</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="314"/>
+        <location filename="../src/editor/dtextedit.cpp" line="406"/>
         <source>Go to Line</source>
         <translation>Mont d&apos;al linenn</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="315"/>
-        <source>Turn on Read-Only mode</source>
-        <translation>Enaouiñ ar mod lenn hepken</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="316"/>
-        <source>Turn off Read-Only mode</source>
-        <translation>Lazhañ ar mod lenn hepken</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="317"/>
+        <location filename="../src/editor/dtextedit.cpp" line="415"/>
         <source>Fullscreen</source>
         <translation>Skramm-leun</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="318"/>
+        <location filename="../src/editor/dtextedit.cpp" line="417"/>
         <source>Exit fullscreen</source>
         <translation>Kuitaat ar skramm-leun</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="319"/>
+        <location filename="../src/editor/dtextedit.cpp" line="419"/>
         <source>Display in file manager</source>
         <translation>Diskouez er merer restroù</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="320"/>
-        <location filename="../src/editor/dtextedit.cpp" line="374"/>
+        <location filename="../src/editor/dtextedit.cpp" line="421"/>
+        <location filename="../src/editor/dtextedit.cpp" line="493"/>
         <source>Add Comment</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="321"/>
+        <location filename="../src/editor/dtextedit.cpp" line="423"/>
         <source>Text to Speech</source>
         <translation>Testenn betek ar vouezh</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="322"/>
-        <source>Stop reading</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="323"/>
+        <location filename="../src/editor/dtextedit.cpp" line="425"/>
         <source>Speech to Text</source>
         <translation>Mouezh betek testenn</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="324"/>
+        <location filename="../src/editor/dtextedit.cpp" line="427"/>
         <source>Translate</source>
         <translation>Treiñ</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="325"/>
+        <location filename="../src/editor/dtextedit.cpp" line="429"/>
         <source>Column Mode</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="326"/>
+        <location filename="../src/editor/dtextedit.cpp" line="431"/>
         <source>Add bookmark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="327"/>
+        <location filename="../src/editor/dtextedit.cpp" line="433"/>
         <source>Remove Bookmark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="328"/>
+        <location filename="../src/editor/dtextedit.cpp" line="435"/>
         <source>Previous bookmark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="329"/>
+        <location filename="../src/editor/dtextedit.cpp" line="437"/>
         <source>Next bookmark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="330"/>
+        <location filename="../src/editor/dtextedit.cpp" line="439"/>
         <source>Remove All Bookmarks</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="331"/>
+        <location filename="../src/editor/dtextedit.cpp" line="441"/>
         <source>Fold All</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="332"/>
+        <location filename="../src/editor/dtextedit.cpp" line="443"/>
         <source>Fold Current Level</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="333"/>
+        <location filename="../src/editor/dtextedit.cpp" line="445"/>
         <source>Unfold All</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="334"/>
+        <location filename="../src/editor/dtextedit.cpp" line="447"/>
         <source>Unfold Current Level</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="339"/>
+        <location filename="../src/editor/dtextedit.cpp" line="453"/>
         <source>Color Mark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="343"/>
+        <location filename="../src/editor/dtextedit.cpp" line="458"/>
         <source>Clear All Marks</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="344"/>
+        <location filename="../src/editor/dtextedit.cpp" line="460"/>
         <source>Clear Last Mark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="353"/>
+        <location filename="../src/editor/dtextedit.cpp" line="470"/>
         <source>Mark</source>
         <translation>Kochañ</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="366"/>
+        <location filename="../src/editor/dtextedit.cpp" line="484"/>
         <source>Mark All</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="375"/>
+        <location filename="../src/editor/dtextedit.cpp" line="494"/>
         <source>Remove Comment</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3208"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3211"/>
+        <location filename="../src/editor/dtextedit.cpp" line="543"/>
+        <source>View Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="3531"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3534"/>
         <source>Copy failed: not enough memory</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3333"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3335"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3656"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3658"/>
         <source>Press ALT and click lines to edit in column mode</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="418"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9574"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9576"/>
+        <source>No audio output device was detected. Please ensure your speakers or headphones are properly connected and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="9583"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9585"/>
+        <source>No audio input device was detected. Please ensure your speakers or headphones are properly connected and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="534"/>
         <source>Change Case</source>
         <translation>Eilpennañ ar skritur-bras</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="419"/>
+        <location filename="../src/editor/dtextedit.cpp" line="409"/>
+        <source>Edit Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="411"/>
+        <source>Read View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="413"/>
+        <source>Live Preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="535"/>
         <source>Upper Case</source>
         <translation>Pennlizherennañ</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="420"/>
+        <location filename="../src/editor/dtextedit.cpp" line="536"/>
         <source>Lower Case</source>
         <translation>Lakaat e lizherennoù bihan</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="421"/>
+        <location filename="../src/editor/dtextedit.cpp" line="537"/>
         <source>Capitalize</source>
         <translation>Pennlizherennañ</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="78"/>
+        <location filename="../src/widgets/bottombar.cpp" line="110"/>
         <source>None</source>
         <translation>Hini ebet</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1363"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1490"/>
         <source>Selected line(s) copied</source>
         <translation>Linenn(où) diuzet eilet</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1370"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1497"/>
         <source>Current line copied</source>
         <translation>Linenn a-vremañ eilet</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1400"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1527"/>
         <source>Selected line(s) clipped</source>
         <translation>Linenn(où) diuzet troc&apos;het</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1412"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1539"/>
         <source>Current line clipped</source>
         <translation>Linenn a-vremañ troc&apos;het</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3227"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3230"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3550"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3553"/>
         <source>Paste failed: not enough memory</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="4548"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4873"/>
         <source>Read-Only mode is off</source>
         <translation>Lenn hepken a zo lazhet</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="4560"/>
-        <location filename="../src/editor/dtextedit.cpp" line="4584"/>
-        <location filename="../src/editor/dtextedit.cpp" line="7896"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8007"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8015"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8026"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4885"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4909"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8236"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8347"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8355"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8366"/>
         <source>Read-Only mode is on</source>
         <translation>Ar mod lenn hepken a zo enaouet</translation>
     </message>
@@ -1231,138 +1299,175 @@
 <context>
     <name>WarningNotices</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="24"/>
+        <location filename="../src/controls/warningnotices.cpp" line="25"/>
         <source>Reload</source>
         <translation>Adkargañ</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/warningnotices.cpp" line="29"/>
+        <source>Edit Anyway</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>Window</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="25"/>
-        <location filename="../src/widgets/window.cpp" line="531"/>
+        <location filename="../src/controls/warningnotices.cpp" line="27"/>
+        <location filename="../src/widgets/window.cpp" line="548"/>
         <source>Save as</source>
         <translation>Enrollañ dindan</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="527"/>
+        <location filename="../src/widgets/window.cpp" line="540"/>
         <source>New window</source>
         <translation>Prenestr nevez</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="528"/>
+        <location filename="../src/widgets/window.cpp" line="542"/>
         <source>New tab</source>
         <translation>Ivinell nevez</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="529"/>
+        <location filename="../src/widgets/window.cpp" line="544"/>
         <source>Open file</source>
         <translation>Digeriñ ur restr</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="530"/>
-        <location filename="../src/widgets/window.cpp" line="3545"/>
+        <location filename="../src/widgets/window.cpp" line="546"/>
+        <location filename="../src/widgets/window.cpp" line="3950"/>
         <source>Save</source>
         <translation>Enrollañ</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="532"/>
+        <location filename="../src/widgets/window.cpp" line="550"/>
         <source>Print</source>
         <translation>Moullañ</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="533"/>
+        <location filename="../src/widgets/window.cpp" line="552"/>
         <source>Switch theme</source>
         <translation>Cheñch tem</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="534"/>
-        <location filename="../src/widgets/window.cpp" line="2448"/>
+        <location filename="../src/widgets/window.cpp" line="554"/>
+        <location filename="../src/widgets/window.cpp" line="2641"/>
         <source>Settings</source>
         <translation>Arventennoù</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="666"/>
-        <location filename="../src/widgets/window.cpp" line="3845"/>
+        <location filename="../src/widgets/window.cpp" line="696"/>
+        <location filename="../src/widgets/window.cpp" line="4250"/>
         <source>Read-Only</source>
         <translation>Lenn hepken</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="687"/>
+        <location filename="../src/widgets/window.cpp" line="719"/>
         <source>You do not have permission to open %1</source>
         <translation>N&apos;ho peus ket an aotre da zigeriñ %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="738"/>
-        <location filename="../src/widgets/window.cpp" line="2963"/>
+        <location filename="../src/widgets/window.cpp" line="773"/>
+        <location filename="../src/widgets/window.cpp" line="3266"/>
         <source>Invalid file: %1</source>
         <translation>Restr direizh: %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="903"/>
-        <location filename="../src/widgets/window.cpp" line="956"/>
+        <location filename="../src/widgets/window.cpp" line="957"/>
+        <location filename="../src/widgets/window.cpp" line="1050"/>
+        <location filename="../src/widgets/window.cpp" line="3217"/>
         <source>Do you want to save this file?</source>
         <translation>Ha fellout a ra deoc&apos;h enrollañ ar restr-mañ?</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1290"/>
+        <location filename="../src/widgets/window.cpp" line="1381"/>
+        <source>Invalid characters detected while saving &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1382"/>
+        <source>If you force save this file, it may cause file corruption. Still want to save?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1386"/>
+        <source>Don&apos;t Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1387"/>
+        <source>Save As</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1388"/>
+        <source>Save Anyway</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1456"/>
         <source>You do not have permission to save %1</source>
         <translation>N&apos;ho peus ket an aotre da enrollañ %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1312"/>
+        <location filename="../src/widgets/window.cpp" line="1428"/>
+        <location filename="../src/widgets/window.cpp" line="1478"/>
         <source>Saved successfully</source>
         <translation>Enrollet gant berzh</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1354"/>
-        <location filename="../src/widgets/window.cpp" line="1481"/>
-        <location filename="../src/widgets/window.cpp" line="1529"/>
+        <location filename="../src/widgets/window.cpp" line="1520"/>
+        <location filename="../src/widgets/window.cpp" line="1665"/>
+        <location filename="../src/widgets/window.cpp" line="1713"/>
         <source>Save File</source>
         <translation>Enrollañ ar restr</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1483"/>
+        <location filename="../src/widgets/window.cpp" line="1569"/>
+        <source>Cannot save as the original file in preview mode. Please choose a different path.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1667"/>
         <source>Encoding</source>
         <translation>Enkodañ</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1773"/>
+        <location filename="../src/widgets/window.cpp" line="1957"/>
         <source>Read-Only mode is on</source>
         <translation>Ar mod lenn hepken a zo enaouet</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2322"/>
+        <location filename="../src/widgets/window.cpp" line="2511"/>
         <source>Current location remembered</source>
         <translation>Lec&apos;hiadur a-vremañ enrollet</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2398"/>
+        <location filename="../src/widgets/window.cpp" line="2591"/>
         <source>Ctrl+&apos;=&apos;</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2401"/>
+        <location filename="../src/widgets/window.cpp" line="2594"/>
         <source>Ctrl+&apos;-&apos;</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2430"/>
+        <location filename="../src/widgets/window.cpp" line="2623"/>
         <source>Editor</source>
         <translation>Aozer</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3061"/>
+        <location filename="../src/widgets/window.cpp" line="3436"/>
         <source>Untitled %1</source>
         <translation>Hep titl %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3543"/>
+        <location filename="../src/widgets/window.cpp" line="3948"/>
         <source>Cancel</source>
         <translation>Nullañ</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3544"/>
+        <location filename="../src/widgets/window.cpp" line="3949"/>
         <source>Discard</source>
         <translation>Na ober van</translation>
     </message>

--- a/translations/deepin-editor_ca.ts
+++ b/translations/deepin-editor_ca.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ca">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ca">
 <context>
     <name>BottomBar</name>
     <message>
@@ -17,17 +19,36 @@
         <translation>Caràcters %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="44"/>
+        <location filename="../src/widgets/bottombar.cpp" line="47"/>
         <source>Loading:</source>
         <translation>Es carrega:</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="73"/>
+        <location filename="../src/widgets/bottombar.cpp" line="91"/>
+        <location filename="../src/widgets/bottombar.cpp" line="499"/>
+        <source>Edit Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="74"/>
+        <location filename="../src/widgets/bottombar.cpp" line="489"/>
+        <source>Read View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="75"/>
+        <location filename="../src/widgets/bottombar.cpp" line="493"/>
+        <source>Live Preview</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DDropdownMenu</name>
     <message>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="362"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="420"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="425"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="363"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="421"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="426"/>
         <source>None</source>
         <translation>Cap</translation>
     </message>
@@ -35,68 +56,57 @@
 <context>
     <name>EditWrapper</name>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="292"/>
-        <location filename="../src/editor/editwrapper.cpp" line="365"/>
-        <location filename="../src/editor/editwrapper.cpp" line="521"/>
-        <location filename="../src/editor/editwrapper.cpp" line="751"/>
+        <location filename="../src/editor/editwrapper.cpp" line="355"/>
+        <location filename="../src/editor/editwrapper.cpp" line="429"/>
+        <location filename="../src/editor/editwrapper.cpp" line="595"/>
+        <location filename="../src/editor/editwrapper.cpp" line="887"/>
         <source>Save</source>
         <translation>Desa</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="516"/>
+        <location filename="../src/editor/editwrapper.cpp" line="590"/>
         <source>Do you want to save this file?</source>
         <translation>Voleu desar aquest fitxer?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="363"/>
-        <location filename="../src/editor/editwrapper.cpp" line="519"/>
+        <location filename="../src/editor/editwrapper.cpp" line="427"/>
+        <location filename="../src/editor/editwrapper.cpp" line="593"/>
         <source>Cancel</source>
         <translation>Cancel·la</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="360"/>
+        <location filename="../src/editor/editwrapper.cpp" line="424"/>
         <source>Encoding changed. Do you want to save the file now?</source>
         <translation>Ha canviat la codificació. Voleu desar el fitxer ara?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="520"/>
+        <location filename="../src/editor/editwrapper.cpp" line="594"/>
         <source>Discard</source>
         <translation>Descarta</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="274"/>
-        <location filename="../src/editor/editwrapper.cpp" line="620"/>
+        <location filename="../src/editor/editwrapper.cpp" line="1121"/>
+        <source>The file contains invalid characters (NUL). Preview mode is read-only.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="337"/>
+        <location filename="../src/editor/editwrapper.cpp" line="705"/>
         <source>You do not have permission to save %1</source>
         <translation>No teniu permís per desar %1</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="836"/>
+        <location filename="../src/editor/editwrapper.cpp" line="987"/>
         <source>File removed on the disk. Save it now?</source>
         <translation>El fitxer s&apos;ha eliminat del disc. El voleu desar ara?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="842"/>
+        <location filename="../src/editor/editwrapper.cpp" line="993"/>
         <source>File has changed on disk. Reload?</source>
         <translation>El fitxer ha canviat al disc. El torno a carregar?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="884"/>
-        <location filename="../src/widgets/bottombar.cpp" line="74"/>
-        <source>INSERT</source>
-        <translation>INSEREIX</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="888"/>
-        <source>OVERWRITE</source>
-        <translation>SOBREESCRIU</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="892"/>
-        <source>R/O</source>
-        <translation>N/L</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="1618"/>
+        <location filename="../src/editor/editwrapper.cpp" line="1806"/>
         <source>The file cannot be read, which may be too large or has been damaged!</source>
         <translation>El fitxer no es pot llegir. Pot ser massa gros o estar malmès!</translation>
     </message>
@@ -109,17 +119,17 @@
         <translation>Troba</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="36"/>
+        <location filename="../src/controls/findbar.cpp" line="38"/>
         <source>Previous</source>
         <translation>Anterior</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="37"/>
+        <location filename="../src/controls/findbar.cpp" line="40"/>
         <source>Next</source>
         <translation>Següent</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="38"/>
+        <location filename="../src/controls/findbar.cpp" line="42"/>
         <source>Replace</source>
         <translation>Reemplaça</translation>
     </message>
@@ -127,9 +137,17 @@
 <context>
     <name>JumpLineBar</name>
     <message>
-        <location filename="../src/controls/jumplinebar.cpp" line="45"/>
+        <location filename="../src/controls/jumplinebar.cpp" line="46"/>
         <source>Go to Line: </source>
         <translation>Ves a la línia:</translation>
+    </message>
+</context>
+<context>
+    <name>LineBar</name>
+    <message>
+        <location filename="../src/controls/linebar.cpp" line="144"/>
+        <source>第%1/%2项</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -146,19 +164,47 @@
     </message>
 </context>
 <context>
+    <name>MarkdownBridge</name>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="37"/>
+        <source>Collapse code block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="38"/>
+        <source>Expand code block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="39"/>
+        <source>Copy code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="40"/>
+        <source>Expand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="42"/>
+        <source>%1 line(s) of code collapsed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PathSettingWgt</name>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="84"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="90"/>
         <source>Remember the last used path</source>
         <translation>Recorda el darrer camí usat.</translation>
     </message>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="85"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="91"/>
         <source>Same path as the current file</source>
         <translation>El mateix camí del fitxer actual</translation>
     </message>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="86"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="92"/>
         <source>Customize the default path</source>
         <translation>Personalització del camí predeterminat</translation>
     </message>
@@ -171,15 +217,20 @@
         <translation>Editor de text</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="294"/>
-        <location filename="../src/editor/editwrapper.cpp" line="761"/>
-        <location filename="../src/editor/editwrapper.cpp" line="776"/>
-        <location filename="../src/widgets/window.cpp" line="1362"/>
-        <location filename="../src/widgets/window.cpp" line="1390"/>
-        <location filename="../src/widgets/window.cpp" line="1531"/>
-        <location filename="../src/widgets/window.cpp" line="1548"/>
+        <location filename="../src/editor/editwrapper.cpp" line="357"/>
+        <location filename="../src/editor/editwrapper.cpp" line="897"/>
+        <location filename="../src/editor/editwrapper.cpp" line="912"/>
+        <location filename="../src/widgets/window.cpp" line="1528"/>
+        <location filename="../src/widgets/window.cpp" line="1556"/>
+        <location filename="../src/widgets/window.cpp" line="1715"/>
+        <location filename="../src/widgets/window.cpp" line="1732"/>
         <source>Encoding</source>
         <translation>Codificació</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="2001"/>
+        <source>视图模式</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="11"/>
@@ -215,7 +266,7 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="18"/>
         <location filename="../src/controls/settingsdialog.cpp" line="96"/>
-        <location filename="../src/widgets/window.cpp" line="2388"/>
+        <location filename="../src/widgets/window.cpp" line="2581"/>
         <source>Window</source>
         <translation>Finestra</translation>
     </message>
@@ -755,68 +806,68 @@
         <translation>Vietnamita</translation>
     </message>
     <message>
-        <location filename="../src/startmanager.cpp" line="971"/>
+        <location filename="../src/startmanager.cpp" line="1035"/>
         <source>File not saved</source>
         <translation>Fitxer no desat</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1532"/>
-        <location filename="../src/widgets/window.cpp" line="1549"/>
+        <location filename="../src/widgets/window.cpp" line="1716"/>
+        <location filename="../src/widgets/window.cpp" line="1733"/>
         <source>Line Endings</source>
         <translation>Finals de línia</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="243"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="379"/>
         <source>Please install &apos;UOS AI&apos; from the App Store before using</source>
         <translation>Si us plau, instal·li &apos;UOS AI&apos; de l&apos;App Store abans d&apos;utilitzar</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="245"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="381"/>
         <source>No audio input device detected. Please check and try again</source>
         <translation>No s&apos;ha detectat cap dispositiu d&apos;entrada d&apos;àudio. Comproveu i torneu a provar</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="247"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="383"/>
         <source>No audio output device detected. Please check and try again</source>
         <translation>No s&apos;ha detectat cap dispositiu de sortida d&apos;àudio. Comproveu i torneu a provar</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="69"/>
+        <location filename="../src/common/text_file_saver.cpp" line="74"/>
         <source>File path is empty</source>
         <translation>La ruta del fitxer està buida</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="155"/>
+        <location filename="../src/common/text_file_saver.cpp" line="153"/>
         <source>Insufficient memory to load document content</source>
         <translation>No hi ha memòria suficient per carregar el contingut del document</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="177"/>
+        <location filename="../src/common/text_file_saver.cpp" line="178"/>
         <source>Insufficient memory for encoding conversion</source>
         <translation>No hi ha memòria suficient per a la conversió d&apos;encodatge</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="183"/>
+        <location filename="../src/common/text_file_saver.cpp" line="184"/>
         <source>Encoding conversion failed</source>
         <translation>La conversió d&apos;encodatge ha fallat</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="189"/>
+        <location filename="../src/common/text_file_saver.cpp" line="190"/>
         <source>Converted content is empty</source>
         <translation>El contingut convertit està buit</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="207"/>
+        <location filename="../src/common/text_file_saver.cpp" line="208"/>
         <source>Memory allocation failed</source>
         <translation>Ha fallat l&apos;assignació de memòria</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="211"/>
+        <location filename="../src/common/text_file_saver.cpp" line="212"/>
         <source>Error occurred: %1</source>
         <translation>S&apos;ha produït un error: %1</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="215"/>
+        <location filename="../src/common/text_file_saver.cpp" line="216"/>
         <source>Unknown error occurred</source>
         <translation>S&apos;ha produït un error desconegut</translation>
     </message>
@@ -829,27 +880,27 @@
         <translation>Troba</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="34"/>
+        <location filename="../src/controls/replacebar.cpp" line="36"/>
         <source>Replace With</source>
         <translation>Reemplaça amb</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="36"/>
+        <location filename="../src/controls/replacebar.cpp" line="40"/>
         <source>Replace</source>
         <translation>Reemplaça</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="37"/>
+        <location filename="../src/controls/replacebar.cpp" line="42"/>
         <source>Skip</source>
         <translation>Omet</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="38"/>
+        <location filename="../src/controls/replacebar.cpp" line="44"/>
         <source>Replace Rest</source>
         <translation>Reemplaça&apos;n la resta</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="39"/>
+        <location filename="../src/controls/replacebar.cpp" line="46"/>
         <source>Replace All</source>
         <translation>Reemplaça-ho tot</translation>
     </message>
@@ -858,9 +909,9 @@
     <name>S:</name>
     <message>
         <location filename="../third/libiconv-1.16/src/iconv.c" line="103"/>
-        <source/>
+        <source></source>
         <comment>The first line of the short usage message.</comment>
-        <translation type="unfinished"/>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -891,34 +942,34 @@
         <translation>Pantalla completa</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="484"/>
+        <location filename="../src/common/settings.cpp" line="491"/>
         <source>This shortcut conflicts with system shortcut %1</source>
         <translation>Aquesta drecera entra en conflicte amb la drecera del sistema %1</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="487"/>
+        <location filename="../src/common/settings.cpp" line="494"/>
         <source>This shortcut conflicts with %1, click on Replace to make this shortcut effective immediately</source>
         <translation>Aquesta tecla de drecera té conflicte amb %1. Cliqueu a Reemplaça perquè aquesta drecera tingui efecte immediatament.</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="682"/>
-        <location filename="../src/common/settings.cpp" line="695"/>
-        <location filename="../src/common/settings.cpp" line="704"/>
+        <location filename="../src/common/settings.cpp" line="689"/>
+        <location filename="../src/common/settings.cpp" line="702"/>
+        <location filename="../src/common/settings.cpp" line="711"/>
         <source>The shortcut %1 is invalid, please set another one.</source>
         <translation>La drecera %1 no és vàlida. Establiu-ne una altra.</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="736"/>
+        <location filename="../src/common/settings.cpp" line="743"/>
         <source>Cancel</source>
         <translation>Cancel·la</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="737"/>
+        <location filename="../src/common/settings.cpp" line="744"/>
         <source>Replace</source>
         <translation>Reemplaça</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="740"/>
+        <location filename="../src/common/settings.cpp" line="747"/>
         <source>OK</source>
         <translation>D&apos;acord</translation>
     </message>
@@ -926,7 +977,7 @@
 <context>
     <name>StartManager</name>
     <message>
-        <location filename="../src/startmanager.cpp" line="411"/>
+        <location filename="../src/startmanager.cpp" line="425"/>
         <source>Untitled %1</source>
         <translation>Sense títol: %1</translation>
     </message>
@@ -934,32 +985,32 @@
 <context>
     <name>Tabbar</name>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="641"/>
+        <location filename="../src/controls/tabbar.cpp" line="678"/>
         <source>Close tab</source>
         <translation>Tanca la pestanya</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="642"/>
+        <location filename="../src/controls/tabbar.cpp" line="680"/>
         <source>Close other tabs</source>
         <translation>Tanca les altres pestanyes</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="643"/>
+        <location filename="../src/controls/tabbar.cpp" line="682"/>
         <source>More options</source>
         <translation>Més opcions</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="644"/>
+        <location filename="../src/controls/tabbar.cpp" line="684"/>
         <source>Close tabs to the left</source>
         <translation>Tanca les pestanyes de l&apos;esquerra</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="645"/>
+        <location filename="../src/controls/tabbar.cpp" line="686"/>
         <source>Close tabs to the right</source>
         <translation>Tanca les pestanyes de la dreta</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="646"/>
+        <location filename="../src/controls/tabbar.cpp" line="688"/>
         <source>Close unmodified tabs</source>
         <translation>Tanca les pestanyes no modificades</translation>
     </message>
@@ -967,263 +1018,280 @@
 <context>
     <name>TextEdit</name>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="305"/>
+        <location filename="../src/editor/dtextedit.cpp" line="388"/>
         <source>Undo</source>
         <translation>Desfés</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="306"/>
+        <location filename="../src/editor/dtextedit.cpp" line="390"/>
         <source>Redo</source>
         <translation>Refés</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="307"/>
+        <location filename="../src/editor/dtextedit.cpp" line="392"/>
         <source>Cut</source>
         <translation>Retalla</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="308"/>
+        <location filename="../src/editor/dtextedit.cpp" line="394"/>
         <source>Copy</source>
         <translation>Copia</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="309"/>
+        <location filename="../src/editor/dtextedit.cpp" line="396"/>
         <source>Paste</source>
         <translation>Enganxa</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="310"/>
+        <location filename="../src/editor/dtextedit.cpp" line="398"/>
         <source>Delete</source>
         <translation>Suprimeix</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="311"/>
+        <location filename="../src/editor/dtextedit.cpp" line="400"/>
         <source>Select All</source>
         <translation>Selecciona-ho tot</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="312"/>
-        <location filename="../src/widgets/window.cpp" line="535"/>
+        <location filename="../src/editor/dtextedit.cpp" line="402"/>
+        <location filename="../src/widgets/window.cpp" line="556"/>
         <source>Find</source>
         <translation>Troba</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="313"/>
-        <location filename="../src/widgets/window.cpp" line="536"/>
+        <location filename="../src/editor/dtextedit.cpp" line="404"/>
+        <location filename="../src/widgets/window.cpp" line="558"/>
         <source>Replace</source>
         <translation>Reemplaça</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="314"/>
+        <location filename="../src/editor/dtextedit.cpp" line="406"/>
         <source>Go to Line</source>
         <translation>Ves a la línia</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="315"/>
-        <source>Turn on Read-Only mode</source>
-        <translation>Activa el mode només de lectura</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="316"/>
-        <source>Turn off Read-Only mode</source>
-        <translation>Desactiva el mode només de lectura</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="317"/>
+        <location filename="../src/editor/dtextedit.cpp" line="415"/>
         <source>Fullscreen</source>
         <translation>Pantalla completa</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="318"/>
+        <location filename="../src/editor/dtextedit.cpp" line="417"/>
         <source>Exit fullscreen</source>
         <translation>Surt de la pantalla completa</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="319"/>
+        <location filename="../src/editor/dtextedit.cpp" line="419"/>
         <source>Display in file manager</source>
         <translation>Mostra-ho al gestor de fitxers</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="320"/>
-        <location filename="../src/editor/dtextedit.cpp" line="374"/>
+        <location filename="../src/editor/dtextedit.cpp" line="421"/>
+        <location filename="../src/editor/dtextedit.cpp" line="493"/>
         <source>Add Comment</source>
         <translation>Afegeix-hi un comentari</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="321"/>
+        <location filename="../src/editor/dtextedit.cpp" line="423"/>
         <source>Text to Speech</source>
         <translation>Text a veu</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="322"/>
-        <source>Stop reading</source>
-        <translation>Atura la lectura</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="323"/>
+        <location filename="../src/editor/dtextedit.cpp" line="425"/>
         <source>Speech to Text</source>
         <translation>Veu a text</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="324"/>
+        <location filename="../src/editor/dtextedit.cpp" line="427"/>
         <source>Translate</source>
         <translation>Tradueix</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="325"/>
+        <location filename="../src/editor/dtextedit.cpp" line="429"/>
         <source>Column Mode</source>
         <translation>Mode de columna</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="326"/>
+        <location filename="../src/editor/dtextedit.cpp" line="431"/>
         <source>Add bookmark</source>
         <translation>Afegeix-hi un marcador</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="327"/>
+        <location filename="../src/editor/dtextedit.cpp" line="433"/>
         <source>Remove Bookmark</source>
         <translation>Elimina el marcador</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="328"/>
+        <location filename="../src/editor/dtextedit.cpp" line="435"/>
         <source>Previous bookmark</source>
         <translation>Marcador anterior</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="329"/>
+        <location filename="../src/editor/dtextedit.cpp" line="437"/>
         <source>Next bookmark</source>
         <translation>Marcador següent</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="330"/>
+        <location filename="../src/editor/dtextedit.cpp" line="439"/>
         <source>Remove All Bookmarks</source>
         <translation>Elimina tots els marcadors</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="331"/>
+        <location filename="../src/editor/dtextedit.cpp" line="441"/>
         <source>Fold All</source>
         <translation>Plega-ho tot</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="332"/>
+        <location filename="../src/editor/dtextedit.cpp" line="443"/>
         <source>Fold Current Level</source>
         <translation>Plega el nivell actual</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="333"/>
+        <location filename="../src/editor/dtextedit.cpp" line="445"/>
         <source>Unfold All</source>
         <translation>Desplega-ho tot</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="334"/>
+        <location filename="../src/editor/dtextedit.cpp" line="447"/>
         <source>Unfold Current Level</source>
         <translation>Desplega el nivell actual</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="339"/>
+        <location filename="../src/editor/dtextedit.cpp" line="453"/>
         <source>Color Mark</source>
         <translation>Marca de color</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="343"/>
+        <location filename="../src/editor/dtextedit.cpp" line="458"/>
         <source>Clear All Marks</source>
         <translation>Neteja totes les marques</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="344"/>
+        <location filename="../src/editor/dtextedit.cpp" line="460"/>
         <source>Clear Last Mark</source>
         <translation>Neteja la darrera marca</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="353"/>
+        <location filename="../src/editor/dtextedit.cpp" line="470"/>
         <source>Mark</source>
         <translation>Marca</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="366"/>
+        <location filename="../src/editor/dtextedit.cpp" line="484"/>
         <source>Mark All</source>
         <translation>Marca-ho tot</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="375"/>
+        <location filename="../src/editor/dtextedit.cpp" line="494"/>
         <source>Remove Comment</source>
         <translation>Elimina el comentari</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3208"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3211"/>
+        <location filename="../src/editor/dtextedit.cpp" line="543"/>
+        <source>View Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="3531"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3534"/>
         <source>Copy failed: not enough memory</source>
         <translation>La còpia ha fallat: no hi ha prou memòria.</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3333"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3335"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3656"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3658"/>
         <source>Press ALT and click lines to edit in column mode</source>
         <translation>Premeu ALT i feu clic a les línies per editar-lo en mode columna</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="418"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9574"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9576"/>
+        <source>No audio output device was detected. Please ensure your speakers or headphones are properly connected and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="9583"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9585"/>
+        <source>No audio input device was detected. Please ensure your speakers or headphones are properly connected and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="534"/>
         <source>Change Case</source>
         <translation>Canvia&apos;n la caixa</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="419"/>
+        <location filename="../src/editor/dtextedit.cpp" line="409"/>
+        <source>Edit Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="411"/>
+        <source>Read View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="413"/>
+        <source>Live Preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="535"/>
         <source>Upper Case</source>
         <translation>Majúscules</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="420"/>
+        <location filename="../src/editor/dtextedit.cpp" line="536"/>
         <source>Lower Case</source>
         <translation>Minúscules</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="421"/>
+        <location filename="../src/editor/dtextedit.cpp" line="537"/>
         <source>Capitalize</source>
         <translation>Posa en majúscules</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="78"/>
+        <location filename="../src/widgets/bottombar.cpp" line="110"/>
         <source>None</source>
         <translation>Cap</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1363"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1490"/>
         <source>Selected line(s) copied</source>
         <translation>S&apos;han copiat les línies seleccionades.</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1370"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1497"/>
         <source>Current line copied</source>
         <translation>S&apos;ha copiat la línia actual.</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1400"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1527"/>
         <source>Selected line(s) clipped</source>
         <translation>S&apos;han retallat les línies seleccionades.</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1412"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1539"/>
         <source>Current line clipped</source>
         <translation>S&apos;ha retallat la línia actual.</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3227"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3230"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3550"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3553"/>
         <source>Paste failed: not enough memory</source>
         <translation>Ha fallat l&apos;acció d&apos;enganxar: no hi ha prou memòria.</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="4548"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4873"/>
         <source>Read-Only mode is off</source>
         <translation>Mode de lectura desactivat</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="4560"/>
-        <location filename="../src/editor/dtextedit.cpp" line="4584"/>
-        <location filename="../src/editor/dtextedit.cpp" line="7896"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8007"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8015"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8026"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4885"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4909"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8236"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8347"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8355"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8366"/>
         <source>Read-Only mode is on</source>
         <translation>Mode de lectura activat</translation>
     </message>
@@ -1231,138 +1299,175 @@
 <context>
     <name>WarningNotices</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="24"/>
+        <location filename="../src/controls/warningnotices.cpp" line="25"/>
         <source>Reload</source>
         <translation>Torna-ho a carregar</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/warningnotices.cpp" line="29"/>
+        <source>Edit Anyway</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>Window</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="25"/>
-        <location filename="../src/widgets/window.cpp" line="531"/>
+        <location filename="../src/controls/warningnotices.cpp" line="27"/>
+        <location filename="../src/widgets/window.cpp" line="548"/>
         <source>Save as</source>
         <translation>Desa com a</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="527"/>
+        <location filename="../src/widgets/window.cpp" line="540"/>
         <source>New window</source>
         <translation>Finestra nova</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="528"/>
+        <location filename="../src/widgets/window.cpp" line="542"/>
         <source>New tab</source>
         <translation>Pestanya nova</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="529"/>
+        <location filename="../src/widgets/window.cpp" line="544"/>
         <source>Open file</source>
         <translation>Obre un fitxer</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="530"/>
-        <location filename="../src/widgets/window.cpp" line="3545"/>
+        <location filename="../src/widgets/window.cpp" line="546"/>
+        <location filename="../src/widgets/window.cpp" line="3950"/>
         <source>Save</source>
         <translation>Desa</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="532"/>
+        <location filename="../src/widgets/window.cpp" line="550"/>
         <source>Print</source>
         <translation>Imprimeix</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="533"/>
+        <location filename="../src/widgets/window.cpp" line="552"/>
         <source>Switch theme</source>
         <translation>Canvia el tema</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="534"/>
-        <location filename="../src/widgets/window.cpp" line="2448"/>
+        <location filename="../src/widgets/window.cpp" line="554"/>
+        <location filename="../src/widgets/window.cpp" line="2641"/>
         <source>Settings</source>
         <translation>Paràmetres</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="666"/>
-        <location filename="../src/widgets/window.cpp" line="3845"/>
+        <location filename="../src/widgets/window.cpp" line="696"/>
+        <location filename="../src/widgets/window.cpp" line="4250"/>
         <source>Read-Only</source>
         <translation>Només de lectura</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="687"/>
+        <location filename="../src/widgets/window.cpp" line="719"/>
         <source>You do not have permission to open %1</source>
         <translation>No teniu permís per obrir %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="738"/>
-        <location filename="../src/widgets/window.cpp" line="2963"/>
+        <location filename="../src/widgets/window.cpp" line="773"/>
+        <location filename="../src/widgets/window.cpp" line="3266"/>
         <source>Invalid file: %1</source>
         <translation>Fitxer no vàlid: %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="903"/>
-        <location filename="../src/widgets/window.cpp" line="956"/>
+        <location filename="../src/widgets/window.cpp" line="957"/>
+        <location filename="../src/widgets/window.cpp" line="1050"/>
+        <location filename="../src/widgets/window.cpp" line="3217"/>
         <source>Do you want to save this file?</source>
         <translation>Voleu desar aquest fitxer?</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1290"/>
+        <location filename="../src/widgets/window.cpp" line="1381"/>
+        <source>Invalid characters detected while saving &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1382"/>
+        <source>If you force save this file, it may cause file corruption. Still want to save?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1386"/>
+        <source>Don&apos;t Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1387"/>
+        <source>Save As</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1388"/>
+        <source>Save Anyway</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1456"/>
         <source>You do not have permission to save %1</source>
         <translation>No teniu permís per desar %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1312"/>
+        <location filename="../src/widgets/window.cpp" line="1428"/>
+        <location filename="../src/widgets/window.cpp" line="1478"/>
         <source>Saved successfully</source>
         <translation>S&apos;ha desat correctament</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1354"/>
-        <location filename="../src/widgets/window.cpp" line="1481"/>
-        <location filename="../src/widgets/window.cpp" line="1529"/>
+        <location filename="../src/widgets/window.cpp" line="1520"/>
+        <location filename="../src/widgets/window.cpp" line="1665"/>
+        <location filename="../src/widgets/window.cpp" line="1713"/>
         <source>Save File</source>
         <translation>Desa el fitxer</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1483"/>
+        <location filename="../src/widgets/window.cpp" line="1569"/>
+        <source>Cannot save as the original file in preview mode. Please choose a different path.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1667"/>
         <source>Encoding</source>
         <translation>Codificació</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1773"/>
+        <location filename="../src/widgets/window.cpp" line="1957"/>
         <source>Read-Only mode is on</source>
         <translation>Mode de lectura activat</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2322"/>
+        <location filename="../src/widgets/window.cpp" line="2511"/>
         <source>Current location remembered</source>
         <translation>Es recorda la ubicació actual.</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2398"/>
+        <location filename="../src/widgets/window.cpp" line="2591"/>
         <source>Ctrl+&apos;=&apos;</source>
         <translation>Ctrl + =</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2401"/>
+        <location filename="../src/widgets/window.cpp" line="2594"/>
         <source>Ctrl+&apos;-&apos;</source>
         <translation>Ctrl + -</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2430"/>
+        <location filename="../src/widgets/window.cpp" line="2623"/>
         <source>Editor</source>
         <translation>Editor</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3061"/>
+        <location filename="../src/widgets/window.cpp" line="3436"/>
         <source>Untitled %1</source>
         <translation>Sense títol: %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3543"/>
+        <location filename="../src/widgets/window.cpp" line="3948"/>
         <source>Cancel</source>
         <translation>Cancel·la</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3544"/>
+        <location filename="../src/widgets/window.cpp" line="3949"/>
         <source>Discard</source>
         <translation>Descarta</translation>
     </message>

--- a/translations/deepin-editor_cs.ts
+++ b/translations/deepin-editor_cs.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="cs">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="cs">
 <context>
     <name>BottomBar</name>
     <message>
@@ -17,17 +19,36 @@
         <translation>Znaků %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="44"/>
+        <location filename="../src/widgets/bottombar.cpp" line="47"/>
         <source>Loading:</source>
         <translation>Nahrává se:</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="73"/>
+        <location filename="../src/widgets/bottombar.cpp" line="91"/>
+        <location filename="../src/widgets/bottombar.cpp" line="499"/>
+        <source>Edit Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="74"/>
+        <location filename="../src/widgets/bottombar.cpp" line="489"/>
+        <source>Read View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="75"/>
+        <location filename="../src/widgets/bottombar.cpp" line="493"/>
+        <source>Live Preview</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DDropdownMenu</name>
     <message>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="362"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="420"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="425"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="363"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="421"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="426"/>
         <source>None</source>
         <translation>Žádné</translation>
     </message>
@@ -35,68 +56,57 @@
 <context>
     <name>EditWrapper</name>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="292"/>
-        <location filename="../src/editor/editwrapper.cpp" line="365"/>
-        <location filename="../src/editor/editwrapper.cpp" line="521"/>
-        <location filename="../src/editor/editwrapper.cpp" line="751"/>
+        <location filename="../src/editor/editwrapper.cpp" line="355"/>
+        <location filename="../src/editor/editwrapper.cpp" line="429"/>
+        <location filename="../src/editor/editwrapper.cpp" line="595"/>
+        <location filename="../src/editor/editwrapper.cpp" line="887"/>
         <source>Save</source>
         <translation>Uložit</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="516"/>
+        <location filename="../src/editor/editwrapper.cpp" line="590"/>
         <source>Do you want to save this file?</source>
         <translation>Chcete tento soubor uložit?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="363"/>
-        <location filename="../src/editor/editwrapper.cpp" line="519"/>
+        <location filename="../src/editor/editwrapper.cpp" line="427"/>
+        <location filename="../src/editor/editwrapper.cpp" line="593"/>
         <source>Cancel</source>
         <translation>Zrušit</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="360"/>
+        <location filename="../src/editor/editwrapper.cpp" line="424"/>
         <source>Encoding changed. Do you want to save the file now?</source>
         <translation>Kódování změněno. Chcete tento soubor uložit nyní?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="520"/>
+        <location filename="../src/editor/editwrapper.cpp" line="594"/>
         <source>Discard</source>
         <translation>Zahodit</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="274"/>
-        <location filename="../src/editor/editwrapper.cpp" line="620"/>
+        <location filename="../src/editor/editwrapper.cpp" line="1121"/>
+        <source>The file contains invalid characters (NUL). Preview mode is read-only.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="337"/>
+        <location filename="../src/editor/editwrapper.cpp" line="705"/>
         <source>You do not have permission to save %1</source>
         <translation>Nemáte oprávnění pro uložení %1</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="836"/>
+        <location filename="../src/editor/editwrapper.cpp" line="987"/>
         <source>File removed on the disk. Save it now?</source>
         <translation>Soubor byl mezitím na disku odstraněn. Uložit ho nyní?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="842"/>
+        <location filename="../src/editor/editwrapper.cpp" line="993"/>
         <source>File has changed on disk. Reload?</source>
         <translation>Soubor byl mezitím na disku změněn. Načíst znovu?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="884"/>
-        <location filename="../src/widgets/bottombar.cpp" line="74"/>
-        <source>INSERT</source>
-        <translation>VLOŽIT</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="888"/>
-        <source>OVERWRITE</source>
-        <translation>PŘEPSAT</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="892"/>
-        <source>R/O</source>
-        <translation>Pouze pro čtení</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="1618"/>
+        <location filename="../src/editor/editwrapper.cpp" line="1806"/>
         <source>The file cannot be read, which may be too large or has been damaged!</source>
         <translation>Soubor nelze přečíst, může být příliš velký nebo poškozený!</translation>
     </message>
@@ -109,17 +119,17 @@
         <translation>Najít</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="36"/>
+        <location filename="../src/controls/findbar.cpp" line="38"/>
         <source>Previous</source>
         <translation>Předchozí</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="37"/>
+        <location filename="../src/controls/findbar.cpp" line="40"/>
         <source>Next</source>
         <translation>Další</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="38"/>
+        <location filename="../src/controls/findbar.cpp" line="42"/>
         <source>Replace</source>
         <translation>Nahradit</translation>
     </message>
@@ -127,9 +137,17 @@
 <context>
     <name>JumpLineBar</name>
     <message>
-        <location filename="../src/controls/jumplinebar.cpp" line="45"/>
+        <location filename="../src/controls/jumplinebar.cpp" line="46"/>
         <source>Go to Line: </source>
         <translation>Jít na řádek:</translation>
+    </message>
+</context>
+<context>
+    <name>LineBar</name>
+    <message>
+        <location filename="../src/controls/linebar.cpp" line="144"/>
+        <source>第%1/%2项</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -146,19 +164,47 @@
     </message>
 </context>
 <context>
+    <name>MarkdownBridge</name>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="37"/>
+        <source>Collapse code block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="38"/>
+        <source>Expand code block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="39"/>
+        <source>Copy code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="40"/>
+        <source>Expand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="42"/>
+        <source>%1 line(s) of code collapsed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PathSettingWgt</name>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="84"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="90"/>
         <source>Remember the last used path</source>
         <translation>Pamatovat si poslední použitou cestu</translation>
     </message>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="85"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="91"/>
         <source>Same path as the current file</source>
         <translation>Stejná cesta jako k nynějšímu souboru</translation>
     </message>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="86"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="92"/>
         <source>Customize the default path</source>
         <translation>Přizpůsobit výchozí cestu</translation>
     </message>
@@ -171,15 +217,20 @@
         <translation>Textový editor</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="294"/>
-        <location filename="../src/editor/editwrapper.cpp" line="761"/>
-        <location filename="../src/editor/editwrapper.cpp" line="776"/>
-        <location filename="../src/widgets/window.cpp" line="1362"/>
-        <location filename="../src/widgets/window.cpp" line="1390"/>
-        <location filename="../src/widgets/window.cpp" line="1531"/>
-        <location filename="../src/widgets/window.cpp" line="1548"/>
+        <location filename="../src/editor/editwrapper.cpp" line="357"/>
+        <location filename="../src/editor/editwrapper.cpp" line="897"/>
+        <location filename="../src/editor/editwrapper.cpp" line="912"/>
+        <location filename="../src/widgets/window.cpp" line="1528"/>
+        <location filename="../src/widgets/window.cpp" line="1556"/>
+        <location filename="../src/widgets/window.cpp" line="1715"/>
+        <location filename="../src/widgets/window.cpp" line="1732"/>
         <source>Encoding</source>
         <translation>Kódování znaků</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="2001"/>
+        <source>视图模式</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="11"/>
@@ -215,7 +266,7 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="18"/>
         <location filename="../src/controls/settingsdialog.cpp" line="96"/>
-        <location filename="../src/widgets/window.cpp" line="2388"/>
+        <location filename="../src/widgets/window.cpp" line="2581"/>
         <source>Window</source>
         <translation>Okno</translation>
     </message>
@@ -755,68 +806,68 @@
         <translation>Vietnamské</translation>
     </message>
     <message>
-        <location filename="../src/startmanager.cpp" line="971"/>
+        <location filename="../src/startmanager.cpp" line="1035"/>
         <source>File not saved</source>
         <translation>Soubor neuložen</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1532"/>
-        <location filename="../src/widgets/window.cpp" line="1549"/>
+        <location filename="../src/widgets/window.cpp" line="1716"/>
+        <location filename="../src/widgets/window.cpp" line="1733"/>
         <source>Line Endings</source>
         <translation>Konce řádků</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="243"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="379"/>
         <source>Please install &apos;UOS AI&apos; from the App Store before using</source>
         <translation>Před použitím si prosím nainstalujte „UOS AI&quot; z App Store</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="245"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="381"/>
         <source>No audio input device detected. Please check and try again</source>
         <translation>Není detekován žádný vstupní audio zařízení. Zkontrolujte a zkuste to znovu</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="247"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="383"/>
         <source>No audio output device detected. Please check and try again</source>
         <translation>Není detekován žádný výstupní audio zařízení. Zkontrolujte a zkuste to znovu</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="69"/>
+        <location filename="../src/common/text_file_saver.cpp" line="74"/>
         <source>File path is empty</source>
         <translation>Cesta k souboru je prázdná</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="155"/>
+        <location filename="../src/common/text_file_saver.cpp" line="153"/>
         <source>Insufficient memory to load document content</source>
         <translation>Nedostatek paměti pro načtení obsahu dokumentu</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="177"/>
+        <location filename="../src/common/text_file_saver.cpp" line="178"/>
         <source>Insufficient memory for encoding conversion</source>
         <translation>Nedostatek paměti pro převod kódování</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="183"/>
+        <location filename="../src/common/text_file_saver.cpp" line="184"/>
         <source>Encoding conversion failed</source>
         <translation>Převod kódování se nezdařil</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="189"/>
+        <location filename="../src/common/text_file_saver.cpp" line="190"/>
         <source>Converted content is empty</source>
         <translation>Převedený obsah je prázdný</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="207"/>
+        <location filename="../src/common/text_file_saver.cpp" line="208"/>
         <source>Memory allocation failed</source>
         <translation>Přidělení paměti se nezdařilo</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="211"/>
+        <location filename="../src/common/text_file_saver.cpp" line="212"/>
         <source>Error occurred: %1</source>
         <translation>Došlo k chybě: %1</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="215"/>
+        <location filename="../src/common/text_file_saver.cpp" line="216"/>
         <source>Unknown error occurred</source>
         <translation>Došlo k neznámé chybě</translation>
     </message>
@@ -829,27 +880,27 @@
         <translation>Najít</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="34"/>
+        <location filename="../src/controls/replacebar.cpp" line="36"/>
         <source>Replace With</source>
         <translation>Nahradit za</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="36"/>
+        <location filename="../src/controls/replacebar.cpp" line="40"/>
         <source>Replace</source>
         <translation>Nahradit</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="37"/>
+        <location filename="../src/controls/replacebar.cpp" line="42"/>
         <source>Skip</source>
         <translation>Přeskočit</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="38"/>
+        <location filename="../src/controls/replacebar.cpp" line="44"/>
         <source>Replace Rest</source>
         <translation>Nahradit zbytek</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="39"/>
+        <location filename="../src/controls/replacebar.cpp" line="46"/>
         <source>Replace All</source>
         <translation>Nahradit vše</translation>
     </message>
@@ -858,9 +909,9 @@
     <name>S:</name>
     <message>
         <location filename="../third/libiconv-1.16/src/iconv.c" line="103"/>
-        <source/>
+        <source></source>
         <comment>The first line of the short usage message.</comment>
-        <translation type="unfinished"/>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -891,34 +942,34 @@
         <translation>Na celou obrazovku</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="484"/>
+        <location filename="../src/common/settings.cpp" line="491"/>
         <source>This shortcut conflicts with system shortcut %1</source>
         <translation>Tato zkratka je v konfliktu se systémovou %1</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="487"/>
+        <location filename="../src/common/settings.cpp" line="494"/>
         <source>This shortcut conflicts with %1, click on Replace to make this shortcut effective immediately</source>
         <translation>Tato zkratka koliduje s %1 – klepněte na Nahradit, pokud chcete, aby začala platit pro tuto akci</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="682"/>
-        <location filename="../src/common/settings.cpp" line="695"/>
-        <location filename="../src/common/settings.cpp" line="704"/>
+        <location filename="../src/common/settings.cpp" line="689"/>
+        <location filename="../src/common/settings.cpp" line="702"/>
+        <location filename="../src/common/settings.cpp" line="711"/>
         <source>The shortcut %1 is invalid, please set another one.</source>
         <translation>Zkratka %1 není platná – prosím nastavte jinou.</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="736"/>
+        <location filename="../src/common/settings.cpp" line="743"/>
         <source>Cancel</source>
         <translation>Zrušit</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="737"/>
+        <location filename="../src/common/settings.cpp" line="744"/>
         <source>Replace</source>
         <translation>Nahradit</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="740"/>
+        <location filename="../src/common/settings.cpp" line="747"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
@@ -926,7 +977,7 @@
 <context>
     <name>StartManager</name>
     <message>
-        <location filename="../src/startmanager.cpp" line="411"/>
+        <location filename="../src/startmanager.cpp" line="425"/>
         <source>Untitled %1</source>
         <translation>Bez názvu %1</translation>
     </message>
@@ -934,32 +985,32 @@
 <context>
     <name>Tabbar</name>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="641"/>
+        <location filename="../src/controls/tabbar.cpp" line="678"/>
         <source>Close tab</source>
         <translation>Zavřít kartu</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="642"/>
+        <location filename="../src/controls/tabbar.cpp" line="680"/>
         <source>Close other tabs</source>
         <translation>Zavřít ostatní karty</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="643"/>
+        <location filename="../src/controls/tabbar.cpp" line="682"/>
         <source>More options</source>
         <translation>Další volby</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="644"/>
+        <location filename="../src/controls/tabbar.cpp" line="684"/>
         <source>Close tabs to the left</source>
         <translation>Zavřít karty nalevo</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="645"/>
+        <location filename="../src/controls/tabbar.cpp" line="686"/>
         <source>Close tabs to the right</source>
         <translation>Zavřít karty napravo</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="646"/>
+        <location filename="../src/controls/tabbar.cpp" line="688"/>
         <source>Close unmodified tabs</source>
         <translation>Zavřít karty, kterých obsah se nezměnil</translation>
     </message>
@@ -967,263 +1018,280 @@
 <context>
     <name>TextEdit</name>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="305"/>
+        <location filename="../src/editor/dtextedit.cpp" line="388"/>
         <source>Undo</source>
         <translation>Zpět</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="306"/>
+        <location filename="../src/editor/dtextedit.cpp" line="390"/>
         <source>Redo</source>
         <translation>Znovu</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="307"/>
+        <location filename="../src/editor/dtextedit.cpp" line="392"/>
         <source>Cut</source>
         <translation>Vyjmout</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="308"/>
+        <location filename="../src/editor/dtextedit.cpp" line="394"/>
         <source>Copy</source>
         <translation>Zkopírovat</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="309"/>
+        <location filename="../src/editor/dtextedit.cpp" line="396"/>
         <source>Paste</source>
         <translation>Vložit</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="310"/>
+        <location filename="../src/editor/dtextedit.cpp" line="398"/>
         <source>Delete</source>
         <translation>Smazat</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="311"/>
+        <location filename="../src/editor/dtextedit.cpp" line="400"/>
         <source>Select All</source>
         <translation>Vybrat vše</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="312"/>
-        <location filename="../src/widgets/window.cpp" line="535"/>
+        <location filename="../src/editor/dtextedit.cpp" line="402"/>
+        <location filename="../src/widgets/window.cpp" line="556"/>
         <source>Find</source>
         <translation>Najít</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="313"/>
-        <location filename="../src/widgets/window.cpp" line="536"/>
+        <location filename="../src/editor/dtextedit.cpp" line="404"/>
+        <location filename="../src/widgets/window.cpp" line="558"/>
         <source>Replace</source>
         <translation>Nahradit</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="314"/>
+        <location filename="../src/editor/dtextedit.cpp" line="406"/>
         <source>Go to Line</source>
         <translation>Jít na řádek</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="315"/>
-        <source>Turn on Read-Only mode</source>
-        <translation>Zapnout režim pouze pro čtení</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="316"/>
-        <source>Turn off Read-Only mode</source>
-        <translation>Vypnout režim pouze pro čtení</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="317"/>
+        <location filename="../src/editor/dtextedit.cpp" line="415"/>
         <source>Fullscreen</source>
         <translation>Na celou obrazovku</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="318"/>
+        <location filename="../src/editor/dtextedit.cpp" line="417"/>
         <source>Exit fullscreen</source>
         <translation>Opustit zobrazení na celou obrazovku</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="319"/>
+        <location filename="../src/editor/dtextedit.cpp" line="419"/>
         <source>Display in file manager</source>
         <translation>Zobrazit ve správci souborů</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="320"/>
-        <location filename="../src/editor/dtextedit.cpp" line="374"/>
+        <location filename="../src/editor/dtextedit.cpp" line="421"/>
+        <location filename="../src/editor/dtextedit.cpp" line="493"/>
         <source>Add Comment</source>
         <translation>Přidat komentář</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="321"/>
+        <location filename="../src/editor/dtextedit.cpp" line="423"/>
         <source>Text to Speech</source>
         <translation>Text na řeč</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="322"/>
-        <source>Stop reading</source>
-        <translation>Zastavit předčítání</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="323"/>
+        <location filename="../src/editor/dtextedit.cpp" line="425"/>
         <source>Speech to Text</source>
         <translation>Řeč na text</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="324"/>
+        <location filename="../src/editor/dtextedit.cpp" line="427"/>
         <source>Translate</source>
         <translation>Přeložit</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="325"/>
+        <location filename="../src/editor/dtextedit.cpp" line="429"/>
         <source>Column Mode</source>
         <translation>Sloupcový režim</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="326"/>
+        <location filename="../src/editor/dtextedit.cpp" line="431"/>
         <source>Add bookmark</source>
         <translation>Přidat záložku</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="327"/>
+        <location filename="../src/editor/dtextedit.cpp" line="433"/>
         <source>Remove Bookmark</source>
         <translation>Odebrat záložku</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="328"/>
+        <location filename="../src/editor/dtextedit.cpp" line="435"/>
         <source>Previous bookmark</source>
         <translation>Předchozí záložka</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="329"/>
+        <location filename="../src/editor/dtextedit.cpp" line="437"/>
         <source>Next bookmark</source>
         <translation>Další záložka</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="330"/>
+        <location filename="../src/editor/dtextedit.cpp" line="439"/>
         <source>Remove All Bookmarks</source>
         <translation>Odebrat veškeré záložky</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="331"/>
+        <location filename="../src/editor/dtextedit.cpp" line="441"/>
         <source>Fold All</source>
         <translation>Sbalit vše</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="332"/>
+        <location filename="../src/editor/dtextedit.cpp" line="443"/>
         <source>Fold Current Level</source>
         <translation>Sbalit stávající úroveň</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="333"/>
+        <location filename="../src/editor/dtextedit.cpp" line="445"/>
         <source>Unfold All</source>
         <translation>Rozbalit vše</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="334"/>
+        <location filename="../src/editor/dtextedit.cpp" line="447"/>
         <source>Unfold Current Level</source>
         <translation>Rozbalit stávající úroveň</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="339"/>
+        <location filename="../src/editor/dtextedit.cpp" line="453"/>
         <source>Color Mark</source>
         <translation>Barevná značka</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="343"/>
+        <location filename="../src/editor/dtextedit.cpp" line="458"/>
         <source>Clear All Marks</source>
         <translation>Vymazat všechny značky</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="344"/>
+        <location filename="../src/editor/dtextedit.cpp" line="460"/>
         <source>Clear Last Mark</source>
         <translation>Vymazat poslední značku</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="353"/>
+        <location filename="../src/editor/dtextedit.cpp" line="470"/>
         <source>Mark</source>
         <translation>Označit</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="366"/>
+        <location filename="../src/editor/dtextedit.cpp" line="484"/>
         <source>Mark All</source>
         <translation>Označit vše</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="375"/>
+        <location filename="../src/editor/dtextedit.cpp" line="494"/>
         <source>Remove Comment</source>
         <translation>Odebrat komentář</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3208"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3211"/>
+        <location filename="../src/editor/dtextedit.cpp" line="543"/>
+        <source>View Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="3531"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3534"/>
         <source>Copy failed: not enough memory</source>
         <translation>Kopírování se nezdařilo: nedostatek paměti</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3333"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3335"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3656"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3658"/>
         <source>Press ALT and click lines to edit in column mode</source>
         <translation>Pro upravování ve sloupcovém režimu stiskněte ALT a klepejte na řádky</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="418"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9574"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9576"/>
+        <source>No audio output device was detected. Please ensure your speakers or headphones are properly connected and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="9583"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9585"/>
+        <source>No audio input device was detected. Please ensure your speakers or headphones are properly connected and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="534"/>
         <source>Change Case</source>
         <translation>Změnit velikost písmen</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="419"/>
+        <location filename="../src/editor/dtextedit.cpp" line="409"/>
+        <source>Edit Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="411"/>
+        <source>Read View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="413"/>
+        <source>Live Preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="535"/>
         <source>Upper Case</source>
         <translation>Velká písmena</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="420"/>
+        <location filename="../src/editor/dtextedit.cpp" line="536"/>
         <source>Lower Case</source>
         <translation>Malá písmena</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="421"/>
+        <location filename="../src/editor/dtextedit.cpp" line="537"/>
         <source>Capitalize</source>
         <translation>Vše velkými písmeny</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="78"/>
+        <location filename="../src/widgets/bottombar.cpp" line="110"/>
         <source>None</source>
         <translation>Žádné</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1363"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1490"/>
         <source>Selected line(s) copied</source>
         <translation>Vybraný řádek (řádky) zkopírován</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1370"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1497"/>
         <source>Current line copied</source>
         <translation>Stávající řádek zkopírován</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1400"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1527"/>
         <source>Selected line(s) clipped</source>
         <translation>Vybraný řádek (řádky) zkrácen</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1412"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1539"/>
         <source>Current line clipped</source>
         <translation>Stávající řádek zkrácen</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3227"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3230"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3550"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3553"/>
         <source>Paste failed: not enough memory</source>
         <translation>Vložení se nezdařilo: nedostatek paměti</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="4548"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4873"/>
         <source>Read-Only mode is off</source>
         <translation>Režim pouze pro čtení je vypnut</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="4560"/>
-        <location filename="../src/editor/dtextedit.cpp" line="4584"/>
-        <location filename="../src/editor/dtextedit.cpp" line="7896"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8007"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8015"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8026"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4885"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4909"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8236"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8347"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8355"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8366"/>
         <source>Read-Only mode is on</source>
         <translation>Režim pouze pro čtení je zapnut</translation>
     </message>
@@ -1231,138 +1299,175 @@
 <context>
     <name>WarningNotices</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="24"/>
+        <location filename="../src/controls/warningnotices.cpp" line="25"/>
         <source>Reload</source>
         <translation>Načíst znovu</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/warningnotices.cpp" line="29"/>
+        <source>Edit Anyway</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>Window</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="25"/>
-        <location filename="../src/widgets/window.cpp" line="531"/>
+        <location filename="../src/controls/warningnotices.cpp" line="27"/>
+        <location filename="../src/widgets/window.cpp" line="548"/>
         <source>Save as</source>
         <translation>Uložit jako</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="527"/>
+        <location filename="../src/widgets/window.cpp" line="540"/>
         <source>New window</source>
         <translation>Nové okno</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="528"/>
+        <location filename="../src/widgets/window.cpp" line="542"/>
         <source>New tab</source>
         <translation>Nová karta</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="529"/>
+        <location filename="../src/widgets/window.cpp" line="544"/>
         <source>Open file</source>
         <translation>Otevřít soubor</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="530"/>
-        <location filename="../src/widgets/window.cpp" line="3545"/>
+        <location filename="../src/widgets/window.cpp" line="546"/>
+        <location filename="../src/widgets/window.cpp" line="3950"/>
         <source>Save</source>
         <translation>Uložit</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="532"/>
+        <location filename="../src/widgets/window.cpp" line="550"/>
         <source>Print</source>
         <translation>Tisk</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="533"/>
+        <location filename="../src/widgets/window.cpp" line="552"/>
         <source>Switch theme</source>
         <translation>Přepnout vzhled</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="534"/>
-        <location filename="../src/widgets/window.cpp" line="2448"/>
+        <location filename="../src/widgets/window.cpp" line="554"/>
+        <location filename="../src/widgets/window.cpp" line="2641"/>
         <source>Settings</source>
         <translation>Nastavení</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="666"/>
-        <location filename="../src/widgets/window.cpp" line="3845"/>
+        <location filename="../src/widgets/window.cpp" line="696"/>
+        <location filename="../src/widgets/window.cpp" line="4250"/>
         <source>Read-Only</source>
         <translation>Pouze pro čtení</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="687"/>
+        <location filename="../src/widgets/window.cpp" line="719"/>
         <source>You do not have permission to open %1</source>
         <translation>Nemáte oprávnění pro otevření %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="738"/>
-        <location filename="../src/widgets/window.cpp" line="2963"/>
+        <location filename="../src/widgets/window.cpp" line="773"/>
+        <location filename="../src/widgets/window.cpp" line="3266"/>
         <source>Invalid file: %1</source>
         <translation>Neplatný soubor: %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="903"/>
-        <location filename="../src/widgets/window.cpp" line="956"/>
+        <location filename="../src/widgets/window.cpp" line="957"/>
+        <location filename="../src/widgets/window.cpp" line="1050"/>
+        <location filename="../src/widgets/window.cpp" line="3217"/>
         <source>Do you want to save this file?</source>
         <translation>Chcete tento soubor uložit?</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1290"/>
+        <location filename="../src/widgets/window.cpp" line="1381"/>
+        <source>Invalid characters detected while saving &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1382"/>
+        <source>If you force save this file, it may cause file corruption. Still want to save?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1386"/>
+        <source>Don&apos;t Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1387"/>
+        <source>Save As</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1388"/>
+        <source>Save Anyway</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1456"/>
         <source>You do not have permission to save %1</source>
         <translation>Nemáte oprávnění pro uložení %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1312"/>
+        <location filename="../src/widgets/window.cpp" line="1428"/>
+        <location filename="../src/widgets/window.cpp" line="1478"/>
         <source>Saved successfully</source>
         <translation>Úspěšně uloženo</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1354"/>
-        <location filename="../src/widgets/window.cpp" line="1481"/>
-        <location filename="../src/widgets/window.cpp" line="1529"/>
+        <location filename="../src/widgets/window.cpp" line="1520"/>
+        <location filename="../src/widgets/window.cpp" line="1665"/>
+        <location filename="../src/widgets/window.cpp" line="1713"/>
         <source>Save File</source>
         <translation>Uložit soubor</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1483"/>
+        <location filename="../src/widgets/window.cpp" line="1569"/>
+        <source>Cannot save as the original file in preview mode. Please choose a different path.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1667"/>
         <source>Encoding</source>
         <translation>Kódování znaků</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1773"/>
+        <location filename="../src/widgets/window.cpp" line="1957"/>
         <source>Read-Only mode is on</source>
         <translation>Režim pouze pro čtení je zapnut</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2322"/>
+        <location filename="../src/widgets/window.cpp" line="2511"/>
         <source>Current location remembered</source>
         <translation>Stávající pozice zapamatována</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2398"/>
+        <location filename="../src/widgets/window.cpp" line="2591"/>
         <source>Ctrl+&apos;=&apos;</source>
         <translation>Ctrl + =</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2401"/>
+        <location filename="../src/widgets/window.cpp" line="2594"/>
         <source>Ctrl+&apos;-&apos;</source>
         <translation>Ctlr + -</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2430"/>
+        <location filename="../src/widgets/window.cpp" line="2623"/>
         <source>Editor</source>
         <translation>Editor</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3061"/>
+        <location filename="../src/widgets/window.cpp" line="3436"/>
         <source>Untitled %1</source>
         <translation>Bez názvu %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3543"/>
+        <location filename="../src/widgets/window.cpp" line="3948"/>
         <source>Cancel</source>
         <translation>Zrušit</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3544"/>
+        <location filename="../src/widgets/window.cpp" line="3949"/>
         <source>Discard</source>
         <translation>Zahodit</translation>
     </message>

--- a/translations/deepin-editor_da.ts
+++ b/translations/deepin-editor_da.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="da">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="da">
 <context>
     <name>BottomBar</name>
     <message>
@@ -17,17 +19,36 @@
         <translation>Tegn %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="44"/>
+        <location filename="../src/widgets/bottombar.cpp" line="47"/>
         <source>Loading:</source>
         <translation>Indlæser:</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="73"/>
+        <location filename="../src/widgets/bottombar.cpp" line="91"/>
+        <location filename="../src/widgets/bottombar.cpp" line="499"/>
+        <source>Edit Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="74"/>
+        <location filename="../src/widgets/bottombar.cpp" line="489"/>
+        <source>Read View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="75"/>
+        <location filename="../src/widgets/bottombar.cpp" line="493"/>
+        <source>Live Preview</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DDropdownMenu</name>
     <message>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="362"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="420"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="425"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="363"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="421"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="426"/>
         <source>None</source>
         <translation>Ingen</translation>
     </message>
@@ -35,68 +56,57 @@
 <context>
     <name>EditWrapper</name>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="292"/>
-        <location filename="../src/editor/editwrapper.cpp" line="365"/>
-        <location filename="../src/editor/editwrapper.cpp" line="521"/>
-        <location filename="../src/editor/editwrapper.cpp" line="751"/>
+        <location filename="../src/editor/editwrapper.cpp" line="355"/>
+        <location filename="../src/editor/editwrapper.cpp" line="429"/>
+        <location filename="../src/editor/editwrapper.cpp" line="595"/>
+        <location filename="../src/editor/editwrapper.cpp" line="887"/>
         <source>Save</source>
         <translation>Gem</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="516"/>
+        <location filename="../src/editor/editwrapper.cpp" line="590"/>
         <source>Do you want to save this file?</source>
         <translation>Vil du gemme filen?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="363"/>
-        <location filename="../src/editor/editwrapper.cpp" line="519"/>
+        <location filename="../src/editor/editwrapper.cpp" line="427"/>
+        <location filename="../src/editor/editwrapper.cpp" line="593"/>
         <source>Cancel</source>
         <translation>Annuller</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="360"/>
+        <location filename="../src/editor/editwrapper.cpp" line="424"/>
         <source>Encoding changed. Do you want to save the file now?</source>
         <translation>Kodning ændret. Vil du gemme filen nu?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="520"/>
+        <location filename="../src/editor/editwrapper.cpp" line="594"/>
         <source>Discard</source>
         <translation>Forkast</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="274"/>
-        <location filename="../src/editor/editwrapper.cpp" line="620"/>
+        <location filename="../src/editor/editwrapper.cpp" line="1121"/>
+        <source>The file contains invalid characters (NUL). Preview mode is read-only.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="337"/>
+        <location filename="../src/editor/editwrapper.cpp" line="705"/>
         <source>You do not have permission to save %1</source>
         <translation>Du har ikke tilladelse til at gemme %1</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="836"/>
+        <location filename="../src/editor/editwrapper.cpp" line="987"/>
         <source>File removed on the disk. Save it now?</source>
         <translation>Filen er fjernet fra disken. Gem den nu?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="842"/>
+        <location filename="../src/editor/editwrapper.cpp" line="993"/>
         <source>File has changed on disk. Reload?</source>
         <translation>Filen er blevet ændret på disken. Genindlæs?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="884"/>
-        <location filename="../src/widgets/bottombar.cpp" line="74"/>
-        <source>INSERT</source>
-        <translation>INDSÆT</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="888"/>
-        <source>OVERWRITE</source>
-        <translation>OVERSKRIV</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="892"/>
-        <source>R/O</source>
-        <translation>SB</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="1618"/>
+        <location filename="../src/editor/editwrapper.cpp" line="1806"/>
         <source>The file cannot be read, which may be too large or has been damaged!</source>
         <translation>Filen kan ikke læses, hvilket kan skyldes, at den er for stor eller beskadiget!</translation>
     </message>
@@ -109,17 +119,17 @@
         <translation>Find</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="36"/>
+        <location filename="../src/controls/findbar.cpp" line="38"/>
         <source>Previous</source>
         <translation>Forrige</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="37"/>
+        <location filename="../src/controls/findbar.cpp" line="40"/>
         <source>Next</source>
         <translation>Næste</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="38"/>
+        <location filename="../src/controls/findbar.cpp" line="42"/>
         <source>Replace</source>
         <translation>Erstat</translation>
     </message>
@@ -127,9 +137,17 @@
 <context>
     <name>JumpLineBar</name>
     <message>
-        <location filename="../src/controls/jumplinebar.cpp" line="45"/>
+        <location filename="../src/controls/jumplinebar.cpp" line="46"/>
         <source>Go to Line: </source>
         <translation>Gå til linje: </translation>
+    </message>
+</context>
+<context>
+    <name>LineBar</name>
+    <message>
+        <location filename="../src/controls/linebar.cpp" line="144"/>
+        <source>第%1/%2项</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -146,19 +164,47 @@
     </message>
 </context>
 <context>
+    <name>MarkdownBridge</name>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="37"/>
+        <source>Collapse code block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="38"/>
+        <source>Expand code block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="39"/>
+        <source>Copy code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="40"/>
+        <source>Expand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="42"/>
+        <source>%1 line(s) of code collapsed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PathSettingWgt</name>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="84"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="90"/>
         <source>Remember the last used path</source>
         <translation>Husk den sidst brugte sti</translation>
     </message>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="85"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="91"/>
         <source>Same path as the current file</source>
         <translation>Samme sti som den aktuelle fil</translation>
     </message>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="86"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="92"/>
         <source>Customize the default path</source>
         <translation>Tilpas standardsti</translation>
     </message>
@@ -171,15 +217,20 @@
         <translation>Teksteditor</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="294"/>
-        <location filename="../src/editor/editwrapper.cpp" line="761"/>
-        <location filename="../src/editor/editwrapper.cpp" line="776"/>
-        <location filename="../src/widgets/window.cpp" line="1362"/>
-        <location filename="../src/widgets/window.cpp" line="1390"/>
-        <location filename="../src/widgets/window.cpp" line="1531"/>
-        <location filename="../src/widgets/window.cpp" line="1548"/>
+        <location filename="../src/editor/editwrapper.cpp" line="357"/>
+        <location filename="../src/editor/editwrapper.cpp" line="897"/>
+        <location filename="../src/editor/editwrapper.cpp" line="912"/>
+        <location filename="../src/widgets/window.cpp" line="1528"/>
+        <location filename="../src/widgets/window.cpp" line="1556"/>
+        <location filename="../src/widgets/window.cpp" line="1715"/>
+        <location filename="../src/widgets/window.cpp" line="1732"/>
         <source>Encoding</source>
         <translation>Kodning</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="2001"/>
+        <source>视图模式</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="11"/>
@@ -215,7 +266,7 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="18"/>
         <location filename="../src/controls/settingsdialog.cpp" line="96"/>
-        <location filename="../src/widgets/window.cpp" line="2388"/>
+        <location filename="../src/widgets/window.cpp" line="2581"/>
         <source>Window</source>
         <translation>Vindue</translation>
     </message>
@@ -755,68 +806,68 @@
         <translation>Vietnamesisk</translation>
     </message>
     <message>
-        <location filename="../src/startmanager.cpp" line="971"/>
+        <location filename="../src/startmanager.cpp" line="1035"/>
         <source>File not saved</source>
         <translation>Filen er ikke gemt</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1532"/>
-        <location filename="../src/widgets/window.cpp" line="1549"/>
+        <location filename="../src/widgets/window.cpp" line="1716"/>
+        <location filename="../src/widgets/window.cpp" line="1733"/>
         <source>Line Endings</source>
         <translation>Linjeskift</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="243"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="379"/>
         <source>Please install &apos;UOS AI&apos; from the App Store before using</source>
         <translation>Vennligst installer &apos;UOS AI&apos; fra AppStore inden brug</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="245"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="381"/>
         <source>No audio input device detected. Please check and try again</source>
         <translation>Ingen lydindgangsudstyr er detekteret. Tjek og prøv igen</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="247"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="383"/>
         <source>No audio output device detected. Please check and try again</source>
         <translation>Ingen lydoutputudstyr er detekteret. Tjek og prøv igen</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="69"/>
+        <location filename="../src/common/text_file_saver.cpp" line="74"/>
         <source>File path is empty</source>
         <translation>Filenavnet er tomt</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="155"/>
+        <location filename="../src/common/text_file_saver.cpp" line="153"/>
         <source>Insufficient memory to load document content</source>
         <translation>Utilstrækkeligt hukommelse til at indlæse dokumentindhold</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="177"/>
+        <location filename="../src/common/text_file_saver.cpp" line="178"/>
         <source>Insufficient memory for encoding conversion</source>
         <translation>Utilstrækkeligt hukommelse til kodetranslation</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="183"/>
+        <location filename="../src/common/text_file_saver.cpp" line="184"/>
         <source>Encoding conversion failed</source>
         <translation>Kodetranslation fejlede</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="189"/>
+        <location filename="../src/common/text_file_saver.cpp" line="190"/>
         <source>Converted content is empty</source>
         <translation>Det konverterede indhold er tomt</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="207"/>
+        <location filename="../src/common/text_file_saver.cpp" line="208"/>
         <source>Memory allocation failed</source>
         <translation>Hukommelsesallokering fejlede</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="211"/>
+        <location filename="../src/common/text_file_saver.cpp" line="212"/>
         <source>Error occurred: %1</source>
         <translation>Fejl opstod: %1</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="215"/>
+        <location filename="../src/common/text_file_saver.cpp" line="216"/>
         <source>Unknown error occurred</source>
         <translation>Ukendt fejl opstod</translation>
     </message>
@@ -829,27 +880,27 @@
         <translation>Find</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="34"/>
+        <location filename="../src/controls/replacebar.cpp" line="36"/>
         <source>Replace With</source>
         <translation>Erstat med</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="36"/>
+        <location filename="../src/controls/replacebar.cpp" line="40"/>
         <source>Replace</source>
         <translation>Erstat</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="37"/>
+        <location filename="../src/controls/replacebar.cpp" line="42"/>
         <source>Skip</source>
         <translation>Spring over</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="38"/>
+        <location filename="../src/controls/replacebar.cpp" line="44"/>
         <source>Replace Rest</source>
         <translation>Erstat resten</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="39"/>
+        <location filename="../src/controls/replacebar.cpp" line="46"/>
         <source>Replace All</source>
         <translation>Erstat alle</translation>
     </message>
@@ -858,9 +909,9 @@
     <name>S:</name>
     <message>
         <location filename="../third/libiconv-1.16/src/iconv.c" line="103"/>
-        <source/>
+        <source></source>
         <comment>The first line of the short usage message.</comment>
-        <translation type="unfinished"/>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -891,36 +942,36 @@
         <translation>Fuldskærm</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="484"/>
+        <location filename="../src/common/settings.cpp" line="491"/>
         <source>This shortcut conflicts with system shortcut %1</source>
         <translation>Denne genknytning kolliderer med systemgenk nyttelse %1</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="487"/>
+        <location filename="../src/common/settings.cpp" line="494"/>
         <source>This shortcut conflicts with %1, click on Replace to make this shortcut effective immediately</source>
         <translation>&gt;-
 Denne genknytning kolliderer med %1, klik på Erstat for at gøre denne genknytning
 aktiv umiddelbart</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="682"/>
-        <location filename="../src/common/settings.cpp" line="695"/>
-        <location filename="../src/common/settings.cpp" line="704"/>
+        <location filename="../src/common/settings.cpp" line="689"/>
+        <location filename="../src/common/settings.cpp" line="702"/>
+        <location filename="../src/common/settings.cpp" line="711"/>
         <source>The shortcut %1 is invalid, please set another one.</source>
         <translation>Denne genknytning %1 er ugyldig, venligst indstil en anden.</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="736"/>
+        <location filename="../src/common/settings.cpp" line="743"/>
         <source>Cancel</source>
         <translation>Annuller</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="737"/>
+        <location filename="../src/common/settings.cpp" line="744"/>
         <source>Replace</source>
         <translation>Erstat</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="740"/>
+        <location filename="../src/common/settings.cpp" line="747"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
@@ -928,7 +979,7 @@ aktiv umiddelbart</translation>
 <context>
     <name>StartManager</name>
     <message>
-        <location filename="../src/startmanager.cpp" line="411"/>
+        <location filename="../src/startmanager.cpp" line="425"/>
         <source>Untitled %1</source>
         <translation>Unavngivet %1</translation>
     </message>
@@ -936,32 +987,32 @@ aktiv umiddelbart</translation>
 <context>
     <name>Tabbar</name>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="641"/>
+        <location filename="../src/controls/tabbar.cpp" line="678"/>
         <source>Close tab</source>
         <translation>Luk faneblad</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="642"/>
+        <location filename="../src/controls/tabbar.cpp" line="680"/>
         <source>Close other tabs</source>
         <translation>Luk andre faneblade</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="643"/>
+        <location filename="../src/controls/tabbar.cpp" line="682"/>
         <source>More options</source>
         <translation>Flere muligheder</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="644"/>
+        <location filename="../src/controls/tabbar.cpp" line="684"/>
         <source>Close tabs to the left</source>
         <translation>Luk faneblad til venstre</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="645"/>
+        <location filename="../src/controls/tabbar.cpp" line="686"/>
         <source>Close tabs to the right</source>
         <translation>Luk faneblad til højre</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="646"/>
+        <location filename="../src/controls/tabbar.cpp" line="688"/>
         <source>Close unmodified tabs</source>
         <translation>Luk ubehandlede faneblad</translation>
     </message>
@@ -969,263 +1020,280 @@ aktiv umiddelbart</translation>
 <context>
     <name>TextEdit</name>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="305"/>
+        <location filename="../src/editor/dtextedit.cpp" line="388"/>
         <source>Undo</source>
         <translation>Fortryd</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="306"/>
+        <location filename="../src/editor/dtextedit.cpp" line="390"/>
         <source>Redo</source>
         <translation>Omgør</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="307"/>
+        <location filename="../src/editor/dtextedit.cpp" line="392"/>
         <source>Cut</source>
         <translation>Klip</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="308"/>
+        <location filename="../src/editor/dtextedit.cpp" line="394"/>
         <source>Copy</source>
         <translation>Kopiér</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="309"/>
+        <location filename="../src/editor/dtextedit.cpp" line="396"/>
         <source>Paste</source>
         <translation>Indsæt</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="310"/>
+        <location filename="../src/editor/dtextedit.cpp" line="398"/>
         <source>Delete</source>
         <translation>Slet</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="311"/>
+        <location filename="../src/editor/dtextedit.cpp" line="400"/>
         <source>Select All</source>
         <translation>Markér alt</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="312"/>
-        <location filename="../src/widgets/window.cpp" line="535"/>
+        <location filename="../src/editor/dtextedit.cpp" line="402"/>
+        <location filename="../src/widgets/window.cpp" line="556"/>
         <source>Find</source>
         <translation>Find</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="313"/>
-        <location filename="../src/widgets/window.cpp" line="536"/>
+        <location filename="../src/editor/dtextedit.cpp" line="404"/>
+        <location filename="../src/widgets/window.cpp" line="558"/>
         <source>Replace</source>
         <translation>Erstat</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="314"/>
+        <location filename="../src/editor/dtextedit.cpp" line="406"/>
         <source>Go to Line</source>
         <translation>Gå til linje</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="315"/>
-        <source>Turn on Read-Only mode</source>
-        <translation>Aktivér skrivebeskyttet tilstand</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="316"/>
-        <source>Turn off Read-Only mode</source>
-        <translation>Deaktivér skrivebeskyttet tilstand</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="317"/>
+        <location filename="../src/editor/dtextedit.cpp" line="415"/>
         <source>Fullscreen</source>
         <translation>Fuldskærm</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="318"/>
+        <location filename="../src/editor/dtextedit.cpp" line="417"/>
         <source>Exit fullscreen</source>
         <translation>Afslut fuldskærm</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="319"/>
+        <location filename="../src/editor/dtextedit.cpp" line="419"/>
         <source>Display in file manager</source>
         <translation>Vis i filhåndtering</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="320"/>
-        <location filename="../src/editor/dtextedit.cpp" line="374"/>
+        <location filename="../src/editor/dtextedit.cpp" line="421"/>
+        <location filename="../src/editor/dtextedit.cpp" line="493"/>
         <source>Add Comment</source>
         <translation>Tilføj kommentar</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="321"/>
+        <location filename="../src/editor/dtextedit.cpp" line="423"/>
         <source>Text to Speech</source>
         <translation>Tekst til tale</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="322"/>
-        <source>Stop reading</source>
-        <translation>Stop reading</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="323"/>
+        <location filename="../src/editor/dtextedit.cpp" line="425"/>
         <source>Speech to Text</source>
         <translation>Tale til tekst</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="324"/>
+        <location filename="../src/editor/dtextedit.cpp" line="427"/>
         <source>Translate</source>
         <translation>Oversæt</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="325"/>
+        <location filename="../src/editor/dtextedit.cpp" line="429"/>
         <source>Column Mode</source>
         <translation>Søjlevis</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="326"/>
+        <location filename="../src/editor/dtextedit.cpp" line="431"/>
         <source>Add bookmark</source>
         <translation>Tilføj bogmærke</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="327"/>
+        <location filename="../src/editor/dtextedit.cpp" line="433"/>
         <source>Remove Bookmark</source>
         <translation>Fjern bogmærke</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="328"/>
+        <location filename="../src/editor/dtextedit.cpp" line="435"/>
         <source>Previous bookmark</source>
         <translation>Forrige bogmærke</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="329"/>
+        <location filename="../src/editor/dtextedit.cpp" line="437"/>
         <source>Next bookmark</source>
         <translation>Næste bogmærke</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="330"/>
+        <location filename="../src/editor/dtextedit.cpp" line="439"/>
         <source>Remove All Bookmarks</source>
         <translation>Fjern alle bogmærker</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="331"/>
+        <location filename="../src/editor/dtextedit.cpp" line="441"/>
         <source>Fold All</source>
         <translation>Fold alle</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="332"/>
+        <location filename="../src/editor/dtextedit.cpp" line="443"/>
         <source>Fold Current Level</source>
         <translation>Fold nuværende niveau</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="333"/>
+        <location filename="../src/editor/dtextedit.cpp" line="445"/>
         <source>Unfold All</source>
         <translation>Ufold alle</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="334"/>
+        <location filename="../src/editor/dtextedit.cpp" line="447"/>
         <source>Unfold Current Level</source>
         <translation>Ufold nuværende niveau</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="339"/>
+        <location filename="../src/editor/dtextedit.cpp" line="453"/>
         <source>Color Mark</source>
         <translation>Farve markering</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="343"/>
+        <location filename="../src/editor/dtextedit.cpp" line="458"/>
         <source>Clear All Marks</source>
         <translation>Ryd alle markeringer</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="344"/>
+        <location filename="../src/editor/dtextedit.cpp" line="460"/>
         <source>Clear Last Mark</source>
         <translation>Ryd sidste markering</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="353"/>
+        <location filename="../src/editor/dtextedit.cpp" line="470"/>
         <source>Mark</source>
         <translation>Sæt mærke</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="366"/>
+        <location filename="../src/editor/dtextedit.cpp" line="484"/>
         <source>Mark All</source>
         <translation>Markér alle</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="375"/>
+        <location filename="../src/editor/dtextedit.cpp" line="494"/>
         <source>Remove Comment</source>
         <translation>Fjern kommentar</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3208"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3211"/>
+        <location filename="../src/editor/dtextedit.cpp" line="543"/>
+        <source>View Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="3531"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3534"/>
         <source>Copy failed: not enough memory</source>
         <translation>Kopier fejlet: ikke nok hukommelse</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3333"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3335"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3656"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3658"/>
         <source>Press ALT and click lines to edit in column mode</source>
         <translation>Tryk ALT og klik på linjer for at redigere i søjlevis</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="418"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9574"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9576"/>
+        <source>No audio output device was detected. Please ensure your speakers or headphones are properly connected and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="9583"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9585"/>
+        <source>No audio input device was detected. Please ensure your speakers or headphones are properly connected and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="534"/>
         <source>Change Case</source>
         <translation>Skift store/små bogstaver</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="419"/>
+        <location filename="../src/editor/dtextedit.cpp" line="409"/>
+        <source>Edit Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="411"/>
+        <source>Read View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="413"/>
+        <source>Live Preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="535"/>
         <source>Upper Case</source>
         <translation>Store bogstaver</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="420"/>
+        <location filename="../src/editor/dtextedit.cpp" line="536"/>
         <source>Lower Case</source>
         <translation>Små bogstaver</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="421"/>
+        <location filename="../src/editor/dtextedit.cpp" line="537"/>
         <source>Capitalize</source>
         <translation>Stort begyndelsesbogstav</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="78"/>
+        <location filename="../src/widgets/bottombar.cpp" line="110"/>
         <source>None</source>
         <translation>Ingen</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1363"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1490"/>
         <source>Selected line(s) copied</source>
         <translation>Valgte linje(r) kopieret</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1370"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1497"/>
         <source>Current line copied</source>
         <translation>Nuværende linje kopieret</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1400"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1527"/>
         <source>Selected line(s) clipped</source>
         <translation>Valgte linje(r) beskåret</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1412"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1539"/>
         <source>Current line clipped</source>
         <translation>Nuværende linje beskåret</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3227"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3230"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3550"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3553"/>
         <source>Paste failed: not enough memory</source>
         <translation>Indsæt fejlet: ikke nok hukommelse</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="4548"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4873"/>
         <source>Read-Only mode is off</source>
         <translation>Skrivebeskyttet tilstand er deaktiveret</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="4560"/>
-        <location filename="../src/editor/dtextedit.cpp" line="4584"/>
-        <location filename="../src/editor/dtextedit.cpp" line="7896"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8007"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8015"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8026"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4885"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4909"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8236"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8347"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8355"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8366"/>
         <source>Read-Only mode is on</source>
         <translation>Skrivebeskyttet tilstand er aktiveret</translation>
     </message>
@@ -1233,138 +1301,175 @@ aktiv umiddelbart</translation>
 <context>
     <name>WarningNotices</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="24"/>
+        <location filename="../src/controls/warningnotices.cpp" line="25"/>
         <source>Reload</source>
         <translation>Genindlæs</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/warningnotices.cpp" line="29"/>
+        <source>Edit Anyway</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>Window</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="25"/>
-        <location filename="../src/widgets/window.cpp" line="531"/>
+        <location filename="../src/controls/warningnotices.cpp" line="27"/>
+        <location filename="../src/widgets/window.cpp" line="548"/>
         <source>Save as</source>
         <translation>Gem som</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="527"/>
+        <location filename="../src/widgets/window.cpp" line="540"/>
         <source>New window</source>
         <translation>Nyt vindue</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="528"/>
+        <location filename="../src/widgets/window.cpp" line="542"/>
         <source>New tab</source>
         <translation>Nyt faneblad</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="529"/>
+        <location filename="../src/widgets/window.cpp" line="544"/>
         <source>Open file</source>
         <translation>Åbn fil</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="530"/>
-        <location filename="../src/widgets/window.cpp" line="3545"/>
+        <location filename="../src/widgets/window.cpp" line="546"/>
+        <location filename="../src/widgets/window.cpp" line="3950"/>
         <source>Save</source>
         <translation>Gem</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="532"/>
+        <location filename="../src/widgets/window.cpp" line="550"/>
         <source>Print</source>
         <translation>Udskriv</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="533"/>
+        <location filename="../src/widgets/window.cpp" line="552"/>
         <source>Switch theme</source>
         <translation>Skift tema</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="534"/>
-        <location filename="../src/widgets/window.cpp" line="2448"/>
+        <location filename="../src/widgets/window.cpp" line="554"/>
+        <location filename="../src/widgets/window.cpp" line="2641"/>
         <source>Settings</source>
         <translation>Indstillinger</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="666"/>
-        <location filename="../src/widgets/window.cpp" line="3845"/>
+        <location filename="../src/widgets/window.cpp" line="696"/>
+        <location filename="../src/widgets/window.cpp" line="4250"/>
         <source>Read-Only</source>
         <translation>Skrivebeskyttet</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="687"/>
+        <location filename="../src/widgets/window.cpp" line="719"/>
         <source>You do not have permission to open %1</source>
         <translation>Du har ikke tilladelse til at åbne %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="738"/>
-        <location filename="../src/widgets/window.cpp" line="2963"/>
+        <location filename="../src/widgets/window.cpp" line="773"/>
+        <location filename="../src/widgets/window.cpp" line="3266"/>
         <source>Invalid file: %1</source>
         <translation>Ugyldig fil: %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="903"/>
-        <location filename="../src/widgets/window.cpp" line="956"/>
+        <location filename="../src/widgets/window.cpp" line="957"/>
+        <location filename="../src/widgets/window.cpp" line="1050"/>
+        <location filename="../src/widgets/window.cpp" line="3217"/>
         <source>Do you want to save this file?</source>
         <translation>Vil du gemme filen?</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1290"/>
+        <location filename="../src/widgets/window.cpp" line="1381"/>
+        <source>Invalid characters detected while saving &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1382"/>
+        <source>If you force save this file, it may cause file corruption. Still want to save?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1386"/>
+        <source>Don&apos;t Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1387"/>
+        <source>Save As</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1388"/>
+        <source>Save Anyway</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1456"/>
         <source>You do not have permission to save %1</source>
         <translation>Du har ikke tilladelse til at gemme %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1312"/>
+        <location filename="../src/widgets/window.cpp" line="1428"/>
+        <location filename="../src/widgets/window.cpp" line="1478"/>
         <source>Saved successfully</source>
         <translation>Gemt</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1354"/>
-        <location filename="../src/widgets/window.cpp" line="1481"/>
-        <location filename="../src/widgets/window.cpp" line="1529"/>
+        <location filename="../src/widgets/window.cpp" line="1520"/>
+        <location filename="../src/widgets/window.cpp" line="1665"/>
+        <location filename="../src/widgets/window.cpp" line="1713"/>
         <source>Save File</source>
         <translation>Gem fil</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1483"/>
+        <location filename="../src/widgets/window.cpp" line="1569"/>
+        <source>Cannot save as the original file in preview mode. Please choose a different path.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1667"/>
         <source>Encoding</source>
         <translation>Kodning</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1773"/>
+        <location filename="../src/widgets/window.cpp" line="1957"/>
         <source>Read-Only mode is on</source>
         <translation>Skrivebeskyttet tilstand er aktiveret</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2322"/>
+        <location filename="../src/widgets/window.cpp" line="2511"/>
         <source>Current location remembered</source>
         <translation>Nuværende placering husket</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2398"/>
+        <location filename="../src/widgets/window.cpp" line="2591"/>
         <source>Ctrl+&apos;=&apos;</source>
         <translation>Ctrl+=&apos;&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2401"/>
+        <location filename="../src/widgets/window.cpp" line="2594"/>
         <source>Ctrl+&apos;-&apos;</source>
         <translation>Ctrl=&apos;-&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2430"/>
+        <location filename="../src/widgets/window.cpp" line="2623"/>
         <source>Editor</source>
         <translation>Editor</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3061"/>
+        <location filename="../src/widgets/window.cpp" line="3436"/>
         <source>Untitled %1</source>
         <translation>Unavngivet %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3543"/>
+        <location filename="../src/widgets/window.cpp" line="3948"/>
         <source>Cancel</source>
         <translation>Annuller</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3544"/>
+        <location filename="../src/widgets/window.cpp" line="3949"/>
         <source>Discard</source>
         <translation>Forkast</translation>
     </message>

--- a/translations/deepin-editor_de.ts
+++ b/translations/deepin-editor_de.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="de">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="de">
 <context>
     <name>BottomBar</name>
     <message>
@@ -17,17 +19,36 @@
         <translation>Zeichen %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="44"/>
+        <location filename="../src/widgets/bottombar.cpp" line="47"/>
         <source>Loading:</source>
         <translation>Wird geladen:</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="73"/>
+        <location filename="../src/widgets/bottombar.cpp" line="91"/>
+        <location filename="../src/widgets/bottombar.cpp" line="499"/>
+        <source>Edit Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="74"/>
+        <location filename="../src/widgets/bottombar.cpp" line="489"/>
+        <source>Read View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="75"/>
+        <location filename="../src/widgets/bottombar.cpp" line="493"/>
+        <source>Live Preview</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DDropdownMenu</name>
     <message>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="362"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="420"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="425"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="363"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="421"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="426"/>
         <source>None</source>
         <translation>Keines</translation>
     </message>
@@ -35,68 +56,57 @@
 <context>
     <name>EditWrapper</name>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="292"/>
-        <location filename="../src/editor/editwrapper.cpp" line="365"/>
-        <location filename="../src/editor/editwrapper.cpp" line="521"/>
-        <location filename="../src/editor/editwrapper.cpp" line="751"/>
+        <location filename="../src/editor/editwrapper.cpp" line="355"/>
+        <location filename="../src/editor/editwrapper.cpp" line="429"/>
+        <location filename="../src/editor/editwrapper.cpp" line="595"/>
+        <location filename="../src/editor/editwrapper.cpp" line="887"/>
         <source>Save</source>
         <translation>Speichern</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="516"/>
+        <location filename="../src/editor/editwrapper.cpp" line="590"/>
         <source>Do you want to save this file?</source>
         <translation>Möchten Sie diese Datei speichern?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="363"/>
-        <location filename="../src/editor/editwrapper.cpp" line="519"/>
+        <location filename="../src/editor/editwrapper.cpp" line="427"/>
+        <location filename="../src/editor/editwrapper.cpp" line="593"/>
         <source>Cancel</source>
         <translation>Abbrechen</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="360"/>
+        <location filename="../src/editor/editwrapper.cpp" line="424"/>
         <source>Encoding changed. Do you want to save the file now?</source>
         <translation>Kodierung geändert. Wollen Sie die Datei jetzt speichern?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="520"/>
+        <location filename="../src/editor/editwrapper.cpp" line="594"/>
         <source>Discard</source>
         <translation>Verwerfen</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="274"/>
-        <location filename="../src/editor/editwrapper.cpp" line="620"/>
+        <location filename="../src/editor/editwrapper.cpp" line="1121"/>
+        <source>The file contains invalid characters (NUL). Preview mode is read-only.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="337"/>
+        <location filename="../src/editor/editwrapper.cpp" line="705"/>
         <source>You do not have permission to save %1</source>
         <translation>Berechtigung zum Speichern von %1 fehlt</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="836"/>
+        <location filename="../src/editor/editwrapper.cpp" line="987"/>
         <source>File removed on the disk. Save it now?</source>
         <translation>Die Datei wurde von der Festplatte entfernt. Soll die Datei jetzt gespeichert werden. </translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="842"/>
+        <location filename="../src/editor/editwrapper.cpp" line="993"/>
         <source>File has changed on disk. Reload?</source>
         <translation>Die Datei wurde verändert.. Soll die Datei neu geladen werden?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="884"/>
-        <location filename="../src/widgets/bottombar.cpp" line="74"/>
-        <source>INSERT</source>
-        <translation>EINFÜGEN</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="888"/>
-        <source>OVERWRITE</source>
-        <translation>ÜBERSCHREIBEN</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="892"/>
-        <source>R/O</source>
-        <translation>R/O</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="1618"/>
+        <location filename="../src/editor/editwrapper.cpp" line="1806"/>
         <source>The file cannot be read, which may be too large or has been damaged!</source>
         <translation>Die Datei kann nicht gelesen werden, da sie möglicherweise zu groß oder beschädigt ist!</translation>
     </message>
@@ -109,17 +119,17 @@
         <translation>Suchen</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="36"/>
+        <location filename="../src/controls/findbar.cpp" line="38"/>
         <source>Previous</source>
         <translation>Vorheriges</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="37"/>
+        <location filename="../src/controls/findbar.cpp" line="40"/>
         <source>Next</source>
         <translation>Nächstes</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="38"/>
+        <location filename="../src/controls/findbar.cpp" line="42"/>
         <source>Replace</source>
         <translation>Ersetzen</translation>
     </message>
@@ -127,9 +137,17 @@
 <context>
     <name>JumpLineBar</name>
     <message>
-        <location filename="../src/controls/jumplinebar.cpp" line="45"/>
+        <location filename="../src/controls/jumplinebar.cpp" line="46"/>
         <source>Go to Line: </source>
         <translation>Gehe zu Zeile:</translation>
+    </message>
+</context>
+<context>
+    <name>LineBar</name>
+    <message>
+        <location filename="../src/controls/linebar.cpp" line="144"/>
+        <source>第%1/%2项</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -146,19 +164,47 @@
     </message>
 </context>
 <context>
+    <name>MarkdownBridge</name>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="37"/>
+        <source>Collapse code block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="38"/>
+        <source>Expand code block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="39"/>
+        <source>Copy code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="40"/>
+        <source>Expand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="42"/>
+        <source>%1 line(s) of code collapsed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PathSettingWgt</name>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="84"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="90"/>
         <source>Remember the last used path</source>
         <translation>Zuletzt verwendeten Pfad merken</translation>
     </message>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="85"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="91"/>
         <source>Same path as the current file</source>
         <translation>Gleicher Pfad wie bei der aktuellen Datei</translation>
     </message>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="86"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="92"/>
         <source>Customize the default path</source>
         <translation>Anpassen des Standardpfads</translation>
     </message>
@@ -171,15 +217,20 @@
         <translation>Texteditor</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="294"/>
-        <location filename="../src/editor/editwrapper.cpp" line="761"/>
-        <location filename="../src/editor/editwrapper.cpp" line="776"/>
-        <location filename="../src/widgets/window.cpp" line="1362"/>
-        <location filename="../src/widgets/window.cpp" line="1390"/>
-        <location filename="../src/widgets/window.cpp" line="1531"/>
-        <location filename="../src/widgets/window.cpp" line="1548"/>
+        <location filename="../src/editor/editwrapper.cpp" line="357"/>
+        <location filename="../src/editor/editwrapper.cpp" line="897"/>
+        <location filename="../src/editor/editwrapper.cpp" line="912"/>
+        <location filename="../src/widgets/window.cpp" line="1528"/>
+        <location filename="../src/widgets/window.cpp" line="1556"/>
+        <location filename="../src/widgets/window.cpp" line="1715"/>
+        <location filename="../src/widgets/window.cpp" line="1732"/>
         <source>Encoding</source>
         <translation>Kodierung</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="2001"/>
+        <source>视图模式</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="11"/>
@@ -215,7 +266,7 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="18"/>
         <location filename="../src/controls/settingsdialog.cpp" line="96"/>
-        <location filename="../src/widgets/window.cpp" line="2388"/>
+        <location filename="../src/widgets/window.cpp" line="2581"/>
         <source>Window</source>
         <translation>Fenster</translation>
     </message>
@@ -755,68 +806,68 @@
         <translation>Vietnamesisch</translation>
     </message>
     <message>
-        <location filename="../src/startmanager.cpp" line="971"/>
+        <location filename="../src/startmanager.cpp" line="1035"/>
         <source>File not saved</source>
         <translation>Datei nicht gespeichert</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1532"/>
-        <location filename="../src/widgets/window.cpp" line="1549"/>
+        <location filename="../src/widgets/window.cpp" line="1716"/>
+        <location filename="../src/widgets/window.cpp" line="1733"/>
         <source>Line Endings</source>
         <translation>Zeilenenden</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="243"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="379"/>
         <source>Please install &apos;UOS AI&apos; from the App Store before using</source>
         <translation>Bitte installieren Sie &apos;UOS AI&apos; aus dem App Store, bevor Sie es verwenden</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="245"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="381"/>
         <source>No audio input device detected. Please check and try again</source>
         <translation>Kein Audio-Eingabegerät erkannt. Bitte überprüfen Sie und versuchen Sie es erneut</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="247"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="383"/>
         <source>No audio output device detected. Please check and try again</source>
         <translation>Kein Audio-Ausgabegerät erkannt. Bitte überprüfen Sie und versuchen Sie es erneut</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="69"/>
+        <location filename="../src/common/text_file_saver.cpp" line="74"/>
         <source>File path is empty</source>
         <translation>Dateipfad ist leer</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="155"/>
+        <location filename="../src/common/text_file_saver.cpp" line="153"/>
         <source>Insufficient memory to load document content</source>
         <translation>Nicht genügend Speicher zum Laden des Dokumentinhalts</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="177"/>
+        <location filename="../src/common/text_file_saver.cpp" line="178"/>
         <source>Insufficient memory for encoding conversion</source>
         <translation>Nicht genügend Speicher für Kodierungsumwandlung</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="183"/>
+        <location filename="../src/common/text_file_saver.cpp" line="184"/>
         <source>Encoding conversion failed</source>
         <translation>Kodierungsumwandlung fehlgeschlagen</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="189"/>
+        <location filename="../src/common/text_file_saver.cpp" line="190"/>
         <source>Converted content is empty</source>
         <translation>Umgewandelter Inhalt ist leer</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="207"/>
+        <location filename="../src/common/text_file_saver.cpp" line="208"/>
         <source>Memory allocation failed</source>
         <translation>Speicherzuweisung fehlgeschlagen</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="211"/>
+        <location filename="../src/common/text_file_saver.cpp" line="212"/>
         <source>Error occurred: %1</source>
         <translation>Fehler aufgetreten: %1</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="215"/>
+        <location filename="../src/common/text_file_saver.cpp" line="216"/>
         <source>Unknown error occurred</source>
         <translation>Unbekannter Fehler aufgetreten</translation>
     </message>
@@ -829,27 +880,27 @@
         <translation>Suchen</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="34"/>
+        <location filename="../src/controls/replacebar.cpp" line="36"/>
         <source>Replace With</source>
         <translation>Ersetzen mit</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="36"/>
+        <location filename="../src/controls/replacebar.cpp" line="40"/>
         <source>Replace</source>
         <translation>Ersetzen</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="37"/>
+        <location filename="../src/controls/replacebar.cpp" line="42"/>
         <source>Skip</source>
         <translation>Überspringen</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="38"/>
+        <location filename="../src/controls/replacebar.cpp" line="44"/>
         <source>Replace Rest</source>
         <translation>Rest ersetzen</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="39"/>
+        <location filename="../src/controls/replacebar.cpp" line="46"/>
         <source>Replace All</source>
         <translation>Alles ersetzen</translation>
     </message>
@@ -858,9 +909,9 @@
     <name>S:</name>
     <message>
         <location filename="../third/libiconv-1.16/src/iconv.c" line="103"/>
-        <source/>
+        <source></source>
         <comment>The first line of the short usage message.</comment>
-        <translation type="unfinished"/>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -891,34 +942,34 @@
         <translation>Vollbild</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="484"/>
+        <location filename="../src/common/settings.cpp" line="491"/>
         <source>This shortcut conflicts with system shortcut %1</source>
         <translation>Dieses Tastaturkürzel steht im Konflikt mit dem Systemkürzel %1</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="487"/>
+        <location filename="../src/common/settings.cpp" line="494"/>
         <source>This shortcut conflicts with %1, click on Replace to make this shortcut effective immediately</source>
         <translation>Dieses Tastaturkürzel steht im Konflikt mit %1, klicke auf Ersetzen, um dieses Kürzel sofort wirksam zu machen</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="682"/>
-        <location filename="../src/common/settings.cpp" line="695"/>
-        <location filename="../src/common/settings.cpp" line="704"/>
+        <location filename="../src/common/settings.cpp" line="689"/>
+        <location filename="../src/common/settings.cpp" line="702"/>
+        <location filename="../src/common/settings.cpp" line="711"/>
         <source>The shortcut %1 is invalid, please set another one.</source>
         <translation>Das Tastaturkürzel %1 ist ungültig, bitte stelle ein anderes ein.</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="736"/>
+        <location filename="../src/common/settings.cpp" line="743"/>
         <source>Cancel</source>
         <translation>Abbrechen</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="737"/>
+        <location filename="../src/common/settings.cpp" line="744"/>
         <source>Replace</source>
         <translation>Ersetzen</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="740"/>
+        <location filename="../src/common/settings.cpp" line="747"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
@@ -926,7 +977,7 @@
 <context>
     <name>StartManager</name>
     <message>
-        <location filename="../src/startmanager.cpp" line="411"/>
+        <location filename="../src/startmanager.cpp" line="425"/>
         <source>Untitled %1</source>
         <translation>Unbenannt %1</translation>
     </message>
@@ -934,32 +985,32 @@
 <context>
     <name>Tabbar</name>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="641"/>
+        <location filename="../src/controls/tabbar.cpp" line="678"/>
         <source>Close tab</source>
         <translation>Tab schließen</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="642"/>
+        <location filename="../src/controls/tabbar.cpp" line="680"/>
         <source>Close other tabs</source>
         <translation>Schließe restliche Tabs</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="643"/>
+        <location filename="../src/controls/tabbar.cpp" line="682"/>
         <source>More options</source>
         <translation>Weitere Optionen</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="644"/>
+        <location filename="../src/controls/tabbar.cpp" line="684"/>
         <source>Close tabs to the left</source>
         <translation>Tabs nach links schließen</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="645"/>
+        <location filename="../src/controls/tabbar.cpp" line="686"/>
         <source>Close tabs to the right</source>
         <translation>Tabs nach rechts schließen</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="646"/>
+        <location filename="../src/controls/tabbar.cpp" line="688"/>
         <source>Close unmodified tabs</source>
         <translation>Unveränderte Tabs schließen</translation>
     </message>
@@ -967,263 +1018,280 @@
 <context>
     <name>TextEdit</name>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="305"/>
+        <location filename="../src/editor/dtextedit.cpp" line="388"/>
         <source>Undo</source>
         <translation>Rückgängig</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="306"/>
+        <location filename="../src/editor/dtextedit.cpp" line="390"/>
         <source>Redo</source>
         <translation>Wiederherstellen</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="307"/>
+        <location filename="../src/editor/dtextedit.cpp" line="392"/>
         <source>Cut</source>
         <translation>Ausschneiden</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="308"/>
+        <location filename="../src/editor/dtextedit.cpp" line="394"/>
         <source>Copy</source>
         <translation>Kopieren</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="309"/>
+        <location filename="../src/editor/dtextedit.cpp" line="396"/>
         <source>Paste</source>
         <translation>Einfügen</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="310"/>
+        <location filename="../src/editor/dtextedit.cpp" line="398"/>
         <source>Delete</source>
         <translation>Löschen</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="311"/>
+        <location filename="../src/editor/dtextedit.cpp" line="400"/>
         <source>Select All</source>
         <translation>Alles auswählen</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="312"/>
-        <location filename="../src/widgets/window.cpp" line="535"/>
+        <location filename="../src/editor/dtextedit.cpp" line="402"/>
+        <location filename="../src/widgets/window.cpp" line="556"/>
         <source>Find</source>
         <translation>Suchen</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="313"/>
-        <location filename="../src/widgets/window.cpp" line="536"/>
+        <location filename="../src/editor/dtextedit.cpp" line="404"/>
+        <location filename="../src/widgets/window.cpp" line="558"/>
         <source>Replace</source>
         <translation>Ersetzen</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="314"/>
+        <location filename="../src/editor/dtextedit.cpp" line="406"/>
         <source>Go to Line</source>
         <translation>Gehe zu Zeile</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="315"/>
-        <source>Turn on Read-Only mode</source>
-        <translation>Nur-Lese-Modus aktivieren</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="316"/>
-        <source>Turn off Read-Only mode</source>
-        <translation>Nur-Lese-Modus deaktivieren</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="317"/>
+        <location filename="../src/editor/dtextedit.cpp" line="415"/>
         <source>Fullscreen</source>
         <translation>Vollbild</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="318"/>
+        <location filename="../src/editor/dtextedit.cpp" line="417"/>
         <source>Exit fullscreen</source>
         <translation>Vollbild beenden</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="319"/>
+        <location filename="../src/editor/dtextedit.cpp" line="419"/>
         <source>Display in file manager</source>
         <translation>Im Dateimanager anzeigen</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="320"/>
-        <location filename="../src/editor/dtextedit.cpp" line="374"/>
+        <location filename="../src/editor/dtextedit.cpp" line="421"/>
+        <location filename="../src/editor/dtextedit.cpp" line="493"/>
         <source>Add Comment</source>
         <translation>Kommentar hinzufügen</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="321"/>
+        <location filename="../src/editor/dtextedit.cpp" line="423"/>
         <source>Text to Speech</source>
         <translation>Text zu Sprache</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="322"/>
-        <source>Stop reading</source>
-        <translation>Lesen beenden</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="323"/>
+        <location filename="../src/editor/dtextedit.cpp" line="425"/>
         <source>Speech to Text</source>
         <translation>Sprache zu Text</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="324"/>
+        <location filename="../src/editor/dtextedit.cpp" line="427"/>
         <source>Translate</source>
         <translation>Übersetzen</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="325"/>
+        <location filename="../src/editor/dtextedit.cpp" line="429"/>
         <source>Column Mode</source>
         <translation>Spaltenmodus</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="326"/>
+        <location filename="../src/editor/dtextedit.cpp" line="431"/>
         <source>Add bookmark</source>
         <translation>Lesezeichen hinzufügen</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="327"/>
+        <location filename="../src/editor/dtextedit.cpp" line="433"/>
         <source>Remove Bookmark</source>
         <translation>Lesezeichen entfernen</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="328"/>
+        <location filename="../src/editor/dtextedit.cpp" line="435"/>
         <source>Previous bookmark</source>
         <translation>Vorheriges Lesezeichen</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="329"/>
+        <location filename="../src/editor/dtextedit.cpp" line="437"/>
         <source>Next bookmark</source>
         <translation>Nächstes Lesezeichen</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="330"/>
+        <location filename="../src/editor/dtextedit.cpp" line="439"/>
         <source>Remove All Bookmarks</source>
         <translation>Alle Lesezeichen entfernen</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="331"/>
+        <location filename="../src/editor/dtextedit.cpp" line="441"/>
         <source>Fold All</source>
         <translation>Alles einfalten</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="332"/>
+        <location filename="../src/editor/dtextedit.cpp" line="443"/>
         <source>Fold Current Level</source>
         <translation>Aktuelle Ebene einfalten</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="333"/>
+        <location filename="../src/editor/dtextedit.cpp" line="445"/>
         <source>Unfold All</source>
         <translation>Alles ausfalten</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="334"/>
+        <location filename="../src/editor/dtextedit.cpp" line="447"/>
         <source>Unfold Current Level</source>
         <translation>Aktuelle Ebene ausfalten</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="339"/>
+        <location filename="../src/editor/dtextedit.cpp" line="453"/>
         <source>Color Mark</source>
         <translation>Farbmarkierung</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="343"/>
+        <location filename="../src/editor/dtextedit.cpp" line="458"/>
         <source>Clear All Marks</source>
         <translation>Alle Markierungen löschen</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="344"/>
+        <location filename="../src/editor/dtextedit.cpp" line="460"/>
         <source>Clear Last Mark</source>
         <translation>Letzte Markierung löschen</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="353"/>
+        <location filename="../src/editor/dtextedit.cpp" line="470"/>
         <source>Mark</source>
         <translation>Markieren</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="366"/>
+        <location filename="../src/editor/dtextedit.cpp" line="484"/>
         <source>Mark All</source>
         <translation>Alles markieren</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="375"/>
+        <location filename="../src/editor/dtextedit.cpp" line="494"/>
         <source>Remove Comment</source>
         <translation>Kommentar entfernen</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3208"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3211"/>
+        <location filename="../src/editor/dtextedit.cpp" line="543"/>
+        <source>View Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="3531"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3534"/>
         <source>Copy failed: not enough memory</source>
         <translation>Kopieren fehlgeschlagen: nicht genügend Speicher</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3333"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3335"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3656"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3658"/>
         <source>Press ALT and click lines to edit in column mode</source>
         <translation>Drücke ALT und klicke auf Zeilen, um im Spaltenmodus zu bearbeiten</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="418"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9574"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9576"/>
+        <source>No audio output device was detected. Please ensure your speakers or headphones are properly connected and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="9583"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9585"/>
+        <source>No audio input device was detected. Please ensure your speakers or headphones are properly connected and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="534"/>
         <source>Change Case</source>
         <translation>Groß-/Kleinschreibung ändern</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="419"/>
+        <location filename="../src/editor/dtextedit.cpp" line="409"/>
+        <source>Edit Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="411"/>
+        <source>Read View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="413"/>
+        <source>Live Preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="535"/>
         <source>Upper Case</source>
         <translation>Großbuchstaben</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="420"/>
+        <location filename="../src/editor/dtextedit.cpp" line="536"/>
         <source>Lower Case</source>
         <translation>Kleinbuchstaben</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="421"/>
+        <location filename="../src/editor/dtextedit.cpp" line="537"/>
         <source>Capitalize</source>
         <translation>Großschreibung</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="78"/>
+        <location filename="../src/widgets/bottombar.cpp" line="110"/>
         <source>None</source>
         <translation>Keines</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1363"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1490"/>
         <source>Selected line(s) copied</source>
         <translation>Ausgewählte Zeile(n) kopiert</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1370"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1497"/>
         <source>Current line copied</source>
         <translation>Aktuelle Zeile kopiert</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1400"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1527"/>
         <source>Selected line(s) clipped</source>
         <translation>Ausgewählte Zeile(n) abgeschnitten</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1412"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1539"/>
         <source>Current line clipped</source>
         <translation>Aktuelle Zeile abgeschnitten</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3227"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3230"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3550"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3553"/>
         <source>Paste failed: not enough memory</source>
         <translation>Einfügen fehlgeschlagen: nicht genügend Speicher</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="4548"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4873"/>
         <source>Read-Only mode is off</source>
         <translation>Nur-Lese-Modus ist ausgeschaltet</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="4560"/>
-        <location filename="../src/editor/dtextedit.cpp" line="4584"/>
-        <location filename="../src/editor/dtextedit.cpp" line="7896"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8007"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8015"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8026"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4885"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4909"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8236"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8347"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8355"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8366"/>
         <source>Read-Only mode is on</source>
         <translation>Nur-Lese-Modus ist eingeschaltet</translation>
     </message>
@@ -1231,138 +1299,175 @@
 <context>
     <name>WarningNotices</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="24"/>
+        <location filename="../src/controls/warningnotices.cpp" line="25"/>
         <source>Reload</source>
         <translation>Neu laden</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/warningnotices.cpp" line="29"/>
+        <source>Edit Anyway</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>Window</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="25"/>
-        <location filename="../src/widgets/window.cpp" line="531"/>
+        <location filename="../src/controls/warningnotices.cpp" line="27"/>
+        <location filename="../src/widgets/window.cpp" line="548"/>
         <source>Save as</source>
         <translation>Speichern unter</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="527"/>
+        <location filename="../src/widgets/window.cpp" line="540"/>
         <source>New window</source>
         <translation>Neues Fenster</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="528"/>
+        <location filename="../src/widgets/window.cpp" line="542"/>
         <source>New tab</source>
         <translation>Neuer Tab</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="529"/>
+        <location filename="../src/widgets/window.cpp" line="544"/>
         <source>Open file</source>
         <translation>Datei öffnen</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="530"/>
-        <location filename="../src/widgets/window.cpp" line="3545"/>
+        <location filename="../src/widgets/window.cpp" line="546"/>
+        <location filename="../src/widgets/window.cpp" line="3950"/>
         <source>Save</source>
         <translation>Speichern</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="532"/>
+        <location filename="../src/widgets/window.cpp" line="550"/>
         <source>Print</source>
         <translation>Drucken</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="533"/>
+        <location filename="../src/widgets/window.cpp" line="552"/>
         <source>Switch theme</source>
         <translation>Theme wechseln</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="534"/>
-        <location filename="../src/widgets/window.cpp" line="2448"/>
+        <location filename="../src/widgets/window.cpp" line="554"/>
+        <location filename="../src/widgets/window.cpp" line="2641"/>
         <source>Settings</source>
         <translation>Einstellungen</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="666"/>
-        <location filename="../src/widgets/window.cpp" line="3845"/>
+        <location filename="../src/widgets/window.cpp" line="696"/>
+        <location filename="../src/widgets/window.cpp" line="4250"/>
         <source>Read-Only</source>
         <translation>Nur Lesen</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="687"/>
+        <location filename="../src/widgets/window.cpp" line="719"/>
         <source>You do not have permission to open %1</source>
         <translation>Berechtigung zum Öffnen von %1 fehlt</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="738"/>
-        <location filename="../src/widgets/window.cpp" line="2963"/>
+        <location filename="../src/widgets/window.cpp" line="773"/>
+        <location filename="../src/widgets/window.cpp" line="3266"/>
         <source>Invalid file: %1</source>
         <translation>Ungültige Datei: %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="903"/>
-        <location filename="../src/widgets/window.cpp" line="956"/>
+        <location filename="../src/widgets/window.cpp" line="957"/>
+        <location filename="../src/widgets/window.cpp" line="1050"/>
+        <location filename="../src/widgets/window.cpp" line="3217"/>
         <source>Do you want to save this file?</source>
         <translation>Möchten Sie diese Datei speichern?</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1290"/>
+        <location filename="../src/widgets/window.cpp" line="1381"/>
+        <source>Invalid characters detected while saving &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1382"/>
+        <source>If you force save this file, it may cause file corruption. Still want to save?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1386"/>
+        <source>Don&apos;t Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1387"/>
+        <source>Save As</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1388"/>
+        <source>Save Anyway</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1456"/>
         <source>You do not have permission to save %1</source>
         <translation>Berechtigung zum Speichern von %1 fehlt</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1312"/>
+        <location filename="../src/widgets/window.cpp" line="1428"/>
+        <location filename="../src/widgets/window.cpp" line="1478"/>
         <source>Saved successfully</source>
         <translation>Erfolgreich gespeichert</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1354"/>
-        <location filename="../src/widgets/window.cpp" line="1481"/>
-        <location filename="../src/widgets/window.cpp" line="1529"/>
+        <location filename="../src/widgets/window.cpp" line="1520"/>
+        <location filename="../src/widgets/window.cpp" line="1665"/>
+        <location filename="../src/widgets/window.cpp" line="1713"/>
         <source>Save File</source>
         <translation>Datei speichern</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1483"/>
+        <location filename="../src/widgets/window.cpp" line="1569"/>
+        <source>Cannot save as the original file in preview mode. Please choose a different path.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1667"/>
         <source>Encoding</source>
         <translation>Kodierung</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1773"/>
+        <location filename="../src/widgets/window.cpp" line="1957"/>
         <source>Read-Only mode is on</source>
         <translation>Nur-Lese-Modus ist aktiviert</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2322"/>
+        <location filename="../src/widgets/window.cpp" line="2511"/>
         <source>Current location remembered</source>
         <translation>Aktueller Standort gespeichert</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2398"/>
+        <location filename="../src/widgets/window.cpp" line="2591"/>
         <source>Ctrl+&apos;=&apos;</source>
         <translation>Strg+&apos;=&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2401"/>
+        <location filename="../src/widgets/window.cpp" line="2594"/>
         <source>Ctrl+&apos;-&apos;</source>
         <translation>Strg+&apos;-&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2430"/>
+        <location filename="../src/widgets/window.cpp" line="2623"/>
         <source>Editor</source>
         <translation>Editor</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3061"/>
+        <location filename="../src/widgets/window.cpp" line="3436"/>
         <source>Untitled %1</source>
         <translation>Unbenannt %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3543"/>
+        <location filename="../src/widgets/window.cpp" line="3948"/>
         <source>Cancel</source>
         <translation>Abbrechen</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3544"/>
+        <location filename="../src/widgets/window.cpp" line="3949"/>
         <source>Discard</source>
         <translation>Verwerfen</translation>
     </message>

--- a/translations/deepin-editor_el.ts
+++ b/translations/deepin-editor_el.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="el">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="el">
 <context>
     <name>BottomBar</name>
     <message>
@@ -17,17 +19,36 @@
         <translation>Χαρακτήρες %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="44"/>
+        <location filename="../src/widgets/bottombar.cpp" line="47"/>
         <source>Loading:</source>
         <translation>Φόρτωση:</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="73"/>
+        <location filename="../src/widgets/bottombar.cpp" line="91"/>
+        <location filename="../src/widgets/bottombar.cpp" line="499"/>
+        <source>Edit Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="74"/>
+        <location filename="../src/widgets/bottombar.cpp" line="489"/>
+        <source>Read View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="75"/>
+        <location filename="../src/widgets/bottombar.cpp" line="493"/>
+        <source>Live Preview</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DDropdownMenu</name>
     <message>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="362"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="420"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="425"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="363"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="421"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="426"/>
         <source>None</source>
         <translation>Κανένα</translation>
     </message>
@@ -35,70 +56,59 @@
 <context>
     <name>EditWrapper</name>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="292"/>
-        <location filename="../src/editor/editwrapper.cpp" line="365"/>
-        <location filename="../src/editor/editwrapper.cpp" line="521"/>
-        <location filename="../src/editor/editwrapper.cpp" line="751"/>
+        <location filename="../src/editor/editwrapper.cpp" line="355"/>
+        <location filename="../src/editor/editwrapper.cpp" line="429"/>
+        <location filename="../src/editor/editwrapper.cpp" line="595"/>
+        <location filename="../src/editor/editwrapper.cpp" line="887"/>
         <source>Save</source>
         <translation>Αποθήκευση</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="516"/>
+        <location filename="../src/editor/editwrapper.cpp" line="590"/>
         <source>Do you want to save this file?</source>
         <translation>Θέλεις να αποθηκευτεί αυτό το αρχείο;</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="363"/>
-        <location filename="../src/editor/editwrapper.cpp" line="519"/>
+        <location filename="../src/editor/editwrapper.cpp" line="427"/>
+        <location filename="../src/editor/editwrapper.cpp" line="593"/>
         <source>Cancel</source>
         <translation>Άκυρο</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="360"/>
+        <location filename="../src/editor/editwrapper.cpp" line="424"/>
         <source>Encoding changed. Do you want to save the file now?</source>
         <translation>Αλλαγή κωδικοποίησης. Θέλεις αποθήκευση του αρχείου;</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="520"/>
+        <location filename="../src/editor/editwrapper.cpp" line="594"/>
         <source>Discard</source>
         <translation>Απόρριψη</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="274"/>
-        <location filename="../src/editor/editwrapper.cpp" line="620"/>
+        <location filename="../src/editor/editwrapper.cpp" line="1121"/>
+        <source>The file contains invalid characters (NUL). Preview mode is read-only.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="337"/>
+        <location filename="../src/editor/editwrapper.cpp" line="705"/>
         <source>You do not have permission to save %1</source>
         <translation>Δεν έχετε άδεια να αποθηκεύσετε το %1</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="836"/>
+        <location filename="../src/editor/editwrapper.cpp" line="987"/>
         <source>File removed on the disk. Save it now?</source>
         <translation>Το αρχείο αφαιρέθηκε από το δίσκο. Να αποθηκευτεί τώρα;</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="842"/>
+        <location filename="../src/editor/editwrapper.cpp" line="993"/>
         <source>File has changed on disk. Reload?</source>
         <translation>Το αρχείο άλλαξε στο δίσκο. Επαναφόρτωση;</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="884"/>
-        <location filename="../src/widgets/bottombar.cpp" line="74"/>
-        <source>INSERT</source>
-        <translation>INSERT</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="888"/>
-        <source>OVERWRITE</source>
-        <translation>OVERWRITE</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="892"/>
-        <source>R/O</source>
-        <translation>R/O</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="1618"/>
+        <location filename="../src/editor/editwrapper.cpp" line="1806"/>
         <source>The file cannot be read, which may be too large or has been damaged!</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -109,17 +119,17 @@
         <translation>Εύρεση</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="36"/>
+        <location filename="../src/controls/findbar.cpp" line="38"/>
         <source>Previous</source>
         <translation>Προηγούμενο</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="37"/>
+        <location filename="../src/controls/findbar.cpp" line="40"/>
         <source>Next</source>
         <translation>Επόμενο</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="38"/>
+        <location filename="../src/controls/findbar.cpp" line="42"/>
         <source>Replace</source>
         <translation>Αντικατάσταση</translation>
     </message>
@@ -127,9 +137,17 @@
 <context>
     <name>JumpLineBar</name>
     <message>
-        <location filename="../src/controls/jumplinebar.cpp" line="45"/>
+        <location filename="../src/controls/jumplinebar.cpp" line="46"/>
         <source>Go to Line: </source>
         <translation>Μετακίνηση στη Γραμμή:</translation>
+    </message>
+</context>
+<context>
+    <name>LineBar</name>
+    <message>
+        <location filename="../src/controls/linebar.cpp" line="144"/>
+        <source>第%1/%2项</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -137,7 +155,7 @@
     <message>
         <location filename="../src/editorapplication.cpp" line="12"/>
         <source>Text Editor is a powerful tool for viewing and editing text files.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/editorapplication.cpp" line="34"/>
@@ -146,19 +164,47 @@
     </message>
 </context>
 <context>
+    <name>MarkdownBridge</name>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="37"/>
+        <source>Collapse code block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="38"/>
+        <source>Expand code block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="39"/>
+        <source>Copy code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="40"/>
+        <source>Expand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="42"/>
+        <source>%1 line(s) of code collapsed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PathSettingWgt</name>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="84"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="90"/>
         <source>Remember the last used path</source>
         <translation>Θυμηθείτε την τελευταία χρησιμοποιούμενη διαδρομή</translation>
     </message>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="85"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="91"/>
         <source>Same path as the current file</source>
         <translation>Ίδια διαδρομή με το τρέχον αρχείο</translation>
     </message>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="86"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="92"/>
         <source>Customize the default path</source>
         <translation>Προσαρμογή της προεπιλεγμένης διαδρομής</translation>
     </message>
@@ -171,15 +217,20 @@
         <translation>Επεξεργαστής Κειμένου</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="294"/>
-        <location filename="../src/editor/editwrapper.cpp" line="761"/>
-        <location filename="../src/editor/editwrapper.cpp" line="776"/>
-        <location filename="../src/widgets/window.cpp" line="1362"/>
-        <location filename="../src/widgets/window.cpp" line="1390"/>
-        <location filename="../src/widgets/window.cpp" line="1531"/>
-        <location filename="../src/widgets/window.cpp" line="1548"/>
+        <location filename="../src/editor/editwrapper.cpp" line="357"/>
+        <location filename="../src/editor/editwrapper.cpp" line="897"/>
+        <location filename="../src/editor/editwrapper.cpp" line="912"/>
+        <location filename="../src/widgets/window.cpp" line="1528"/>
+        <location filename="../src/widgets/window.cpp" line="1556"/>
+        <location filename="../src/widgets/window.cpp" line="1715"/>
+        <location filename="../src/widgets/window.cpp" line="1732"/>
         <source>Encoding</source>
         <translation>Κωδικοποίηση</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="2001"/>
+        <source>视图模式</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="11"/>
@@ -215,7 +266,7 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="18"/>
         <location filename="../src/controls/settingsdialog.cpp" line="96"/>
-        <location filename="../src/widgets/window.cpp" line="2388"/>
+        <location filename="../src/widgets/window.cpp" line="2581"/>
         <source>Window</source>
         <translation>Παράθυρο</translation>
     </message>
@@ -262,7 +313,7 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="27"/>
         <source>Restore tab</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="28"/>
@@ -347,7 +398,7 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="44"/>
         <source>Editor</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="45"/>
@@ -362,22 +413,22 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="47"/>
         <source>Forward character</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="48"/>
         <source>Backward character</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="49"/>
         <source>Forward word</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="50"/>
         <source>Backward word</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="51"/>
@@ -407,37 +458,37 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="56"/>
         <source>Duplicate line</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="57"/>
         <source>Delete to end of line</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="58"/>
         <source>Delete current line</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="59"/>
         <source>Swap line up</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="60"/>
         <source>Swap line down</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="61"/>
         <source>Scroll up one line</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="62"/>
         <source>Scroll down one line</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="63"/>
@@ -452,27 +503,27 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="65"/>
         <source>Move to end of line</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="66"/>
         <source>Move to start of line</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="67"/>
         <source>Move to end of text</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="68"/>
         <source>Move to start of text</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="69"/>
         <source>Move to line indentation</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="70"/>
@@ -487,27 +538,27 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="72"/>
         <source>Capitalize</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="73"/>
         <source>Delete backward word</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="74"/>
         <source>Delete forward word</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="75"/>
         <source>Forward over a pair</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="76"/>
         <source>Backward over a pair</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="77"/>
@@ -532,17 +583,17 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="81"/>
         <source>Transpose character</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="82"/>
         <source>Mark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="83"/>
         <source>Unmark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="84"/>
@@ -557,12 +608,12 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="86"/>
         <source>Merge lines</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="87"/>
         <source>Read-Only mode</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="88"/>
@@ -582,27 +633,27 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="91"/>
         <source>Redo</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="92"/>
         <source>Add/Remove bookmark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="93"/>
         <source>Move to previous bookmark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="94"/>
         <source>Move to next bookmark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="95"/>
         <source>Advanced</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="97"/>
@@ -617,32 +668,32 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="99"/>
         <source>Paste by pressing a middle mouse button</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="101"/>
         <source>Startup</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="102"/>
         <source>Reopen last closed tabs</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="104"/>
         <source>Open/Save Settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="106"/>
         <source>Word wrap</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="107"/>
         <source>Code folding flag</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="108"/>
@@ -652,22 +703,22 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="109"/>
         <source>Show bookmarks icon</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="110"/>
         <source>Show whitespaces and tabs</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="111"/>
         <source>Highlight current line</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="112"/>
         <source>Color mark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="115"/>
@@ -677,148 +728,148 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="116"/>
         <source>WesternEuropean</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="117"/>
         <source>CentralEuropean</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="118"/>
         <source>Baltic</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="119"/>
         <source>Cyrillic</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="120"/>
         <source>Arabic</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="125"/>
         <source>Celtic</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="126"/>
         <source>SouthEasternEuropean</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="121"/>
         <source>Greek</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="122"/>
         <source>Hebrew</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="127"/>
         <source>ChineseSimplified</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="128"/>
         <source>ChineseTraditional</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="129"/>
         <source>Japanese</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="130"/>
         <source>Korean</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="124"/>
         <source>Thai</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="123"/>
         <source>Turkish</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="131"/>
         <source>Vietnamese</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/startmanager.cpp" line="971"/>
+        <location filename="../src/startmanager.cpp" line="1035"/>
         <source>File not saved</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1532"/>
-        <location filename="../src/widgets/window.cpp" line="1549"/>
+        <location filename="../src/widgets/window.cpp" line="1716"/>
+        <location filename="../src/widgets/window.cpp" line="1733"/>
         <source>Line Endings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="243"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="379"/>
         <source>Please install &apos;UOS AI&apos; from the App Store before using</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="245"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="381"/>
         <source>No audio input device detected. Please check and try again</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="247"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="383"/>
         <source>No audio output device detected. Please check and try again</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="69"/>
+        <location filename="../src/common/text_file_saver.cpp" line="74"/>
         <source>File path is empty</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="155"/>
+        <location filename="../src/common/text_file_saver.cpp" line="153"/>
         <source>Insufficient memory to load document content</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="177"/>
+        <location filename="../src/common/text_file_saver.cpp" line="178"/>
         <source>Insufficient memory for encoding conversion</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="183"/>
+        <location filename="../src/common/text_file_saver.cpp" line="184"/>
         <source>Encoding conversion failed</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="189"/>
+        <location filename="../src/common/text_file_saver.cpp" line="190"/>
         <source>Converted content is empty</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="207"/>
+        <location filename="../src/common/text_file_saver.cpp" line="208"/>
         <source>Memory allocation failed</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="211"/>
+        <location filename="../src/common/text_file_saver.cpp" line="212"/>
         <source>Error occurred: %1</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="215"/>
+        <location filename="../src/common/text_file_saver.cpp" line="216"/>
         <source>Unknown error occurred</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -829,27 +880,27 @@
         <translation>Εύρεση</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="34"/>
+        <location filename="../src/controls/replacebar.cpp" line="36"/>
         <source>Replace With</source>
         <translation>Αντικατάσταση Με</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="36"/>
+        <location filename="../src/controls/replacebar.cpp" line="40"/>
         <source>Replace</source>
         <translation>Αντικατάσταση</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="37"/>
+        <location filename="../src/controls/replacebar.cpp" line="42"/>
         <source>Skip</source>
         <translation>Παράλειψη</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="38"/>
+        <location filename="../src/controls/replacebar.cpp" line="44"/>
         <source>Replace Rest</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="39"/>
+        <location filename="../src/controls/replacebar.cpp" line="46"/>
         <source>Replace All</source>
         <translation>Αντικατάσταση Όλων</translation>
     </message>
@@ -858,9 +909,9 @@
     <name>S:</name>
     <message>
         <location filename="../third/libiconv-1.16/src/iconv.c" line="103"/>
-        <source/>
+        <source></source>
         <comment>The first line of the short usage message.</comment>
-        <translation type="unfinished"/>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -868,22 +919,22 @@
     <message>
         <location filename="../src/common/settings.cpp" line="141"/>
         <source>Standard</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/common/settings.cpp" line="141"/>
         <source>Customize</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/common/settings.cpp" line="154"/>
         <source>Normal</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/common/settings.cpp" line="154"/>
         <source>Maximum</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/common/settings.cpp" line="154"/>
@@ -891,34 +942,34 @@
         <translation>Πλήρης οθόνη</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="484"/>
+        <location filename="../src/common/settings.cpp" line="491"/>
         <source>This shortcut conflicts with system shortcut %1</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="487"/>
+        <location filename="../src/common/settings.cpp" line="494"/>
         <source>This shortcut conflicts with %1, click on Replace to make this shortcut effective immediately</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="682"/>
-        <location filename="../src/common/settings.cpp" line="695"/>
-        <location filename="../src/common/settings.cpp" line="704"/>
+        <location filename="../src/common/settings.cpp" line="689"/>
+        <location filename="../src/common/settings.cpp" line="702"/>
+        <location filename="../src/common/settings.cpp" line="711"/>
         <source>The shortcut %1 is invalid, please set another one.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="736"/>
+        <location filename="../src/common/settings.cpp" line="743"/>
         <source>Cancel</source>
         <translation>Άκυρο</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="737"/>
+        <location filename="../src/common/settings.cpp" line="744"/>
         <source>Replace</source>
         <translation>Αντικατάσταση</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="740"/>
+        <location filename="../src/common/settings.cpp" line="747"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
@@ -926,7 +977,7 @@
 <context>
     <name>StartManager</name>
     <message>
-        <location filename="../src/startmanager.cpp" line="411"/>
+        <location filename="../src/startmanager.cpp" line="425"/>
         <source>Untitled %1</source>
         <translation>Ανώνυμο %1</translation>
     </message>
@@ -934,435 +985,489 @@
 <context>
     <name>Tabbar</name>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="641"/>
+        <location filename="../src/controls/tabbar.cpp" line="678"/>
         <source>Close tab</source>
         <translation>Κλείσιμο καρτέλας</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="642"/>
+        <location filename="../src/controls/tabbar.cpp" line="680"/>
         <source>Close other tabs</source>
         <translation>Κλείσιμο υπολοίπων καρτελών</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="643"/>
+        <location filename="../src/controls/tabbar.cpp" line="682"/>
         <source>More options</source>
         <translation>Περισσότερες επιλογές</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="644"/>
+        <location filename="../src/controls/tabbar.cpp" line="684"/>
         <source>Close tabs to the left</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="645"/>
+        <location filename="../src/controls/tabbar.cpp" line="686"/>
         <source>Close tabs to the right</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="646"/>
+        <location filename="../src/controls/tabbar.cpp" line="688"/>
         <source>Close unmodified tabs</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>TextEdit</name>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="305"/>
+        <location filename="../src/editor/dtextedit.cpp" line="388"/>
         <source>Undo</source>
         <translation>Αναίρεση</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="306"/>
+        <location filename="../src/editor/dtextedit.cpp" line="390"/>
         <source>Redo</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="307"/>
+        <location filename="../src/editor/dtextedit.cpp" line="392"/>
         <source>Cut</source>
         <translation>Αποκοπή</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="308"/>
+        <location filename="../src/editor/dtextedit.cpp" line="394"/>
         <source>Copy</source>
         <translation>Αντιγραφή</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="309"/>
+        <location filename="../src/editor/dtextedit.cpp" line="396"/>
         <source>Paste</source>
         <translation>Επικόλληση</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="310"/>
+        <location filename="../src/editor/dtextedit.cpp" line="398"/>
         <source>Delete</source>
         <translation>Διαγραφή</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="311"/>
+        <location filename="../src/editor/dtextedit.cpp" line="400"/>
         <source>Select All</source>
         <translation>Επιλογή Όλων</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="312"/>
-        <location filename="../src/widgets/window.cpp" line="535"/>
+        <location filename="../src/editor/dtextedit.cpp" line="402"/>
+        <location filename="../src/widgets/window.cpp" line="556"/>
         <source>Find</source>
         <translation>Εύρεση</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="313"/>
-        <location filename="../src/widgets/window.cpp" line="536"/>
+        <location filename="../src/editor/dtextedit.cpp" line="404"/>
+        <location filename="../src/widgets/window.cpp" line="558"/>
         <source>Replace</source>
         <translation>Αντικατάσταση</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="314"/>
+        <location filename="../src/editor/dtextedit.cpp" line="406"/>
         <source>Go to Line</source>
         <translation>Μετακίνηση στη Γραμμή</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="315"/>
-        <source>Turn on Read-Only mode</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="316"/>
-        <source>Turn off Read-Only mode</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="317"/>
+        <location filename="../src/editor/dtextedit.cpp" line="415"/>
         <source>Fullscreen</source>
         <translation>Πλήρης οθόνη</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="318"/>
+        <location filename="../src/editor/dtextedit.cpp" line="417"/>
         <source>Exit fullscreen</source>
         <translation>Έξοδος από πλήρη οθόνη</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="319"/>
+        <location filename="../src/editor/dtextedit.cpp" line="419"/>
         <source>Display in file manager</source>
         <translation>Προβολή στον διαχειριστή αρχείων</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="320"/>
-        <location filename="../src/editor/dtextedit.cpp" line="374"/>
+        <location filename="../src/editor/dtextedit.cpp" line="421"/>
+        <location filename="../src/editor/dtextedit.cpp" line="493"/>
         <source>Add Comment</source>
         <translation>Προσθήκη Σχολίου</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="321"/>
+        <location filename="../src/editor/dtextedit.cpp" line="423"/>
         <source>Text to Speech</source>
         <translation>Κείμενο σε Ομιλία</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="322"/>
-        <source>Stop reading</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="323"/>
+        <location filename="../src/editor/dtextedit.cpp" line="425"/>
         <source>Speech to Text</source>
         <translation>Ομιλία σε Κείμενο</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="324"/>
+        <location filename="../src/editor/dtextedit.cpp" line="427"/>
         <source>Translate</source>
         <translation>Μετάφραση</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="325"/>
+        <location filename="../src/editor/dtextedit.cpp" line="429"/>
         <source>Column Mode</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="326"/>
+        <location filename="../src/editor/dtextedit.cpp" line="431"/>
         <source>Add bookmark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="327"/>
+        <location filename="../src/editor/dtextedit.cpp" line="433"/>
         <source>Remove Bookmark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="328"/>
+        <location filename="../src/editor/dtextedit.cpp" line="435"/>
         <source>Previous bookmark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="329"/>
+        <location filename="../src/editor/dtextedit.cpp" line="437"/>
         <source>Next bookmark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="330"/>
+        <location filename="../src/editor/dtextedit.cpp" line="439"/>
         <source>Remove All Bookmarks</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="331"/>
+        <location filename="../src/editor/dtextedit.cpp" line="441"/>
         <source>Fold All</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="332"/>
+        <location filename="../src/editor/dtextedit.cpp" line="443"/>
         <source>Fold Current Level</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="333"/>
+        <location filename="../src/editor/dtextedit.cpp" line="445"/>
         <source>Unfold All</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="334"/>
+        <location filename="../src/editor/dtextedit.cpp" line="447"/>
         <source>Unfold Current Level</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="339"/>
+        <location filename="../src/editor/dtextedit.cpp" line="453"/>
         <source>Color Mark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="343"/>
+        <location filename="../src/editor/dtextedit.cpp" line="458"/>
         <source>Clear All Marks</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="344"/>
+        <location filename="../src/editor/dtextedit.cpp" line="460"/>
         <source>Clear Last Mark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="353"/>
+        <location filename="../src/editor/dtextedit.cpp" line="470"/>
         <source>Mark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="366"/>
+        <location filename="../src/editor/dtextedit.cpp" line="484"/>
         <source>Mark All</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="375"/>
+        <location filename="../src/editor/dtextedit.cpp" line="494"/>
         <source>Remove Comment</source>
         <translation>Διαγραφή Σχολίου</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3208"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3211"/>
+        <location filename="../src/editor/dtextedit.cpp" line="543"/>
+        <source>View Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="3531"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3534"/>
         <source>Copy failed: not enough memory</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3333"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3335"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3656"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3658"/>
         <source>Press ALT and click lines to edit in column mode</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="418"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9574"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9576"/>
+        <source>No audio output device was detected. Please ensure your speakers or headphones are properly connected and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="9583"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9585"/>
+        <source>No audio input device was detected. Please ensure your speakers or headphones are properly connected and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="534"/>
         <source>Change Case</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="419"/>
+        <location filename="../src/editor/dtextedit.cpp" line="409"/>
+        <source>Edit Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="411"/>
+        <source>Read View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="413"/>
+        <source>Live Preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="535"/>
         <source>Upper Case</source>
         <translation>Κεφαλαία</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="420"/>
+        <location filename="../src/editor/dtextedit.cpp" line="536"/>
         <source>Lower Case</source>
         <translation>Πεζά</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="421"/>
+        <location filename="../src/editor/dtextedit.cpp" line="537"/>
         <source>Capitalize</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="78"/>
+        <location filename="../src/widgets/bottombar.cpp" line="110"/>
         <source>None</source>
         <translation>Κανένα</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1363"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1490"/>
         <source>Selected line(s) copied</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1370"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1497"/>
         <source>Current line copied</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1400"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1527"/>
         <source>Selected line(s) clipped</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1412"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1539"/>
         <source>Current line clipped</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3227"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3230"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3550"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3553"/>
         <source>Paste failed: not enough memory</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="4548"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4873"/>
         <source>Read-Only mode is off</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="4560"/>
-        <location filename="../src/editor/dtextedit.cpp" line="4584"/>
-        <location filename="../src/editor/dtextedit.cpp" line="7896"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8007"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8015"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8026"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4885"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4909"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8236"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8347"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8355"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8366"/>
         <source>Read-Only mode is on</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>WarningNotices</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="24"/>
+        <location filename="../src/controls/warningnotices.cpp" line="25"/>
         <source>Reload</source>
         <translation>Επαναφόρτωση</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/warningnotices.cpp" line="29"/>
+        <source>Edit Anyway</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>Window</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="25"/>
-        <location filename="../src/widgets/window.cpp" line="531"/>
+        <location filename="../src/controls/warningnotices.cpp" line="27"/>
+        <location filename="../src/widgets/window.cpp" line="548"/>
         <source>Save as</source>
         <translation>Αποθήκευση ως</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="527"/>
+        <location filename="../src/widgets/window.cpp" line="540"/>
         <source>New window</source>
         <translation>Νέο παράθυρο</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="528"/>
+        <location filename="../src/widgets/window.cpp" line="542"/>
         <source>New tab</source>
         <translation>Νέα καρτέλα</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="529"/>
+        <location filename="../src/widgets/window.cpp" line="544"/>
         <source>Open file</source>
         <translation>Άνοιγμα αρχείου</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="530"/>
-        <location filename="../src/widgets/window.cpp" line="3545"/>
+        <location filename="../src/widgets/window.cpp" line="546"/>
+        <location filename="../src/widgets/window.cpp" line="3950"/>
         <source>Save</source>
         <translation>Αποθήκευση</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="532"/>
+        <location filename="../src/widgets/window.cpp" line="550"/>
         <source>Print</source>
         <translation>Εκτύπωση</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="533"/>
+        <location filename="../src/widgets/window.cpp" line="552"/>
         <source>Switch theme</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="534"/>
-        <location filename="../src/widgets/window.cpp" line="2448"/>
+        <location filename="../src/widgets/window.cpp" line="554"/>
+        <location filename="../src/widgets/window.cpp" line="2641"/>
         <source>Settings</source>
         <translation>Ρυθμίσεις</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="666"/>
-        <location filename="../src/widgets/window.cpp" line="3845"/>
+        <location filename="../src/widgets/window.cpp" line="696"/>
+        <location filename="../src/widgets/window.cpp" line="4250"/>
         <source>Read-Only</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="687"/>
+        <location filename="../src/widgets/window.cpp" line="719"/>
         <source>You do not have permission to open %1</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="738"/>
-        <location filename="../src/widgets/window.cpp" line="2963"/>
+        <location filename="../src/widgets/window.cpp" line="773"/>
+        <location filename="../src/widgets/window.cpp" line="3266"/>
         <source>Invalid file: %1</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="903"/>
-        <location filename="../src/widgets/window.cpp" line="956"/>
+        <location filename="../src/widgets/window.cpp" line="957"/>
+        <location filename="../src/widgets/window.cpp" line="1050"/>
+        <location filename="../src/widgets/window.cpp" line="3217"/>
         <source>Do you want to save this file?</source>
         <translation>Θέλεις να αποθηκευτεί αυτό το αρχείο;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1290"/>
+        <location filename="../src/widgets/window.cpp" line="1381"/>
+        <source>Invalid characters detected while saving &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1382"/>
+        <source>If you force save this file, it may cause file corruption. Still want to save?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1386"/>
+        <source>Don&apos;t Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1387"/>
+        <source>Save As</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1388"/>
+        <source>Save Anyway</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1456"/>
         <source>You do not have permission to save %1</source>
         <translation>Δεν έχετε άδεια να αποθηκεύσετε το %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1312"/>
+        <location filename="../src/widgets/window.cpp" line="1428"/>
+        <location filename="../src/widgets/window.cpp" line="1478"/>
         <source>Saved successfully</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1354"/>
-        <location filename="../src/widgets/window.cpp" line="1481"/>
-        <location filename="../src/widgets/window.cpp" line="1529"/>
+        <location filename="../src/widgets/window.cpp" line="1520"/>
+        <location filename="../src/widgets/window.cpp" line="1665"/>
+        <location filename="../src/widgets/window.cpp" line="1713"/>
         <source>Save File</source>
         <translation>Αποθήκευση Αρχείου</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1483"/>
+        <location filename="../src/widgets/window.cpp" line="1569"/>
+        <source>Cannot save as the original file in preview mode. Please choose a different path.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1667"/>
         <source>Encoding</source>
         <translation>Κωδικοποίηση</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1773"/>
+        <location filename="../src/widgets/window.cpp" line="1957"/>
         <source>Read-Only mode is on</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2322"/>
+        <location filename="../src/widgets/window.cpp" line="2511"/>
         <source>Current location remembered</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2398"/>
+        <location filename="../src/widgets/window.cpp" line="2591"/>
         <source>Ctrl+&apos;=&apos;</source>
         <translation>Ctrl+&apos;=&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2401"/>
+        <location filename="../src/widgets/window.cpp" line="2594"/>
         <source>Ctrl+&apos;-&apos;</source>
         <translation>Ctrl+&apos;-&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2430"/>
+        <location filename="../src/widgets/window.cpp" line="2623"/>
         <source>Editor</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3061"/>
+        <location filename="../src/widgets/window.cpp" line="3436"/>
         <source>Untitled %1</source>
         <translation>Ανώνυμο %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3543"/>
+        <location filename="../src/widgets/window.cpp" line="3948"/>
         <source>Cancel</source>
         <translation>Άκυρο</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3544"/>
+        <location filename="../src/widgets/window.cpp" line="3949"/>
         <source>Discard</source>
         <translation>Απόρριψη</translation>
     </message>

--- a/translations/deepin-editor_es.ts
+++ b/translations/deepin-editor_es.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="es">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="es">
 <context>
     <name>BottomBar</name>
     <message>
@@ -17,17 +19,36 @@
         <translation>Caracteres %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="44"/>
+        <location filename="../src/widgets/bottombar.cpp" line="47"/>
         <source>Loading:</source>
         <translation>Cargando:</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="73"/>
+        <location filename="../src/widgets/bottombar.cpp" line="91"/>
+        <location filename="../src/widgets/bottombar.cpp" line="499"/>
+        <source>Edit Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="74"/>
+        <location filename="../src/widgets/bottombar.cpp" line="489"/>
+        <source>Read View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="75"/>
+        <location filename="../src/widgets/bottombar.cpp" line="493"/>
+        <source>Live Preview</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DDropdownMenu</name>
     <message>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="362"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="420"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="425"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="363"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="421"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="426"/>
         <source>None</source>
         <translation>Ninguno</translation>
     </message>
@@ -35,68 +56,57 @@
 <context>
     <name>EditWrapper</name>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="292"/>
-        <location filename="../src/editor/editwrapper.cpp" line="365"/>
-        <location filename="../src/editor/editwrapper.cpp" line="521"/>
-        <location filename="../src/editor/editwrapper.cpp" line="751"/>
+        <location filename="../src/editor/editwrapper.cpp" line="355"/>
+        <location filename="../src/editor/editwrapper.cpp" line="429"/>
+        <location filename="../src/editor/editwrapper.cpp" line="595"/>
+        <location filename="../src/editor/editwrapper.cpp" line="887"/>
         <source>Save</source>
         <translation>Guardar</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="516"/>
+        <location filename="../src/editor/editwrapper.cpp" line="590"/>
         <source>Do you want to save this file?</source>
         <translation>¿Desea guardar este archivo?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="363"/>
-        <location filename="../src/editor/editwrapper.cpp" line="519"/>
+        <location filename="../src/editor/editwrapper.cpp" line="427"/>
+        <location filename="../src/editor/editwrapper.cpp" line="593"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="360"/>
+        <location filename="../src/editor/editwrapper.cpp" line="424"/>
         <source>Encoding changed. Do you want to save the file now?</source>
         <translation>La codificación ha cambiado. ¿Desea guardar el archivo ahora?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="520"/>
+        <location filename="../src/editor/editwrapper.cpp" line="594"/>
         <source>Discard</source>
         <translation>Descartar</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="274"/>
-        <location filename="../src/editor/editwrapper.cpp" line="620"/>
+        <location filename="../src/editor/editwrapper.cpp" line="1121"/>
+        <source>The file contains invalid characters (NUL). Preview mode is read-only.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="337"/>
+        <location filename="../src/editor/editwrapper.cpp" line="705"/>
         <source>You do not have permission to save %1</source>
         <translation>No tienes permisos para guardar %1</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="836"/>
+        <location filename="../src/editor/editwrapper.cpp" line="987"/>
         <source>File removed on the disk. Save it now?</source>
         <translation>Archivo eliminado en el disco. ¿Desea guardarlo?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="842"/>
+        <location filename="../src/editor/editwrapper.cpp" line="993"/>
         <source>File has changed on disk. Reload?</source>
         <translation>El archivo ha cambiado en el disco. ¿Recargar?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="884"/>
-        <location filename="../src/widgets/bottombar.cpp" line="74"/>
-        <source>INSERT</source>
-        <translation>INSERTAR</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="888"/>
-        <source>OVERWRITE</source>
-        <translation>SOBRESCRIBIR</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="892"/>
-        <source>R/O</source>
-        <translation>R/O</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="1618"/>
+        <location filename="../src/editor/editwrapper.cpp" line="1806"/>
         <source>The file cannot be read, which may be too large or has been damaged!</source>
         <translation>¡No se puede leer el archivo, puede ser demasiado grande o estar dañado!</translation>
     </message>
@@ -109,17 +119,17 @@
         <translation>Buscar</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="36"/>
+        <location filename="../src/controls/findbar.cpp" line="38"/>
         <source>Previous</source>
         <translation>Anterior</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="37"/>
+        <location filename="../src/controls/findbar.cpp" line="40"/>
         <source>Next</source>
         <translation>Siguiente</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="38"/>
+        <location filename="../src/controls/findbar.cpp" line="42"/>
         <source>Replace</source>
         <translation>Reemplazar</translation>
     </message>
@@ -127,9 +137,17 @@
 <context>
     <name>JumpLineBar</name>
     <message>
-        <location filename="../src/controls/jumplinebar.cpp" line="45"/>
+        <location filename="../src/controls/jumplinebar.cpp" line="46"/>
         <source>Go to Line: </source>
         <translation>Ir a la línea</translation>
+    </message>
+</context>
+<context>
+    <name>LineBar</name>
+    <message>
+        <location filename="../src/controls/linebar.cpp" line="144"/>
+        <source>第%1/%2项</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -146,19 +164,47 @@
     </message>
 </context>
 <context>
+    <name>MarkdownBridge</name>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="37"/>
+        <source>Collapse code block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="38"/>
+        <source>Expand code block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="39"/>
+        <source>Copy code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="40"/>
+        <source>Expand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="42"/>
+        <source>%1 line(s) of code collapsed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PathSettingWgt</name>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="84"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="90"/>
         <source>Remember the last used path</source>
         <translation>Recordar la última ruta usada</translation>
     </message>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="85"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="91"/>
         <source>Same path as the current file</source>
         <translation>Misma ruta que el archivo actual</translation>
     </message>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="86"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="92"/>
         <source>Customize the default path</source>
         <translation>Personalizar la ruta predeterminada</translation>
     </message>
@@ -171,15 +217,20 @@
         <translation>Editor de texto</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="294"/>
-        <location filename="../src/editor/editwrapper.cpp" line="761"/>
-        <location filename="../src/editor/editwrapper.cpp" line="776"/>
-        <location filename="../src/widgets/window.cpp" line="1362"/>
-        <location filename="../src/widgets/window.cpp" line="1390"/>
-        <location filename="../src/widgets/window.cpp" line="1531"/>
-        <location filename="../src/widgets/window.cpp" line="1548"/>
+        <location filename="../src/editor/editwrapper.cpp" line="357"/>
+        <location filename="../src/editor/editwrapper.cpp" line="897"/>
+        <location filename="../src/editor/editwrapper.cpp" line="912"/>
+        <location filename="../src/widgets/window.cpp" line="1528"/>
+        <location filename="../src/widgets/window.cpp" line="1556"/>
+        <location filename="../src/widgets/window.cpp" line="1715"/>
+        <location filename="../src/widgets/window.cpp" line="1732"/>
         <source>Encoding</source>
         <translation>Codificación</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="2001"/>
+        <source>视图模式</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="11"/>
@@ -215,7 +266,7 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="18"/>
         <location filename="../src/controls/settingsdialog.cpp" line="96"/>
-        <location filename="../src/widgets/window.cpp" line="2388"/>
+        <location filename="../src/widgets/window.cpp" line="2581"/>
         <source>Window</source>
         <translation>Ventana</translation>
     </message>
@@ -755,68 +806,68 @@
         <translation>Vietnamita</translation>
     </message>
     <message>
-        <location filename="../src/startmanager.cpp" line="971"/>
+        <location filename="../src/startmanager.cpp" line="1035"/>
         <source>File not saved</source>
         <translation>No se guardó el archivo</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1532"/>
-        <location filename="../src/widgets/window.cpp" line="1549"/>
+        <location filename="../src/widgets/window.cpp" line="1716"/>
+        <location filename="../src/widgets/window.cpp" line="1733"/>
         <source>Line Endings</source>
         <translation>Finales de línea</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="243"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="379"/>
         <source>Please install &apos;UOS AI&apos; from the App Store before using</source>
         <translation>Por favor, instale &apos;UOS AI&apos; desde la App Store antes de usarlo</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="245"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="381"/>
         <source>No audio input device detected. Please check and try again</source>
         <translation>No se detectó ningún dispositivo de entrada de audio. Por favor, compruebe y pruebe de nuevo</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="247"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="383"/>
         <source>No audio output device detected. Please check and try again</source>
         <translation>No se detectó ningún dispositivo de salida de audio. Por favor, compruebe y pruebe de nuevo</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="69"/>
+        <location filename="../src/common/text_file_saver.cpp" line="74"/>
         <source>File path is empty</source>
         <translation>La ruta del archivo está vacía</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="155"/>
+        <location filename="../src/common/text_file_saver.cpp" line="153"/>
         <source>Insufficient memory to load document content</source>
         <translation>Memoria insuficiente para cargar el contenido del documento</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="177"/>
+        <location filename="../src/common/text_file_saver.cpp" line="178"/>
         <source>Insufficient memory for encoding conversion</source>
         <translation>Memoria insuficiente para la conversión de codificación</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="183"/>
+        <location filename="../src/common/text_file_saver.cpp" line="184"/>
         <source>Encoding conversion failed</source>
         <translation>La conversión de codificación falló</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="189"/>
+        <location filename="../src/common/text_file_saver.cpp" line="190"/>
         <source>Converted content is empty</source>
         <translation>El contenido convertido está vacío</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="207"/>
+        <location filename="../src/common/text_file_saver.cpp" line="208"/>
         <source>Memory allocation failed</source>
         <translation>La asignación de memoria falló</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="211"/>
+        <location filename="../src/common/text_file_saver.cpp" line="212"/>
         <source>Error occurred: %1</source>
         <translation>Se produjo un error: %1</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="215"/>
+        <location filename="../src/common/text_file_saver.cpp" line="216"/>
         <source>Unknown error occurred</source>
         <translation>Se produjo un error desconocido</translation>
     </message>
@@ -829,27 +880,27 @@
         <translation>Buscar</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="34"/>
+        <location filename="../src/controls/replacebar.cpp" line="36"/>
         <source>Replace With</source>
         <translation>Reemplazar con</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="36"/>
+        <location filename="../src/controls/replacebar.cpp" line="40"/>
         <source>Replace</source>
         <translation>Reemplazar</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="37"/>
+        <location filename="../src/controls/replacebar.cpp" line="42"/>
         <source>Skip</source>
         <translation>Omitir</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="38"/>
+        <location filename="../src/controls/replacebar.cpp" line="44"/>
         <source>Replace Rest</source>
         <translation>Reemplazar el resto</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="39"/>
+        <location filename="../src/controls/replacebar.cpp" line="46"/>
         <source>Replace All</source>
         <translation>Reemplazar todo</translation>
     </message>
@@ -858,9 +909,9 @@
     <name>S:</name>
     <message>
         <location filename="../third/libiconv-1.16/src/iconv.c" line="103"/>
-        <source/>
+        <source></source>
         <comment>The first line of the short usage message.</comment>
-        <translation type="unfinished"/>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -891,34 +942,34 @@
         <translation>Pantalla completa</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="484"/>
+        <location filename="../src/common/settings.cpp" line="491"/>
         <source>This shortcut conflicts with system shortcut %1</source>
         <translation>Este atajo entra en conflicto con el atajo del sistema %1</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="487"/>
+        <location filename="../src/common/settings.cpp" line="494"/>
         <source>This shortcut conflicts with %1, click on Replace to make this shortcut effective immediately</source>
         <translation>Este atajo entra en conflicto con %1, haga clic en Reemplazar para que este atajo sea efectivo inmediatamente</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="682"/>
-        <location filename="../src/common/settings.cpp" line="695"/>
-        <location filename="../src/common/settings.cpp" line="704"/>
+        <location filename="../src/common/settings.cpp" line="689"/>
+        <location filename="../src/common/settings.cpp" line="702"/>
+        <location filename="../src/common/settings.cpp" line="711"/>
         <source>The shortcut %1 is invalid, please set another one.</source>
         <translation>El atajo %1 es inválido, por favor ponga otro.</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="736"/>
+        <location filename="../src/common/settings.cpp" line="743"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="737"/>
+        <location filename="../src/common/settings.cpp" line="744"/>
         <source>Replace</source>
         <translation>Reemplazar</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="740"/>
+        <location filename="../src/common/settings.cpp" line="747"/>
         <source>OK</source>
         <translation>Aceptar</translation>
     </message>
@@ -926,7 +977,7 @@
 <context>
     <name>StartManager</name>
     <message>
-        <location filename="../src/startmanager.cpp" line="411"/>
+        <location filename="../src/startmanager.cpp" line="425"/>
         <source>Untitled %1</source>
         <translation>Sin título %1</translation>
     </message>
@@ -934,32 +985,32 @@
 <context>
     <name>Tabbar</name>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="641"/>
+        <location filename="../src/controls/tabbar.cpp" line="678"/>
         <source>Close tab</source>
         <translation>Cerrar pestaña</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="642"/>
+        <location filename="../src/controls/tabbar.cpp" line="680"/>
         <source>Close other tabs</source>
         <translation>Cerrar otras pestañas</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="643"/>
+        <location filename="../src/controls/tabbar.cpp" line="682"/>
         <source>More options</source>
         <translation>Más opciones</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="644"/>
+        <location filename="../src/controls/tabbar.cpp" line="684"/>
         <source>Close tabs to the left</source>
         <translation>Cerrar las pestañas de la izquierda</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="645"/>
+        <location filename="../src/controls/tabbar.cpp" line="686"/>
         <source>Close tabs to the right</source>
         <translation>Cerrar las pestañas de la derecha</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="646"/>
+        <location filename="../src/controls/tabbar.cpp" line="688"/>
         <source>Close unmodified tabs</source>
         <translation>Cerrar las pestañas sin modificar</translation>
     </message>
@@ -967,263 +1018,280 @@
 <context>
     <name>TextEdit</name>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="305"/>
+        <location filename="../src/editor/dtextedit.cpp" line="388"/>
         <source>Undo</source>
         <translation>Deshacer</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="306"/>
+        <location filename="../src/editor/dtextedit.cpp" line="390"/>
         <source>Redo</source>
         <translation>Rehacer</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="307"/>
+        <location filename="../src/editor/dtextedit.cpp" line="392"/>
         <source>Cut</source>
         <translation>Cortar</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="308"/>
+        <location filename="../src/editor/dtextedit.cpp" line="394"/>
         <source>Copy</source>
         <translation>Copiar</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="309"/>
+        <location filename="../src/editor/dtextedit.cpp" line="396"/>
         <source>Paste</source>
         <translation>Pegar</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="310"/>
+        <location filename="../src/editor/dtextedit.cpp" line="398"/>
         <source>Delete</source>
         <translation>Borrar</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="311"/>
+        <location filename="../src/editor/dtextedit.cpp" line="400"/>
         <source>Select All</source>
         <translation>Seleccionar todo</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="312"/>
-        <location filename="../src/widgets/window.cpp" line="535"/>
+        <location filename="../src/editor/dtextedit.cpp" line="402"/>
+        <location filename="../src/widgets/window.cpp" line="556"/>
         <source>Find</source>
         <translation>Buscar</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="313"/>
-        <location filename="../src/widgets/window.cpp" line="536"/>
+        <location filename="../src/editor/dtextedit.cpp" line="404"/>
+        <location filename="../src/widgets/window.cpp" line="558"/>
         <source>Replace</source>
         <translation>Reemplazar</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="314"/>
+        <location filename="../src/editor/dtextedit.cpp" line="406"/>
         <source>Go to Line</source>
         <translation>Ir a la línea</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="315"/>
-        <source>Turn on Read-Only mode</source>
-        <translation>Activar modo solo lectura</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="316"/>
-        <source>Turn off Read-Only mode</source>
-        <translation>Desactivar modo solo lectura</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="317"/>
+        <location filename="../src/editor/dtextedit.cpp" line="415"/>
         <source>Fullscreen</source>
         <translation>Pantalla completa</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="318"/>
+        <location filename="../src/editor/dtextedit.cpp" line="417"/>
         <source>Exit fullscreen</source>
         <translation>Salir de la pantalla completa</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="319"/>
+        <location filename="../src/editor/dtextedit.cpp" line="419"/>
         <source>Display in file manager</source>
         <translation>Mostrar en el administrador de archivos</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="320"/>
-        <location filename="../src/editor/dtextedit.cpp" line="374"/>
+        <location filename="../src/editor/dtextedit.cpp" line="421"/>
+        <location filename="../src/editor/dtextedit.cpp" line="493"/>
         <source>Add Comment</source>
         <translation>Añadir comentario</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="321"/>
+        <location filename="../src/editor/dtextedit.cpp" line="423"/>
         <source>Text to Speech</source>
         <translation>Texto a voz</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="322"/>
-        <source>Stop reading</source>
-        <translation>Detener lectura</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="323"/>
+        <location filename="../src/editor/dtextedit.cpp" line="425"/>
         <source>Speech to Text</source>
         <translation>Voz a texto</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="324"/>
+        <location filename="../src/editor/dtextedit.cpp" line="427"/>
         <source>Translate</source>
         <translation>Traducir</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="325"/>
+        <location filename="../src/editor/dtextedit.cpp" line="429"/>
         <source>Column Mode</source>
         <translation>Modo de columna</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="326"/>
+        <location filename="../src/editor/dtextedit.cpp" line="431"/>
         <source>Add bookmark</source>
         <translation>Añadir marcador</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="327"/>
+        <location filename="../src/editor/dtextedit.cpp" line="433"/>
         <source>Remove Bookmark</source>
         <translation>Quitar marcador</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="328"/>
+        <location filename="../src/editor/dtextedit.cpp" line="435"/>
         <source>Previous bookmark</source>
         <translation>Marcador anterior</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="329"/>
+        <location filename="../src/editor/dtextedit.cpp" line="437"/>
         <source>Next bookmark</source>
         <translation>Marcador siguiente</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="330"/>
+        <location filename="../src/editor/dtextedit.cpp" line="439"/>
         <source>Remove All Bookmarks</source>
         <translation>Quitar todos los marcadores</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="331"/>
+        <location filename="../src/editor/dtextedit.cpp" line="441"/>
         <source>Fold All</source>
         <translation>Ocultar todo</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="332"/>
+        <location filename="../src/editor/dtextedit.cpp" line="443"/>
         <source>Fold Current Level</source>
         <translation>Ocultar el nivel actual</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="333"/>
+        <location filename="../src/editor/dtextedit.cpp" line="445"/>
         <source>Unfold All</source>
         <translation>Mostrar todo</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="334"/>
+        <location filename="../src/editor/dtextedit.cpp" line="447"/>
         <source>Unfold Current Level</source>
         <translation>Mostrar el nivel actual</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="339"/>
+        <location filename="../src/editor/dtextedit.cpp" line="453"/>
         <source>Color Mark</source>
         <translation>Resaltador</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="343"/>
+        <location filename="../src/editor/dtextedit.cpp" line="458"/>
         <source>Clear All Marks</source>
         <translation>Borrar todo lo resaltado</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="344"/>
+        <location filename="../src/editor/dtextedit.cpp" line="460"/>
         <source>Clear Last Mark</source>
         <translation>Borrar último resalte</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="353"/>
+        <location filename="../src/editor/dtextedit.cpp" line="470"/>
         <source>Mark</source>
         <translation>Resaltar</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="366"/>
+        <location filename="../src/editor/dtextedit.cpp" line="484"/>
         <source>Mark All</source>
         <translation>Resaltar todo</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="375"/>
+        <location filename="../src/editor/dtextedit.cpp" line="494"/>
         <source>Remove Comment</source>
         <translation>Borrar comentario</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3208"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3211"/>
+        <location filename="../src/editor/dtextedit.cpp" line="543"/>
+        <source>View Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="3531"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3534"/>
         <source>Copy failed: not enough memory</source>
         <translation>Copia fallida: no hay suficiente memoria</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3333"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3335"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3656"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3658"/>
         <source>Press ALT and click lines to edit in column mode</source>
         <translation>Presiona ALT y haga clic en las líneas para editar en el modo de columna</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="418"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9574"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9576"/>
+        <source>No audio output device was detected. Please ensure your speakers or headphones are properly connected and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="9583"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9585"/>
+        <source>No audio input device was detected. Please ensure your speakers or headphones are properly connected and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="534"/>
         <source>Change Case</source>
         <translation>Formato de texto</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="419"/>
+        <location filename="../src/editor/dtextedit.cpp" line="409"/>
+        <source>Edit Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="411"/>
+        <source>Read View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="413"/>
+        <source>Live Preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="535"/>
         <source>Upper Case</source>
         <translation>Mayúsculas</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="420"/>
+        <location filename="../src/editor/dtextedit.cpp" line="536"/>
         <source>Lower Case</source>
         <translation>Minúsculas</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="421"/>
+        <location filename="../src/editor/dtextedit.cpp" line="537"/>
         <source>Capitalize</source>
         <translation>Capitalizar</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="78"/>
+        <location filename="../src/widgets/bottombar.cpp" line="110"/>
         <source>None</source>
         <translation>Ninguno</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1363"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1490"/>
         <source>Selected line(s) copied</source>
         <translation>Líneas seleccionadas copiadas</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1370"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1497"/>
         <source>Current line copied</source>
         <translation>Línea actual copiada</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1400"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1527"/>
         <source>Selected line(s) clipped</source>
         <translation>Líneas seleccionadas cortadas</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1412"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1539"/>
         <source>Current line clipped</source>
         <translation>Línea actual cortada</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3227"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3230"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3550"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3553"/>
         <source>Paste failed: not enough memory</source>
         <translation>Fallo al pegar: no hay suficiente memoria</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="4548"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4873"/>
         <source>Read-Only mode is off</source>
         <translation>Modo solo lectura desactivado</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="4560"/>
-        <location filename="../src/editor/dtextedit.cpp" line="4584"/>
-        <location filename="../src/editor/dtextedit.cpp" line="7896"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8007"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8015"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8026"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4885"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4909"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8236"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8347"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8355"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8366"/>
         <source>Read-Only mode is on</source>
         <translation>Modo solo lectura activado</translation>
     </message>
@@ -1231,138 +1299,175 @@
 <context>
     <name>WarningNotices</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="24"/>
+        <location filename="../src/controls/warningnotices.cpp" line="25"/>
         <source>Reload</source>
         <translation>Recargar</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/warningnotices.cpp" line="29"/>
+        <source>Edit Anyway</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>Window</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="25"/>
-        <location filename="../src/widgets/window.cpp" line="531"/>
+        <location filename="../src/controls/warningnotices.cpp" line="27"/>
+        <location filename="../src/widgets/window.cpp" line="548"/>
         <source>Save as</source>
         <translation>Guardar como</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="527"/>
+        <location filename="../src/widgets/window.cpp" line="540"/>
         <source>New window</source>
         <translation>Nueva ventana</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="528"/>
+        <location filename="../src/widgets/window.cpp" line="542"/>
         <source>New tab</source>
         <translation>Nueva pestaña</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="529"/>
+        <location filename="../src/widgets/window.cpp" line="544"/>
         <source>Open file</source>
         <translation>Abrir archivo</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="530"/>
-        <location filename="../src/widgets/window.cpp" line="3545"/>
+        <location filename="../src/widgets/window.cpp" line="546"/>
+        <location filename="../src/widgets/window.cpp" line="3950"/>
         <source>Save</source>
         <translation>Guardar</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="532"/>
+        <location filename="../src/widgets/window.cpp" line="550"/>
         <source>Print</source>
         <translation>Imprimir</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="533"/>
+        <location filename="../src/widgets/window.cpp" line="552"/>
         <source>Switch theme</source>
         <translation>Cambiar el tema</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="534"/>
-        <location filename="../src/widgets/window.cpp" line="2448"/>
+        <location filename="../src/widgets/window.cpp" line="554"/>
+        <location filename="../src/widgets/window.cpp" line="2641"/>
         <source>Settings</source>
         <translation>Ajustes</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="666"/>
-        <location filename="../src/widgets/window.cpp" line="3845"/>
+        <location filename="../src/widgets/window.cpp" line="696"/>
+        <location filename="../src/widgets/window.cpp" line="4250"/>
         <source>Read-Only</source>
         <translation>Sólo lectura</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="687"/>
+        <location filename="../src/widgets/window.cpp" line="719"/>
         <source>You do not have permission to open %1</source>
         <translation>No tienes permisos para abrir %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="738"/>
-        <location filename="../src/widgets/window.cpp" line="2963"/>
+        <location filename="../src/widgets/window.cpp" line="773"/>
+        <location filename="../src/widgets/window.cpp" line="3266"/>
         <source>Invalid file: %1</source>
         <translation>Archivo inválido: %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="903"/>
-        <location filename="../src/widgets/window.cpp" line="956"/>
+        <location filename="../src/widgets/window.cpp" line="957"/>
+        <location filename="../src/widgets/window.cpp" line="1050"/>
+        <location filename="../src/widgets/window.cpp" line="3217"/>
         <source>Do you want to save this file?</source>
         <translation>¿Desea guardar este archivo?</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1290"/>
+        <location filename="../src/widgets/window.cpp" line="1381"/>
+        <source>Invalid characters detected while saving &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1382"/>
+        <source>If you force save this file, it may cause file corruption. Still want to save?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1386"/>
+        <source>Don&apos;t Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1387"/>
+        <source>Save As</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1388"/>
+        <source>Save Anyway</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1456"/>
         <source>You do not have permission to save %1</source>
         <translation>No tienes permisos para guardar %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1312"/>
+        <location filename="../src/widgets/window.cpp" line="1428"/>
+        <location filename="../src/widgets/window.cpp" line="1478"/>
         <source>Saved successfully</source>
         <translation>Guardado exitosamente</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1354"/>
-        <location filename="../src/widgets/window.cpp" line="1481"/>
-        <location filename="../src/widgets/window.cpp" line="1529"/>
+        <location filename="../src/widgets/window.cpp" line="1520"/>
+        <location filename="../src/widgets/window.cpp" line="1665"/>
+        <location filename="../src/widgets/window.cpp" line="1713"/>
         <source>Save File</source>
         <translation>Guardar el archivo</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1483"/>
+        <location filename="../src/widgets/window.cpp" line="1569"/>
+        <source>Cannot save as the original file in preview mode. Please choose a different path.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1667"/>
         <source>Encoding</source>
         <translation>Codificación</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1773"/>
+        <location filename="../src/widgets/window.cpp" line="1957"/>
         <source>Read-Only mode is on</source>
         <translation>Modo solo lectura activado</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2322"/>
+        <location filename="../src/widgets/window.cpp" line="2511"/>
         <source>Current location remembered</source>
         <translation>Guardar ubicación actual</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2398"/>
+        <location filename="../src/widgets/window.cpp" line="2591"/>
         <source>Ctrl+&apos;=&apos;</source>
         <translation>Ctrl+&apos;=&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2401"/>
+        <location filename="../src/widgets/window.cpp" line="2594"/>
         <source>Ctrl+&apos;-&apos;</source>
         <translation>Ctrl+&apos;-&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2430"/>
+        <location filename="../src/widgets/window.cpp" line="2623"/>
         <source>Editor</source>
         <translation>Editor</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3061"/>
+        <location filename="../src/widgets/window.cpp" line="3436"/>
         <source>Untitled %1</source>
         <translation>Sin título %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3543"/>
+        <location filename="../src/widgets/window.cpp" line="3948"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3544"/>
+        <location filename="../src/widgets/window.cpp" line="3949"/>
         <source>Discard</source>
         <translation>Descartar</translation>
     </message>

--- a/translations/deepin-editor_et.ts
+++ b/translations/deepin-editor_et.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="et">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="et">
 <context>
     <name>BottomBar</name>
     <message>
@@ -14,20 +16,39 @@
     <message>
         <location filename="../src/widgets/bottombar.cpp" line="32"/>
         <source>Characters %1</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="44"/>
+        <location filename="../src/widgets/bottombar.cpp" line="47"/>
         <source>Loading:</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="73"/>
+        <location filename="../src/widgets/bottombar.cpp" line="91"/>
+        <location filename="../src/widgets/bottombar.cpp" line="499"/>
+        <source>Edit Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="74"/>
+        <location filename="../src/widgets/bottombar.cpp" line="489"/>
+        <source>Read View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="75"/>
+        <location filename="../src/widgets/bottombar.cpp" line="493"/>
+        <source>Live Preview</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DDropdownMenu</name>
     <message>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="362"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="420"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="425"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="363"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="421"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="426"/>
         <source>None</source>
         <translation>Pole</translation>
     </message>
@@ -35,70 +56,59 @@
 <context>
     <name>EditWrapper</name>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="292"/>
-        <location filename="../src/editor/editwrapper.cpp" line="365"/>
-        <location filename="../src/editor/editwrapper.cpp" line="521"/>
-        <location filename="../src/editor/editwrapper.cpp" line="751"/>
+        <location filename="../src/editor/editwrapper.cpp" line="355"/>
+        <location filename="../src/editor/editwrapper.cpp" line="429"/>
+        <location filename="../src/editor/editwrapper.cpp" line="595"/>
+        <location filename="../src/editor/editwrapper.cpp" line="887"/>
         <source>Save</source>
         <translation>Salvesta</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="516"/>
+        <location filename="../src/editor/editwrapper.cpp" line="590"/>
         <source>Do you want to save this file?</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="363"/>
-        <location filename="../src/editor/editwrapper.cpp" line="519"/>
+        <location filename="../src/editor/editwrapper.cpp" line="427"/>
+        <location filename="../src/editor/editwrapper.cpp" line="593"/>
         <source>Cancel</source>
         <translation>Loobu</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="360"/>
+        <location filename="../src/editor/editwrapper.cpp" line="424"/>
         <source>Encoding changed. Do you want to save the file now?</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="520"/>
+        <location filename="../src/editor/editwrapper.cpp" line="594"/>
         <source>Discard</source>
         <translation>Loobu</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="274"/>
-        <location filename="../src/editor/editwrapper.cpp" line="620"/>
+        <location filename="../src/editor/editwrapper.cpp" line="1121"/>
+        <source>The file contains invalid characters (NUL). Preview mode is read-only.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="337"/>
+        <location filename="../src/editor/editwrapper.cpp" line="705"/>
         <source>You do not have permission to save %1</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="836"/>
+        <location filename="../src/editor/editwrapper.cpp" line="987"/>
         <source>File removed on the disk. Save it now?</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="842"/>
+        <location filename="../src/editor/editwrapper.cpp" line="993"/>
         <source>File has changed on disk. Reload?</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="884"/>
-        <location filename="../src/widgets/bottombar.cpp" line="74"/>
-        <source>INSERT</source>
-        <translation>SISESTA</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="888"/>
-        <source>OVERWRITE</source>
-        <translation>KIRJUTA ÜLE</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="892"/>
-        <source>R/O</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="1618"/>
+        <location filename="../src/editor/editwrapper.cpp" line="1806"/>
         <source>The file cannot be read, which may be too large or has been damaged!</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -109,17 +119,17 @@
         <translation>Leia</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="36"/>
+        <location filename="../src/controls/findbar.cpp" line="38"/>
         <source>Previous</source>
         <translation>Eelmine</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="37"/>
+        <location filename="../src/controls/findbar.cpp" line="40"/>
         <source>Next</source>
         <translation>Järgmine</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="38"/>
+        <location filename="../src/controls/findbar.cpp" line="42"/>
         <source>Replace</source>
         <translation>Asenda</translation>
     </message>
@@ -127,9 +137,17 @@
 <context>
     <name>JumpLineBar</name>
     <message>
-        <location filename="../src/controls/jumplinebar.cpp" line="45"/>
+        <location filename="../src/controls/jumplinebar.cpp" line="46"/>
         <source>Go to Line: </source>
         <translation>Mine reale:</translation>
+    </message>
+</context>
+<context>
+    <name>LineBar</name>
+    <message>
+        <location filename="../src/controls/linebar.cpp" line="144"/>
+        <source>第%1/%2项</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -137,7 +155,7 @@
     <message>
         <location filename="../src/editorapplication.cpp" line="12"/>
         <source>Text Editor is a powerful tool for viewing and editing text files.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/editorapplication.cpp" line="34"/>
@@ -146,21 +164,49 @@
     </message>
 </context>
 <context>
+    <name>MarkdownBridge</name>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="37"/>
+        <source>Collapse code block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="38"/>
+        <source>Expand code block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="39"/>
+        <source>Copy code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="40"/>
+        <source>Expand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="42"/>
+        <source>%1 line(s) of code collapsed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PathSettingWgt</name>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="84"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="90"/>
         <source>Remember the last used path</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="85"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="91"/>
         <source>Same path as the current file</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="86"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="92"/>
         <source>Customize the default path</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -171,15 +217,20 @@
         <translation>Tekstiredaktor</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="294"/>
-        <location filename="../src/editor/editwrapper.cpp" line="761"/>
-        <location filename="../src/editor/editwrapper.cpp" line="776"/>
-        <location filename="../src/widgets/window.cpp" line="1362"/>
-        <location filename="../src/widgets/window.cpp" line="1390"/>
-        <location filename="../src/widgets/window.cpp" line="1531"/>
-        <location filename="../src/widgets/window.cpp" line="1548"/>
+        <location filename="../src/editor/editwrapper.cpp" line="357"/>
+        <location filename="../src/editor/editwrapper.cpp" line="897"/>
+        <location filename="../src/editor/editwrapper.cpp" line="912"/>
+        <location filename="../src/widgets/window.cpp" line="1528"/>
+        <location filename="../src/widgets/window.cpp" line="1556"/>
+        <location filename="../src/widgets/window.cpp" line="1715"/>
+        <location filename="../src/widgets/window.cpp" line="1732"/>
         <source>Encoding</source>
         <translation>Kodeering</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="2001"/>
+        <source>视图模式</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="11"/>
@@ -210,12 +261,12 @@
         <location filename="../src/controls/settingsdialog.cpp" line="16"/>
         <location filename="../src/controls/settingsdialog.cpp" line="17"/>
         <source>Keymap</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="18"/>
         <location filename="../src/controls/settingsdialog.cpp" line="96"/>
-        <location filename="../src/widgets/window.cpp" line="2388"/>
+        <location filename="../src/widgets/window.cpp" line="2581"/>
         <source>Window</source>
         <translation>Aken</translation>
     </message>
@@ -262,7 +313,7 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="27"/>
         <source>Restore tab</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="28"/>
@@ -272,17 +323,17 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="29"/>
         <source>Increment font size</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="30"/>
         <source>Decrement font size</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="31"/>
         <source>Reset font size</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="32"/>
@@ -292,7 +343,7 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="33"/>
         <source>Toggle fullscreen</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="34"/>
@@ -302,12 +353,12 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="35"/>
         <source>Find Next</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="36"/>
         <source>Find Previous</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="37"/>
@@ -322,12 +373,12 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="39"/>
         <source>Save cursor position</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="40"/>
         <source>Reset cursor position</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="41"/>
@@ -337,7 +388,7 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="42"/>
         <source>Display shortcuts</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="43"/>
@@ -352,32 +403,32 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="45"/>
         <source>Increase indent</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="46"/>
         <source>Decrease indent</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="47"/>
         <source>Forward character</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="48"/>
         <source>Backward character</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="49"/>
         <source>Forward word</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="50"/>
         <source>Backward word</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="51"/>
@@ -397,117 +448,117 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="54"/>
         <source>New line above</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="55"/>
         <source>New line below</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="56"/>
         <source>Duplicate line</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="57"/>
         <source>Delete to end of line</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="58"/>
         <source>Delete current line</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="59"/>
         <source>Swap line up</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="60"/>
         <source>Swap line down</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="61"/>
         <source>Scroll up one line</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="62"/>
         <source>Scroll down one line</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="63"/>
         <source>Page up</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="64"/>
         <source>Page down</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="65"/>
         <source>Move to end of line</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="66"/>
         <source>Move to start of line</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="67"/>
         <source>Move to end of text</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="68"/>
         <source>Move to start of text</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="69"/>
         <source>Move to line indentation</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="70"/>
         <source>Upper case</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="71"/>
         <source>Lower case</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="72"/>
         <source>Capitalize</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="73"/>
         <source>Delete backward word</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="74"/>
         <source>Delete forward word</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="75"/>
         <source>Forward over a pair</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="76"/>
         <source>Backward over a pair</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="77"/>
@@ -532,17 +583,17 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="81"/>
         <source>Transpose character</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="82"/>
         <source>Mark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="83"/>
         <source>Unmark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="84"/>
@@ -557,52 +608,52 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="86"/>
         <source>Merge lines</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="87"/>
         <source>Read-Only mode</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="88"/>
         <source>Add comment</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="89"/>
         <source>Remove comment</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="90"/>
         <source>Undo</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="91"/>
         <source>Redo</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="92"/>
         <source>Add/Remove bookmark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="93"/>
         <source>Move to previous bookmark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="94"/>
         <source>Move to next bookmark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="95"/>
         <source>Advanced</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="97"/>
@@ -612,213 +663,213 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="98"/>
         <source>Tab width</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="99"/>
         <source>Paste by pressing a middle mouse button</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="101"/>
         <source>Startup</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="102"/>
         <source>Reopen last closed tabs</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="104"/>
         <source>Open/Save Settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="106"/>
         <source>Word wrap</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="107"/>
         <source>Code folding flag</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="108"/>
         <source>Show line numbers</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="109"/>
         <source>Show bookmarks icon</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="110"/>
         <source>Show whitespaces and tabs</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="111"/>
         <source>Highlight current line</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="112"/>
         <source>Color mark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="115"/>
         <source>Unicode</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="116"/>
         <source>WesternEuropean</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="117"/>
         <source>CentralEuropean</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="118"/>
         <source>Baltic</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="119"/>
         <source>Cyrillic</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="120"/>
         <source>Arabic</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="125"/>
         <source>Celtic</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="126"/>
         <source>SouthEasternEuropean</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="121"/>
         <source>Greek</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="122"/>
         <source>Hebrew</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="127"/>
         <source>ChineseSimplified</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="128"/>
         <source>ChineseTraditional</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="129"/>
         <source>Japanese</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="130"/>
         <source>Korean</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="124"/>
         <source>Thai</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="123"/>
         <source>Turkish</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="131"/>
         <source>Vietnamese</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/startmanager.cpp" line="971"/>
+        <location filename="../src/startmanager.cpp" line="1035"/>
         <source>File not saved</source>
         <translation>Faili pole salvestatud</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1532"/>
-        <location filename="../src/widgets/window.cpp" line="1549"/>
+        <location filename="../src/widgets/window.cpp" line="1716"/>
+        <location filename="../src/widgets/window.cpp" line="1733"/>
         <source>Line Endings</source>
         <translation>Realõpud</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="243"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="379"/>
         <source>Please install &apos;UOS AI&apos; from the App Store before using</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="245"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="381"/>
         <source>No audio input device detected. Please check and try again</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="247"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="383"/>
         <source>No audio output device detected. Please check and try again</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="69"/>
+        <location filename="../src/common/text_file_saver.cpp" line="74"/>
         <source>File path is empty</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="155"/>
+        <location filename="../src/common/text_file_saver.cpp" line="153"/>
         <source>Insufficient memory to load document content</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="177"/>
+        <location filename="../src/common/text_file_saver.cpp" line="178"/>
         <source>Insufficient memory for encoding conversion</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="183"/>
+        <location filename="../src/common/text_file_saver.cpp" line="184"/>
         <source>Encoding conversion failed</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="189"/>
+        <location filename="../src/common/text_file_saver.cpp" line="190"/>
         <source>Converted content is empty</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="207"/>
+        <location filename="../src/common/text_file_saver.cpp" line="208"/>
         <source>Memory allocation failed</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="211"/>
+        <location filename="../src/common/text_file_saver.cpp" line="212"/>
         <source>Error occurred: %1</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="215"/>
+        <location filename="../src/common/text_file_saver.cpp" line="216"/>
         <source>Unknown error occurred</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -829,27 +880,27 @@
         <translation>Leia</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="34"/>
+        <location filename="../src/controls/replacebar.cpp" line="36"/>
         <source>Replace With</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="36"/>
+        <location filename="../src/controls/replacebar.cpp" line="40"/>
         <source>Replace</source>
         <translation>Asenda</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="37"/>
+        <location filename="../src/controls/replacebar.cpp" line="42"/>
         <source>Skip</source>
         <translation>Jäta vahele</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="38"/>
+        <location filename="../src/controls/replacebar.cpp" line="44"/>
         <source>Replace Rest</source>
         <translation>Asenda ülejäänud</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="39"/>
+        <location filename="../src/controls/replacebar.cpp" line="46"/>
         <source>Replace All</source>
         <translation>Asenda kõik</translation>
     </message>
@@ -858,9 +909,9 @@
     <name>S:</name>
     <message>
         <location filename="../third/libiconv-1.16/src/iconv.c" line="103"/>
-        <source/>
+        <source></source>
         <comment>The first line of the short usage message.</comment>
-        <translation type="unfinished"/>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -891,42 +942,42 @@
         <translation>Täieskraan</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="484"/>
+        <location filename="../src/common/settings.cpp" line="491"/>
         <source>This shortcut conflicts with system shortcut %1</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="487"/>
+        <location filename="../src/common/settings.cpp" line="494"/>
         <source>This shortcut conflicts with %1, click on Replace to make this shortcut effective immediately</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="682"/>
-        <location filename="../src/common/settings.cpp" line="695"/>
-        <location filename="../src/common/settings.cpp" line="704"/>
+        <location filename="../src/common/settings.cpp" line="689"/>
+        <location filename="../src/common/settings.cpp" line="702"/>
+        <location filename="../src/common/settings.cpp" line="711"/>
         <source>The shortcut %1 is invalid, please set another one.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="736"/>
+        <location filename="../src/common/settings.cpp" line="743"/>
         <source>Cancel</source>
         <translation>Loobu</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="737"/>
+        <location filename="../src/common/settings.cpp" line="744"/>
         <source>Replace</source>
         <translation>Asenda</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="740"/>
+        <location filename="../src/common/settings.cpp" line="747"/>
         <source>OK</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>StartManager</name>
     <message>
-        <location filename="../src/startmanager.cpp" line="411"/>
+        <location filename="../src/startmanager.cpp" line="425"/>
         <source>Untitled %1</source>
         <translation>Pealkirjata %1</translation>
     </message>
@@ -934,435 +985,489 @@
 <context>
     <name>Tabbar</name>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="641"/>
+        <location filename="../src/controls/tabbar.cpp" line="678"/>
         <source>Close tab</source>
         <translation>Sulge vahekaart</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="642"/>
+        <location filename="../src/controls/tabbar.cpp" line="680"/>
         <source>Close other tabs</source>
         <translation>Sulge muud vahekaardid</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="643"/>
+        <location filename="../src/controls/tabbar.cpp" line="682"/>
         <source>More options</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="644"/>
+        <location filename="../src/controls/tabbar.cpp" line="684"/>
         <source>Close tabs to the left</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="645"/>
+        <location filename="../src/controls/tabbar.cpp" line="686"/>
         <source>Close tabs to the right</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="646"/>
+        <location filename="../src/controls/tabbar.cpp" line="688"/>
         <source>Close unmodified tabs</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>TextEdit</name>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="305"/>
+        <location filename="../src/editor/dtextedit.cpp" line="388"/>
         <source>Undo</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="306"/>
+        <location filename="../src/editor/dtextedit.cpp" line="390"/>
         <source>Redo</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="307"/>
+        <location filename="../src/editor/dtextedit.cpp" line="392"/>
         <source>Cut</source>
         <translation>Lõika</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="308"/>
+        <location filename="../src/editor/dtextedit.cpp" line="394"/>
         <source>Copy</source>
         <translation>Kopeeri</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="309"/>
+        <location filename="../src/editor/dtextedit.cpp" line="396"/>
         <source>Paste</source>
         <translation>Aseta</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="310"/>
+        <location filename="../src/editor/dtextedit.cpp" line="398"/>
         <source>Delete</source>
         <translation>Kustuta</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="311"/>
+        <location filename="../src/editor/dtextedit.cpp" line="400"/>
         <source>Select All</source>
         <translation>Vali kõik</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="312"/>
-        <location filename="../src/widgets/window.cpp" line="535"/>
+        <location filename="../src/editor/dtextedit.cpp" line="402"/>
+        <location filename="../src/widgets/window.cpp" line="556"/>
         <source>Find</source>
         <translation>Leia</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="313"/>
-        <location filename="../src/widgets/window.cpp" line="536"/>
+        <location filename="../src/editor/dtextedit.cpp" line="404"/>
+        <location filename="../src/widgets/window.cpp" line="558"/>
         <source>Replace</source>
         <translation>Asenda</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="314"/>
+        <location filename="../src/editor/dtextedit.cpp" line="406"/>
         <source>Go to Line</source>
         <translation>Mine reale</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="315"/>
-        <source>Turn on Read-Only mode</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="316"/>
-        <source>Turn off Read-Only mode</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="317"/>
+        <location filename="../src/editor/dtextedit.cpp" line="415"/>
         <source>Fullscreen</source>
         <translation>Täieskraan</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="318"/>
+        <location filename="../src/editor/dtextedit.cpp" line="417"/>
         <source>Exit fullscreen</source>
         <translation>Välju täisekraanilt</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="319"/>
+        <location filename="../src/editor/dtextedit.cpp" line="419"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="320"/>
-        <location filename="../src/editor/dtextedit.cpp" line="374"/>
+        <location filename="../src/editor/dtextedit.cpp" line="421"/>
+        <location filename="../src/editor/dtextedit.cpp" line="493"/>
         <source>Add Comment</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="321"/>
+        <location filename="../src/editor/dtextedit.cpp" line="423"/>
         <source>Text to Speech</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="322"/>
-        <source>Stop reading</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="323"/>
+        <location filename="../src/editor/dtextedit.cpp" line="425"/>
         <source>Speech to Text</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="324"/>
+        <location filename="../src/editor/dtextedit.cpp" line="427"/>
         <source>Translate</source>
         <translation>Tõlgi</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="325"/>
+        <location filename="../src/editor/dtextedit.cpp" line="429"/>
         <source>Column Mode</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="326"/>
+        <location filename="../src/editor/dtextedit.cpp" line="431"/>
         <source>Add bookmark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="327"/>
+        <location filename="../src/editor/dtextedit.cpp" line="433"/>
         <source>Remove Bookmark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="328"/>
+        <location filename="../src/editor/dtextedit.cpp" line="435"/>
         <source>Previous bookmark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="329"/>
+        <location filename="../src/editor/dtextedit.cpp" line="437"/>
         <source>Next bookmark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="330"/>
+        <location filename="../src/editor/dtextedit.cpp" line="439"/>
         <source>Remove All Bookmarks</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="331"/>
+        <location filename="../src/editor/dtextedit.cpp" line="441"/>
         <source>Fold All</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="332"/>
+        <location filename="../src/editor/dtextedit.cpp" line="443"/>
         <source>Fold Current Level</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="333"/>
+        <location filename="../src/editor/dtextedit.cpp" line="445"/>
         <source>Unfold All</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="334"/>
+        <location filename="../src/editor/dtextedit.cpp" line="447"/>
         <source>Unfold Current Level</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="339"/>
+        <location filename="../src/editor/dtextedit.cpp" line="453"/>
         <source>Color Mark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="343"/>
+        <location filename="../src/editor/dtextedit.cpp" line="458"/>
         <source>Clear All Marks</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="344"/>
+        <location filename="../src/editor/dtextedit.cpp" line="460"/>
         <source>Clear Last Mark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="353"/>
+        <location filename="../src/editor/dtextedit.cpp" line="470"/>
         <source>Mark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="366"/>
+        <location filename="../src/editor/dtextedit.cpp" line="484"/>
         <source>Mark All</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="375"/>
+        <location filename="../src/editor/dtextedit.cpp" line="494"/>
         <source>Remove Comment</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3208"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3211"/>
+        <location filename="../src/editor/dtextedit.cpp" line="543"/>
+        <source>View Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="3531"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3534"/>
         <source>Copy failed: not enough memory</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3333"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3335"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3656"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3658"/>
         <source>Press ALT and click lines to edit in column mode</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="418"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9574"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9576"/>
+        <source>No audio output device was detected. Please ensure your speakers or headphones are properly connected and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="9583"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9585"/>
+        <source>No audio input device was detected. Please ensure your speakers or headphones are properly connected and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="534"/>
         <source>Change Case</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="419"/>
+        <location filename="../src/editor/dtextedit.cpp" line="409"/>
+        <source>Edit Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="411"/>
+        <source>Read View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="413"/>
+        <source>Live Preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="535"/>
         <source>Upper Case</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="420"/>
+        <location filename="../src/editor/dtextedit.cpp" line="536"/>
         <source>Lower Case</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="421"/>
+        <location filename="../src/editor/dtextedit.cpp" line="537"/>
         <source>Capitalize</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="78"/>
+        <location filename="../src/widgets/bottombar.cpp" line="110"/>
         <source>None</source>
         <translation>Pole</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1363"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1490"/>
         <source>Selected line(s) copied</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1370"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1497"/>
         <source>Current line copied</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1400"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1527"/>
         <source>Selected line(s) clipped</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1412"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1539"/>
         <source>Current line clipped</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3227"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3230"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3550"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3553"/>
         <source>Paste failed: not enough memory</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="4548"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4873"/>
         <source>Read-Only mode is off</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="4560"/>
-        <location filename="../src/editor/dtextedit.cpp" line="4584"/>
-        <location filename="../src/editor/dtextedit.cpp" line="7896"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8007"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8015"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8026"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4885"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4909"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8236"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8347"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8355"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8366"/>
         <source>Read-Only mode is on</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>WarningNotices</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="24"/>
+        <location filename="../src/controls/warningnotices.cpp" line="25"/>
         <source>Reload</source>
         <translation>Laadi uuesti</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/warningnotices.cpp" line="29"/>
+        <source>Edit Anyway</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>Window</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="25"/>
-        <location filename="../src/widgets/window.cpp" line="531"/>
+        <location filename="../src/controls/warningnotices.cpp" line="27"/>
+        <location filename="../src/widgets/window.cpp" line="548"/>
         <source>Save as</source>
         <translation>Salvesta kui</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="527"/>
+        <location filename="../src/widgets/window.cpp" line="540"/>
         <source>New window</source>
         <translation>Uus aken</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="528"/>
+        <location filename="../src/widgets/window.cpp" line="542"/>
         <source>New tab</source>
         <translation>Uus vahekaart</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="529"/>
+        <location filename="../src/widgets/window.cpp" line="544"/>
         <source>Open file</source>
         <translation>Ava fail</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="530"/>
-        <location filename="../src/widgets/window.cpp" line="3545"/>
+        <location filename="../src/widgets/window.cpp" line="546"/>
+        <location filename="../src/widgets/window.cpp" line="3950"/>
         <source>Save</source>
         <translation>Salvesta</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="532"/>
+        <location filename="../src/widgets/window.cpp" line="550"/>
         <source>Print</source>
         <translation>Prindi</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="533"/>
+        <location filename="../src/widgets/window.cpp" line="552"/>
         <source>Switch theme</source>
         <translation>Vaheta teemat</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="534"/>
-        <location filename="../src/widgets/window.cpp" line="2448"/>
+        <location filename="../src/widgets/window.cpp" line="554"/>
+        <location filename="../src/widgets/window.cpp" line="2641"/>
         <source>Settings</source>
         <translation>Seaded</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="666"/>
-        <location filename="../src/widgets/window.cpp" line="3845"/>
+        <location filename="../src/widgets/window.cpp" line="696"/>
+        <location filename="../src/widgets/window.cpp" line="4250"/>
         <source>Read-Only</source>
         <translation>lt loetav</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="687"/>
+        <location filename="../src/widgets/window.cpp" line="719"/>
         <source>You do not have permission to open %1</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="738"/>
-        <location filename="../src/widgets/window.cpp" line="2963"/>
+        <location filename="../src/widgets/window.cpp" line="773"/>
+        <location filename="../src/widgets/window.cpp" line="3266"/>
         <source>Invalid file: %1</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="903"/>
-        <location filename="../src/widgets/window.cpp" line="956"/>
+        <location filename="../src/widgets/window.cpp" line="957"/>
+        <location filename="../src/widgets/window.cpp" line="1050"/>
+        <location filename="../src/widgets/window.cpp" line="3217"/>
         <source>Do you want to save this file?</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1290"/>
+        <location filename="../src/widgets/window.cpp" line="1381"/>
+        <source>Invalid characters detected while saving &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1382"/>
+        <source>If you force save this file, it may cause file corruption. Still want to save?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1386"/>
+        <source>Don&apos;t Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1387"/>
+        <source>Save As</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1388"/>
+        <source>Save Anyway</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1456"/>
         <source>You do not have permission to save %1</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1312"/>
+        <location filename="../src/widgets/window.cpp" line="1428"/>
+        <location filename="../src/widgets/window.cpp" line="1478"/>
         <source>Saved successfully</source>
         <translation>Salvestatud</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1354"/>
-        <location filename="../src/widgets/window.cpp" line="1481"/>
-        <location filename="../src/widgets/window.cpp" line="1529"/>
+        <location filename="../src/widgets/window.cpp" line="1520"/>
+        <location filename="../src/widgets/window.cpp" line="1665"/>
+        <location filename="../src/widgets/window.cpp" line="1713"/>
         <source>Save File</source>
         <translation>Salvesta fail</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1483"/>
+        <location filename="../src/widgets/window.cpp" line="1569"/>
+        <source>Cannot save as the original file in preview mode. Please choose a different path.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1667"/>
         <source>Encoding</source>
         <translation>Kodeering</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1773"/>
+        <location filename="../src/widgets/window.cpp" line="1957"/>
         <source>Read-Only mode is on</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2322"/>
+        <location filename="../src/widgets/window.cpp" line="2511"/>
         <source>Current location remembered</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2398"/>
+        <location filename="../src/widgets/window.cpp" line="2591"/>
         <source>Ctrl+&apos;=&apos;</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2401"/>
+        <location filename="../src/widgets/window.cpp" line="2594"/>
         <source>Ctrl+&apos;-&apos;</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2430"/>
+        <location filename="../src/widgets/window.cpp" line="2623"/>
         <source>Editor</source>
         <translation>Redaktor</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3061"/>
+        <location filename="../src/widgets/window.cpp" line="3436"/>
         <source>Untitled %1</source>
         <translation>Pealkirjata %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3543"/>
+        <location filename="../src/widgets/window.cpp" line="3948"/>
         <source>Cancel</source>
         <translation>Loobu</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3544"/>
+        <location filename="../src/widgets/window.cpp" line="3949"/>
         <source>Discard</source>
         <translation>Loobu</translation>
     </message>

--- a/translations/deepin-editor_fa.ts
+++ b/translations/deepin-editor_fa.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="fa">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="fa">
 <context>
     <name>BottomBar</name>
     <message>
@@ -17,17 +19,36 @@
         <translation>کاراکتر %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="44"/>
+        <location filename="../src/widgets/bottombar.cpp" line="47"/>
         <source>Loading:</source>
         <translation>بارگذاری:</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="73"/>
+        <location filename="../src/widgets/bottombar.cpp" line="91"/>
+        <location filename="../src/widgets/bottombar.cpp" line="499"/>
+        <source>Edit Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="74"/>
+        <location filename="../src/widgets/bottombar.cpp" line="489"/>
+        <source>Read View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="75"/>
+        <location filename="../src/widgets/bottombar.cpp" line="493"/>
+        <source>Live Preview</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DDropdownMenu</name>
     <message>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="362"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="420"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="425"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="363"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="421"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="426"/>
         <source>None</source>
         <translation>هیچ یک</translation>
     </message>
@@ -35,68 +56,57 @@
 <context>
     <name>EditWrapper</name>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="292"/>
-        <location filename="../src/editor/editwrapper.cpp" line="365"/>
-        <location filename="../src/editor/editwrapper.cpp" line="521"/>
-        <location filename="../src/editor/editwrapper.cpp" line="751"/>
+        <location filename="../src/editor/editwrapper.cpp" line="355"/>
+        <location filename="../src/editor/editwrapper.cpp" line="429"/>
+        <location filename="../src/editor/editwrapper.cpp" line="595"/>
+        <location filename="../src/editor/editwrapper.cpp" line="887"/>
         <source>Save</source>
         <translation>ذخیره</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="516"/>
+        <location filename="../src/editor/editwrapper.cpp" line="590"/>
         <source>Do you want to save this file?</source>
         <translation>آیا می خواهید این فایل را ذخیره کنید؟</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="363"/>
-        <location filename="../src/editor/editwrapper.cpp" line="519"/>
+        <location filename="../src/editor/editwrapper.cpp" line="427"/>
+        <location filename="../src/editor/editwrapper.cpp" line="593"/>
         <source>Cancel</source>
         <translation>لغو</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="360"/>
+        <location filename="../src/editor/editwrapper.cpp" line="424"/>
         <source>Encoding changed. Do you want to save the file now?</source>
         <translation>کدگذاری تغییر کرد. آیا می‌خواهید فایل را اکنون ذخیره کنید؟</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="520"/>
+        <location filename="../src/editor/editwrapper.cpp" line="594"/>
         <source>Discard</source>
         <translation>دور انداختن</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="274"/>
-        <location filename="../src/editor/editwrapper.cpp" line="620"/>
+        <location filename="../src/editor/editwrapper.cpp" line="1121"/>
+        <source>The file contains invalid characters (NUL). Preview mode is read-only.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="337"/>
+        <location filename="../src/editor/editwrapper.cpp" line="705"/>
         <source>You do not have permission to save %1</source>
         <translation>شما اجازه ذخیره %1 را ندارید</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="836"/>
+        <location filename="../src/editor/editwrapper.cpp" line="987"/>
         <source>File removed on the disk. Save it now?</source>
         <translation>فایل بر روی دیسک حذف شد. اکنون آن را ذخیره می کنید؟</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="842"/>
+        <location filename="../src/editor/editwrapper.cpp" line="993"/>
         <source>File has changed on disk. Reload?</source>
         <translation>فایل روی دیسک تغییر کرده است. بارگیری مجدد شود؟</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="884"/>
-        <location filename="../src/widgets/bottombar.cpp" line="74"/>
-        <source>INSERT</source>
-        <translation>الحاق</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="888"/>
-        <source>OVERWRITE</source>
-        <translation>بازنویسی</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="892"/>
-        <source>R/O</source>
-        <translation>R/O</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="1618"/>
+        <location filename="../src/editor/editwrapper.cpp" line="1806"/>
         <source>The file cannot be read, which may be too large or has been damaged!</source>
         <translation>فایل قابل خواندن نیست، که ممکن است بسیار بزرگ یا خراب شده باشد!</translation>
     </message>
@@ -109,17 +119,17 @@
         <translation>یافتن</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="36"/>
+        <location filename="../src/controls/findbar.cpp" line="38"/>
         <source>Previous</source>
         <translation>قبلی</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="37"/>
+        <location filename="../src/controls/findbar.cpp" line="40"/>
         <source>Next</source>
         <translation>بعدی</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="38"/>
+        <location filename="../src/controls/findbar.cpp" line="42"/>
         <source>Replace</source>
         <translation>جایگزین</translation>
     </message>
@@ -127,9 +137,17 @@
 <context>
     <name>JumpLineBar</name>
     <message>
-        <location filename="../src/controls/jumplinebar.cpp" line="45"/>
+        <location filename="../src/controls/jumplinebar.cpp" line="46"/>
         <source>Go to Line: </source>
         <translation>برو به خط:</translation>
+    </message>
+</context>
+<context>
+    <name>LineBar</name>
+    <message>
+        <location filename="../src/controls/linebar.cpp" line="144"/>
+        <source>第%1/%2项</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -146,19 +164,47 @@
     </message>
 </context>
 <context>
+    <name>MarkdownBridge</name>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="37"/>
+        <source>Collapse code block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="38"/>
+        <source>Expand code block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="39"/>
+        <source>Copy code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="40"/>
+        <source>Expand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="42"/>
+        <source>%1 line(s) of code collapsed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PathSettingWgt</name>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="84"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="90"/>
         <source>Remember the last used path</source>
         <translation>مسیر آخر استفاده شده را به خاطر بسپار</translation>
     </message>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="85"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="91"/>
         <source>Same path as the current file</source>
         <translation>مسیر یکسان با فایل جاری</translation>
     </message>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="86"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="92"/>
         <source>Customize the default path</source>
         <translation>مسیر پیش‌فرض را شخصی‌سازی کنید</translation>
     </message>
@@ -171,15 +217,20 @@
         <translation>ویرایشگر متن</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="294"/>
-        <location filename="../src/editor/editwrapper.cpp" line="761"/>
-        <location filename="../src/editor/editwrapper.cpp" line="776"/>
-        <location filename="../src/widgets/window.cpp" line="1362"/>
-        <location filename="../src/widgets/window.cpp" line="1390"/>
-        <location filename="../src/widgets/window.cpp" line="1531"/>
-        <location filename="../src/widgets/window.cpp" line="1548"/>
+        <location filename="../src/editor/editwrapper.cpp" line="357"/>
+        <location filename="../src/editor/editwrapper.cpp" line="897"/>
+        <location filename="../src/editor/editwrapper.cpp" line="912"/>
+        <location filename="../src/widgets/window.cpp" line="1528"/>
+        <location filename="../src/widgets/window.cpp" line="1556"/>
+        <location filename="../src/widgets/window.cpp" line="1715"/>
+        <location filename="../src/widgets/window.cpp" line="1732"/>
         <source>Encoding</source>
         <translation>رمزگذاری</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="2001"/>
+        <source>视图模式</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="11"/>
@@ -215,7 +266,7 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="18"/>
         <location filename="../src/controls/settingsdialog.cpp" line="96"/>
-        <location filename="../src/widgets/window.cpp" line="2388"/>
+        <location filename="../src/widgets/window.cpp" line="2581"/>
         <source>Window</source>
         <translation>پنجره</translation>
     </message>
@@ -392,7 +443,7 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="53"/>
         <source>New line</source>
-        <translation>خط جدید</translation>
+        <translation>خط&#xa0;جدید</translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="54"/>
@@ -755,68 +806,68 @@
         <translation>ویتنامی</translation>
     </message>
     <message>
-        <location filename="../src/startmanager.cpp" line="971"/>
+        <location filename="../src/startmanager.cpp" line="1035"/>
         <source>File not saved</source>
         <translation>فایل ذخیره نشده است</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1532"/>
-        <location filename="../src/widgets/window.cpp" line="1549"/>
+        <location filename="../src/widgets/window.cpp" line="1716"/>
+        <location filename="../src/widgets/window.cpp" line="1733"/>
         <source>Line Endings</source>
         <translation>خط پایان</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="243"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="379"/>
         <source>Please install &apos;UOS AI&apos; from the App Store before using</source>
         <translation>لطفاً قبل از استفاده &apos;UOS AI&apos; را از فروشگاه برنامه‌ها نصب کنید</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="245"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="381"/>
         <source>No audio input device detected. Please check and try again</source>
         <translation>دستگاه ورودی صوتی یافت نشد. لطفاً چک کنید و دوباره تلاش کنید</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="247"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="383"/>
         <source>No audio output device detected. Please check and try again</source>
         <translation>دستگاه خروجی صوتی یافت نشد. لطفاً چک کنید و دوباره تلاش کنید</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="69"/>
+        <location filename="../src/common/text_file_saver.cpp" line="74"/>
         <source>File path is empty</source>
         <translation>مسیر فایل خالی است</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="155"/>
+        <location filename="../src/common/text_file_saver.cpp" line="153"/>
         <source>Insufficient memory to load document content</source>
         <translation>حافظه کافی برای بارگذاری محتوای دستورالعمل وجود ندارد</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="177"/>
+        <location filename="../src/common/text_file_saver.cpp" line="178"/>
         <source>Insufficient memory for encoding conversion</source>
         <translation>حافظه کافی برای تبدیل کدگذاری وجود ندارد</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="183"/>
+        <location filename="../src/common/text_file_saver.cpp" line="184"/>
         <source>Encoding conversion failed</source>
         <translation>تبدیل کدگذاری با خطا مواجه شد</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="189"/>
+        <location filename="../src/common/text_file_saver.cpp" line="190"/>
         <source>Converted content is empty</source>
         <translation>محتوای تبدیل شده خالی است</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="207"/>
+        <location filename="../src/common/text_file_saver.cpp" line="208"/>
         <source>Memory allocation failed</source>
         <translation>تخصیص حافظه با خطا مواجه شد</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="211"/>
+        <location filename="../src/common/text_file_saver.cpp" line="212"/>
         <source>Error occurred: %1</source>
         <translation>خطا ایجاد شد: %1</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="215"/>
+        <location filename="../src/common/text_file_saver.cpp" line="216"/>
         <source>Unknown error occurred</source>
         <translation>خطای ناشناخته ایجاد شد</translation>
     </message>
@@ -829,27 +880,27 @@
         <translation>یافتن</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="34"/>
+        <location filename="../src/controls/replacebar.cpp" line="36"/>
         <source>Replace With</source>
         <translation>جایگزین کنید</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="36"/>
+        <location filename="../src/controls/replacebar.cpp" line="40"/>
         <source>Replace</source>
         <translation>جایگزین</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="37"/>
+        <location filename="../src/controls/replacebar.cpp" line="42"/>
         <source>Skip</source>
         <translation>پرش</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="38"/>
+        <location filename="../src/controls/replacebar.cpp" line="44"/>
         <source>Replace Rest</source>
         <translation>جایگزینی بقیه</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="39"/>
+        <location filename="../src/controls/replacebar.cpp" line="46"/>
         <source>Replace All</source>
         <translation>جایگزینی همه</translation>
     </message>
@@ -858,9 +909,9 @@
     <name>S:</name>
     <message>
         <location filename="../third/libiconv-1.16/src/iconv.c" line="103"/>
-        <source/>
+        <source></source>
         <comment>The first line of the short usage message.</comment>
-        <translation type="unfinished"/>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -891,34 +942,34 @@
         <translation>تمام صفحه</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="484"/>
+        <location filename="../src/common/settings.cpp" line="491"/>
         <source>This shortcut conflicts with system shortcut %1</source>
         <translation>این کوتاه‌تر از کوتاه‌تر سیستم %1 تداخل دارد</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="487"/>
+        <location filename="../src/common/settings.cpp" line="494"/>
         <source>This shortcut conflicts with %1, click on Replace to make this shortcut effective immediately</source>
         <translation>این کوتاه‌تر با %1 تداخل دارد، روی جایگزینی کلیک کنید تا این کوتاه‌تر به‌صورت فوری فعال شود</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="682"/>
-        <location filename="../src/common/settings.cpp" line="695"/>
-        <location filename="../src/common/settings.cpp" line="704"/>
+        <location filename="../src/common/settings.cpp" line="689"/>
+        <location filename="../src/common/settings.cpp" line="702"/>
+        <location filename="../src/common/settings.cpp" line="711"/>
         <source>The shortcut %1 is invalid, please set another one.</source>
         <translation>کوتاه‌تر %1 نامعتبر است، لطفاً یکی دیگر را تنظیم کنید.</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="736"/>
+        <location filename="../src/common/settings.cpp" line="743"/>
         <source>Cancel</source>
         <translation>لغو</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="737"/>
+        <location filename="../src/common/settings.cpp" line="744"/>
         <source>Replace</source>
         <translation>جایگزین</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="740"/>
+        <location filename="../src/common/settings.cpp" line="747"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
@@ -926,7 +977,7 @@
 <context>
     <name>StartManager</name>
     <message>
-        <location filename="../src/startmanager.cpp" line="411"/>
+        <location filename="../src/startmanager.cpp" line="425"/>
         <source>Untitled %1</source>
         <translation>بدون عنوان %1</translation>
     </message>
@@ -934,32 +985,32 @@
 <context>
     <name>Tabbar</name>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="641"/>
+        <location filename="../src/controls/tabbar.cpp" line="678"/>
         <source>Close tab</source>
         <translation>بستن زبانه</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="642"/>
+        <location filename="../src/controls/tabbar.cpp" line="680"/>
         <source>Close other tabs</source>
         <translation>بستن بقیه زبانه ها</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="643"/>
+        <location filename="../src/controls/tabbar.cpp" line="682"/>
         <source>More options</source>
         <translation>گزینه‌های بیشتر</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="644"/>
+        <location filename="../src/controls/tabbar.cpp" line="684"/>
         <source>Close tabs to the left</source>
         <translation>فیلترهای چپ را ببند</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="645"/>
+        <location filename="../src/controls/tabbar.cpp" line="686"/>
         <source>Close tabs to the right</source>
         <translation>فیلترهای راست را ببند</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="646"/>
+        <location filename="../src/controls/tabbar.cpp" line="688"/>
         <source>Close unmodified tabs</source>
         <translation>فیلترهای تغییر نکرده را ببند</translation>
     </message>
@@ -967,263 +1018,280 @@
 <context>
     <name>TextEdit</name>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="305"/>
+        <location filename="../src/editor/dtextedit.cpp" line="388"/>
         <source>Undo</source>
         <translation>واچیدن</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="306"/>
+        <location filename="../src/editor/dtextedit.cpp" line="390"/>
         <source>Redo</source>
         <translation>مجدد</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="307"/>
+        <location filename="../src/editor/dtextedit.cpp" line="392"/>
         <source>Cut</source>
         <translation>بریدن</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="308"/>
+        <location filename="../src/editor/dtextedit.cpp" line="394"/>
         <source>Copy</source>
         <translation>کپی</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="309"/>
+        <location filename="../src/editor/dtextedit.cpp" line="396"/>
         <source>Paste</source>
         <translation>چسباندن</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="310"/>
+        <location filename="../src/editor/dtextedit.cpp" line="398"/>
         <source>Delete</source>
         <translation>حذف</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="311"/>
+        <location filename="../src/editor/dtextedit.cpp" line="400"/>
         <source>Select All</source>
         <translation>انتخاب همه</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="312"/>
-        <location filename="../src/widgets/window.cpp" line="535"/>
+        <location filename="../src/editor/dtextedit.cpp" line="402"/>
+        <location filename="../src/widgets/window.cpp" line="556"/>
         <source>Find</source>
         <translation>یافتن</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="313"/>
-        <location filename="../src/widgets/window.cpp" line="536"/>
+        <location filename="../src/editor/dtextedit.cpp" line="404"/>
+        <location filename="../src/widgets/window.cpp" line="558"/>
         <source>Replace</source>
         <translation>جایگزین</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="314"/>
+        <location filename="../src/editor/dtextedit.cpp" line="406"/>
         <source>Go to Line</source>
         <translation>برو به خط</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="315"/>
-        <source>Turn on Read-Only mode</source>
-        <translation>روشن کردن حالت فقط خواندن</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="316"/>
-        <source>Turn off Read-Only mode</source>
-        <translation>خاموش کردن حالت فقط خواندن</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="317"/>
+        <location filename="../src/editor/dtextedit.cpp" line="415"/>
         <source>Fullscreen</source>
         <translation>تمام صفحه</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="318"/>
+        <location filename="../src/editor/dtextedit.cpp" line="417"/>
         <source>Exit fullscreen</source>
         <translation>خروج از تمام صفحه</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="319"/>
+        <location filename="../src/editor/dtextedit.cpp" line="419"/>
         <source>Display in file manager</source>
         <translation>نمایش در مدیریت کننده فایل</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="320"/>
-        <location filename="../src/editor/dtextedit.cpp" line="374"/>
+        <location filename="../src/editor/dtextedit.cpp" line="421"/>
+        <location filename="../src/editor/dtextedit.cpp" line="493"/>
         <source>Add Comment</source>
         <translation>یک نظر اضافه کن</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="321"/>
+        <location filename="../src/editor/dtextedit.cpp" line="423"/>
         <source>Text to Speech</source>
         <translation>متن به پیام رسان</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="322"/>
-        <source>Stop reading</source>
-        <translation>توقف از خواندن</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="323"/>
+        <location filename="../src/editor/dtextedit.cpp" line="425"/>
         <source>Speech to Text</source>
         <translation>پیام رسان به متن</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="324"/>
+        <location filename="../src/editor/dtextedit.cpp" line="427"/>
         <source>Translate</source>
         <translation>ترجمه</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="325"/>
+        <location filename="../src/editor/dtextedit.cpp" line="429"/>
         <source>Column Mode</source>
         <translation>حالت ستونی</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="326"/>
+        <location filename="../src/editor/dtextedit.cpp" line="431"/>
         <source>Add bookmark</source>
         <translation>یک نشانه گذاری کن</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="327"/>
+        <location filename="../src/editor/dtextedit.cpp" line="433"/>
         <source>Remove Bookmark</source>
         <translation>حذف نشانه</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="328"/>
+        <location filename="../src/editor/dtextedit.cpp" line="435"/>
         <source>Previous bookmark</source>
         <translation>نشانه قبلی</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="329"/>
+        <location filename="../src/editor/dtextedit.cpp" line="437"/>
         <source>Next bookmark</source>
         <translation>نشانه بعدی</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="330"/>
+        <location filename="../src/editor/dtextedit.cpp" line="439"/>
         <source>Remove All Bookmarks</source>
         <translation>حذف تمام نشانه‌ها</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="331"/>
+        <location filename="../src/editor/dtextedit.cpp" line="441"/>
         <source>Fold All</source>
         <translation>بستن همه</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="332"/>
+        <location filename="../src/editor/dtextedit.cpp" line="443"/>
         <source>Fold Current Level</source>
         <translation>بستن سطح جاری</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="333"/>
+        <location filename="../src/editor/dtextedit.cpp" line="445"/>
         <source>Unfold All</source>
         <translation>باز کردن همه</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="334"/>
+        <location filename="../src/editor/dtextedit.cpp" line="447"/>
         <source>Unfold Current Level</source>
         <translation>باز کردن سطح جاری</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="339"/>
+        <location filename="../src/editor/dtextedit.cpp" line="453"/>
         <source>Color Mark</source>
         <translation>نشانه رنگی</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="343"/>
+        <location filename="../src/editor/dtextedit.cpp" line="458"/>
         <source>Clear All Marks</source>
         <translation>پاک کردن تمام نشانه‌ها</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="344"/>
+        <location filename="../src/editor/dtextedit.cpp" line="460"/>
         <source>Clear Last Mark</source>
         <translation>پاک کردن آخرین نشانه</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="353"/>
+        <location filename="../src/editor/dtextedit.cpp" line="470"/>
         <source>Mark</source>
         <translation>علامت</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="366"/>
+        <location filename="../src/editor/dtextedit.cpp" line="484"/>
         <source>Mark All</source>
         <translation>نشانه‌گذاری همه</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="375"/>
+        <location filename="../src/editor/dtextedit.cpp" line="494"/>
         <source>Remove Comment</source>
         <translation>حذف نظر</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3208"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3211"/>
+        <location filename="../src/editor/dtextedit.cpp" line="543"/>
+        <source>View Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="3531"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3534"/>
         <source>Copy failed: not enough memory</source>
         <translation>کپی نشد: حافظه کافی نیست</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3333"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3335"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3656"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3658"/>
         <source>Press ALT and click lines to edit in column mode</source>
         <translation>فشار کنید ALT و کلیک روی خطوط برای ویرایش در حالت ستونی</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="418"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9574"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9576"/>
+        <source>No audio output device was detected. Please ensure your speakers or headphones are properly connected and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="9583"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9585"/>
+        <source>No audio input device was detected. Please ensure your speakers or headphones are properly connected and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="534"/>
         <source>Change Case</source>
         <translation>تغییر حالت</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="419"/>
+        <location filename="../src/editor/dtextedit.cpp" line="409"/>
+        <source>Edit Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="411"/>
+        <source>Read View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="413"/>
+        <source>Live Preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="535"/>
         <source>Upper Case</source>
         <translation>حالت بزرگ</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="420"/>
+        <location filename="../src/editor/dtextedit.cpp" line="536"/>
         <source>Lower Case</source>
         <translation>حالت کوچک</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="421"/>
+        <location filename="../src/editor/dtextedit.cpp" line="537"/>
         <source>Capitalize</source>
         <translation>درشت نوشتن</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="78"/>
+        <location filename="../src/widgets/bottombar.cpp" line="110"/>
         <source>None</source>
         <translation>هیچ یک</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1363"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1490"/>
         <source>Selected line(s) copied</source>
         <translation>خط(های) انتخاب شده کپی شد</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1370"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1497"/>
         <source>Current line copied</source>
         <translation>خط فعلی کپی شد</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1400"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1527"/>
         <source>Selected line(s) clipped</source>
         <translation>خط(های) انتخاب شده چسبانده شد</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1412"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1539"/>
         <source>Current line clipped</source>
         <translation>خط فعلی چسبانده شد</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3227"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3230"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3550"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3553"/>
         <source>Paste failed: not enough memory</source>
         <translation>چسباندن ناموفق بود: حافظه کافی نیست</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="4548"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4873"/>
         <source>Read-Only mode is off</source>
         <translation>حالت فقط خواندن خاموش است</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="4560"/>
-        <location filename="../src/editor/dtextedit.cpp" line="4584"/>
-        <location filename="../src/editor/dtextedit.cpp" line="7896"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8007"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8015"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8026"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4885"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4909"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8236"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8347"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8355"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8366"/>
         <source>Read-Only mode is on</source>
         <translation>حالت فقط خواندن روشن است</translation>
     </message>
@@ -1231,138 +1299,175 @@
 <context>
     <name>WarningNotices</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="24"/>
+        <location filename="../src/controls/warningnotices.cpp" line="25"/>
         <source>Reload</source>
         <translation>بارگذاری مجدد</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/warningnotices.cpp" line="29"/>
+        <source>Edit Anyway</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>Window</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="25"/>
-        <location filename="../src/widgets/window.cpp" line="531"/>
+        <location filename="../src/controls/warningnotices.cpp" line="27"/>
+        <location filename="../src/widgets/window.cpp" line="548"/>
         <source>Save as</source>
         <translation>ذخیره به عنوان</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="527"/>
+        <location filename="../src/widgets/window.cpp" line="540"/>
         <source>New window</source>
         <translation>پنجره جدید</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="528"/>
+        <location filename="../src/widgets/window.cpp" line="542"/>
         <source>New tab</source>
         <translation>زبانه جدید</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="529"/>
+        <location filename="../src/widgets/window.cpp" line="544"/>
         <source>Open file</source>
         <translation>باز کردن فایل</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="530"/>
-        <location filename="../src/widgets/window.cpp" line="3545"/>
+        <location filename="../src/widgets/window.cpp" line="546"/>
+        <location filename="../src/widgets/window.cpp" line="3950"/>
         <source>Save</source>
         <translation>ذخیره</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="532"/>
+        <location filename="../src/widgets/window.cpp" line="550"/>
         <source>Print</source>
         <translation>چاپ</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="533"/>
+        <location filename="../src/widgets/window.cpp" line="552"/>
         <source>Switch theme</source>
         <translation>تغییر تم</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="534"/>
-        <location filename="../src/widgets/window.cpp" line="2448"/>
+        <location filename="../src/widgets/window.cpp" line="554"/>
+        <location filename="../src/widgets/window.cpp" line="2641"/>
         <source>Settings</source>
         <translation>تنظیمات</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="666"/>
-        <location filename="../src/widgets/window.cpp" line="3845"/>
+        <location filename="../src/widgets/window.cpp" line="696"/>
+        <location filename="../src/widgets/window.cpp" line="4250"/>
         <source>Read-Only</source>
         <translation>فقط خواندنی</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="687"/>
+        <location filename="../src/widgets/window.cpp" line="719"/>
         <source>You do not have permission to open %1</source>
         <translation>شما اجازه باز کردن %1 را ندارید</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="738"/>
-        <location filename="../src/widgets/window.cpp" line="2963"/>
+        <location filename="../src/widgets/window.cpp" line="773"/>
+        <location filename="../src/widgets/window.cpp" line="3266"/>
         <source>Invalid file: %1</source>
         <translation>فایل نامعتبر: %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="903"/>
-        <location filename="../src/widgets/window.cpp" line="956"/>
+        <location filename="../src/widgets/window.cpp" line="957"/>
+        <location filename="../src/widgets/window.cpp" line="1050"/>
+        <location filename="../src/widgets/window.cpp" line="3217"/>
         <source>Do you want to save this file?</source>
         <translation>آیا می خواهید این فایل را ذخیره کنید؟</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1290"/>
+        <location filename="../src/widgets/window.cpp" line="1381"/>
+        <source>Invalid characters detected while saving &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1382"/>
+        <source>If you force save this file, it may cause file corruption. Still want to save?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1386"/>
+        <source>Don&apos;t Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1387"/>
+        <source>Save As</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1388"/>
+        <source>Save Anyway</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1456"/>
         <source>You do not have permission to save %1</source>
         <translation>شما اجازه ذخیره %1 را ندارید</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1312"/>
+        <location filename="../src/widgets/window.cpp" line="1428"/>
+        <location filename="../src/widgets/window.cpp" line="1478"/>
         <source>Saved successfully</source>
         <translation>با موفقیت ذخیره شد</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1354"/>
-        <location filename="../src/widgets/window.cpp" line="1481"/>
-        <location filename="../src/widgets/window.cpp" line="1529"/>
+        <location filename="../src/widgets/window.cpp" line="1520"/>
+        <location filename="../src/widgets/window.cpp" line="1665"/>
+        <location filename="../src/widgets/window.cpp" line="1713"/>
         <source>Save File</source>
         <translation>ذخیره فایل</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1483"/>
+        <location filename="../src/widgets/window.cpp" line="1569"/>
+        <source>Cannot save as the original file in preview mode. Please choose a different path.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1667"/>
         <source>Encoding</source>
         <translation>رمزگذاری</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1773"/>
+        <location filename="../src/widgets/window.cpp" line="1957"/>
         <source>Read-Only mode is on</source>
         <translation>حالت فقط خواندن روشن است</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2322"/>
+        <location filename="../src/widgets/window.cpp" line="2511"/>
         <source>Current location remembered</source>
         <translation>مکان فعلی به یاد گرفته شد</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2398"/>
+        <location filename="../src/widgets/window.cpp" line="2591"/>
         <source>Ctrl+&apos;=&apos;</source>
         <translation>Ctrl+&apos;=&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2401"/>
+        <location filename="../src/widgets/window.cpp" line="2594"/>
         <source>Ctrl+&apos;-&apos;</source>
         <translation>Ctrl+&apos;-&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2430"/>
+        <location filename="../src/widgets/window.cpp" line="2623"/>
         <source>Editor</source>
         <translation>ویرایشگر</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3061"/>
+        <location filename="../src/widgets/window.cpp" line="3436"/>
         <source>Untitled %1</source>
         <translation>بدون عنوان %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3543"/>
+        <location filename="../src/widgets/window.cpp" line="3948"/>
         <source>Cancel</source>
         <translation>لغو</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3544"/>
+        <location filename="../src/widgets/window.cpp" line="3949"/>
         <source>Discard</source>
         <translation>دور انداختن</translation>
     </message>

--- a/translations/deepin-editor_fi.ts
+++ b/translations/deepin-editor_fi.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="fi">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="fi">
 <context>
     <name>BottomBar</name>
     <message>
@@ -17,17 +19,36 @@
         <translation>Merkit %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="44"/>
+        <location filename="../src/widgets/bottombar.cpp" line="47"/>
         <source>Loading:</source>
         <translation>Lataaminen:</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="73"/>
+        <location filename="../src/widgets/bottombar.cpp" line="91"/>
+        <location filename="../src/widgets/bottombar.cpp" line="499"/>
+        <source>Edit Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="74"/>
+        <location filename="../src/widgets/bottombar.cpp" line="489"/>
+        <source>Read View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="75"/>
+        <location filename="../src/widgets/bottombar.cpp" line="493"/>
+        <source>Live Preview</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DDropdownMenu</name>
     <message>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="362"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="420"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="425"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="363"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="421"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="426"/>
         <source>None</source>
         <translation>Tyhjä</translation>
     </message>
@@ -35,68 +56,57 @@
 <context>
     <name>EditWrapper</name>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="292"/>
-        <location filename="../src/editor/editwrapper.cpp" line="365"/>
-        <location filename="../src/editor/editwrapper.cpp" line="521"/>
-        <location filename="../src/editor/editwrapper.cpp" line="751"/>
+        <location filename="../src/editor/editwrapper.cpp" line="355"/>
+        <location filename="../src/editor/editwrapper.cpp" line="429"/>
+        <location filename="../src/editor/editwrapper.cpp" line="595"/>
+        <location filename="../src/editor/editwrapper.cpp" line="887"/>
         <source>Save</source>
         <translation>Tallenna</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="516"/>
+        <location filename="../src/editor/editwrapper.cpp" line="590"/>
         <source>Do you want to save this file?</source>
         <translation>Haluatko tallentaa tämän tiedoston?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="363"/>
-        <location filename="../src/editor/editwrapper.cpp" line="519"/>
+        <location filename="../src/editor/editwrapper.cpp" line="427"/>
+        <location filename="../src/editor/editwrapper.cpp" line="593"/>
         <source>Cancel</source>
         <translation>Peru</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="360"/>
+        <location filename="../src/editor/editwrapper.cpp" line="424"/>
         <source>Encoding changed. Do you want to save the file now?</source>
         <translation>Koodaus muutettu. Haluatko tallentaa tiedoston nyt?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="520"/>
+        <location filename="../src/editor/editwrapper.cpp" line="594"/>
         <source>Discard</source>
         <translation>Hylkää</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="274"/>
-        <location filename="../src/editor/editwrapper.cpp" line="620"/>
+        <location filename="../src/editor/editwrapper.cpp" line="1121"/>
+        <source>The file contains invalid characters (NUL). Preview mode is read-only.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="337"/>
+        <location filename="../src/editor/editwrapper.cpp" line="705"/>
         <source>You do not have permission to save %1</source>
         <translation>Sinulla ei ole lupaa tallentaa %1</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="836"/>
+        <location filename="../src/editor/editwrapper.cpp" line="987"/>
         <source>File removed on the disk. Save it now?</source>
         <translation>Tiedosto on poistettu. Tallenna se nyt?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="842"/>
+        <location filename="../src/editor/editwrapper.cpp" line="993"/>
         <source>File has changed on disk. Reload?</source>
         <translation>Tiedosto on muuttunut. Päivitä?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="884"/>
-        <location filename="../src/widgets/bottombar.cpp" line="74"/>
-        <source>INSERT</source>
-        <translation>Lisää</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="888"/>
-        <source>OVERWRITE</source>
-        <translation>Ylikirjoita</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="892"/>
-        <source>R/O</source>
-        <translation>R/O</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="1618"/>
+        <location filename="../src/editor/editwrapper.cpp" line="1806"/>
         <source>The file cannot be read, which may be too large or has been damaged!</source>
         <translation>Tiedostoa ei voi lukea, se voi olla liian suuri tai vahingoittunut!</translation>
     </message>
@@ -109,17 +119,17 @@
         <translation>Etsi</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="36"/>
+        <location filename="../src/controls/findbar.cpp" line="38"/>
         <source>Previous</source>
         <translation>Edellinen</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="37"/>
+        <location filename="../src/controls/findbar.cpp" line="40"/>
         <source>Next</source>
         <translation>Seuraava</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="38"/>
+        <location filename="../src/controls/findbar.cpp" line="42"/>
         <source>Replace</source>
         <translation>Korvaa</translation>
     </message>
@@ -127,9 +137,17 @@
 <context>
     <name>JumpLineBar</name>
     <message>
-        <location filename="../src/controls/jumplinebar.cpp" line="45"/>
+        <location filename="../src/controls/jumplinebar.cpp" line="46"/>
         <source>Go to Line: </source>
         <translation>Siirry riville:</translation>
+    </message>
+</context>
+<context>
+    <name>LineBar</name>
+    <message>
+        <location filename="../src/controls/linebar.cpp" line="144"/>
+        <source>第%1/%2项</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -146,19 +164,47 @@
     </message>
 </context>
 <context>
+    <name>MarkdownBridge</name>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="37"/>
+        <source>Collapse code block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="38"/>
+        <source>Expand code block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="39"/>
+        <source>Copy code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="40"/>
+        <source>Expand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="42"/>
+        <source>%1 line(s) of code collapsed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PathSettingWgt</name>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="84"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="90"/>
         <source>Remember the last used path</source>
         <translation>Muista viimeksi käytetty polku</translation>
     </message>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="85"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="91"/>
         <source>Same path as the current file</source>
         <translation>Sama polku kuin nykyisessä tiedostossa</translation>
     </message>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="86"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="92"/>
         <source>Customize the default path</source>
         <translation>Mukauta oletuspolkua</translation>
     </message>
@@ -171,15 +217,20 @@
         <translation>Tekstieditori</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="294"/>
-        <location filename="../src/editor/editwrapper.cpp" line="761"/>
-        <location filename="../src/editor/editwrapper.cpp" line="776"/>
-        <location filename="../src/widgets/window.cpp" line="1362"/>
-        <location filename="../src/widgets/window.cpp" line="1390"/>
-        <location filename="../src/widgets/window.cpp" line="1531"/>
-        <location filename="../src/widgets/window.cpp" line="1548"/>
+        <location filename="../src/editor/editwrapper.cpp" line="357"/>
+        <location filename="../src/editor/editwrapper.cpp" line="897"/>
+        <location filename="../src/editor/editwrapper.cpp" line="912"/>
+        <location filename="../src/widgets/window.cpp" line="1528"/>
+        <location filename="../src/widgets/window.cpp" line="1556"/>
+        <location filename="../src/widgets/window.cpp" line="1715"/>
+        <location filename="../src/widgets/window.cpp" line="1732"/>
         <source>Encoding</source>
         <translation>Koodaus</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="2001"/>
+        <source>视图模式</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="11"/>
@@ -215,7 +266,7 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="18"/>
         <location filename="../src/controls/settingsdialog.cpp" line="96"/>
-        <location filename="../src/widgets/window.cpp" line="2388"/>
+        <location filename="../src/widgets/window.cpp" line="2581"/>
         <source>Window</source>
         <translation>Ikkuna</translation>
     </message>
@@ -755,68 +806,68 @@
         <translation>Vietnami</translation>
     </message>
     <message>
-        <location filename="../src/startmanager.cpp" line="971"/>
+        <location filename="../src/startmanager.cpp" line="1035"/>
         <source>File not saved</source>
         <translation>Tiedostoa ei tallennettu</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1532"/>
-        <location filename="../src/widgets/window.cpp" line="1549"/>
+        <location filename="../src/widgets/window.cpp" line="1716"/>
+        <location filename="../src/widgets/window.cpp" line="1733"/>
         <source>Line Endings</source>
         <translation>Rivin loppu</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="243"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="379"/>
         <source>Please install &apos;UOS AI&apos; from the App Store before using</source>
         <translation>Asenna &apos;UOS AI&apos; sovellustilaamosta ennen käyttöä</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="245"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="381"/>
         <source>No audio input device detected. Please check and try again</source>
         <translation>Äänensignaalipäätettä ei havaittu. Tarkista ja yritä uudelleen</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="247"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="383"/>
         <source>No audio output device detected. Please check and try again</source>
         <translation>Äänensignaalivahvistimen ei havaittu. Tarkista ja yritä uudelleen</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="69"/>
+        <location filename="../src/common/text_file_saver.cpp" line="74"/>
         <source>File path is empty</source>
         <translation>Tiedostopolku on tyhjä</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="155"/>
+        <location filename="../src/common/text_file_saver.cpp" line="153"/>
         <source>Insufficient memory to load document content</source>
         <translation>Ei tarpeeksi muistia asiakirjan sisällön lataamiseen</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="177"/>
+        <location filename="../src/common/text_file_saver.cpp" line="178"/>
         <source>Insufficient memory for encoding conversion</source>
         <translation>Ei tarpeeksi muistia koodausmuunnoksen suorittamiseen</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="183"/>
+        <location filename="../src/common/text_file_saver.cpp" line="184"/>
         <source>Encoding conversion failed</source>
         <translation>Koodausmuunnos epäonnistui</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="189"/>
+        <location filename="../src/common/text_file_saver.cpp" line="190"/>
         <source>Converted content is empty</source>
         <translation>Muunnettu sisältö on tyhjä</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="207"/>
+        <location filename="../src/common/text_file_saver.cpp" line="208"/>
         <source>Memory allocation failed</source>
         <translation>Muistin varaus epäonnistui</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="211"/>
+        <location filename="../src/common/text_file_saver.cpp" line="212"/>
         <source>Error occurred: %1</source>
         <translation>Virhe tapahtui: %1</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="215"/>
+        <location filename="../src/common/text_file_saver.cpp" line="216"/>
         <source>Unknown error occurred</source>
         <translation>Tuntematon virhe tapahtui</translation>
     </message>
@@ -829,27 +880,27 @@
         <translation>Etsi</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="34"/>
+        <location filename="../src/controls/replacebar.cpp" line="36"/>
         <source>Replace With</source>
         <translation>Korvaa</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="36"/>
+        <location filename="../src/controls/replacebar.cpp" line="40"/>
         <source>Replace</source>
         <translation>Korvaa</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="37"/>
+        <location filename="../src/controls/replacebar.cpp" line="42"/>
         <source>Skip</source>
         <translation>Ohita</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="38"/>
+        <location filename="../src/controls/replacebar.cpp" line="44"/>
         <source>Replace Rest</source>
         <translation>Korvaa loput</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="39"/>
+        <location filename="../src/controls/replacebar.cpp" line="46"/>
         <source>Replace All</source>
         <translation>Korvaa kaikki</translation>
     </message>
@@ -858,9 +909,9 @@
     <name>S:</name>
     <message>
         <location filename="../third/libiconv-1.16/src/iconv.c" line="103"/>
-        <source/>
+        <source></source>
         <comment>The first line of the short usage message.</comment>
-        <translation type="unfinished"/>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -891,34 +942,34 @@
         <translation>Koko näyttö</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="484"/>
+        <location filename="../src/common/settings.cpp" line="491"/>
         <source>This shortcut conflicts with system shortcut %1</source>
         <translation>Tämä pikanäppäin on ristiriidassa järjestelmän %1 kanssa</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="487"/>
+        <location filename="../src/common/settings.cpp" line="494"/>
         <source>This shortcut conflicts with %1, click on Replace to make this shortcut effective immediately</source>
         <translation>Tämä on ristiriidassa %1 kanssa, valitse Korvaa, jotta tämä pikanäppäin tulee voimaan välittömästi</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="682"/>
-        <location filename="../src/common/settings.cpp" line="695"/>
-        <location filename="../src/common/settings.cpp" line="704"/>
+        <location filename="../src/common/settings.cpp" line="689"/>
+        <location filename="../src/common/settings.cpp" line="702"/>
+        <location filename="../src/common/settings.cpp" line="711"/>
         <source>The shortcut %1 is invalid, please set another one.</source>
         <translation>Pikanäppäin %1 on virheellinen, aseta toinen.</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="736"/>
+        <location filename="../src/common/settings.cpp" line="743"/>
         <source>Cancel</source>
         <translation>Peru</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="737"/>
+        <location filename="../src/common/settings.cpp" line="744"/>
         <source>Replace</source>
         <translation>Korvaa</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="740"/>
+        <location filename="../src/common/settings.cpp" line="747"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
@@ -926,7 +977,7 @@
 <context>
     <name>StartManager</name>
     <message>
-        <location filename="../src/startmanager.cpp" line="411"/>
+        <location filename="../src/startmanager.cpp" line="425"/>
         <source>Untitled %1</source>
         <translation>Nimetön %1</translation>
     </message>
@@ -934,32 +985,32 @@
 <context>
     <name>Tabbar</name>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="641"/>
+        <location filename="../src/controls/tabbar.cpp" line="678"/>
         <source>Close tab</source>
         <translation>Sulje välilehti</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="642"/>
+        <location filename="../src/controls/tabbar.cpp" line="680"/>
         <source>Close other tabs</source>
         <translation>Sulje välilehdet</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="643"/>
+        <location filename="../src/controls/tabbar.cpp" line="682"/>
         <source>More options</source>
         <translation>Lisää vaihtoehtoja</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="644"/>
+        <location filename="../src/controls/tabbar.cpp" line="684"/>
         <source>Close tabs to the left</source>
         <translation>Sulje välilehdet vasemmalla</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="645"/>
+        <location filename="../src/controls/tabbar.cpp" line="686"/>
         <source>Close tabs to the right</source>
         <translation>Sulje välilehdet oikealla</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="646"/>
+        <location filename="../src/controls/tabbar.cpp" line="688"/>
         <source>Close unmodified tabs</source>
         <translation>Sulje muuttumattomat välilehdet</translation>
     </message>
@@ -967,263 +1018,280 @@
 <context>
     <name>TextEdit</name>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="305"/>
+        <location filename="../src/editor/dtextedit.cpp" line="388"/>
         <source>Undo</source>
         <translation>Kumoa</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="306"/>
+        <location filename="../src/editor/dtextedit.cpp" line="390"/>
         <source>Redo</source>
         <translation>Uudelleen</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="307"/>
+        <location filename="../src/editor/dtextedit.cpp" line="392"/>
         <source>Cut</source>
         <translation>Leikkaa</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="308"/>
+        <location filename="../src/editor/dtextedit.cpp" line="394"/>
         <source>Copy</source>
         <translation>Kopioi</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="309"/>
+        <location filename="../src/editor/dtextedit.cpp" line="396"/>
         <source>Paste</source>
         <translation>Liitä</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="310"/>
+        <location filename="../src/editor/dtextedit.cpp" line="398"/>
         <source>Delete</source>
         <translation>Poista</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="311"/>
+        <location filename="../src/editor/dtextedit.cpp" line="400"/>
         <source>Select All</source>
         <translation>Valitse kaikki</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="312"/>
-        <location filename="../src/widgets/window.cpp" line="535"/>
+        <location filename="../src/editor/dtextedit.cpp" line="402"/>
+        <location filename="../src/widgets/window.cpp" line="556"/>
         <source>Find</source>
         <translation>Etsi</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="313"/>
-        <location filename="../src/widgets/window.cpp" line="536"/>
+        <location filename="../src/editor/dtextedit.cpp" line="404"/>
+        <location filename="../src/widgets/window.cpp" line="558"/>
         <source>Replace</source>
         <translation>Korvaa</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="314"/>
+        <location filename="../src/editor/dtextedit.cpp" line="406"/>
         <source>Go to Line</source>
         <translation>Siirry riville</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="315"/>
-        <source>Turn on Read-Only mode</source>
-        <translation>Vain lukutila</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="316"/>
-        <source>Turn off Read-Only mode</source>
-        <translation>Poista vain lukutila</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="317"/>
+        <location filename="../src/editor/dtextedit.cpp" line="415"/>
         <source>Fullscreen</source>
         <translation>Koko näyttö</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="318"/>
+        <location filename="../src/editor/dtextedit.cpp" line="417"/>
         <source>Exit fullscreen</source>
         <translation>Poistu koko näytöstä</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="319"/>
+        <location filename="../src/editor/dtextedit.cpp" line="419"/>
         <source>Display in file manager</source>
         <translation>Näytä tiedostojenhallinnassa</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="320"/>
-        <location filename="../src/editor/dtextedit.cpp" line="374"/>
+        <location filename="../src/editor/dtextedit.cpp" line="421"/>
+        <location filename="../src/editor/dtextedit.cpp" line="493"/>
         <source>Add Comment</source>
         <translation>Lisää kommentti</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="321"/>
+        <location filename="../src/editor/dtextedit.cpp" line="423"/>
         <source>Text to Speech</source>
         <translation>Teksti puheeksi</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="322"/>
-        <source>Stop reading</source>
-        <translation>Lopeta lukeminen</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="323"/>
+        <location filename="../src/editor/dtextedit.cpp" line="425"/>
         <source>Speech to Text</source>
         <translation>Puhe tekstiksi</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="324"/>
+        <location filename="../src/editor/dtextedit.cpp" line="427"/>
         <source>Translate</source>
         <translation>Kääntäjä</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="325"/>
+        <location filename="../src/editor/dtextedit.cpp" line="429"/>
         <source>Column Mode</source>
         <translation>Saraketila</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="326"/>
+        <location filename="../src/editor/dtextedit.cpp" line="431"/>
         <source>Add bookmark</source>
         <translation>Lisää kirjanmerkki</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="327"/>
+        <location filename="../src/editor/dtextedit.cpp" line="433"/>
         <source>Remove Bookmark</source>
         <translation>Poista kirjanmerkki</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="328"/>
+        <location filename="../src/editor/dtextedit.cpp" line="435"/>
         <source>Previous bookmark</source>
         <translation>Edellinen kirjanmerkki</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="329"/>
+        <location filename="../src/editor/dtextedit.cpp" line="437"/>
         <source>Next bookmark</source>
         <translation>Seuraava kirjanmerkki</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="330"/>
+        <location filename="../src/editor/dtextedit.cpp" line="439"/>
         <source>Remove All Bookmarks</source>
         <translation>Poista kaikki kirjanmerkkit</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="331"/>
+        <location filename="../src/editor/dtextedit.cpp" line="441"/>
         <source>Fold All</source>
         <translation>Taita kaikki</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="332"/>
+        <location filename="../src/editor/dtextedit.cpp" line="443"/>
         <source>Fold Current Level</source>
         <translation>Taita nykyinen taso</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="333"/>
+        <location filename="../src/editor/dtextedit.cpp" line="445"/>
         <source>Unfold All</source>
         <translation>Avaa kaikki</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="334"/>
+        <location filename="../src/editor/dtextedit.cpp" line="447"/>
         <source>Unfold Current Level</source>
         <translation>Avaa nykyinen taso</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="339"/>
+        <location filename="../src/editor/dtextedit.cpp" line="453"/>
         <source>Color Mark</source>
         <translation>Värimerkki</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="343"/>
+        <location filename="../src/editor/dtextedit.cpp" line="458"/>
         <source>Clear All Marks</source>
         <translation>Poista kaikki merkit</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="344"/>
+        <location filename="../src/editor/dtextedit.cpp" line="460"/>
         <source>Clear Last Mark</source>
         <translation>Poista viimeinen merkki</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="353"/>
+        <location filename="../src/editor/dtextedit.cpp" line="470"/>
         <source>Mark</source>
         <translation>Merkki</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="366"/>
+        <location filename="../src/editor/dtextedit.cpp" line="484"/>
         <source>Mark All</source>
         <translation>Merkitse kaikki</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="375"/>
+        <location filename="../src/editor/dtextedit.cpp" line="494"/>
         <source>Remove Comment</source>
         <translation>Poista kommentti</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3208"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3211"/>
+        <location filename="../src/editor/dtextedit.cpp" line="543"/>
+        <source>View Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="3531"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3534"/>
         <source>Copy failed: not enough memory</source>
         <translation>Kopiointi epäonnistui: muisti ei riitä</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3333"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3335"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3656"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3658"/>
         <source>Press ALT and click lines to edit in column mode</source>
         <translation>Paina ALT-näppäintä ja napsauta riviä, jos haluat muokata sitä saraketilassa</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="418"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9574"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9576"/>
+        <source>No audio output device was detected. Please ensure your speakers or headphones are properly connected and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="9583"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9585"/>
+        <source>No audio input device was detected. Please ensure your speakers or headphones are properly connected and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="534"/>
         <source>Change Case</source>
         <translation>Vaihda kirjainkokoa</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="419"/>
+        <location filename="../src/editor/dtextedit.cpp" line="409"/>
+        <source>Edit Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="411"/>
+        <source>Read View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="413"/>
+        <source>Live Preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="535"/>
         <source>Upper Case</source>
         <translation>Isot kirjaimet</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="420"/>
+        <location filename="../src/editor/dtextedit.cpp" line="536"/>
         <source>Lower Case</source>
         <translation>Pienet kirjaimet</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="421"/>
+        <location filename="../src/editor/dtextedit.cpp" line="537"/>
         <source>Capitalize</source>
         <translation>Suuret kirjaimet</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="78"/>
+        <location filename="../src/widgets/bottombar.cpp" line="110"/>
         <source>None</source>
         <translation>Tyhjä</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1363"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1490"/>
         <source>Selected line(s) copied</source>
         <translation>Valitut rivit kopioitu</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1370"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1497"/>
         <source>Current line copied</source>
         <translation>Nykyinen rivi kopioitu</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1400"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1527"/>
         <source>Selected line(s) clipped</source>
         <translation>Valitut rivit leikattu</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1412"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1539"/>
         <source>Current line clipped</source>
         <translation>Nykyinen rivi leikattu</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3227"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3230"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3550"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3553"/>
         <source>Paste failed: not enough memory</source>
         <translation>Liittäminen epäonnistui: muisti ei riitä</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="4548"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4873"/>
         <source>Read-Only mode is off</source>
         <translation>Lukutila on pois päältä</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="4560"/>
-        <location filename="../src/editor/dtextedit.cpp" line="4584"/>
-        <location filename="../src/editor/dtextedit.cpp" line="7896"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8007"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8015"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8026"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4885"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4909"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8236"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8347"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8355"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8366"/>
         <source>Read-Only mode is on</source>
         <translation>Lukutila on päällä</translation>
     </message>
@@ -1231,138 +1299,175 @@
 <context>
     <name>WarningNotices</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="24"/>
+        <location filename="../src/controls/warningnotices.cpp" line="25"/>
         <source>Reload</source>
         <translation>Päivitä</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/warningnotices.cpp" line="29"/>
+        <source>Edit Anyway</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>Window</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="25"/>
-        <location filename="../src/widgets/window.cpp" line="531"/>
+        <location filename="../src/controls/warningnotices.cpp" line="27"/>
+        <location filename="../src/widgets/window.cpp" line="548"/>
         <source>Save as</source>
         <translation>Tallenna nimellä</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="527"/>
+        <location filename="../src/widgets/window.cpp" line="540"/>
         <source>New window</source>
         <translation>Uusi ikkuna</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="528"/>
+        <location filename="../src/widgets/window.cpp" line="542"/>
         <source>New tab</source>
         <translation>Uusi välilehti</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="529"/>
+        <location filename="../src/widgets/window.cpp" line="544"/>
         <source>Open file</source>
         <translation>Avaa tiedosto</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="530"/>
-        <location filename="../src/widgets/window.cpp" line="3545"/>
+        <location filename="../src/widgets/window.cpp" line="546"/>
+        <location filename="../src/widgets/window.cpp" line="3950"/>
         <source>Save</source>
         <translation>Tallenna</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="532"/>
+        <location filename="../src/widgets/window.cpp" line="550"/>
         <source>Print</source>
         <translation>Tulosta</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="533"/>
+        <location filename="../src/widgets/window.cpp" line="552"/>
         <source>Switch theme</source>
         <translation>Vaihda teema</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="534"/>
-        <location filename="../src/widgets/window.cpp" line="2448"/>
+        <location filename="../src/widgets/window.cpp" line="554"/>
+        <location filename="../src/widgets/window.cpp" line="2641"/>
         <source>Settings</source>
         <translation>Asetukset</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="666"/>
-        <location filename="../src/widgets/window.cpp" line="3845"/>
+        <location filename="../src/widgets/window.cpp" line="696"/>
+        <location filename="../src/widgets/window.cpp" line="4250"/>
         <source>Read-Only</source>
         <translation>Luettavissa</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="687"/>
+        <location filename="../src/widgets/window.cpp" line="719"/>
         <source>You do not have permission to open %1</source>
         <translation>Sinulla ei ole lupaa avata %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="738"/>
-        <location filename="../src/widgets/window.cpp" line="2963"/>
+        <location filename="../src/widgets/window.cpp" line="773"/>
+        <location filename="../src/widgets/window.cpp" line="3266"/>
         <source>Invalid file: %1</source>
         <translation>Virheellinen tiedosto: %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="903"/>
-        <location filename="../src/widgets/window.cpp" line="956"/>
+        <location filename="../src/widgets/window.cpp" line="957"/>
+        <location filename="../src/widgets/window.cpp" line="1050"/>
+        <location filename="../src/widgets/window.cpp" line="3217"/>
         <source>Do you want to save this file?</source>
         <translation>Haluatko tallentaa tämän tiedoston?</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1290"/>
+        <location filename="../src/widgets/window.cpp" line="1381"/>
+        <source>Invalid characters detected while saving &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1382"/>
+        <source>If you force save this file, it may cause file corruption. Still want to save?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1386"/>
+        <source>Don&apos;t Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1387"/>
+        <source>Save As</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1388"/>
+        <source>Save Anyway</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1456"/>
         <source>You do not have permission to save %1</source>
         <translation>Sinulla ei ole lupaa tallentaa %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1312"/>
+        <location filename="../src/widgets/window.cpp" line="1428"/>
+        <location filename="../src/widgets/window.cpp" line="1478"/>
         <source>Saved successfully</source>
         <translation>Tallennus onnistui</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1354"/>
-        <location filename="../src/widgets/window.cpp" line="1481"/>
-        <location filename="../src/widgets/window.cpp" line="1529"/>
+        <location filename="../src/widgets/window.cpp" line="1520"/>
+        <location filename="../src/widgets/window.cpp" line="1665"/>
+        <location filename="../src/widgets/window.cpp" line="1713"/>
         <source>Save File</source>
         <translation>Tallenna tiedosto</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1483"/>
+        <location filename="../src/widgets/window.cpp" line="1569"/>
+        <source>Cannot save as the original file in preview mode. Please choose a different path.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1667"/>
         <source>Encoding</source>
         <translation>Koodaus</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1773"/>
+        <location filename="../src/widgets/window.cpp" line="1957"/>
         <source>Read-Only mode is on</source>
         <translation>Lukutila on päällä</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2322"/>
+        <location filename="../src/widgets/window.cpp" line="2511"/>
         <source>Current location remembered</source>
         <translation>Nykyinen sijainti muistetaan</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2398"/>
+        <location filename="../src/widgets/window.cpp" line="2591"/>
         <source>Ctrl+&apos;=&apos;</source>
         <translation>Ctrl+&apos;=&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2401"/>
+        <location filename="../src/widgets/window.cpp" line="2594"/>
         <source>Ctrl+&apos;-&apos;</source>
         <translation>Ctrl+&apos;-&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2430"/>
+        <location filename="../src/widgets/window.cpp" line="2623"/>
         <source>Editor</source>
         <translation>Editori</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3061"/>
+        <location filename="../src/widgets/window.cpp" line="3436"/>
         <source>Untitled %1</source>
         <translation>Nimetön %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3543"/>
+        <location filename="../src/widgets/window.cpp" line="3948"/>
         <source>Cancel</source>
         <translation>Peru</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3544"/>
+        <location filename="../src/widgets/window.cpp" line="3949"/>
         <source>Discard</source>
         <translation>Hylkää</translation>
     </message>

--- a/translations/deepin-editor_fr.ts
+++ b/translations/deepin-editor_fr.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="fr">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="fr">
 <context>
     <name>BottomBar</name>
     <message>
@@ -17,17 +19,36 @@
         <translation>Caractères %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="44"/>
+        <location filename="../src/widgets/bottombar.cpp" line="47"/>
         <source>Loading:</source>
         <translation>Chargement :</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="73"/>
+        <location filename="../src/widgets/bottombar.cpp" line="91"/>
+        <location filename="../src/widgets/bottombar.cpp" line="499"/>
+        <source>Edit Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="74"/>
+        <location filename="../src/widgets/bottombar.cpp" line="489"/>
+        <source>Read View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="75"/>
+        <location filename="../src/widgets/bottombar.cpp" line="493"/>
+        <source>Live Preview</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DDropdownMenu</name>
     <message>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="362"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="420"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="425"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="363"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="421"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="426"/>
         <source>None</source>
         <translation>Aucun</translation>
     </message>
@@ -35,68 +56,57 @@
 <context>
     <name>EditWrapper</name>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="292"/>
-        <location filename="../src/editor/editwrapper.cpp" line="365"/>
-        <location filename="../src/editor/editwrapper.cpp" line="521"/>
-        <location filename="../src/editor/editwrapper.cpp" line="751"/>
+        <location filename="../src/editor/editwrapper.cpp" line="355"/>
+        <location filename="../src/editor/editwrapper.cpp" line="429"/>
+        <location filename="../src/editor/editwrapper.cpp" line="595"/>
+        <location filename="../src/editor/editwrapper.cpp" line="887"/>
         <source>Save</source>
         <translation>Sauvegarder</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="516"/>
+        <location filename="../src/editor/editwrapper.cpp" line="590"/>
         <source>Do you want to save this file?</source>
         <translation>Voulez-vous enregistrer ce fichier ?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="363"/>
-        <location filename="../src/editor/editwrapper.cpp" line="519"/>
+        <location filename="../src/editor/editwrapper.cpp" line="427"/>
+        <location filename="../src/editor/editwrapper.cpp" line="593"/>
         <source>Cancel</source>
         <translation>Annuler</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="360"/>
+        <location filename="../src/editor/editwrapper.cpp" line="424"/>
         <source>Encoding changed. Do you want to save the file now?</source>
         <translation>L&apos;encodage a changé. Voulez-vous enregistrer le fichier maintenant ?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="520"/>
+        <location filename="../src/editor/editwrapper.cpp" line="594"/>
         <source>Discard</source>
         <translation>Abandonner</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="274"/>
-        <location filename="../src/editor/editwrapper.cpp" line="620"/>
+        <location filename="../src/editor/editwrapper.cpp" line="1121"/>
+        <source>The file contains invalid characters (NUL). Preview mode is read-only.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="337"/>
+        <location filename="../src/editor/editwrapper.cpp" line="705"/>
         <source>You do not have permission to save %1</source>
         <translation>Vous n&apos;avez pas la permission de sauvegarder %1</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="836"/>
+        <location filename="../src/editor/editwrapper.cpp" line="987"/>
         <source>File removed on the disk. Save it now?</source>
         <translation>Fichier supprimé du disque. L&apos;enregistrer maintenant ?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="842"/>
+        <location filename="../src/editor/editwrapper.cpp" line="993"/>
         <source>File has changed on disk. Reload?</source>
         <translation>Le fichier a été modifié sur le disque. Recharger ?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="884"/>
-        <location filename="../src/widgets/bottombar.cpp" line="74"/>
-        <source>INSERT</source>
-        <translation>INSÉRER</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="888"/>
-        <source>OVERWRITE</source>
-        <translation>ÉCRASER</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="892"/>
-        <source>R/O</source>
-        <translation>L/S</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="1618"/>
+        <location filename="../src/editor/editwrapper.cpp" line="1806"/>
         <source>The file cannot be read, which may be too large or has been damaged!</source>
         <translation>Le fichier ne peut être lu, il peut être trop gros ou endommagé.</translation>
     </message>
@@ -109,17 +119,17 @@
         <translation>Rechercher</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="36"/>
+        <location filename="../src/controls/findbar.cpp" line="38"/>
         <source>Previous</source>
         <translation>Précédent</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="37"/>
+        <location filename="../src/controls/findbar.cpp" line="40"/>
         <source>Next</source>
         <translation>Suivant</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="38"/>
+        <location filename="../src/controls/findbar.cpp" line="42"/>
         <source>Replace</source>
         <translation>Remplacer</translation>
     </message>
@@ -127,9 +137,17 @@
 <context>
     <name>JumpLineBar</name>
     <message>
-        <location filename="../src/controls/jumplinebar.cpp" line="45"/>
+        <location filename="../src/controls/jumplinebar.cpp" line="46"/>
         <source>Go to Line: </source>
         <translation>Aller à la ligne :</translation>
+    </message>
+</context>
+<context>
+    <name>LineBar</name>
+    <message>
+        <location filename="../src/controls/linebar.cpp" line="144"/>
+        <source>第%1/%2项</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -146,19 +164,47 @@
     </message>
 </context>
 <context>
+    <name>MarkdownBridge</name>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="37"/>
+        <source>Collapse code block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="38"/>
+        <source>Expand code block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="39"/>
+        <source>Copy code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="40"/>
+        <source>Expand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="42"/>
+        <source>%1 line(s) of code collapsed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PathSettingWgt</name>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="84"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="90"/>
         <source>Remember the last used path</source>
         <translation>Se souvenir du dernier chemin utilisé</translation>
     </message>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="85"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="91"/>
         <source>Same path as the current file</source>
         <translation>Même chemin que le fichier actuel</translation>
     </message>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="86"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="92"/>
         <source>Customize the default path</source>
         <translation>Personnaliser le chemin par défaut</translation>
     </message>
@@ -171,15 +217,20 @@
         <translation>Éditeur de texte</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="294"/>
-        <location filename="../src/editor/editwrapper.cpp" line="761"/>
-        <location filename="../src/editor/editwrapper.cpp" line="776"/>
-        <location filename="../src/widgets/window.cpp" line="1362"/>
-        <location filename="../src/widgets/window.cpp" line="1390"/>
-        <location filename="../src/widgets/window.cpp" line="1531"/>
-        <location filename="../src/widgets/window.cpp" line="1548"/>
+        <location filename="../src/editor/editwrapper.cpp" line="357"/>
+        <location filename="../src/editor/editwrapper.cpp" line="897"/>
+        <location filename="../src/editor/editwrapper.cpp" line="912"/>
+        <location filename="../src/widgets/window.cpp" line="1528"/>
+        <location filename="../src/widgets/window.cpp" line="1556"/>
+        <location filename="../src/widgets/window.cpp" line="1715"/>
+        <location filename="../src/widgets/window.cpp" line="1732"/>
         <source>Encoding</source>
         <translation>Encodage</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="2001"/>
+        <source>视图模式</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="11"/>
@@ -215,7 +266,7 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="18"/>
         <location filename="../src/controls/settingsdialog.cpp" line="96"/>
-        <location filename="../src/widgets/window.cpp" line="2388"/>
+        <location filename="../src/widgets/window.cpp" line="2581"/>
         <source>Window</source>
         <translation>Fenêtre</translation>
     </message>
@@ -755,68 +806,68 @@
         <translation>Vietnamien</translation>
     </message>
     <message>
-        <location filename="../src/startmanager.cpp" line="971"/>
+        <location filename="../src/startmanager.cpp" line="1035"/>
         <source>File not saved</source>
         <translation>Fichier non sauvegardé</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1532"/>
-        <location filename="../src/widgets/window.cpp" line="1549"/>
+        <location filename="../src/widgets/window.cpp" line="1716"/>
+        <location filename="../src/widgets/window.cpp" line="1733"/>
         <source>Line Endings</source>
         <translation>Fin de ligne</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="243"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="379"/>
         <source>Please install &apos;UOS AI&apos; from the App Store before using</source>
         <translation>Veuillez installer &apos;UOS AI&apos; de l&apos;App Store avant d&apos;utiliser</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="245"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="381"/>
         <source>No audio input device detected. Please check and try again</source>
         <translation>Aucun périphérique d&apos;entrée audio détecté. Veuillez vérifier et réessayer</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="247"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="383"/>
         <source>No audio output device detected. Please check and try again</source>
         <translation>Aucun périphérique de sortie audio détecté. Veuillez vérifier et réessayer</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="69"/>
+        <location filename="../src/common/text_file_saver.cpp" line="74"/>
         <source>File path is empty</source>
         <translation>Le chemin du fichier est vide</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="155"/>
+        <location filename="../src/common/text_file_saver.cpp" line="153"/>
         <source>Insufficient memory to load document content</source>
         <translation>Mémoire insuffisante pour charger le contenu du document</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="177"/>
+        <location filename="../src/common/text_file_saver.cpp" line="178"/>
         <source>Insufficient memory for encoding conversion</source>
         <translation>Mémoire insuffisante pour la conversion d&apos;encodage</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="183"/>
+        <location filename="../src/common/text_file_saver.cpp" line="184"/>
         <source>Encoding conversion failed</source>
         <translation>La conversion d&apos;encodage a échoué</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="189"/>
+        <location filename="../src/common/text_file_saver.cpp" line="190"/>
         <source>Converted content is empty</source>
         <translation>Le contenu converti est vide</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="207"/>
+        <location filename="../src/common/text_file_saver.cpp" line="208"/>
         <source>Memory allocation failed</source>
         <translation>L&apos;allocation de mémoire a échoué</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="211"/>
+        <location filename="../src/common/text_file_saver.cpp" line="212"/>
         <source>Error occurred: %1</source>
         <translation>Une erreur s&apos;est produite : %1</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="215"/>
+        <location filename="../src/common/text_file_saver.cpp" line="216"/>
         <source>Unknown error occurred</source>
         <translation>Une erreur inconnue s&apos;est produite</translation>
     </message>
@@ -829,27 +880,27 @@
         <translation>Rechercher</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="34"/>
+        <location filename="../src/controls/replacebar.cpp" line="36"/>
         <source>Replace With</source>
         <translation>Remplacer par</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="36"/>
+        <location filename="../src/controls/replacebar.cpp" line="40"/>
         <source>Replace</source>
         <translation>Remplacer</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="37"/>
+        <location filename="../src/controls/replacebar.cpp" line="42"/>
         <source>Skip</source>
         <translation>Passer</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="38"/>
+        <location filename="../src/controls/replacebar.cpp" line="44"/>
         <source>Replace Rest</source>
         <translation>Remplacer la suite</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="39"/>
+        <location filename="../src/controls/replacebar.cpp" line="46"/>
         <source>Replace All</source>
         <translation>Tout remplacer</translation>
     </message>
@@ -858,9 +909,9 @@
     <name>S:</name>
     <message>
         <location filename="../third/libiconv-1.16/src/iconv.c" line="103"/>
-        <source/>
+        <source></source>
         <comment>The first line of the short usage message.</comment>
-        <translation type="unfinished"/>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -891,34 +942,34 @@
         <translation>Plein écran</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="484"/>
+        <location filename="../src/common/settings.cpp" line="491"/>
         <source>This shortcut conflicts with system shortcut %1</source>
         <translation>Ce raccourci entre en conflit avec le raccourci système %1</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="487"/>
+        <location filename="../src/common/settings.cpp" line="494"/>
         <source>This shortcut conflicts with %1, click on Replace to make this shortcut effective immediately</source>
         <translation>Ce raccourci entre en conflit avec %1, cliquez sur Remplacer pour rendre ce raccourci effectif immédiatement</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="682"/>
-        <location filename="../src/common/settings.cpp" line="695"/>
-        <location filename="../src/common/settings.cpp" line="704"/>
+        <location filename="../src/common/settings.cpp" line="689"/>
+        <location filename="../src/common/settings.cpp" line="702"/>
+        <location filename="../src/common/settings.cpp" line="711"/>
         <source>The shortcut %1 is invalid, please set another one.</source>
         <translation>Le raccourci %1 n&apos;est pas valide, veuillez en définir un autre.</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="736"/>
+        <location filename="../src/common/settings.cpp" line="743"/>
         <source>Cancel</source>
         <translation>Annuler</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="737"/>
+        <location filename="../src/common/settings.cpp" line="744"/>
         <source>Replace</source>
         <translation>Remplacer</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="740"/>
+        <location filename="../src/common/settings.cpp" line="747"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
@@ -926,7 +977,7 @@
 <context>
     <name>StartManager</name>
     <message>
-        <location filename="../src/startmanager.cpp" line="411"/>
+        <location filename="../src/startmanager.cpp" line="425"/>
         <source>Untitled %1</source>
         <translation>Sans titre %1</translation>
     </message>
@@ -934,32 +985,32 @@
 <context>
     <name>Tabbar</name>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="641"/>
+        <location filename="../src/controls/tabbar.cpp" line="678"/>
         <source>Close tab</source>
         <translation>Fermer l&apos;onglet</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="642"/>
+        <location filename="../src/controls/tabbar.cpp" line="680"/>
         <source>Close other tabs</source>
         <translation>Fermer les autres onglets</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="643"/>
+        <location filename="../src/controls/tabbar.cpp" line="682"/>
         <source>More options</source>
         <translation>Plus d&apos;options</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="644"/>
+        <location filename="../src/controls/tabbar.cpp" line="684"/>
         <source>Close tabs to the left</source>
         <translation>Fermer les onglets à gauche</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="645"/>
+        <location filename="../src/controls/tabbar.cpp" line="686"/>
         <source>Close tabs to the right</source>
         <translation>Fermer les onglets à droite</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="646"/>
+        <location filename="../src/controls/tabbar.cpp" line="688"/>
         <source>Close unmodified tabs</source>
         <translation>Fermer les onglets non modifiés</translation>
     </message>
@@ -967,263 +1018,280 @@
 <context>
     <name>TextEdit</name>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="305"/>
+        <location filename="../src/editor/dtextedit.cpp" line="388"/>
         <source>Undo</source>
         <translation>Annuler</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="306"/>
+        <location filename="../src/editor/dtextedit.cpp" line="390"/>
         <source>Redo</source>
         <translation>Rétablir</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="307"/>
+        <location filename="../src/editor/dtextedit.cpp" line="392"/>
         <source>Cut</source>
         <translation>Couper</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="308"/>
+        <location filename="../src/editor/dtextedit.cpp" line="394"/>
         <source>Copy</source>
         <translation>Copier</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="309"/>
+        <location filename="../src/editor/dtextedit.cpp" line="396"/>
         <source>Paste</source>
         <translation>Coller</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="310"/>
+        <location filename="../src/editor/dtextedit.cpp" line="398"/>
         <source>Delete</source>
         <translation>Supprimer</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="311"/>
+        <location filename="../src/editor/dtextedit.cpp" line="400"/>
         <source>Select All</source>
         <translation>Tout sélectionner</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="312"/>
-        <location filename="../src/widgets/window.cpp" line="535"/>
+        <location filename="../src/editor/dtextedit.cpp" line="402"/>
+        <location filename="../src/widgets/window.cpp" line="556"/>
         <source>Find</source>
         <translation>Rechercher</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="313"/>
-        <location filename="../src/widgets/window.cpp" line="536"/>
+        <location filename="../src/editor/dtextedit.cpp" line="404"/>
+        <location filename="../src/widgets/window.cpp" line="558"/>
         <source>Replace</source>
         <translation>Remplacer</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="314"/>
+        <location filename="../src/editor/dtextedit.cpp" line="406"/>
         <source>Go to Line</source>
         <translation>Aller à la ligne</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="315"/>
-        <source>Turn on Read-Only mode</source>
-        <translation>Activer le mode lecture seule</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="316"/>
-        <source>Turn off Read-Only mode</source>
-        <translation>Désactiver le mode lecture seule</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="317"/>
+        <location filename="../src/editor/dtextedit.cpp" line="415"/>
         <source>Fullscreen</source>
         <translation>Plein écran</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="318"/>
+        <location filename="../src/editor/dtextedit.cpp" line="417"/>
         <source>Exit fullscreen</source>
         <translation>Quitter le mode plein écran</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="319"/>
+        <location filename="../src/editor/dtextedit.cpp" line="419"/>
         <source>Display in file manager</source>
         <translation>Afficher dans l&apos;explorateur de fichiers</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="320"/>
-        <location filename="../src/editor/dtextedit.cpp" line="374"/>
+        <location filename="../src/editor/dtextedit.cpp" line="421"/>
+        <location filename="../src/editor/dtextedit.cpp" line="493"/>
         <source>Add Comment</source>
         <translation>Ajouter un commentaire</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="321"/>
+        <location filename="../src/editor/dtextedit.cpp" line="423"/>
         <source>Text to Speech</source>
         <translation>Texte vers voix</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="322"/>
-        <source>Stop reading</source>
-        <translation>Arrêter de lire</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="323"/>
+        <location filename="../src/editor/dtextedit.cpp" line="425"/>
         <source>Speech to Text</source>
         <translation>Voix vers texte</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="324"/>
+        <location filename="../src/editor/dtextedit.cpp" line="427"/>
         <source>Translate</source>
         <translation>Traduire</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="325"/>
+        <location filename="../src/editor/dtextedit.cpp" line="429"/>
         <source>Column Mode</source>
         <translation>Mode colonne</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="326"/>
+        <location filename="../src/editor/dtextedit.cpp" line="431"/>
         <source>Add bookmark</source>
         <translation>Ajouter un signet</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="327"/>
+        <location filename="../src/editor/dtextedit.cpp" line="433"/>
         <source>Remove Bookmark</source>
         <translation>Supprimer le signet</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="328"/>
+        <location filename="../src/editor/dtextedit.cpp" line="435"/>
         <source>Previous bookmark</source>
         <translation>Signet précédent</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="329"/>
+        <location filename="../src/editor/dtextedit.cpp" line="437"/>
         <source>Next bookmark</source>
         <translation>Signet suivant</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="330"/>
+        <location filename="../src/editor/dtextedit.cpp" line="439"/>
         <source>Remove All Bookmarks</source>
         <translation>Supprimer tous les signets</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="331"/>
+        <location filename="../src/editor/dtextedit.cpp" line="441"/>
         <source>Fold All</source>
         <translation>Tout plier</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="332"/>
+        <location filename="../src/editor/dtextedit.cpp" line="443"/>
         <source>Fold Current Level</source>
         <translation>Plier le niveau actuel</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="333"/>
+        <location filename="../src/editor/dtextedit.cpp" line="445"/>
         <source>Unfold All</source>
         <translation>Tout déplier</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="334"/>
+        <location filename="../src/editor/dtextedit.cpp" line="447"/>
         <source>Unfold Current Level</source>
         <translation>Déplier le niveau actuel</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="339"/>
+        <location filename="../src/editor/dtextedit.cpp" line="453"/>
         <source>Color Mark</source>
         <translation>Marque de couleur</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="343"/>
+        <location filename="../src/editor/dtextedit.cpp" line="458"/>
         <source>Clear All Marks</source>
         <translation>Effacer toutes les marques</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="344"/>
+        <location filename="../src/editor/dtextedit.cpp" line="460"/>
         <source>Clear Last Mark</source>
         <translation>Effacer la dernière marque</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="353"/>
+        <location filename="../src/editor/dtextedit.cpp" line="470"/>
         <source>Mark</source>
         <translation>Cocher</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="366"/>
+        <location filename="../src/editor/dtextedit.cpp" line="484"/>
         <source>Mark All</source>
         <translation>Marquer tout</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="375"/>
+        <location filename="../src/editor/dtextedit.cpp" line="494"/>
         <source>Remove Comment</source>
         <translation>Supprimer le commentaire</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3208"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3211"/>
+        <location filename="../src/editor/dtextedit.cpp" line="543"/>
+        <source>View Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="3531"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3534"/>
         <source>Copy failed: not enough memory</source>
         <translation>Copie ratée: pas assez de mémoire</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3333"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3335"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3656"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3658"/>
         <source>Press ALT and click lines to edit in column mode</source>
         <translation>Appuyer sur ALT et cliquer sur les lignes pour éditer en mode colonne</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="418"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9574"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9576"/>
+        <source>No audio output device was detected. Please ensure your speakers or headphones are properly connected and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="9583"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9585"/>
+        <source>No audio input device was detected. Please ensure your speakers or headphones are properly connected and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="534"/>
         <source>Change Case</source>
         <translation>Changer de case</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="419"/>
+        <location filename="../src/editor/dtextedit.cpp" line="409"/>
+        <source>Edit Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="411"/>
+        <source>Read View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="413"/>
+        <source>Live Preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="535"/>
         <source>Upper Case</source>
         <translation>Mettre en majuscules</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="420"/>
+        <location filename="../src/editor/dtextedit.cpp" line="536"/>
         <source>Lower Case</source>
         <translation>Mettre en minuscules</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="421"/>
+        <location filename="../src/editor/dtextedit.cpp" line="537"/>
         <source>Capitalize</source>
         <translation>Mettre en majuscules</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="78"/>
+        <location filename="../src/widgets/bottombar.cpp" line="110"/>
         <source>None</source>
         <translation>Aucun</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1363"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1490"/>
         <source>Selected line(s) copied</source>
         <translation>Ligne(s) sélectionnée(s) copiée(s)</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1370"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1497"/>
         <source>Current line copied</source>
         <translation>Ligne actuelle copiée</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1400"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1527"/>
         <source>Selected line(s) clipped</source>
         <translation>Ligne(s) sélectionnée(s) coupée(s)</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1412"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1539"/>
         <source>Current line clipped</source>
         <translation>Ligne actuelle coupée</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3227"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3230"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3550"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3553"/>
         <source>Paste failed: not enough memory</source>
-        <translation>Échec du collage : mémoire insuffisante</translation>
+        <translation>Échec du collage&#xa0;: mémoire insuffisante</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="4548"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4873"/>
         <source>Read-Only mode is off</source>
         <translation>Le mode lecture seule est désactivé</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="4560"/>
-        <location filename="../src/editor/dtextedit.cpp" line="4584"/>
-        <location filename="../src/editor/dtextedit.cpp" line="7896"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8007"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8015"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8026"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4885"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4909"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8236"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8347"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8355"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8366"/>
         <source>Read-Only mode is on</source>
         <translation>Le mode lecture seule est activé</translation>
     </message>
@@ -1231,138 +1299,175 @@
 <context>
     <name>WarningNotices</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="24"/>
+        <location filename="../src/controls/warningnotices.cpp" line="25"/>
         <source>Reload</source>
         <translation>Recharger</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/warningnotices.cpp" line="29"/>
+        <source>Edit Anyway</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>Window</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="25"/>
-        <location filename="../src/widgets/window.cpp" line="531"/>
+        <location filename="../src/controls/warningnotices.cpp" line="27"/>
+        <location filename="../src/widgets/window.cpp" line="548"/>
         <source>Save as</source>
         <translation>Enregistrer sous</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="527"/>
+        <location filename="../src/widgets/window.cpp" line="540"/>
         <source>New window</source>
         <translation>Nouvelle fenêtre</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="528"/>
+        <location filename="../src/widgets/window.cpp" line="542"/>
         <source>New tab</source>
         <translation>Nouvel onglet</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="529"/>
+        <location filename="../src/widgets/window.cpp" line="544"/>
         <source>Open file</source>
         <translation>Ouvrir un fichier</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="530"/>
-        <location filename="../src/widgets/window.cpp" line="3545"/>
+        <location filename="../src/widgets/window.cpp" line="546"/>
+        <location filename="../src/widgets/window.cpp" line="3950"/>
         <source>Save</source>
         <translation>Enregistrer</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="532"/>
+        <location filename="../src/widgets/window.cpp" line="550"/>
         <source>Print</source>
         <translation>Imprimer</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="533"/>
+        <location filename="../src/widgets/window.cpp" line="552"/>
         <source>Switch theme</source>
         <translation>Changer de thème</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="534"/>
-        <location filename="../src/widgets/window.cpp" line="2448"/>
+        <location filename="../src/widgets/window.cpp" line="554"/>
+        <location filename="../src/widgets/window.cpp" line="2641"/>
         <source>Settings</source>
         <translation>Paramètres</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="666"/>
-        <location filename="../src/widgets/window.cpp" line="3845"/>
+        <location filename="../src/widgets/window.cpp" line="696"/>
+        <location filename="../src/widgets/window.cpp" line="4250"/>
         <source>Read-Only</source>
         <translation>Lecture seule</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="687"/>
+        <location filename="../src/widgets/window.cpp" line="719"/>
         <source>You do not have permission to open %1</source>
         <translation>Vous n&apos;avez pas la permission d&apos;ouvrir %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="738"/>
-        <location filename="../src/widgets/window.cpp" line="2963"/>
+        <location filename="../src/widgets/window.cpp" line="773"/>
+        <location filename="../src/widgets/window.cpp" line="3266"/>
         <source>Invalid file: %1</source>
         <translation>Fichier invalide : %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="903"/>
-        <location filename="../src/widgets/window.cpp" line="956"/>
+        <location filename="../src/widgets/window.cpp" line="957"/>
+        <location filename="../src/widgets/window.cpp" line="1050"/>
+        <location filename="../src/widgets/window.cpp" line="3217"/>
         <source>Do you want to save this file?</source>
         <translation>Voulez-vous enregistrer ce fichier ?</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1290"/>
+        <location filename="../src/widgets/window.cpp" line="1381"/>
+        <source>Invalid characters detected while saving &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1382"/>
+        <source>If you force save this file, it may cause file corruption. Still want to save?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1386"/>
+        <source>Don&apos;t Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1387"/>
+        <source>Save As</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1388"/>
+        <source>Save Anyway</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1456"/>
         <source>You do not have permission to save %1</source>
         <translation>Vous n&apos;avez pas la permission de sauvegarder %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1312"/>
+        <location filename="../src/widgets/window.cpp" line="1428"/>
+        <location filename="../src/widgets/window.cpp" line="1478"/>
         <source>Saved successfully</source>
         <translation>Enregistré avec succès</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1354"/>
-        <location filename="../src/widgets/window.cpp" line="1481"/>
-        <location filename="../src/widgets/window.cpp" line="1529"/>
+        <location filename="../src/widgets/window.cpp" line="1520"/>
+        <location filename="../src/widgets/window.cpp" line="1665"/>
+        <location filename="../src/widgets/window.cpp" line="1713"/>
         <source>Save File</source>
         <translation>Sauvegarder le fichier</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1483"/>
+        <location filename="../src/widgets/window.cpp" line="1569"/>
+        <source>Cannot save as the original file in preview mode. Please choose a different path.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1667"/>
         <source>Encoding</source>
         <translation>Encodage</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1773"/>
+        <location filename="../src/widgets/window.cpp" line="1957"/>
         <source>Read-Only mode is on</source>
         <translation>Le mode lecture seule est activé</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2322"/>
+        <location filename="../src/widgets/window.cpp" line="2511"/>
         <source>Current location remembered</source>
         <translation>Location actuelle sauvegardée</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2398"/>
+        <location filename="../src/widgets/window.cpp" line="2591"/>
         <source>Ctrl+&apos;=&apos;</source>
         <translation>Ctrl + &apos;=&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2401"/>
+        <location filename="../src/widgets/window.cpp" line="2594"/>
         <source>Ctrl+&apos;-&apos;</source>
         <translation>Ctrl + &apos;-&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2430"/>
+        <location filename="../src/widgets/window.cpp" line="2623"/>
         <source>Editor</source>
         <translation>Éditeur</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3061"/>
+        <location filename="../src/widgets/window.cpp" line="3436"/>
         <source>Untitled %1</source>
         <translation>Sans titre %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3543"/>
+        <location filename="../src/widgets/window.cpp" line="3948"/>
         <source>Cancel</source>
         <translation>Annuler</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3544"/>
+        <location filename="../src/widgets/window.cpp" line="3949"/>
         <source>Discard</source>
         <translation>Abandonner</translation>
     </message>

--- a/translations/deepin-editor_gl_ES.ts
+++ b/translations/deepin-editor_gl_ES.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="gl_ES">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="gl_ES">
 <context>
     <name>BottomBar</name>
     <message>
@@ -17,17 +19,36 @@
         <translation>Caracteres %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="44"/>
+        <location filename="../src/widgets/bottombar.cpp" line="47"/>
         <source>Loading:</source>
         <translation>Cargando:</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="73"/>
+        <location filename="../src/widgets/bottombar.cpp" line="91"/>
+        <location filename="../src/widgets/bottombar.cpp" line="499"/>
+        <source>Edit Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="74"/>
+        <location filename="../src/widgets/bottombar.cpp" line="489"/>
+        <source>Read View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="75"/>
+        <location filename="../src/widgets/bottombar.cpp" line="493"/>
+        <source>Live Preview</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DDropdownMenu</name>
     <message>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="362"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="420"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="425"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="363"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="421"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="426"/>
         <source>None</source>
         <translation>Ningún</translation>
     </message>
@@ -35,68 +56,57 @@
 <context>
     <name>EditWrapper</name>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="292"/>
-        <location filename="../src/editor/editwrapper.cpp" line="365"/>
-        <location filename="../src/editor/editwrapper.cpp" line="521"/>
-        <location filename="../src/editor/editwrapper.cpp" line="751"/>
+        <location filename="../src/editor/editwrapper.cpp" line="355"/>
+        <location filename="../src/editor/editwrapper.cpp" line="429"/>
+        <location filename="../src/editor/editwrapper.cpp" line="595"/>
+        <location filename="../src/editor/editwrapper.cpp" line="887"/>
         <source>Save</source>
         <translation>Gardar</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="516"/>
+        <location filename="../src/editor/editwrapper.cpp" line="590"/>
         <source>Do you want to save this file?</source>
         <translation>Quere gardar este ficheiro?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="363"/>
-        <location filename="../src/editor/editwrapper.cpp" line="519"/>
+        <location filename="../src/editor/editwrapper.cpp" line="427"/>
+        <location filename="../src/editor/editwrapper.cpp" line="593"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="360"/>
+        <location filename="../src/editor/editwrapper.cpp" line="424"/>
         <source>Encoding changed. Do you want to save the file now?</source>
         <translation>A codificación cambiou. Quere gardar o ficheiro agora?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="520"/>
+        <location filename="../src/editor/editwrapper.cpp" line="594"/>
         <source>Discard</source>
         <translation>Descartar</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="274"/>
-        <location filename="../src/editor/editwrapper.cpp" line="620"/>
+        <location filename="../src/editor/editwrapper.cpp" line="1121"/>
+        <source>The file contains invalid characters (NUL). Preview mode is read-only.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="337"/>
+        <location filename="../src/editor/editwrapper.cpp" line="705"/>
         <source>You do not have permission to save %1</source>
         <translation>Non tes permiso para gardar% 1</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="836"/>
+        <location filename="../src/editor/editwrapper.cpp" line="987"/>
         <source>File removed on the disk. Save it now?</source>
         <translation>Ficheiro eliminado no disco. Gardalo agora?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="842"/>
+        <location filename="../src/editor/editwrapper.cpp" line="993"/>
         <source>File has changed on disk. Reload?</source>
         <translation>O ficheiro cambiou no disco. Recargar?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="884"/>
-        <location filename="../src/widgets/bottombar.cpp" line="74"/>
-        <source>INSERT</source>
-        <translation>INSERTAR</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="888"/>
-        <source>OVERWRITE</source>
-        <translation>SUBSTITUÍR</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="892"/>
-        <source>R/O</source>
-        <translation>R/O</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="1618"/>
+        <location filename="../src/editor/editwrapper.cpp" line="1806"/>
         <source>The file cannot be read, which may be too large or has been damaged!</source>
         <translation>O ficheiro non pode lerse, pode ser demasiado grande ou está danado!</translation>
     </message>
@@ -109,17 +119,17 @@
         <translation>Atopar</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="36"/>
+        <location filename="../src/controls/findbar.cpp" line="38"/>
         <source>Previous</source>
         <translation>Anterior</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="37"/>
+        <location filename="../src/controls/findbar.cpp" line="40"/>
         <source>Next</source>
         <translation>Seguinte</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="38"/>
+        <location filename="../src/controls/findbar.cpp" line="42"/>
         <source>Replace</source>
         <translation>Substituír</translation>
     </message>
@@ -127,9 +137,17 @@
 <context>
     <name>JumpLineBar</name>
     <message>
-        <location filename="../src/controls/jumplinebar.cpp" line="45"/>
+        <location filename="../src/controls/jumplinebar.cpp" line="46"/>
         <source>Go to Line: </source>
         <translation>Ir á liña:</translation>
+    </message>
+</context>
+<context>
+    <name>LineBar</name>
+    <message>
+        <location filename="../src/controls/linebar.cpp" line="144"/>
+        <source>第%1/%2项</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -146,19 +164,47 @@
     </message>
 </context>
 <context>
+    <name>MarkdownBridge</name>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="37"/>
+        <source>Collapse code block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="38"/>
+        <source>Expand code block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="39"/>
+        <source>Copy code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="40"/>
+        <source>Expand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="42"/>
+        <source>%1 line(s) of code collapsed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PathSettingWgt</name>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="84"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="90"/>
         <source>Remember the last used path</source>
         <translation>Lembrar o camiño utilizado anteriormente</translation>
     </message>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="85"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="91"/>
         <source>Same path as the current file</source>
         <translation>O mesmo camiño que o ficheiro actual</translation>
     </message>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="86"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="92"/>
         <source>Customize the default path</source>
         <translation>Personalizar o camiño predeterminado</translation>
     </message>
@@ -171,15 +217,20 @@
         <translation>Editor de texto</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="294"/>
-        <location filename="../src/editor/editwrapper.cpp" line="761"/>
-        <location filename="../src/editor/editwrapper.cpp" line="776"/>
-        <location filename="../src/widgets/window.cpp" line="1362"/>
-        <location filename="../src/widgets/window.cpp" line="1390"/>
-        <location filename="../src/widgets/window.cpp" line="1531"/>
-        <location filename="../src/widgets/window.cpp" line="1548"/>
+        <location filename="../src/editor/editwrapper.cpp" line="357"/>
+        <location filename="../src/editor/editwrapper.cpp" line="897"/>
+        <location filename="../src/editor/editwrapper.cpp" line="912"/>
+        <location filename="../src/widgets/window.cpp" line="1528"/>
+        <location filename="../src/widgets/window.cpp" line="1556"/>
+        <location filename="../src/widgets/window.cpp" line="1715"/>
+        <location filename="../src/widgets/window.cpp" line="1732"/>
         <source>Encoding</source>
         <translation>Codificación</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="2001"/>
+        <source>视图模式</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="11"/>
@@ -215,7 +266,7 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="18"/>
         <location filename="../src/controls/settingsdialog.cpp" line="96"/>
-        <location filename="../src/widgets/window.cpp" line="2388"/>
+        <location filename="../src/widgets/window.cpp" line="2581"/>
         <source>Window</source>
         <translation>Xanela</translation>
     </message>
@@ -755,68 +806,68 @@
         <translation>الفيتنامي</translation>
     </message>
     <message>
-        <location filename="../src/startmanager.cpp" line="971"/>
+        <location filename="../src/startmanager.cpp" line="1035"/>
         <source>File not saved</source>
         <translation>Ficheiro non gardado</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1532"/>
-        <location filename="../src/widgets/window.cpp" line="1549"/>
+        <location filename="../src/widgets/window.cpp" line="1716"/>
+        <location filename="../src/widgets/window.cpp" line="1733"/>
         <source>Line Endings</source>
         <translation>Finais das liñas</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="243"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="379"/>
         <source>Please install &apos;UOS AI&apos; from the App Store before using</source>
         <translation>الرجاء تثبيت &apos;UOS AI&apos; من متجر التطبيقات قبل الاستخدام</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="245"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="381"/>
         <source>No audio input device detected. Please check and try again</source>
         <translation>لم يتم اكتشاف جهاز إدخال صوتي. الرجاء التحقق وحاول مرة أخرى</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="247"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="383"/>
         <source>No audio output device detected. Please check and try again</source>
         <translation>لم يتم اكتشاف جهاز إخراج صوتي. الرجاء التحقق وحاول مرة أخرى</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="69"/>
+        <location filename="../src/common/text_file_saver.cpp" line="74"/>
         <source>File path is empty</source>
         <translation>مسار الملف فارغ</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="155"/>
+        <location filename="../src/common/text_file_saver.cpp" line="153"/>
         <source>Insufficient memory to load document content</source>
         <translation>لا يتوفر ذاكرة كافية لتحميل محتوى المستند</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="177"/>
+        <location filename="../src/common/text_file_saver.cpp" line="178"/>
         <source>Insufficient memory for encoding conversion</source>
         <translation>لا يتوفر ذاكرة كافية لتحويل الترميز</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="183"/>
+        <location filename="../src/common/text_file_saver.cpp" line="184"/>
         <source>Encoding conversion failed</source>
         <translation>فشل تحويل الترميز</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="189"/>
+        <location filename="../src/common/text_file_saver.cpp" line="190"/>
         <source>Converted content is empty</source>
         <translation>محتوى التحويل فارغ</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="207"/>
+        <location filename="../src/common/text_file_saver.cpp" line="208"/>
         <source>Memory allocation failed</source>
         <translation>فشل تخصيص الذاكرة</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="211"/>
+        <location filename="../src/common/text_file_saver.cpp" line="212"/>
         <source>Error occurred: %1</source>
         <translation>حدث خطأ: %1</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="215"/>
+        <location filename="../src/common/text_file_saver.cpp" line="216"/>
         <source>Unknown error occurred</source>
         <translation>حدث خطأ غير معروف</translation>
     </message>
@@ -829,27 +880,27 @@
         <translation>Atopar</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="34"/>
+        <location filename="../src/controls/replacebar.cpp" line="36"/>
         <source>Replace With</source>
         <translation>Substituír con</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="36"/>
+        <location filename="../src/controls/replacebar.cpp" line="40"/>
         <source>Replace</source>
         <translation>Substituír</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="37"/>
+        <location filename="../src/controls/replacebar.cpp" line="42"/>
         <source>Skip</source>
         <translation>Saltar</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="38"/>
+        <location filename="../src/controls/replacebar.cpp" line="44"/>
         <source>Replace Rest</source>
         <translation>Substituír o resto</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="39"/>
+        <location filename="../src/controls/replacebar.cpp" line="46"/>
         <source>Replace All</source>
         <translation>Substituír todo</translation>
     </message>
@@ -858,9 +909,9 @@
     <name>S:</name>
     <message>
         <location filename="../third/libiconv-1.16/src/iconv.c" line="103"/>
-        <source/>
+        <source></source>
         <comment>The first line of the short usage message.</comment>
-        <translation type="unfinished"/>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -891,34 +942,34 @@
         <translation>Pantalla completa</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="484"/>
+        <location filename="../src/common/settings.cpp" line="491"/>
         <source>This shortcut conflicts with system shortcut %1</source>
         <translation>هذا المختصر يتعارض مع مختصر النظام %1</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="487"/>
+        <location filename="../src/common/settings.cpp" line="494"/>
         <source>This shortcut conflicts with %1, click on Replace to make this shortcut effective immediately</source>
         <translation>Este atallo entra en conflito con% 1, prema en Substituír para facer efectivo este atallo inmediatamente</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="682"/>
-        <location filename="../src/common/settings.cpp" line="695"/>
-        <location filename="../src/common/settings.cpp" line="704"/>
+        <location filename="../src/common/settings.cpp" line="689"/>
+        <location filename="../src/common/settings.cpp" line="702"/>
+        <location filename="../src/common/settings.cpp" line="711"/>
         <source>The shortcut %1 is invalid, please set another one.</source>
         <translation>المختصر %1 غير صحيح، الرجاء تحديد مختصر آخر.</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="736"/>
+        <location filename="../src/common/settings.cpp" line="743"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="737"/>
+        <location filename="../src/common/settings.cpp" line="744"/>
         <source>Replace</source>
         <translation>Substituír</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="740"/>
+        <location filename="../src/common/settings.cpp" line="747"/>
         <source>OK</source>
         <translation>موافق</translation>
     </message>
@@ -926,7 +977,7 @@
 <context>
     <name>StartManager</name>
     <message>
-        <location filename="../src/startmanager.cpp" line="411"/>
+        <location filename="../src/startmanager.cpp" line="425"/>
         <source>Untitled %1</source>
         <translation>Sen título %1</translation>
     </message>
@@ -934,32 +985,32 @@
 <context>
     <name>Tabbar</name>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="641"/>
+        <location filename="../src/controls/tabbar.cpp" line="678"/>
         <source>Close tab</source>
         <translation>Lapela pechada</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="642"/>
+        <location filename="../src/controls/tabbar.cpp" line="680"/>
         <source>Close other tabs</source>
         <translation>Pechar outras lapelas</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="643"/>
+        <location filename="../src/controls/tabbar.cpp" line="682"/>
         <source>More options</source>
         <translation>Máis opcións</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="644"/>
+        <location filename="../src/controls/tabbar.cpp" line="684"/>
         <source>Close tabs to the left</source>
         <translation>Pechar lapelas á esquerda</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="645"/>
+        <location filename="../src/controls/tabbar.cpp" line="686"/>
         <source>Close tabs to the right</source>
         <translation>Pechar lapelas á dereita</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="646"/>
+        <location filename="../src/controls/tabbar.cpp" line="688"/>
         <source>Close unmodified tabs</source>
         <translation>Pechar lapelas non modificadas</translation>
     </message>
@@ -967,263 +1018,280 @@
 <context>
     <name>TextEdit</name>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="305"/>
+        <location filename="../src/editor/dtextedit.cpp" line="388"/>
         <source>Undo</source>
         <translation>Desfacer</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="306"/>
+        <location filename="../src/editor/dtextedit.cpp" line="390"/>
         <source>Redo</source>
         <translation>Refacer</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="307"/>
+        <location filename="../src/editor/dtextedit.cpp" line="392"/>
         <source>Cut</source>
         <translation>Cortar</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="308"/>
+        <location filename="../src/editor/dtextedit.cpp" line="394"/>
         <source>Copy</source>
         <translation>Copiar</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="309"/>
+        <location filename="../src/editor/dtextedit.cpp" line="396"/>
         <source>Paste</source>
         <translation>Pegar</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="310"/>
+        <location filename="../src/editor/dtextedit.cpp" line="398"/>
         <source>Delete</source>
         <translation>Eliminar</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="311"/>
+        <location filename="../src/editor/dtextedit.cpp" line="400"/>
         <source>Select All</source>
         <translation>Seleccionar todo</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="312"/>
-        <location filename="../src/widgets/window.cpp" line="535"/>
+        <location filename="../src/editor/dtextedit.cpp" line="402"/>
+        <location filename="../src/widgets/window.cpp" line="556"/>
         <source>Find</source>
         <translation>Atopar</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="313"/>
-        <location filename="../src/widgets/window.cpp" line="536"/>
+        <location filename="../src/editor/dtextedit.cpp" line="404"/>
+        <location filename="../src/widgets/window.cpp" line="558"/>
         <source>Replace</source>
         <translation>Substituír</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="314"/>
+        <location filename="../src/editor/dtextedit.cpp" line="406"/>
         <source>Go to Line</source>
         <translation>Ir á liña</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="315"/>
-        <source>Turn on Read-Only mode</source>
-        <translation>Activar modo só-ler</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="316"/>
-        <source>Turn off Read-Only mode</source>
-        <translation>Desactivar modo só-ler</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="317"/>
+        <location filename="../src/editor/dtextedit.cpp" line="415"/>
         <source>Fullscreen</source>
         <translation>Pantalla completa</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="318"/>
+        <location filename="../src/editor/dtextedit.cpp" line="417"/>
         <source>Exit fullscreen</source>
         <translation>Saír da pantalla completa</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="319"/>
+        <location filename="../src/editor/dtextedit.cpp" line="419"/>
         <source>Display in file manager</source>
         <translation>Amosar no xestor do ficheiros</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="320"/>
-        <location filename="../src/editor/dtextedit.cpp" line="374"/>
+        <location filename="../src/editor/dtextedit.cpp" line="421"/>
+        <location filename="../src/editor/dtextedit.cpp" line="493"/>
         <source>Add Comment</source>
         <translation>Engadir comentario</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="321"/>
+        <location filename="../src/editor/dtextedit.cpp" line="423"/>
         <source>Text to Speech</source>
         <translation>Texto a Voz</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="322"/>
-        <source>Stop reading</source>
-        <translation>توقف عن القراءة</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="323"/>
+        <location filename="../src/editor/dtextedit.cpp" line="425"/>
         <source>Speech to Text</source>
         <translation>Voz a Texto</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="324"/>
+        <location filename="../src/editor/dtextedit.cpp" line="427"/>
         <source>Translate</source>
         <translation>Traducir</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="325"/>
+        <location filename="../src/editor/dtextedit.cpp" line="429"/>
         <source>Column Mode</source>
         <translation>Modo columna</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="326"/>
+        <location filename="../src/editor/dtextedit.cpp" line="431"/>
         <source>Add bookmark</source>
         <translation>أضف مرجعًا</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="327"/>
+        <location filename="../src/editor/dtextedit.cpp" line="433"/>
         <source>Remove Bookmark</source>
         <translation>Eliminar marcador</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="328"/>
+        <location filename="../src/editor/dtextedit.cpp" line="435"/>
         <source>Previous bookmark</source>
         <translation>المرجع السابق</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="329"/>
+        <location filename="../src/editor/dtextedit.cpp" line="437"/>
         <source>Next bookmark</source>
         <translation>المرجع التالي</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="330"/>
+        <location filename="../src/editor/dtextedit.cpp" line="439"/>
         <source>Remove All Bookmarks</source>
         <translation>Eliminar todos os marcadores</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="331"/>
+        <location filename="../src/editor/dtextedit.cpp" line="441"/>
         <source>Fold All</source>
         <translation>Dobrar todo</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="332"/>
+        <location filename="../src/editor/dtextedit.cpp" line="443"/>
         <source>Fold Current Level</source>
         <translation>Dobrar o nivel actual</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="333"/>
+        <location filename="../src/editor/dtextedit.cpp" line="445"/>
         <source>Unfold All</source>
         <translation>Desdobrar todo</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="334"/>
+        <location filename="../src/editor/dtextedit.cpp" line="447"/>
         <source>Unfold Current Level</source>
         <translation>Desdobrar o nivel actual</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="339"/>
+        <location filename="../src/editor/dtextedit.cpp" line="453"/>
         <source>Color Mark</source>
         <translation>Marcar a cor</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="343"/>
+        <location filename="../src/editor/dtextedit.cpp" line="458"/>
         <source>Clear All Marks</source>
         <translation>Borrar todos os marcadores</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="344"/>
+        <location filename="../src/editor/dtextedit.cpp" line="460"/>
         <source>Clear Last Mark</source>
         <translation>Borrar o último marcador</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="353"/>
+        <location filename="../src/editor/dtextedit.cpp" line="470"/>
         <source>Mark</source>
         <translation>Marcar</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="366"/>
+        <location filename="../src/editor/dtextedit.cpp" line="484"/>
         <source>Mark All</source>
         <translation>Marcar todo</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="375"/>
+        <location filename="../src/editor/dtextedit.cpp" line="494"/>
         <source>Remove Comment</source>
         <translation>Eliminar comentario</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3208"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3211"/>
+        <location filename="../src/editor/dtextedit.cpp" line="543"/>
+        <source>View Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="3531"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3534"/>
         <source>Copy failed: not enough memory</source>
         <translation>فشل النسخ: لا يوجد ذاكرة كافية</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3333"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3335"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3656"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3658"/>
         <source>Press ALT and click lines to edit in column mode</source>
         <translation>اضغط على ALT وانقر على السطور للتحرير في وضع العمود</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="418"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9574"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9576"/>
+        <source>No audio output device was detected. Please ensure your speakers or headphones are properly connected and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="9583"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9585"/>
+        <source>No audio input device was detected. Please ensure your speakers or headphones are properly connected and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="534"/>
         <source>Change Case</source>
         <translation>Cambiar caso</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="419"/>
+        <location filename="../src/editor/dtextedit.cpp" line="409"/>
+        <source>Edit Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="411"/>
+        <source>Read View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="413"/>
+        <source>Live Preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="535"/>
         <source>Upper Case</source>
         <translation>Maiúscula</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="420"/>
+        <location filename="../src/editor/dtextedit.cpp" line="536"/>
         <source>Lower Case</source>
         <translation>Minúscula</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="421"/>
+        <location filename="../src/editor/dtextedit.cpp" line="537"/>
         <source>Capitalize</source>
         <translation>Capitalizar</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="78"/>
+        <location filename="../src/widgets/bottombar.cpp" line="110"/>
         <source>None</source>
         <translation>Ningún</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1363"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1490"/>
         <source>Selected line(s) copied</source>
         <translation>Liña(s) seleccionada/s copiada/s</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1370"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1497"/>
         <source>Current line copied</source>
         <translation>Liña actual copiada</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1400"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1527"/>
         <source>Selected line(s) clipped</source>
         <translation>Liña(s) selecciona/s enganchada/s</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1412"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1539"/>
         <source>Current line clipped</source>
         <translation>Liña actual enganchada</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3227"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3230"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3550"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3553"/>
         <source>Paste failed: not enough memory</source>
         <translation>فشل اللصق: لا يوجد ذاكرة كافية</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="4548"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4873"/>
         <source>Read-Only mode is off</source>
         <translation>O modo só-ler está apagado</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="4560"/>
-        <location filename="../src/editor/dtextedit.cpp" line="4584"/>
-        <location filename="../src/editor/dtextedit.cpp" line="7896"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8007"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8015"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8026"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4885"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4909"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8236"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8347"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8355"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8366"/>
         <source>Read-Only mode is on</source>
         <translation>O modo só-ler está acendido</translation>
     </message>
@@ -1231,138 +1299,175 @@
 <context>
     <name>WarningNotices</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="24"/>
+        <location filename="../src/controls/warningnotices.cpp" line="25"/>
         <source>Reload</source>
         <translation>Recargar</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/warningnotices.cpp" line="29"/>
+        <source>Edit Anyway</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>Window</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="25"/>
-        <location filename="../src/widgets/window.cpp" line="531"/>
+        <location filename="../src/controls/warningnotices.cpp" line="27"/>
+        <location filename="../src/widgets/window.cpp" line="548"/>
         <source>Save as</source>
         <translation>Gardar como</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="527"/>
+        <location filename="../src/widgets/window.cpp" line="540"/>
         <source>New window</source>
         <translation>Nova xanela</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="528"/>
+        <location filename="../src/widgets/window.cpp" line="542"/>
         <source>New tab</source>
         <translation>Nova lapela</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="529"/>
+        <location filename="../src/widgets/window.cpp" line="544"/>
         <source>Open file</source>
         <translation>Abrir ficheiro</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="530"/>
-        <location filename="../src/widgets/window.cpp" line="3545"/>
+        <location filename="../src/widgets/window.cpp" line="546"/>
+        <location filename="../src/widgets/window.cpp" line="3950"/>
         <source>Save</source>
         <translation>Gardar</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="532"/>
+        <location filename="../src/widgets/window.cpp" line="550"/>
         <source>Print</source>
         <translation>Imprimir</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="533"/>
+        <location filename="../src/widgets/window.cpp" line="552"/>
         <source>Switch theme</source>
         <translation>Cambiar tema</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="534"/>
-        <location filename="../src/widgets/window.cpp" line="2448"/>
+        <location filename="../src/widgets/window.cpp" line="554"/>
+        <location filename="../src/widgets/window.cpp" line="2641"/>
         <source>Settings</source>
         <translation>Configuracións</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="666"/>
-        <location filename="../src/widgets/window.cpp" line="3845"/>
+        <location filename="../src/widgets/window.cpp" line="696"/>
+        <location filename="../src/widgets/window.cpp" line="4250"/>
         <source>Read-Only</source>
         <translation>Só-ler</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="687"/>
+        <location filename="../src/widgets/window.cpp" line="719"/>
         <source>You do not have permission to open %1</source>
         <translation>Non tes permiso para abrir% 1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="738"/>
-        <location filename="../src/widgets/window.cpp" line="2963"/>
+        <location filename="../src/widgets/window.cpp" line="773"/>
+        <location filename="../src/widgets/window.cpp" line="3266"/>
         <source>Invalid file: %1</source>
         <translation>Ficheiro non válido: %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="903"/>
-        <location filename="../src/widgets/window.cpp" line="956"/>
+        <location filename="../src/widgets/window.cpp" line="957"/>
+        <location filename="../src/widgets/window.cpp" line="1050"/>
+        <location filename="../src/widgets/window.cpp" line="3217"/>
         <source>Do you want to save this file?</source>
         <translation>Quere gardar este ficheiro?</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1290"/>
+        <location filename="../src/widgets/window.cpp" line="1381"/>
+        <source>Invalid characters detected while saving &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1382"/>
+        <source>If you force save this file, it may cause file corruption. Still want to save?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1386"/>
+        <source>Don&apos;t Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1387"/>
+        <source>Save As</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1388"/>
+        <source>Save Anyway</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1456"/>
         <source>You do not have permission to save %1</source>
         <translation>Non tes permiso para gardar% 1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1312"/>
+        <location filename="../src/widgets/window.cpp" line="1428"/>
+        <location filename="../src/widgets/window.cpp" line="1478"/>
         <source>Saved successfully</source>
         <translation>Gardado con éxito</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1354"/>
-        <location filename="../src/widgets/window.cpp" line="1481"/>
-        <location filename="../src/widgets/window.cpp" line="1529"/>
+        <location filename="../src/widgets/window.cpp" line="1520"/>
+        <location filename="../src/widgets/window.cpp" line="1665"/>
+        <location filename="../src/widgets/window.cpp" line="1713"/>
         <source>Save File</source>
         <translation>Gardar ficheiro</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1483"/>
+        <location filename="../src/widgets/window.cpp" line="1569"/>
+        <source>Cannot save as the original file in preview mode. Please choose a different path.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1667"/>
         <source>Encoding</source>
         <translation>Codificación</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1773"/>
+        <location filename="../src/widgets/window.cpp" line="1957"/>
         <source>Read-Only mode is on</source>
         <translation>O modo só-ler está acendido</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2322"/>
+        <location filename="../src/widgets/window.cpp" line="2511"/>
         <source>Current location remembered</source>
         <translation>Localización actual recordada</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2398"/>
+        <location filename="../src/widgets/window.cpp" line="2591"/>
         <source>Ctrl+&apos;=&apos;</source>
         <translation>Ctrl+&apos;=&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2401"/>
+        <location filename="../src/widgets/window.cpp" line="2594"/>
         <source>Ctrl+&apos;-&apos;</source>
         <translation>Ctrl+&apos;-&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2430"/>
+        <location filename="../src/widgets/window.cpp" line="2623"/>
         <source>Editor</source>
         <translation>Editor</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3061"/>
+        <location filename="../src/widgets/window.cpp" line="3436"/>
         <source>Untitled %1</source>
         <translation>Sen título %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3543"/>
+        <location filename="../src/widgets/window.cpp" line="3948"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3544"/>
+        <location filename="../src/widgets/window.cpp" line="3949"/>
         <source>Discard</source>
         <translation>Descartar</translation>
     </message>

--- a/translations/deepin-editor_he.ts
+++ b/translations/deepin-editor_he.ts
@@ -1,104 +1,114 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="he">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="he">
 <context>
     <name>BottomBar</name>
     <message>
         <location filename="../src/widgets/bottombar.cpp" line="30"/>
         <source>Row</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/widgets/bottombar.cpp" line="31"/>
         <source>Column</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/widgets/bottombar.cpp" line="32"/>
         <source>Characters %1</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="44"/>
+        <location filename="../src/widgets/bottombar.cpp" line="47"/>
         <source>Loading:</source>
         <translation>טעינה:</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="73"/>
+        <location filename="../src/widgets/bottombar.cpp" line="91"/>
+        <location filename="../src/widgets/bottombar.cpp" line="499"/>
+        <source>Edit Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="74"/>
+        <location filename="../src/widgets/bottombar.cpp" line="489"/>
+        <source>Read View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="75"/>
+        <location filename="../src/widgets/bottombar.cpp" line="493"/>
+        <source>Live Preview</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DDropdownMenu</name>
     <message>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="362"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="420"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="425"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="363"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="421"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="426"/>
         <source>None</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>EditWrapper</name>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="292"/>
-        <location filename="../src/editor/editwrapper.cpp" line="365"/>
-        <location filename="../src/editor/editwrapper.cpp" line="521"/>
-        <location filename="../src/editor/editwrapper.cpp" line="751"/>
+        <location filename="../src/editor/editwrapper.cpp" line="355"/>
+        <location filename="../src/editor/editwrapper.cpp" line="429"/>
+        <location filename="../src/editor/editwrapper.cpp" line="595"/>
+        <location filename="../src/editor/editwrapper.cpp" line="887"/>
         <source>Save</source>
         <translation>שמירה</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="516"/>
+        <location filename="../src/editor/editwrapper.cpp" line="590"/>
         <source>Do you want to save this file?</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="363"/>
-        <location filename="../src/editor/editwrapper.cpp" line="519"/>
+        <location filename="../src/editor/editwrapper.cpp" line="427"/>
+        <location filename="../src/editor/editwrapper.cpp" line="593"/>
         <source>Cancel</source>
         <translation>ביטול</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="360"/>
+        <location filename="../src/editor/editwrapper.cpp" line="424"/>
         <source>Encoding changed. Do you want to save the file now?</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="520"/>
+        <location filename="../src/editor/editwrapper.cpp" line="594"/>
         <source>Discard</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="274"/>
-        <location filename="../src/editor/editwrapper.cpp" line="620"/>
+        <location filename="../src/editor/editwrapper.cpp" line="1121"/>
+        <source>The file contains invalid characters (NUL). Preview mode is read-only.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="337"/>
+        <location filename="../src/editor/editwrapper.cpp" line="705"/>
         <source>You do not have permission to save %1</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="836"/>
+        <location filename="../src/editor/editwrapper.cpp" line="987"/>
         <source>File removed on the disk. Save it now?</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="842"/>
+        <location filename="../src/editor/editwrapper.cpp" line="993"/>
         <source>File has changed on disk. Reload?</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="884"/>
-        <location filename="../src/widgets/bottombar.cpp" line="74"/>
-        <source>INSERT</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="888"/>
-        <source>OVERWRITE</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="892"/>
-        <source>R/O</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="1618"/>
+        <location filename="../src/editor/editwrapper.cpp" line="1806"/>
         <source>The file cannot be read, which may be too large or has been damaged!</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -109,17 +119,17 @@
         <translation>חיפוש</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="36"/>
+        <location filename="../src/controls/findbar.cpp" line="38"/>
         <source>Previous</source>
         <translation>הקודם</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="37"/>
+        <location filename="../src/controls/findbar.cpp" line="40"/>
         <source>Next</source>
         <translation>הבא</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="38"/>
+        <location filename="../src/controls/findbar.cpp" line="42"/>
         <source>Replace</source>
         <translation>החלפה</translation>
     </message>
@@ -127,9 +137,17 @@
 <context>
     <name>JumpLineBar</name>
     <message>
-        <location filename="../src/controls/jumplinebar.cpp" line="45"/>
+        <location filename="../src/controls/jumplinebar.cpp" line="46"/>
         <source>Go to Line: </source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>LineBar</name>
+    <message>
+        <location filename="../src/controls/linebar.cpp" line="144"/>
+        <source>第%1/%2项</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -137,7 +155,7 @@
     <message>
         <location filename="../src/editorapplication.cpp" line="12"/>
         <source>Text Editor is a powerful tool for viewing and editing text files.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/editorapplication.cpp" line="34"/>
@@ -146,21 +164,49 @@
     </message>
 </context>
 <context>
+    <name>MarkdownBridge</name>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="37"/>
+        <source>Collapse code block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="38"/>
+        <source>Expand code block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="39"/>
+        <source>Copy code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="40"/>
+        <source>Expand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="42"/>
+        <source>%1 line(s) of code collapsed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PathSettingWgt</name>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="84"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="90"/>
         <source>Remember the last used path</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="85"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="91"/>
         <source>Same path as the current file</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="86"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="92"/>
         <source>Customize the default path</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -171,15 +217,20 @@
         <translation>עורך טקסט</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="294"/>
-        <location filename="../src/editor/editwrapper.cpp" line="761"/>
-        <location filename="../src/editor/editwrapper.cpp" line="776"/>
-        <location filename="../src/widgets/window.cpp" line="1362"/>
-        <location filename="../src/widgets/window.cpp" line="1390"/>
-        <location filename="../src/widgets/window.cpp" line="1531"/>
-        <location filename="../src/widgets/window.cpp" line="1548"/>
+        <location filename="../src/editor/editwrapper.cpp" line="357"/>
+        <location filename="../src/editor/editwrapper.cpp" line="897"/>
+        <location filename="../src/editor/editwrapper.cpp" line="912"/>
+        <location filename="../src/widgets/window.cpp" line="1528"/>
+        <location filename="../src/widgets/window.cpp" line="1556"/>
+        <location filename="../src/widgets/window.cpp" line="1715"/>
+        <location filename="../src/widgets/window.cpp" line="1732"/>
         <source>Encoding</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="2001"/>
+        <source>视图模式</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="11"/>
@@ -210,12 +261,12 @@
         <location filename="../src/controls/settingsdialog.cpp" line="16"/>
         <location filename="../src/controls/settingsdialog.cpp" line="17"/>
         <source>Keymap</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="18"/>
         <location filename="../src/controls/settingsdialog.cpp" line="96"/>
-        <location filename="../src/widgets/window.cpp" line="2388"/>
+        <location filename="../src/widgets/window.cpp" line="2581"/>
         <source>Window</source>
         <translation>חלון</translation>
     </message>
@@ -257,12 +308,12 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="26"/>
         <source>Close other tabs</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="27"/>
         <source>Restore tab</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="28"/>
@@ -272,17 +323,17 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="29"/>
         <source>Increment font size</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="30"/>
         <source>Decrement font size</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="31"/>
         <source>Reset font size</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="32"/>
@@ -292,7 +343,7 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="33"/>
         <source>Toggle fullscreen</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="34"/>
@@ -317,17 +368,17 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="38"/>
         <source>Go to line</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="39"/>
         <source>Save cursor position</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="40"/>
         <source>Reset cursor position</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="41"/>
@@ -337,7 +388,7 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="42"/>
         <source>Display shortcuts</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="43"/>
@@ -352,12 +403,12 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="45"/>
         <source>Increase indent</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="46"/>
         <source>Decrease indent</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="47"/>
@@ -412,102 +463,102 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="57"/>
         <source>Delete to end of line</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="58"/>
         <source>Delete current line</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="59"/>
         <source>Swap line up</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="60"/>
         <source>Swap line down</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="61"/>
         <source>Scroll up one line</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="62"/>
         <source>Scroll down one line</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="63"/>
         <source>Page up</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="64"/>
         <source>Page down</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="65"/>
         <source>Move to end of line</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="66"/>
         <source>Move to start of line</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="67"/>
         <source>Move to end of text</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="68"/>
         <source>Move to start of text</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="69"/>
         <source>Move to line indentation</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="70"/>
         <source>Upper case</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="71"/>
         <source>Lower case</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="72"/>
         <source>Capitalize</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="73"/>
         <source>Delete backward word</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="74"/>
         <source>Delete forward word</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="75"/>
         <source>Forward over a pair</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="76"/>
         <source>Backward over a pair</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="77"/>
@@ -532,17 +583,17 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="81"/>
         <source>Transpose character</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="82"/>
         <source>Mark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="83"/>
         <source>Unmark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="84"/>
@@ -562,7 +613,7 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="87"/>
         <source>Read-Only mode</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="88"/>
@@ -577,32 +628,32 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="90"/>
         <source>Undo</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="91"/>
         <source>Redo</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="92"/>
         <source>Add/Remove bookmark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="93"/>
         <source>Move to previous bookmark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="94"/>
         <source>Move to next bookmark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="95"/>
         <source>Advanced</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="97"/>
@@ -612,87 +663,87 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="98"/>
         <source>Tab width</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="99"/>
         <source>Paste by pressing a middle mouse button</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="101"/>
         <source>Startup</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="102"/>
         <source>Reopen last closed tabs</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="104"/>
         <source>Open/Save Settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="106"/>
         <source>Word wrap</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="107"/>
         <source>Code folding flag</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="108"/>
         <source>Show line numbers</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="109"/>
         <source>Show bookmarks icon</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="110"/>
         <source>Show whitespaces and tabs</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="111"/>
         <source>Highlight current line</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="112"/>
         <source>Color mark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="115"/>
         <source>Unicode</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="116"/>
         <source>WesternEuropean</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="117"/>
         <source>CentralEuropean</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="118"/>
         <source>Baltic</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="119"/>
         <source>Cyrillic</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="120"/>
@@ -707,7 +758,7 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="126"/>
         <source>SouthEasternEuropean</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="121"/>
@@ -722,12 +773,12 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="127"/>
         <source>ChineseSimplified</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="128"/>
         <source>ChineseTraditional</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="129"/>
@@ -755,70 +806,70 @@
         <translation>ויאטנמית</translation>
     </message>
     <message>
-        <location filename="../src/startmanager.cpp" line="971"/>
+        <location filename="../src/startmanager.cpp" line="1035"/>
         <source>File not saved</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1532"/>
-        <location filename="../src/widgets/window.cpp" line="1549"/>
+        <location filename="../src/widgets/window.cpp" line="1716"/>
+        <location filename="../src/widgets/window.cpp" line="1733"/>
         <source>Line Endings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="243"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="379"/>
         <source>Please install &apos;UOS AI&apos; from the App Store before using</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="245"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="381"/>
         <source>No audio input device detected. Please check and try again</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="247"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="383"/>
         <source>No audio output device detected. Please check and try again</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="69"/>
+        <location filename="../src/common/text_file_saver.cpp" line="74"/>
         <source>File path is empty</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="155"/>
+        <location filename="../src/common/text_file_saver.cpp" line="153"/>
         <source>Insufficient memory to load document content</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="177"/>
+        <location filename="../src/common/text_file_saver.cpp" line="178"/>
         <source>Insufficient memory for encoding conversion</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="183"/>
+        <location filename="../src/common/text_file_saver.cpp" line="184"/>
         <source>Encoding conversion failed</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="189"/>
+        <location filename="../src/common/text_file_saver.cpp" line="190"/>
         <source>Converted content is empty</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="207"/>
+        <location filename="../src/common/text_file_saver.cpp" line="208"/>
         <source>Memory allocation failed</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="211"/>
+        <location filename="../src/common/text_file_saver.cpp" line="212"/>
         <source>Error occurred: %1</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="215"/>
+        <location filename="../src/common/text_file_saver.cpp" line="216"/>
         <source>Unknown error occurred</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -829,27 +880,27 @@
         <translation>חיפוש</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="34"/>
+        <location filename="../src/controls/replacebar.cpp" line="36"/>
         <source>Replace With</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="36"/>
+        <location filename="../src/controls/replacebar.cpp" line="40"/>
         <source>Replace</source>
         <translation>החלפה</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="37"/>
+        <location filename="../src/controls/replacebar.cpp" line="42"/>
         <source>Skip</source>
         <translation>דילוג</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="38"/>
+        <location filename="../src/controls/replacebar.cpp" line="44"/>
         <source>Replace Rest</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="39"/>
+        <location filename="../src/controls/replacebar.cpp" line="46"/>
         <source>Replace All</source>
         <translation>החלפת הכול</translation>
     </message>
@@ -858,9 +909,9 @@
     <name>S:</name>
     <message>
         <location filename="../third/libiconv-1.16/src/iconv.c" line="103"/>
-        <source/>
+        <source></source>
         <comment>The first line of the short usage message.</comment>
-        <translation type="unfinished"/>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -868,22 +919,22 @@
     <message>
         <location filename="../src/common/settings.cpp" line="141"/>
         <source>Standard</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/common/settings.cpp" line="141"/>
         <source>Customize</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/common/settings.cpp" line="154"/>
         <source>Normal</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/common/settings.cpp" line="154"/>
         <source>Maximum</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/common/settings.cpp" line="154"/>
@@ -891,34 +942,34 @@
         <translation>מסך מלא</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="484"/>
+        <location filename="../src/common/settings.cpp" line="491"/>
         <source>This shortcut conflicts with system shortcut %1</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="487"/>
+        <location filename="../src/common/settings.cpp" line="494"/>
         <source>This shortcut conflicts with %1, click on Replace to make this shortcut effective immediately</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="682"/>
-        <location filename="../src/common/settings.cpp" line="695"/>
-        <location filename="../src/common/settings.cpp" line="704"/>
+        <location filename="../src/common/settings.cpp" line="689"/>
+        <location filename="../src/common/settings.cpp" line="702"/>
+        <location filename="../src/common/settings.cpp" line="711"/>
         <source>The shortcut %1 is invalid, please set another one.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="736"/>
+        <location filename="../src/common/settings.cpp" line="743"/>
         <source>Cancel</source>
         <translation>ביטול</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="737"/>
+        <location filename="../src/common/settings.cpp" line="744"/>
         <source>Replace</source>
         <translation>החלפה</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="740"/>
+        <location filename="../src/common/settings.cpp" line="747"/>
         <source>OK</source>
         <translation>בסדר</translation>
     </message>
@@ -926,445 +977,499 @@
 <context>
     <name>StartManager</name>
     <message>
-        <location filename="../src/startmanager.cpp" line="411"/>
+        <location filename="../src/startmanager.cpp" line="425"/>
         <source>Untitled %1</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>Tabbar</name>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="641"/>
+        <location filename="../src/controls/tabbar.cpp" line="678"/>
         <source>Close tab</source>
         <translation>סגירת הכרטיסייה</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="642"/>
+        <location filename="../src/controls/tabbar.cpp" line="680"/>
         <source>Close other tabs</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="643"/>
+        <location filename="../src/controls/tabbar.cpp" line="682"/>
         <source>More options</source>
         <translation>אפשרויות נוספות</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="644"/>
+        <location filename="../src/controls/tabbar.cpp" line="684"/>
         <source>Close tabs to the left</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="645"/>
+        <location filename="../src/controls/tabbar.cpp" line="686"/>
         <source>Close tabs to the right</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="646"/>
+        <location filename="../src/controls/tabbar.cpp" line="688"/>
         <source>Close unmodified tabs</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>TextEdit</name>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="305"/>
+        <location filename="../src/editor/dtextedit.cpp" line="388"/>
         <source>Undo</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="306"/>
+        <location filename="../src/editor/dtextedit.cpp" line="390"/>
         <source>Redo</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="307"/>
+        <location filename="../src/editor/dtextedit.cpp" line="392"/>
         <source>Cut</source>
         <translation>גזירה</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="308"/>
+        <location filename="../src/editor/dtextedit.cpp" line="394"/>
         <source>Copy</source>
         <translation>העתקה</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="309"/>
+        <location filename="../src/editor/dtextedit.cpp" line="396"/>
         <source>Paste</source>
         <translation>הדבקה</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="310"/>
+        <location filename="../src/editor/dtextedit.cpp" line="398"/>
         <source>Delete</source>
         <translation>מחיקה</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="311"/>
+        <location filename="../src/editor/dtextedit.cpp" line="400"/>
         <source>Select All</source>
         <translation>בחירת הכול</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="312"/>
-        <location filename="../src/widgets/window.cpp" line="535"/>
+        <location filename="../src/editor/dtextedit.cpp" line="402"/>
+        <location filename="../src/widgets/window.cpp" line="556"/>
         <source>Find</source>
         <translation>חיפוש</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="313"/>
-        <location filename="../src/widgets/window.cpp" line="536"/>
+        <location filename="../src/editor/dtextedit.cpp" line="404"/>
+        <location filename="../src/widgets/window.cpp" line="558"/>
         <source>Replace</source>
         <translation>החלפה</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="314"/>
+        <location filename="../src/editor/dtextedit.cpp" line="406"/>
         <source>Go to Line</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="315"/>
-        <source>Turn on Read-Only mode</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="316"/>
-        <source>Turn off Read-Only mode</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="317"/>
+        <location filename="../src/editor/dtextedit.cpp" line="415"/>
         <source>Fullscreen</source>
         <translation>מסך מלא</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="318"/>
+        <location filename="../src/editor/dtextedit.cpp" line="417"/>
         <source>Exit fullscreen</source>
         <translation>יציאה ממסך מלא</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="319"/>
+        <location filename="../src/editor/dtextedit.cpp" line="419"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="320"/>
-        <location filename="../src/editor/dtextedit.cpp" line="374"/>
+        <location filename="../src/editor/dtextedit.cpp" line="421"/>
+        <location filename="../src/editor/dtextedit.cpp" line="493"/>
         <source>Add Comment</source>
         <translation>הוספת הערה</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="321"/>
+        <location filename="../src/editor/dtextedit.cpp" line="423"/>
         <source>Text to Speech</source>
         <translation>טקסט לדיבור</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="322"/>
-        <source>Stop reading</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="323"/>
+        <location filename="../src/editor/dtextedit.cpp" line="425"/>
         <source>Speech to Text</source>
         <translation>דיבור לטקסט</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="324"/>
+        <location filename="../src/editor/dtextedit.cpp" line="427"/>
         <source>Translate</source>
         <translation>תרגום</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="325"/>
+        <location filename="../src/editor/dtextedit.cpp" line="429"/>
         <source>Column Mode</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="326"/>
+        <location filename="../src/editor/dtextedit.cpp" line="431"/>
         <source>Add bookmark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="327"/>
+        <location filename="../src/editor/dtextedit.cpp" line="433"/>
         <source>Remove Bookmark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="328"/>
+        <location filename="../src/editor/dtextedit.cpp" line="435"/>
         <source>Previous bookmark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="329"/>
+        <location filename="../src/editor/dtextedit.cpp" line="437"/>
         <source>Next bookmark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="330"/>
+        <location filename="../src/editor/dtextedit.cpp" line="439"/>
         <source>Remove All Bookmarks</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="331"/>
+        <location filename="../src/editor/dtextedit.cpp" line="441"/>
         <source>Fold All</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="332"/>
+        <location filename="../src/editor/dtextedit.cpp" line="443"/>
         <source>Fold Current Level</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="333"/>
+        <location filename="../src/editor/dtextedit.cpp" line="445"/>
         <source>Unfold All</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="334"/>
+        <location filename="../src/editor/dtextedit.cpp" line="447"/>
         <source>Unfold Current Level</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="339"/>
+        <location filename="../src/editor/dtextedit.cpp" line="453"/>
         <source>Color Mark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="343"/>
+        <location filename="../src/editor/dtextedit.cpp" line="458"/>
         <source>Clear All Marks</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="344"/>
+        <location filename="../src/editor/dtextedit.cpp" line="460"/>
         <source>Clear Last Mark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="353"/>
+        <location filename="../src/editor/dtextedit.cpp" line="470"/>
         <source>Mark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="366"/>
+        <location filename="../src/editor/dtextedit.cpp" line="484"/>
         <source>Mark All</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="375"/>
+        <location filename="../src/editor/dtextedit.cpp" line="494"/>
         <source>Remove Comment</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3208"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3211"/>
+        <location filename="../src/editor/dtextedit.cpp" line="543"/>
+        <source>View Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="3531"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3534"/>
         <source>Copy failed: not enough memory</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3333"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3335"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3656"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3658"/>
         <source>Press ALT and click lines to edit in column mode</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="418"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9574"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9576"/>
+        <source>No audio output device was detected. Please ensure your speakers or headphones are properly connected and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="9583"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9585"/>
+        <source>No audio input device was detected. Please ensure your speakers or headphones are properly connected and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="534"/>
         <source>Change Case</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="419"/>
+        <location filename="../src/editor/dtextedit.cpp" line="409"/>
+        <source>Edit Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="411"/>
+        <source>Read View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="413"/>
+        <source>Live Preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="535"/>
         <source>Upper Case</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="420"/>
+        <location filename="../src/editor/dtextedit.cpp" line="536"/>
         <source>Lower Case</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="421"/>
+        <location filename="../src/editor/dtextedit.cpp" line="537"/>
         <source>Capitalize</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="78"/>
+        <location filename="../src/widgets/bottombar.cpp" line="110"/>
         <source>None</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1363"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1490"/>
         <source>Selected line(s) copied</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1370"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1497"/>
         <source>Current line copied</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1400"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1527"/>
         <source>Selected line(s) clipped</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1412"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1539"/>
         <source>Current line clipped</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3227"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3230"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3550"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3553"/>
         <source>Paste failed: not enough memory</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="4548"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4873"/>
         <source>Read-Only mode is off</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="4560"/>
-        <location filename="../src/editor/dtextedit.cpp" line="4584"/>
-        <location filename="../src/editor/dtextedit.cpp" line="7896"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8007"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8015"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8026"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4885"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4909"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8236"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8347"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8355"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8366"/>
         <source>Read-Only mode is on</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>WarningNotices</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="24"/>
+        <location filename="../src/controls/warningnotices.cpp" line="25"/>
         <source>Reload</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/controls/warningnotices.cpp" line="29"/>
+        <source>Edit Anyway</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>Window</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="25"/>
-        <location filename="../src/widgets/window.cpp" line="531"/>
+        <location filename="../src/controls/warningnotices.cpp" line="27"/>
+        <location filename="../src/widgets/window.cpp" line="548"/>
         <source>Save as</source>
         <translation>שמירה בשם</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="527"/>
+        <location filename="../src/widgets/window.cpp" line="540"/>
         <source>New window</source>
         <translation>חלון חדש</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="528"/>
+        <location filename="../src/widgets/window.cpp" line="542"/>
         <source>New tab</source>
         <translation>כרטיסייה חדשה</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="529"/>
+        <location filename="../src/widgets/window.cpp" line="544"/>
         <source>Open file</source>
         <translation>פתיחת קובץ</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="530"/>
-        <location filename="../src/widgets/window.cpp" line="3545"/>
+        <location filename="../src/widgets/window.cpp" line="546"/>
+        <location filename="../src/widgets/window.cpp" line="3950"/>
         <source>Save</source>
         <translation>שמירה</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="532"/>
+        <location filename="../src/widgets/window.cpp" line="550"/>
         <source>Print</source>
         <translation>הדפסה</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="533"/>
+        <location filename="../src/widgets/window.cpp" line="552"/>
         <source>Switch theme</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="534"/>
-        <location filename="../src/widgets/window.cpp" line="2448"/>
+        <location filename="../src/widgets/window.cpp" line="554"/>
+        <location filename="../src/widgets/window.cpp" line="2641"/>
         <source>Settings</source>
         <translation>הגדרות</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="666"/>
-        <location filename="../src/widgets/window.cpp" line="3845"/>
+        <location filename="../src/widgets/window.cpp" line="696"/>
+        <location filename="../src/widgets/window.cpp" line="4250"/>
         <source>Read-Only</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="687"/>
+        <location filename="../src/widgets/window.cpp" line="719"/>
         <source>You do not have permission to open %1</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="738"/>
-        <location filename="../src/widgets/window.cpp" line="2963"/>
+        <location filename="../src/widgets/window.cpp" line="773"/>
+        <location filename="../src/widgets/window.cpp" line="3266"/>
         <source>Invalid file: %1</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="903"/>
-        <location filename="../src/widgets/window.cpp" line="956"/>
+        <location filename="../src/widgets/window.cpp" line="957"/>
+        <location filename="../src/widgets/window.cpp" line="1050"/>
+        <location filename="../src/widgets/window.cpp" line="3217"/>
         <source>Do you want to save this file?</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1290"/>
+        <location filename="../src/widgets/window.cpp" line="1381"/>
+        <source>Invalid characters detected while saving &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1382"/>
+        <source>If you force save this file, it may cause file corruption. Still want to save?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1386"/>
+        <source>Don&apos;t Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1387"/>
+        <source>Save As</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1388"/>
+        <source>Save Anyway</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1456"/>
         <source>You do not have permission to save %1</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1312"/>
+        <location filename="../src/widgets/window.cpp" line="1428"/>
+        <location filename="../src/widgets/window.cpp" line="1478"/>
         <source>Saved successfully</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1354"/>
-        <location filename="../src/widgets/window.cpp" line="1481"/>
-        <location filename="../src/widgets/window.cpp" line="1529"/>
+        <location filename="../src/widgets/window.cpp" line="1520"/>
+        <location filename="../src/widgets/window.cpp" line="1665"/>
+        <location filename="../src/widgets/window.cpp" line="1713"/>
         <source>Save File</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1483"/>
+        <location filename="../src/widgets/window.cpp" line="1569"/>
+        <source>Cannot save as the original file in preview mode. Please choose a different path.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1667"/>
         <source>Encoding</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1773"/>
+        <location filename="../src/widgets/window.cpp" line="1957"/>
         <source>Read-Only mode is on</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2322"/>
+        <location filename="../src/widgets/window.cpp" line="2511"/>
         <source>Current location remembered</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2398"/>
+        <location filename="../src/widgets/window.cpp" line="2591"/>
         <source>Ctrl+&apos;=&apos;</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2401"/>
+        <location filename="../src/widgets/window.cpp" line="2594"/>
         <source>Ctrl+&apos;-&apos;</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2430"/>
+        <location filename="../src/widgets/window.cpp" line="2623"/>
         <source>Editor</source>
         <translation>עורך</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3061"/>
+        <location filename="../src/widgets/window.cpp" line="3436"/>
         <source>Untitled %1</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3543"/>
+        <location filename="../src/widgets/window.cpp" line="3948"/>
         <source>Cancel</source>
         <translation>ביטול</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3544"/>
+        <location filename="../src/widgets/window.cpp" line="3949"/>
         <source>Discard</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/deepin-editor_hi_IN.ts
+++ b/translations/deepin-editor_hi_IN.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="hi_IN">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="hi_IN">
 <context>
     <name>BottomBar</name>
     <message>
@@ -17,17 +19,36 @@
         <translation>अक्षर %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="44"/>
+        <location filename="../src/widgets/bottombar.cpp" line="47"/>
         <source>Loading:</source>
         <translation>लोड हो रहा है:</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="73"/>
+        <location filename="../src/widgets/bottombar.cpp" line="91"/>
+        <location filename="../src/widgets/bottombar.cpp" line="499"/>
+        <source>Edit Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="74"/>
+        <location filename="../src/widgets/bottombar.cpp" line="489"/>
+        <source>Read View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="75"/>
+        <location filename="../src/widgets/bottombar.cpp" line="493"/>
+        <source>Live Preview</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DDropdownMenu</name>
     <message>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="362"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="420"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="425"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="363"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="421"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="426"/>
         <source>None</source>
         <translation>कुछ नहीं</translation>
     </message>
@@ -35,68 +56,57 @@
 <context>
     <name>EditWrapper</name>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="292"/>
-        <location filename="../src/editor/editwrapper.cpp" line="365"/>
-        <location filename="../src/editor/editwrapper.cpp" line="521"/>
-        <location filename="../src/editor/editwrapper.cpp" line="751"/>
+        <location filename="../src/editor/editwrapper.cpp" line="355"/>
+        <location filename="../src/editor/editwrapper.cpp" line="429"/>
+        <location filename="../src/editor/editwrapper.cpp" line="595"/>
+        <location filename="../src/editor/editwrapper.cpp" line="887"/>
         <source>Save</source>
         <translation>संचित करें</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="516"/>
+        <location filename="../src/editor/editwrapper.cpp" line="590"/>
         <source>Do you want to save this file?</source>
         <translation>क्या आप यह फाइल संचित करना चाहते हैं?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="363"/>
-        <location filename="../src/editor/editwrapper.cpp" line="519"/>
+        <location filename="../src/editor/editwrapper.cpp" line="427"/>
+        <location filename="../src/editor/editwrapper.cpp" line="593"/>
         <source>Cancel</source>
         <translation>रद्द करें</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="360"/>
+        <location filename="../src/editor/editwrapper.cpp" line="424"/>
         <source>Encoding changed. Do you want to save the file now?</source>
         <translation>एन्कोडिंग में परिवर्तन हुआ है। क्या आप अब फाइल को संचित करना चाहते हैं?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="520"/>
+        <location filename="../src/editor/editwrapper.cpp" line="594"/>
         <source>Discard</source>
         <translation>निरस्त करें</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="274"/>
-        <location filename="../src/editor/editwrapper.cpp" line="620"/>
+        <location filename="../src/editor/editwrapper.cpp" line="1121"/>
+        <source>The file contains invalid characters (NUL). Preview mode is read-only.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="337"/>
+        <location filename="../src/editor/editwrapper.cpp" line="705"/>
         <source>You do not have permission to save %1</source>
         <translation>आपके पास %1 संचित करने की अनुमति नहीं है</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="836"/>
+        <location filename="../src/editor/editwrapper.cpp" line="987"/>
         <source>File removed on the disk. Save it now?</source>
         <translation>डिस्क से फाइल हटा दी गई है। अभी संचित करें?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="842"/>
+        <location filename="../src/editor/editwrapper.cpp" line="993"/>
         <source>File has changed on disk. Reload?</source>
         <translation>डिस्क पर फाइल में परिवर्तन हुआ है। पुनः लोड करें?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="884"/>
-        <location filename="../src/widgets/bottombar.cpp" line="74"/>
-        <source>INSERT</source>
-        <translation>प्रविष्ट करें</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="888"/>
-        <source>OVERWRITE</source>
-        <translation>अधिलेखित करें</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="892"/>
-        <source>R/O</source>
-        <translation>केवल-रीड योग्य</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="1618"/>
+        <location filename="../src/editor/editwrapper.cpp" line="1806"/>
         <source>The file cannot be read, which may be too large or has been damaged!</source>
         <translation>फाइल पढ़ा नहीं जा सकता है, जो कि या तो बहुत बड़ी हो सकती है या क्षतिपूर्ति की गई हो सकती है!</translation>
     </message>
@@ -109,17 +119,17 @@
         <translation>खोज</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="36"/>
+        <location filename="../src/controls/findbar.cpp" line="38"/>
         <source>Previous</source>
         <translation>पिछली आवृत्ति</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="37"/>
+        <location filename="../src/controls/findbar.cpp" line="40"/>
         <source>Next</source>
         <translation>अगली आवृत्ति</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="38"/>
+        <location filename="../src/controls/findbar.cpp" line="42"/>
         <source>Replace</source>
         <translation>बदलें</translation>
     </message>
@@ -127,9 +137,17 @@
 <context>
     <name>JumpLineBar</name>
     <message>
-        <location filename="../src/controls/jumplinebar.cpp" line="45"/>
+        <location filename="../src/controls/jumplinebar.cpp" line="46"/>
         <source>Go to Line: </source>
         <translation>इस पंक्ति पर जाएँ :</translation>
+    </message>
+</context>
+<context>
+    <name>LineBar</name>
+    <message>
+        <location filename="../src/controls/linebar.cpp" line="144"/>
+        <source>第%1/%2项</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -146,19 +164,47 @@
     </message>
 </context>
 <context>
+    <name>MarkdownBridge</name>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="37"/>
+        <source>Collapse code block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="38"/>
+        <source>Expand code block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="39"/>
+        <source>Copy code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="40"/>
+        <source>Expand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="42"/>
+        <source>%1 line(s) of code collapsed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PathSettingWgt</name>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="84"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="90"/>
         <source>Remember the last used path</source>
         <translation>पिछले उपयोग किए गए पथ को याद रखें</translation>
     </message>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="85"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="91"/>
         <source>Same path as the current file</source>
         <translation>वर्तमान फाइल के समान पथ</translation>
     </message>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="86"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="92"/>
         <source>Customize the default path</source>
         <translation>डिफ़ॉल्ट पथ को संसाधित करें</translation>
     </message>
@@ -171,15 +217,20 @@
         <translation>लेख संपादक</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="294"/>
-        <location filename="../src/editor/editwrapper.cpp" line="761"/>
-        <location filename="../src/editor/editwrapper.cpp" line="776"/>
-        <location filename="../src/widgets/window.cpp" line="1362"/>
-        <location filename="../src/widgets/window.cpp" line="1390"/>
-        <location filename="../src/widgets/window.cpp" line="1531"/>
-        <location filename="../src/widgets/window.cpp" line="1548"/>
+        <location filename="../src/editor/editwrapper.cpp" line="357"/>
+        <location filename="../src/editor/editwrapper.cpp" line="897"/>
+        <location filename="../src/editor/editwrapper.cpp" line="912"/>
+        <location filename="../src/widgets/window.cpp" line="1528"/>
+        <location filename="../src/widgets/window.cpp" line="1556"/>
+        <location filename="../src/widgets/window.cpp" line="1715"/>
+        <location filename="../src/widgets/window.cpp" line="1732"/>
         <source>Encoding</source>
         <translation>एन्कोडिंग</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="2001"/>
+        <source>视图模式</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="11"/>
@@ -215,7 +266,7 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="18"/>
         <location filename="../src/controls/settingsdialog.cpp" line="96"/>
-        <location filename="../src/widgets/window.cpp" line="2388"/>
+        <location filename="../src/widgets/window.cpp" line="2581"/>
         <source>Window</source>
         <translation>विंडो</translation>
     </message>
@@ -755,68 +806,68 @@
         <translation>वियतनामी</translation>
     </message>
     <message>
-        <location filename="../src/startmanager.cpp" line="971"/>
+        <location filename="../src/startmanager.cpp" line="1035"/>
         <source>File not saved</source>
         <translation>फाइल संचय विफल</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1532"/>
-        <location filename="../src/widgets/window.cpp" line="1549"/>
+        <location filename="../src/widgets/window.cpp" line="1716"/>
+        <location filename="../src/widgets/window.cpp" line="1733"/>
         <source>Line Endings</source>
         <translation>पंक्ति अंत</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="243"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="379"/>
         <source>Please install &apos;UOS AI&apos; from the App Store before using</source>
         <translation>इस्तेमाल करने से पहले कृपया &apos;UOS AI&apos; को एप स्टोर से स्थापित करें</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="245"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="381"/>
         <source>No audio input device detected. Please check and try again</source>
         <translation>कोई ऑडियो इनपुट डिवाइस नहीं पता चला। कृपया जांच करें और पुनः प्रयास करें</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="247"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="383"/>
         <source>No audio output device detected. Please check and try again</source>
         <translation>कोई ऑडियो आउटपुट डिवाइस नहीं पता चला। कृपया जांच करें और पुनः प्रयास करें</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="69"/>
+        <location filename="../src/common/text_file_saver.cpp" line="74"/>
         <source>File path is empty</source>
         <translation>फाइल पथ खाली है</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="155"/>
+        <location filename="../src/common/text_file_saver.cpp" line="153"/>
         <source>Insufficient memory to load document content</source>
         <translation>दस्तावेज़ सामग्री लोड करने के लिए कम मेमोरी</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="177"/>
+        <location filename="../src/common/text_file_saver.cpp" line="178"/>
         <source>Insufficient memory for encoding conversion</source>
         <translation>एन्कोडिंग परिवर्तन के लिए कम मेमोरी</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="183"/>
+        <location filename="../src/common/text_file_saver.cpp" line="184"/>
         <source>Encoding conversion failed</source>
         <translation>एन्कोडिंग परिवर्तन विफल</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="189"/>
+        <location filename="../src/common/text_file_saver.cpp" line="190"/>
         <source>Converted content is empty</source>
         <translation>परिवर्तित सामग्री खाली है</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="207"/>
+        <location filename="../src/common/text_file_saver.cpp" line="208"/>
         <source>Memory allocation failed</source>
         <translation>मेमोरी संग्रहण विफल</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="211"/>
+        <location filename="../src/common/text_file_saver.cpp" line="212"/>
         <source>Error occurred: %1</source>
         <translation>त्रुटि हुई: %1</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="215"/>
+        <location filename="../src/common/text_file_saver.cpp" line="216"/>
         <source>Unknown error occurred</source>
         <translation>अज्ञात त्रुटि हुई</translation>
     </message>
@@ -829,27 +880,27 @@
         <translation>खोज</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="34"/>
+        <location filename="../src/controls/replacebar.cpp" line="36"/>
         <source>Replace With</source>
         <translation>इससे बदलें</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="36"/>
+        <location filename="../src/controls/replacebar.cpp" line="40"/>
         <source>Replace</source>
         <translation>बदलें</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="37"/>
+        <location filename="../src/controls/replacebar.cpp" line="42"/>
         <source>Skip</source>
         <translation>निरस्त</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="38"/>
+        <location filename="../src/controls/replacebar.cpp" line="44"/>
         <source>Replace Rest</source>
         <translation>शेष को बदलें</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="39"/>
+        <location filename="../src/controls/replacebar.cpp" line="46"/>
         <source>Replace All</source>
         <translation>सभी को बदलें</translation>
     </message>
@@ -858,9 +909,9 @@
     <name>S:</name>
     <message>
         <location filename="../third/libiconv-1.16/src/iconv.c" line="103"/>
-        <source/>
+        <source></source>
         <comment>The first line of the short usage message.</comment>
-        <translation type="unfinished"/>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -891,34 +942,34 @@
         <translation>पूर्ण स्क्रीन</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="484"/>
+        <location filename="../src/common/settings.cpp" line="491"/>
         <source>This shortcut conflicts with system shortcut %1</source>
         <translation>यह शॉर्टकट %1 सिस्टम शॉर्टकट के विरुद्ध है</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="487"/>
+        <location filename="../src/common/settings.cpp" line="494"/>
         <source>This shortcut conflicts with %1, click on Replace to make this shortcut effective immediately</source>
         <translation>यह शॉर्टकट %1 के विरुद्ध है, बदलें पर क्लिक कर तुरंत प्रभाव से इस शॉर्टकट को क्रियान्वित करें</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="682"/>
-        <location filename="../src/common/settings.cpp" line="695"/>
-        <location filename="../src/common/settings.cpp" line="704"/>
+        <location filename="../src/common/settings.cpp" line="689"/>
+        <location filename="../src/common/settings.cpp" line="702"/>
+        <location filename="../src/common/settings.cpp" line="711"/>
         <source>The shortcut %1 is invalid, please set another one.</source>
         <translation>%1 शॉर्टकट अमान्य है, कृपया अन्य सेट करें।</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="736"/>
+        <location filename="../src/common/settings.cpp" line="743"/>
         <source>Cancel</source>
         <translation>रद्द करें</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="737"/>
+        <location filename="../src/common/settings.cpp" line="744"/>
         <source>Replace</source>
         <translation>बदलें</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="740"/>
+        <location filename="../src/common/settings.cpp" line="747"/>
         <source>OK</source>
         <translation>ठीक है</translation>
     </message>
@@ -926,7 +977,7 @@
 <context>
     <name>StartManager</name>
     <message>
-        <location filename="../src/startmanager.cpp" line="411"/>
+        <location filename="../src/startmanager.cpp" line="425"/>
         <source>Untitled %1</source>
         <translation>शीर्षक रहित %1</translation>
     </message>
@@ -934,32 +985,32 @@
 <context>
     <name>Tabbar</name>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="641"/>
+        <location filename="../src/controls/tabbar.cpp" line="678"/>
         <source>Close tab</source>
         <translation>टैब बंद करें</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="642"/>
+        <location filename="../src/controls/tabbar.cpp" line="680"/>
         <source>Close other tabs</source>
         <translation>अन्य टैब बंद करें</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="643"/>
+        <location filename="../src/controls/tabbar.cpp" line="682"/>
         <source>More options</source>
         <translation>अधिक विकल्प</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="644"/>
+        <location filename="../src/controls/tabbar.cpp" line="684"/>
         <source>Close tabs to the left</source>
         <translation>बाईं ओर के टैब बंद करें</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="645"/>
+        <location filename="../src/controls/tabbar.cpp" line="686"/>
         <source>Close tabs to the right</source>
         <translation>दाईं ओर के टैब बंद करें</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="646"/>
+        <location filename="../src/controls/tabbar.cpp" line="688"/>
         <source>Close unmodified tabs</source>
         <translation>अपरिवर्तित टैब बंद करें</translation>
     </message>
@@ -967,263 +1018,280 @@
 <context>
     <name>TextEdit</name>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="305"/>
+        <location filename="../src/editor/dtextedit.cpp" line="388"/>
         <source>Undo</source>
         <translation>पूर्ववत करें</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="306"/>
+        <location filename="../src/editor/dtextedit.cpp" line="390"/>
         <source>Redo</source>
         <translation>पुनः करें</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="307"/>
+        <location filename="../src/editor/dtextedit.cpp" line="392"/>
         <source>Cut</source>
         <translation>कट करें</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="308"/>
+        <location filename="../src/editor/dtextedit.cpp" line="394"/>
         <source>Copy</source>
         <translation>कॉपी करें</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="309"/>
+        <location filename="../src/editor/dtextedit.cpp" line="396"/>
         <source>Paste</source>
         <translation>पेस्ट करें</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="310"/>
+        <location filename="../src/editor/dtextedit.cpp" line="398"/>
         <source>Delete</source>
         <translation>हटाएँ</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="311"/>
+        <location filename="../src/editor/dtextedit.cpp" line="400"/>
         <source>Select All</source>
         <translation>सभी चयनित करें</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="312"/>
-        <location filename="../src/widgets/window.cpp" line="535"/>
+        <location filename="../src/editor/dtextedit.cpp" line="402"/>
+        <location filename="../src/widgets/window.cpp" line="556"/>
         <source>Find</source>
         <translation>खोज</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="313"/>
-        <location filename="../src/widgets/window.cpp" line="536"/>
+        <location filename="../src/editor/dtextedit.cpp" line="404"/>
+        <location filename="../src/widgets/window.cpp" line="558"/>
         <source>Replace</source>
         <translation>बदलें</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="314"/>
+        <location filename="../src/editor/dtextedit.cpp" line="406"/>
         <source>Go to Line</source>
         <translation>इस पंक्ति पर जाएँ</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="315"/>
-        <source>Turn on Read-Only mode</source>
-        <translation>केवल-रीड योग्य मोड चालू करें</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="316"/>
-        <source>Turn off Read-Only mode</source>
-        <translation>केवल-रीड योग्य मोड बंद करें</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="317"/>
+        <location filename="../src/editor/dtextedit.cpp" line="415"/>
         <source>Fullscreen</source>
         <translation>पूर्ण स्क्रीन</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="318"/>
+        <location filename="../src/editor/dtextedit.cpp" line="417"/>
         <source>Exit fullscreen</source>
         <translation>पूर्ण स्क्रीन बंद करें</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="319"/>
+        <location filename="../src/editor/dtextedit.cpp" line="419"/>
         <source>Display in file manager</source>
         <translation>फाइल प्रबंधक में दिखाएँ</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="320"/>
-        <location filename="../src/editor/dtextedit.cpp" line="374"/>
+        <location filename="../src/editor/dtextedit.cpp" line="421"/>
+        <location filename="../src/editor/dtextedit.cpp" line="493"/>
         <source>Add Comment</source>
         <translation>टिप्पणी जोड़ें</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="321"/>
+        <location filename="../src/editor/dtextedit.cpp" line="423"/>
         <source>Text to Speech</source>
         <translation>लेख से वाणी</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="322"/>
-        <source>Stop reading</source>
-        <translation>वाचन बंद करें</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="323"/>
+        <location filename="../src/editor/dtextedit.cpp" line="425"/>
         <source>Speech to Text</source>
         <translation>वाणी से लेख</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="324"/>
+        <location filename="../src/editor/dtextedit.cpp" line="427"/>
         <source>Translate</source>
         <translation>अनुवाद</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="325"/>
+        <location filename="../src/editor/dtextedit.cpp" line="429"/>
         <source>Column Mode</source>
         <translation>स्तंभ मोड</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="326"/>
+        <location filename="../src/editor/dtextedit.cpp" line="431"/>
         <source>Add bookmark</source>
         <translation>स्मृति-चिन्ह जोड़ें</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="327"/>
+        <location filename="../src/editor/dtextedit.cpp" line="433"/>
         <source>Remove Bookmark</source>
         <translation>स्मृति-चिन्ह हटाएँ</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="328"/>
+        <location filename="../src/editor/dtextedit.cpp" line="435"/>
         <source>Previous bookmark</source>
         <translation>पिछला स्मृति-चिन्ह</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="329"/>
+        <location filename="../src/editor/dtextedit.cpp" line="437"/>
         <source>Next bookmark</source>
         <translation>अगला स्मृति-चिन्ह</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="330"/>
+        <location filename="../src/editor/dtextedit.cpp" line="439"/>
         <source>Remove All Bookmarks</source>
         <translation>सभी स्मृति-चिन्ह हटाएँ</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="331"/>
+        <location filename="../src/editor/dtextedit.cpp" line="441"/>
         <source>Fold All</source>
         <translation>सभी संक्षिप्त करें</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="332"/>
+        <location filename="../src/editor/dtextedit.cpp" line="443"/>
         <source>Fold Current Level</source>
         <translation>वर्तमान स्तर को संक्षिप्त करें</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="333"/>
+        <location filename="../src/editor/dtextedit.cpp" line="445"/>
         <source>Unfold All</source>
         <translation>सभी विस्तृत करें</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="334"/>
+        <location filename="../src/editor/dtextedit.cpp" line="447"/>
         <source>Unfold Current Level</source>
         <translation>वर्तमान स्तर को विस्तृत करें</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="339"/>
+        <location filename="../src/editor/dtextedit.cpp" line="453"/>
         <source>Color Mark</source>
         <translation>रंगीन चिन्ह</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="343"/>
+        <location filename="../src/editor/dtextedit.cpp" line="458"/>
         <source>Clear All Marks</source>
         <translation>सभी चिन्ह हटाएँ</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="344"/>
+        <location filename="../src/editor/dtextedit.cpp" line="460"/>
         <source>Clear Last Mark</source>
         <translation>अंतिम चिन्ह हटाएँ</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="353"/>
+        <location filename="../src/editor/dtextedit.cpp" line="470"/>
         <source>Mark</source>
         <translation>चिन्हित</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="366"/>
+        <location filename="../src/editor/dtextedit.cpp" line="484"/>
         <source>Mark All</source>
         <translation>सभी चिन्हित करें</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="375"/>
+        <location filename="../src/editor/dtextedit.cpp" line="494"/>
         <source>Remove Comment</source>
         <translation>टिप्पणी हटाएँ</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3208"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3211"/>
+        <location filename="../src/editor/dtextedit.cpp" line="543"/>
+        <source>View Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="3531"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3534"/>
         <source>Copy failed: not enough memory</source>
         <translation>कॉपी विफल : अपर्याप्त मेमोरी</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3333"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3335"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3656"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3658"/>
         <source>Press ALT and click lines to edit in column mode</source>
         <translation>स्तंभ मोड में संपादन हेतु ALT कुंजी दबाकर पंक्तियों पर क्लिक करें</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="418"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9574"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9576"/>
+        <source>No audio output device was detected. Please ensure your speakers or headphones are properly connected and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="9583"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9585"/>
+        <source>No audio input device was detected. Please ensure your speakers or headphones are properly connected and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="534"/>
         <source>Change Case</source>
         <translation>केस बदलें</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="419"/>
+        <location filename="../src/editor/dtextedit.cpp" line="409"/>
+        <source>Edit Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="411"/>
+        <source>Read View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="413"/>
+        <source>Live Preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="535"/>
         <source>Upper Case</source>
         <translation>अपरकेस</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="420"/>
+        <location filename="../src/editor/dtextedit.cpp" line="536"/>
         <source>Lower Case</source>
         <translation>लोअरकेस</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="421"/>
+        <location filename="../src/editor/dtextedit.cpp" line="537"/>
         <source>Capitalize</source>
         <translation>कैपिटल अक्षर में बदलें</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="78"/>
+        <location filename="../src/widgets/bottombar.cpp" line="110"/>
         <source>None</source>
         <translation>कुछ नहीं</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1363"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1490"/>
         <source>Selected line(s) copied</source>
         <translation>चयनित पंक्तियाँ कॉपी की गई</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1370"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1497"/>
         <source>Current line copied</source>
         <translation>वर्तमान पंक्ति कॉपी की गई</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1400"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1527"/>
         <source>Selected line(s) clipped</source>
         <translation>चयनित पंक्तियाँ क्लिप की गई</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1412"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1539"/>
         <source>Current line clipped</source>
         <translation>वर्तमान पंक्ति क्लिप की गई</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3227"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3230"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3550"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3553"/>
         <source>Paste failed: not enough memory</source>
         <translation>लेख विफल : अपर्याप्त मेमोरी</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="4548"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4873"/>
         <source>Read-Only mode is off</source>
         <translation>केवल-रीड योग्य मोड निष्क्रिय है</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="4560"/>
-        <location filename="../src/editor/dtextedit.cpp" line="4584"/>
-        <location filename="../src/editor/dtextedit.cpp" line="7896"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8007"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8015"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8026"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4885"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4909"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8236"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8347"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8355"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8366"/>
         <source>Read-Only mode is on</source>
         <translation>केवल-रीड योग्य मोड सक्रिय है</translation>
     </message>
@@ -1231,138 +1299,175 @@
 <context>
     <name>WarningNotices</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="24"/>
+        <location filename="../src/controls/warningnotices.cpp" line="25"/>
         <source>Reload</source>
         <translation>पुनः लोड करें</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/warningnotices.cpp" line="29"/>
+        <source>Edit Anyway</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>Window</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="25"/>
-        <location filename="../src/widgets/window.cpp" line="531"/>
+        <location filename="../src/controls/warningnotices.cpp" line="27"/>
+        <location filename="../src/widgets/window.cpp" line="548"/>
         <source>Save as</source>
         <translation>इस रूप में संचित करें</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="527"/>
+        <location filename="../src/widgets/window.cpp" line="540"/>
         <source>New window</source>
         <translation>नवीन विंडो</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="528"/>
+        <location filename="../src/widgets/window.cpp" line="542"/>
         <source>New tab</source>
         <translation>नवीन टैब</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="529"/>
+        <location filename="../src/widgets/window.cpp" line="544"/>
         <source>Open file</source>
         <translation>फाइल खोलें</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="530"/>
-        <location filename="../src/widgets/window.cpp" line="3545"/>
+        <location filename="../src/widgets/window.cpp" line="546"/>
+        <location filename="../src/widgets/window.cpp" line="3950"/>
         <source>Save</source>
         <translation>संचित करें</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="532"/>
+        <location filename="../src/widgets/window.cpp" line="550"/>
         <source>Print</source>
         <translation>प्रिंट करें</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="533"/>
+        <location filename="../src/widgets/window.cpp" line="552"/>
         <source>Switch theme</source>
         <translation>थीम बदलें</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="534"/>
-        <location filename="../src/widgets/window.cpp" line="2448"/>
+        <location filename="../src/widgets/window.cpp" line="554"/>
+        <location filename="../src/widgets/window.cpp" line="2641"/>
         <source>Settings</source>
         <translation>सेटिंग्स</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="666"/>
-        <location filename="../src/widgets/window.cpp" line="3845"/>
+        <location filename="../src/widgets/window.cpp" line="696"/>
+        <location filename="../src/widgets/window.cpp" line="4250"/>
         <source>Read-Only</source>
         <translation>केवल-रीड योग्य</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="687"/>
+        <location filename="../src/widgets/window.cpp" line="719"/>
         <source>You do not have permission to open %1</source>
         <translation>आपके पास %1 खोलने की अनुमति नहीं है</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="738"/>
-        <location filename="../src/widgets/window.cpp" line="2963"/>
+        <location filename="../src/widgets/window.cpp" line="773"/>
+        <location filename="../src/widgets/window.cpp" line="3266"/>
         <source>Invalid file: %1</source>
         <translation>अमान्य फाइल : %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="903"/>
-        <location filename="../src/widgets/window.cpp" line="956"/>
+        <location filename="../src/widgets/window.cpp" line="957"/>
+        <location filename="../src/widgets/window.cpp" line="1050"/>
+        <location filename="../src/widgets/window.cpp" line="3217"/>
         <source>Do you want to save this file?</source>
         <translation>क्या आप यह फाइल संचित करना चाहते हैं?</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1290"/>
+        <location filename="../src/widgets/window.cpp" line="1381"/>
+        <source>Invalid characters detected while saving &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1382"/>
+        <source>If you force save this file, it may cause file corruption. Still want to save?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1386"/>
+        <source>Don&apos;t Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1387"/>
+        <source>Save As</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1388"/>
+        <source>Save Anyway</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1456"/>
         <source>You do not have permission to save %1</source>
         <translation>आपके पास %1 संचित करने की अनुमति नहीं है</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1312"/>
+        <location filename="../src/widgets/window.cpp" line="1428"/>
+        <location filename="../src/widgets/window.cpp" line="1478"/>
         <source>Saved successfully</source>
         <translation>संचित करना सफल</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1354"/>
-        <location filename="../src/widgets/window.cpp" line="1481"/>
-        <location filename="../src/widgets/window.cpp" line="1529"/>
+        <location filename="../src/widgets/window.cpp" line="1520"/>
+        <location filename="../src/widgets/window.cpp" line="1665"/>
+        <location filename="../src/widgets/window.cpp" line="1713"/>
         <source>Save File</source>
         <translation>फाइल संचित करें</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1483"/>
+        <location filename="../src/widgets/window.cpp" line="1569"/>
+        <source>Cannot save as the original file in preview mode. Please choose a different path.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1667"/>
         <source>Encoding</source>
         <translation>एन्कोडिंग</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1773"/>
+        <location filename="../src/widgets/window.cpp" line="1957"/>
         <source>Read-Only mode is on</source>
         <translation>केवल-रीड योग्य मोड सक्रिय है</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2322"/>
+        <location filename="../src/widgets/window.cpp" line="2511"/>
         <source>Current location remembered</source>
         <translation>वर्तमान स्थान स्मरणित किया</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2398"/>
+        <location filename="../src/widgets/window.cpp" line="2591"/>
         <source>Ctrl+&apos;=&apos;</source>
         <translation>Ctrl+&apos;=&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2401"/>
+        <location filename="../src/widgets/window.cpp" line="2594"/>
         <source>Ctrl+&apos;-&apos;</source>
         <translation>Ctrl+&apos;-&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2430"/>
+        <location filename="../src/widgets/window.cpp" line="2623"/>
         <source>Editor</source>
         <translation>संपादक</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3061"/>
+        <location filename="../src/widgets/window.cpp" line="3436"/>
         <source>Untitled %1</source>
         <translation>शीर्षक रहित %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3543"/>
+        <location filename="../src/widgets/window.cpp" line="3948"/>
         <source>Cancel</source>
         <translation>रद्द करें</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3544"/>
+        <location filename="../src/widgets/window.cpp" line="3949"/>
         <source>Discard</source>
         <translation>निरस्त करें</translation>
     </message>

--- a/translations/deepin-editor_hr.ts
+++ b/translations/deepin-editor_hr.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="hr">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="hr">
 <context>
     <name>BottomBar</name>
     <message>
@@ -17,17 +19,36 @@
         <translation>Znakovi %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="44"/>
+        <location filename="../src/widgets/bottombar.cpp" line="47"/>
         <source>Loading:</source>
         <translation>Učitavam:</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="73"/>
+        <location filename="../src/widgets/bottombar.cpp" line="91"/>
+        <location filename="../src/widgets/bottombar.cpp" line="499"/>
+        <source>Edit Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="74"/>
+        <location filename="../src/widgets/bottombar.cpp" line="489"/>
+        <source>Read View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="75"/>
+        <location filename="../src/widgets/bottombar.cpp" line="493"/>
+        <source>Live Preview</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DDropdownMenu</name>
     <message>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="362"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="420"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="425"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="363"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="421"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="426"/>
         <source>None</source>
         <translation>Nijedno</translation>
     </message>
@@ -35,70 +56,59 @@
 <context>
     <name>EditWrapper</name>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="292"/>
-        <location filename="../src/editor/editwrapper.cpp" line="365"/>
-        <location filename="../src/editor/editwrapper.cpp" line="521"/>
-        <location filename="../src/editor/editwrapper.cpp" line="751"/>
+        <location filename="../src/editor/editwrapper.cpp" line="355"/>
+        <location filename="../src/editor/editwrapper.cpp" line="429"/>
+        <location filename="../src/editor/editwrapper.cpp" line="595"/>
+        <location filename="../src/editor/editwrapper.cpp" line="887"/>
         <source>Save</source>
         <translation>Spremi</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="516"/>
+        <location filename="../src/editor/editwrapper.cpp" line="590"/>
         <source>Do you want to save this file?</source>
         <translation>Želite li spremiti ovu datoteku?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="363"/>
-        <location filename="../src/editor/editwrapper.cpp" line="519"/>
+        <location filename="../src/editor/editwrapper.cpp" line="427"/>
+        <location filename="../src/editor/editwrapper.cpp" line="593"/>
         <source>Cancel</source>
         <translation>Otkaži</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="360"/>
+        <location filename="../src/editor/editwrapper.cpp" line="424"/>
         <source>Encoding changed. Do you want to save the file now?</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="520"/>
+        <location filename="../src/editor/editwrapper.cpp" line="594"/>
         <source>Discard</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="274"/>
-        <location filename="../src/editor/editwrapper.cpp" line="620"/>
+        <location filename="../src/editor/editwrapper.cpp" line="1121"/>
+        <source>The file contains invalid characters (NUL). Preview mode is read-only.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="337"/>
+        <location filename="../src/editor/editwrapper.cpp" line="705"/>
         <source>You do not have permission to save %1</source>
         <translation>Nemate dozvole za spremanje %1</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="836"/>
+        <location filename="../src/editor/editwrapper.cpp" line="987"/>
         <source>File removed on the disk. Save it now?</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="842"/>
+        <location filename="../src/editor/editwrapper.cpp" line="993"/>
         <source>File has changed on disk. Reload?</source>
         <translation>Datoteka je promijenjena na disku. Ponovno učitati?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="884"/>
-        <location filename="../src/widgets/bottombar.cpp" line="74"/>
-        <source>INSERT</source>
-        <translation>UMETNI</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="888"/>
-        <source>OVERWRITE</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="892"/>
-        <source>R/O</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="1618"/>
+        <location filename="../src/editor/editwrapper.cpp" line="1806"/>
         <source>The file cannot be read, which may be too large or has been damaged!</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -109,17 +119,17 @@
         <translation>Nađi</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="36"/>
+        <location filename="../src/controls/findbar.cpp" line="38"/>
         <source>Previous</source>
         <translation>Prethodno</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="37"/>
+        <location filename="../src/controls/findbar.cpp" line="40"/>
         <source>Next</source>
         <translation>Slijedeće</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="38"/>
+        <location filename="../src/controls/findbar.cpp" line="42"/>
         <source>Replace</source>
         <translation>Zamjeni</translation>
     </message>
@@ -127,9 +137,17 @@
 <context>
     <name>JumpLineBar</name>
     <message>
-        <location filename="../src/controls/jumplinebar.cpp" line="45"/>
+        <location filename="../src/controls/jumplinebar.cpp" line="46"/>
         <source>Go to Line: </source>
         <translation>Idi na redak:</translation>
+    </message>
+</context>
+<context>
+    <name>LineBar</name>
+    <message>
+        <location filename="../src/controls/linebar.cpp" line="144"/>
+        <source>第%1/%2项</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -137,7 +155,7 @@
     <message>
         <location filename="../src/editorapplication.cpp" line="12"/>
         <source>Text Editor is a powerful tool for viewing and editing text files.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/editorapplication.cpp" line="34"/>
@@ -146,21 +164,49 @@
     </message>
 </context>
 <context>
+    <name>MarkdownBridge</name>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="37"/>
+        <source>Collapse code block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="38"/>
+        <source>Expand code block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="39"/>
+        <source>Copy code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="40"/>
+        <source>Expand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="42"/>
+        <source>%1 line(s) of code collapsed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PathSettingWgt</name>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="84"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="90"/>
         <source>Remember the last used path</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="85"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="91"/>
         <source>Same path as the current file</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="86"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="92"/>
         <source>Customize the default path</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -171,15 +217,20 @@
         <translation>Uređivač teksta</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="294"/>
-        <location filename="../src/editor/editwrapper.cpp" line="761"/>
-        <location filename="../src/editor/editwrapper.cpp" line="776"/>
-        <location filename="../src/widgets/window.cpp" line="1362"/>
-        <location filename="../src/widgets/window.cpp" line="1390"/>
-        <location filename="../src/widgets/window.cpp" line="1531"/>
-        <location filename="../src/widgets/window.cpp" line="1548"/>
+        <location filename="../src/editor/editwrapper.cpp" line="357"/>
+        <location filename="../src/editor/editwrapper.cpp" line="897"/>
+        <location filename="../src/editor/editwrapper.cpp" line="912"/>
+        <location filename="../src/widgets/window.cpp" line="1528"/>
+        <location filename="../src/widgets/window.cpp" line="1556"/>
+        <location filename="../src/widgets/window.cpp" line="1715"/>
+        <location filename="../src/widgets/window.cpp" line="1732"/>
         <source>Encoding</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="2001"/>
+        <source>视图模式</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="11"/>
@@ -215,7 +266,7 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="18"/>
         <location filename="../src/controls/settingsdialog.cpp" line="96"/>
-        <location filename="../src/widgets/window.cpp" line="2388"/>
+        <location filename="../src/widgets/window.cpp" line="2581"/>
         <source>Window</source>
         <translation>Prozor</translation>
     </message>
@@ -282,7 +333,7 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="31"/>
         <source>Reset font size</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="32"/>
@@ -292,7 +343,7 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="33"/>
         <source>Toggle fullscreen</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="34"/>
@@ -327,7 +378,7 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="40"/>
         <source>Reset cursor position</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="41"/>
@@ -352,32 +403,32 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="45"/>
         <source>Increase indent</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="46"/>
         <source>Decrease indent</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="47"/>
         <source>Forward character</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="48"/>
         <source>Backward character</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="49"/>
         <source>Forward word</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="50"/>
         <source>Backward word</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="51"/>
@@ -407,7 +458,7 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="56"/>
         <source>Duplicate line</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="57"/>
@@ -422,32 +473,32 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="59"/>
         <source>Swap line up</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="60"/>
         <source>Swap line down</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="61"/>
         <source>Scroll up one line</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="62"/>
         <source>Scroll down one line</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="63"/>
         <source>Page up</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="64"/>
         <source>Page down</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="65"/>
@@ -472,7 +523,7 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="69"/>
         <source>Move to line indentation</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="70"/>
@@ -487,27 +538,27 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="72"/>
         <source>Capitalize</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="73"/>
         <source>Delete backward word</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="74"/>
         <source>Delete forward word</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="75"/>
         <source>Forward over a pair</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="76"/>
         <source>Backward over a pair</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="77"/>
@@ -532,17 +583,17 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="81"/>
         <source>Transpose character</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="82"/>
         <source>Mark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="83"/>
         <source>Unmark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="84"/>
@@ -557,12 +608,12 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="86"/>
         <source>Merge lines</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="87"/>
         <source>Read-Only mode</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="88"/>
@@ -577,12 +628,12 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="90"/>
         <source>Undo</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="91"/>
         <source>Redo</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="92"/>
@@ -592,12 +643,12 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="93"/>
         <source>Move to previous bookmark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="94"/>
         <source>Move to next bookmark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="95"/>
@@ -612,37 +663,37 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="98"/>
         <source>Tab width</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="99"/>
         <source>Paste by pressing a middle mouse button</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="101"/>
         <source>Startup</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="102"/>
         <source>Reopen last closed tabs</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="104"/>
         <source>Open/Save Settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="106"/>
         <source>Word wrap</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="107"/>
         <source>Code folding flag</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="108"/>
@@ -657,22 +708,22 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="110"/>
         <source>Show whitespaces and tabs</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="111"/>
         <source>Highlight current line</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="112"/>
         <source>Color mark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="115"/>
         <source>Unicode</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="116"/>
@@ -755,70 +806,70 @@
         <translation>Vijetnamski</translation>
     </message>
     <message>
-        <location filename="../src/startmanager.cpp" line="971"/>
+        <location filename="../src/startmanager.cpp" line="1035"/>
         <source>File not saved</source>
         <translation>Datoteka nije spremljena</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1532"/>
-        <location filename="../src/widgets/window.cpp" line="1549"/>
+        <location filename="../src/widgets/window.cpp" line="1716"/>
+        <location filename="../src/widgets/window.cpp" line="1733"/>
         <source>Line Endings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="243"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="379"/>
         <source>Please install &apos;UOS AI&apos; from the App Store before using</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="245"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="381"/>
         <source>No audio input device detected. Please check and try again</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="247"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="383"/>
         <source>No audio output device detected. Please check and try again</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="69"/>
+        <location filename="../src/common/text_file_saver.cpp" line="74"/>
         <source>File path is empty</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="155"/>
+        <location filename="../src/common/text_file_saver.cpp" line="153"/>
         <source>Insufficient memory to load document content</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="177"/>
+        <location filename="../src/common/text_file_saver.cpp" line="178"/>
         <source>Insufficient memory for encoding conversion</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="183"/>
+        <location filename="../src/common/text_file_saver.cpp" line="184"/>
         <source>Encoding conversion failed</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="189"/>
+        <location filename="../src/common/text_file_saver.cpp" line="190"/>
         <source>Converted content is empty</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="207"/>
+        <location filename="../src/common/text_file_saver.cpp" line="208"/>
         <source>Memory allocation failed</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="211"/>
+        <location filename="../src/common/text_file_saver.cpp" line="212"/>
         <source>Error occurred: %1</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="215"/>
+        <location filename="../src/common/text_file_saver.cpp" line="216"/>
         <source>Unknown error occurred</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -829,27 +880,27 @@
         <translation>Nađi</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="34"/>
+        <location filename="../src/controls/replacebar.cpp" line="36"/>
         <source>Replace With</source>
         <translation>Zamijeni sa</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="36"/>
+        <location filename="../src/controls/replacebar.cpp" line="40"/>
         <source>Replace</source>
         <translation>Zamjeni</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="37"/>
+        <location filename="../src/controls/replacebar.cpp" line="42"/>
         <source>Skip</source>
         <translation>Preskoči</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="38"/>
+        <location filename="../src/controls/replacebar.cpp" line="44"/>
         <source>Replace Rest</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="39"/>
+        <location filename="../src/controls/replacebar.cpp" line="46"/>
         <source>Replace All</source>
         <translation>Zamijeni sve</translation>
     </message>
@@ -858,9 +909,9 @@
     <name>S:</name>
     <message>
         <location filename="../third/libiconv-1.16/src/iconv.c" line="103"/>
-        <source/>
+        <source></source>
         <comment>The first line of the short usage message.</comment>
-        <translation type="unfinished"/>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -891,34 +942,34 @@
         <translation>Cijeli zaslon</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="484"/>
+        <location filename="../src/common/settings.cpp" line="491"/>
         <source>This shortcut conflicts with system shortcut %1</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="487"/>
+        <location filename="../src/common/settings.cpp" line="494"/>
         <source>This shortcut conflicts with %1, click on Replace to make this shortcut effective immediately</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="682"/>
-        <location filename="../src/common/settings.cpp" line="695"/>
-        <location filename="../src/common/settings.cpp" line="704"/>
+        <location filename="../src/common/settings.cpp" line="689"/>
+        <location filename="../src/common/settings.cpp" line="702"/>
+        <location filename="../src/common/settings.cpp" line="711"/>
         <source>The shortcut %1 is invalid, please set another one.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="736"/>
+        <location filename="../src/common/settings.cpp" line="743"/>
         <source>Cancel</source>
         <translation>Otkaži</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="737"/>
+        <location filename="../src/common/settings.cpp" line="744"/>
         <source>Replace</source>
         <translation>Zamjeni</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="740"/>
+        <location filename="../src/common/settings.cpp" line="747"/>
         <source>OK</source>
         <translation>U redu</translation>
     </message>
@@ -926,40 +977,40 @@
 <context>
     <name>StartManager</name>
     <message>
-        <location filename="../src/startmanager.cpp" line="411"/>
+        <location filename="../src/startmanager.cpp" line="425"/>
         <source>Untitled %1</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>Tabbar</name>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="641"/>
+        <location filename="../src/controls/tabbar.cpp" line="678"/>
         <source>Close tab</source>
         <translation>Zatvori karticu</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="642"/>
+        <location filename="../src/controls/tabbar.cpp" line="680"/>
         <source>Close other tabs</source>
         <translation>Zatvori ostale kartice</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="643"/>
+        <location filename="../src/controls/tabbar.cpp" line="682"/>
         <source>More options</source>
         <translation>Više opcija</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="644"/>
+        <location filename="../src/controls/tabbar.cpp" line="684"/>
         <source>Close tabs to the left</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="645"/>
+        <location filename="../src/controls/tabbar.cpp" line="686"/>
         <source>Close tabs to the right</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="646"/>
+        <location filename="../src/controls/tabbar.cpp" line="688"/>
         <source>Close unmodified tabs</source>
         <translation>Zatvori neizmijenjene kartice</translation>
     </message>
@@ -967,404 +1018,458 @@
 <context>
     <name>TextEdit</name>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="305"/>
+        <location filename="../src/editor/dtextedit.cpp" line="388"/>
         <source>Undo</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="306"/>
+        <location filename="../src/editor/dtextedit.cpp" line="390"/>
         <source>Redo</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="307"/>
+        <location filename="../src/editor/dtextedit.cpp" line="392"/>
         <source>Cut</source>
         <translation>Izreži</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="308"/>
+        <location filename="../src/editor/dtextedit.cpp" line="394"/>
         <source>Copy</source>
         <translation>Kopiraj</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="309"/>
+        <location filename="../src/editor/dtextedit.cpp" line="396"/>
         <source>Paste</source>
         <translation>Zalijepi</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="310"/>
+        <location filename="../src/editor/dtextedit.cpp" line="398"/>
         <source>Delete</source>
         <translation>Izbriši</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="311"/>
+        <location filename="../src/editor/dtextedit.cpp" line="400"/>
         <source>Select All</source>
         <translation>Izaberi sve</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="312"/>
-        <location filename="../src/widgets/window.cpp" line="535"/>
+        <location filename="../src/editor/dtextedit.cpp" line="402"/>
+        <location filename="../src/widgets/window.cpp" line="556"/>
         <source>Find</source>
         <translation>Nađi</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="313"/>
-        <location filename="../src/widgets/window.cpp" line="536"/>
+        <location filename="../src/editor/dtextedit.cpp" line="404"/>
+        <location filename="../src/widgets/window.cpp" line="558"/>
         <source>Replace</source>
         <translation>Zamjeni</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="314"/>
+        <location filename="../src/editor/dtextedit.cpp" line="406"/>
         <source>Go to Line</source>
         <translation>Idi na redak</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="315"/>
-        <source>Turn on Read-Only mode</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="316"/>
-        <source>Turn off Read-Only mode</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="317"/>
+        <location filename="../src/editor/dtextedit.cpp" line="415"/>
         <source>Fullscreen</source>
         <translation>Cijeli zaslon</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="318"/>
+        <location filename="../src/editor/dtextedit.cpp" line="417"/>
         <source>Exit fullscreen</source>
         <translation>Izađi iz cijelog zaslona</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="319"/>
+        <location filename="../src/editor/dtextedit.cpp" line="419"/>
         <source>Display in file manager</source>
         <translation>Prikaži u upravitelju datotekama</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="320"/>
-        <location filename="../src/editor/dtextedit.cpp" line="374"/>
+        <location filename="../src/editor/dtextedit.cpp" line="421"/>
+        <location filename="../src/editor/dtextedit.cpp" line="493"/>
         <source>Add Comment</source>
         <translation>Dodaj komentar</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="321"/>
+        <location filename="../src/editor/dtextedit.cpp" line="423"/>
         <source>Text to Speech</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="322"/>
-        <source>Stop reading</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="323"/>
+        <location filename="../src/editor/dtextedit.cpp" line="425"/>
         <source>Speech to Text</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="324"/>
+        <location filename="../src/editor/dtextedit.cpp" line="427"/>
         <source>Translate</source>
         <translation>Prevedi</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="325"/>
+        <location filename="../src/editor/dtextedit.cpp" line="429"/>
         <source>Column Mode</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="326"/>
+        <location filename="../src/editor/dtextedit.cpp" line="431"/>
         <source>Add bookmark</source>
         <translation>Dodaj zabilješku</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="327"/>
+        <location filename="../src/editor/dtextedit.cpp" line="433"/>
         <source>Remove Bookmark</source>
         <translation>Ukloni zabilješku</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="328"/>
+        <location filename="../src/editor/dtextedit.cpp" line="435"/>
         <source>Previous bookmark</source>
         <translation>Prethodna zabilješka</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="329"/>
+        <location filename="../src/editor/dtextedit.cpp" line="437"/>
         <source>Next bookmark</source>
         <translation>Slijedeća zabilješka</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="330"/>
+        <location filename="../src/editor/dtextedit.cpp" line="439"/>
         <source>Remove All Bookmarks</source>
         <translation>Ukloni sve zabilješke</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="331"/>
+        <location filename="../src/editor/dtextedit.cpp" line="441"/>
         <source>Fold All</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="332"/>
+        <location filename="../src/editor/dtextedit.cpp" line="443"/>
         <source>Fold Current Level</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="333"/>
+        <location filename="../src/editor/dtextedit.cpp" line="445"/>
         <source>Unfold All</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="334"/>
+        <location filename="../src/editor/dtextedit.cpp" line="447"/>
         <source>Unfold Current Level</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="339"/>
+        <location filename="../src/editor/dtextedit.cpp" line="453"/>
         <source>Color Mark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="343"/>
+        <location filename="../src/editor/dtextedit.cpp" line="458"/>
         <source>Clear All Marks</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="344"/>
+        <location filename="../src/editor/dtextedit.cpp" line="460"/>
         <source>Clear Last Mark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="353"/>
+        <location filename="../src/editor/dtextedit.cpp" line="470"/>
         <source>Mark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="366"/>
+        <location filename="../src/editor/dtextedit.cpp" line="484"/>
         <source>Mark All</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="375"/>
+        <location filename="../src/editor/dtextedit.cpp" line="494"/>
         <source>Remove Comment</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3208"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3211"/>
+        <location filename="../src/editor/dtextedit.cpp" line="543"/>
+        <source>View Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="3531"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3534"/>
         <source>Copy failed: not enough memory</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3333"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3335"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3656"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3658"/>
         <source>Press ALT and click lines to edit in column mode</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="418"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9574"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9576"/>
+        <source>No audio output device was detected. Please ensure your speakers or headphones are properly connected and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="9583"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9585"/>
+        <source>No audio input device was detected. Please ensure your speakers or headphones are properly connected and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="534"/>
         <source>Change Case</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="419"/>
+        <location filename="../src/editor/dtextedit.cpp" line="409"/>
+        <source>Edit Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="411"/>
+        <source>Read View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="413"/>
+        <source>Live Preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="535"/>
         <source>Upper Case</source>
         <translation>Veliko slovo</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="420"/>
+        <location filename="../src/editor/dtextedit.cpp" line="536"/>
         <source>Lower Case</source>
         <translation>Malo slovo</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="421"/>
+        <location filename="../src/editor/dtextedit.cpp" line="537"/>
         <source>Capitalize</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="78"/>
+        <location filename="../src/widgets/bottombar.cpp" line="110"/>
         <source>None</source>
         <translation>Nijedno</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1363"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1490"/>
         <source>Selected line(s) copied</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1370"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1497"/>
         <source>Current line copied</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1400"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1527"/>
         <source>Selected line(s) clipped</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1412"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1539"/>
         <source>Current line clipped</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3227"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3230"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3550"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3553"/>
         <source>Paste failed: not enough memory</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="4548"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4873"/>
         <source>Read-Only mode is off</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="4560"/>
-        <location filename="../src/editor/dtextedit.cpp" line="4584"/>
-        <location filename="../src/editor/dtextedit.cpp" line="7896"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8007"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8015"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8026"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4885"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4909"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8236"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8347"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8355"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8366"/>
         <source>Read-Only mode is on</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>WarningNotices</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="24"/>
+        <location filename="../src/controls/warningnotices.cpp" line="25"/>
         <source>Reload</source>
         <translation>Ponovno učitaj</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/warningnotices.cpp" line="29"/>
+        <source>Edit Anyway</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>Window</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="25"/>
-        <location filename="../src/widgets/window.cpp" line="531"/>
+        <location filename="../src/controls/warningnotices.cpp" line="27"/>
+        <location filename="../src/widgets/window.cpp" line="548"/>
         <source>Save as</source>
         <translation>Spremi kao</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="527"/>
+        <location filename="../src/widgets/window.cpp" line="540"/>
         <source>New window</source>
         <translation>Novi prozor</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="528"/>
+        <location filename="../src/widgets/window.cpp" line="542"/>
         <source>New tab</source>
         <translation>Nova kartica</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="529"/>
+        <location filename="../src/widgets/window.cpp" line="544"/>
         <source>Open file</source>
         <translation>Otvori datoteku</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="530"/>
-        <location filename="../src/widgets/window.cpp" line="3545"/>
+        <location filename="../src/widgets/window.cpp" line="546"/>
+        <location filename="../src/widgets/window.cpp" line="3950"/>
         <source>Save</source>
         <translation>Spremi</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="532"/>
+        <location filename="../src/widgets/window.cpp" line="550"/>
         <source>Print</source>
         <translation>Ispis</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="533"/>
+        <location filename="../src/widgets/window.cpp" line="552"/>
         <source>Switch theme</source>
         <translation>Promijeni temu</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="534"/>
-        <location filename="../src/widgets/window.cpp" line="2448"/>
+        <location filename="../src/widgets/window.cpp" line="554"/>
+        <location filename="../src/widgets/window.cpp" line="2641"/>
         <source>Settings</source>
         <translation>Postavke</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="666"/>
-        <location filename="../src/widgets/window.cpp" line="3845"/>
+        <location filename="../src/widgets/window.cpp" line="696"/>
+        <location filename="../src/widgets/window.cpp" line="4250"/>
         <source>Read-Only</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="687"/>
+        <location filename="../src/widgets/window.cpp" line="719"/>
         <source>You do not have permission to open %1</source>
         <translation>Nemate dozvole za otvoriti %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="738"/>
-        <location filename="../src/widgets/window.cpp" line="2963"/>
+        <location filename="../src/widgets/window.cpp" line="773"/>
+        <location filename="../src/widgets/window.cpp" line="3266"/>
         <source>Invalid file: %1</source>
         <translation>Neispravna datoteka: %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="903"/>
-        <location filename="../src/widgets/window.cpp" line="956"/>
+        <location filename="../src/widgets/window.cpp" line="957"/>
+        <location filename="../src/widgets/window.cpp" line="1050"/>
+        <location filename="../src/widgets/window.cpp" line="3217"/>
         <source>Do you want to save this file?</source>
         <translation>Želite li spremiti ovu datoteku?</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1290"/>
+        <location filename="../src/widgets/window.cpp" line="1381"/>
+        <source>Invalid characters detected while saving &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1382"/>
+        <source>If you force save this file, it may cause file corruption. Still want to save?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1386"/>
+        <source>Don&apos;t Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1387"/>
+        <source>Save As</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1388"/>
+        <source>Save Anyway</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1456"/>
         <source>You do not have permission to save %1</source>
         <translation>Nemate dozvole za spremanje %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1312"/>
+        <location filename="../src/widgets/window.cpp" line="1428"/>
+        <location filename="../src/widgets/window.cpp" line="1478"/>
         <source>Saved successfully</source>
         <translation>Uspješno spremljeno</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1354"/>
-        <location filename="../src/widgets/window.cpp" line="1481"/>
-        <location filename="../src/widgets/window.cpp" line="1529"/>
+        <location filename="../src/widgets/window.cpp" line="1520"/>
+        <location filename="../src/widgets/window.cpp" line="1665"/>
+        <location filename="../src/widgets/window.cpp" line="1713"/>
         <source>Save File</source>
         <translation>Spremi datoteku</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1483"/>
+        <location filename="../src/widgets/window.cpp" line="1569"/>
+        <source>Cannot save as the original file in preview mode. Please choose a different path.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1667"/>
         <source>Encoding</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1773"/>
+        <location filename="../src/widgets/window.cpp" line="1957"/>
         <source>Read-Only mode is on</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2322"/>
+        <location filename="../src/widgets/window.cpp" line="2511"/>
         <source>Current location remembered</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2398"/>
+        <location filename="../src/widgets/window.cpp" line="2591"/>
         <source>Ctrl+&apos;=&apos;</source>
         <translation>Ctrl+&apos;=&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2401"/>
+        <location filename="../src/widgets/window.cpp" line="2594"/>
         <source>Ctrl+&apos;-&apos;</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2430"/>
+        <location filename="../src/widgets/window.cpp" line="2623"/>
         <source>Editor</source>
         <translation>Uređivač</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3061"/>
+        <location filename="../src/widgets/window.cpp" line="3436"/>
         <source>Untitled %1</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3543"/>
+        <location filename="../src/widgets/window.cpp" line="3948"/>
         <source>Cancel</source>
         <translation>Otkaži</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3544"/>
+        <location filename="../src/widgets/window.cpp" line="3949"/>
         <source>Discard</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/deepin-editor_hu.ts
+++ b/translations/deepin-editor_hu.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="hu">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="hu">
 <context>
     <name>BottomBar</name>
     <message>
@@ -17,17 +19,36 @@
         <translation>%1 karakter</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="44"/>
+        <location filename="../src/widgets/bottombar.cpp" line="47"/>
         <source>Loading:</source>
         <translation>Betöltés:</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="73"/>
+        <location filename="../src/widgets/bottombar.cpp" line="91"/>
+        <location filename="../src/widgets/bottombar.cpp" line="499"/>
+        <source>Edit Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="74"/>
+        <location filename="../src/widgets/bottombar.cpp" line="489"/>
+        <source>Read View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="75"/>
+        <location filename="../src/widgets/bottombar.cpp" line="493"/>
+        <source>Live Preview</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DDropdownMenu</name>
     <message>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="362"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="420"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="425"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="363"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="421"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="426"/>
         <source>None</source>
         <translation>Semmi</translation>
     </message>
@@ -35,68 +56,57 @@
 <context>
     <name>EditWrapper</name>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="292"/>
-        <location filename="../src/editor/editwrapper.cpp" line="365"/>
-        <location filename="../src/editor/editwrapper.cpp" line="521"/>
-        <location filename="../src/editor/editwrapper.cpp" line="751"/>
+        <location filename="../src/editor/editwrapper.cpp" line="355"/>
+        <location filename="../src/editor/editwrapper.cpp" line="429"/>
+        <location filename="../src/editor/editwrapper.cpp" line="595"/>
+        <location filename="../src/editor/editwrapper.cpp" line="887"/>
         <source>Save</source>
         <translation>Mentés</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="516"/>
+        <location filename="../src/editor/editwrapper.cpp" line="590"/>
         <source>Do you want to save this file?</source>
         <translation>El akarja menteni ezt a fájlt?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="363"/>
-        <location filename="../src/editor/editwrapper.cpp" line="519"/>
+        <location filename="../src/editor/editwrapper.cpp" line="427"/>
+        <location filename="../src/editor/editwrapper.cpp" line="593"/>
         <source>Cancel</source>
         <translation>Mégsem</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="360"/>
+        <location filename="../src/editor/editwrapper.cpp" line="424"/>
         <source>Encoding changed. Do you want to save the file now?</source>
         <translation>A kódolás megváltozott. El akarja menteni a fájlt most?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="520"/>
+        <location filename="../src/editor/editwrapper.cpp" line="594"/>
         <source>Discard</source>
         <translation>Elvetés</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="274"/>
-        <location filename="../src/editor/editwrapper.cpp" line="620"/>
+        <location filename="../src/editor/editwrapper.cpp" line="1121"/>
+        <source>The file contains invalid characters (NUL). Preview mode is read-only.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="337"/>
+        <location filename="../src/editor/editwrapper.cpp" line="705"/>
         <source>You do not have permission to save %1</source>
         <translation>Nincs engedélye a %1 mentéséhez</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="836"/>
+        <location filename="../src/editor/editwrapper.cpp" line="987"/>
         <source>File removed on the disk. Save it now?</source>
         <translation>A fájl eltávolítva a lemezről. Elmenti most?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="842"/>
+        <location filename="../src/editor/editwrapper.cpp" line="993"/>
         <source>File has changed on disk. Reload?</source>
         <translation>A fájl megváltozott a lemezen. Újra betölti?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="884"/>
-        <location filename="../src/widgets/bottombar.cpp" line="74"/>
-        <source>INSERT</source>
-        <translation>BESZÚRÁS</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="888"/>
-        <source>OVERWRITE</source>
-        <translation>FELÜLÍRÁS</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="892"/>
-        <source>R/O</source>
-        <translation>Írásvédett</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="1618"/>
+        <location filename="../src/editor/editwrapper.cpp" line="1806"/>
         <source>The file cannot be read, which may be too large or has been damaged!</source>
         <translation>A fájl nem olvasható, mert túl nagy a mérete, vagy sérült!</translation>
     </message>
@@ -109,17 +119,17 @@
         <translation>Találat</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="36"/>
+        <location filename="../src/controls/findbar.cpp" line="38"/>
         <source>Previous</source>
         <translation>Előző</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="37"/>
+        <location filename="../src/controls/findbar.cpp" line="40"/>
         <source>Next</source>
         <translation>Következő</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="38"/>
+        <location filename="../src/controls/findbar.cpp" line="42"/>
         <source>Replace</source>
         <translation>Helyettesítés</translation>
     </message>
@@ -127,9 +137,17 @@
 <context>
     <name>JumpLineBar</name>
     <message>
-        <location filename="../src/controls/jumplinebar.cpp" line="45"/>
+        <location filename="../src/controls/jumplinebar.cpp" line="46"/>
         <source>Go to Line: </source>
         <translation>Ugrás megadott sorra:</translation>
+    </message>
+</context>
+<context>
+    <name>LineBar</name>
+    <message>
+        <location filename="../src/controls/linebar.cpp" line="144"/>
+        <source>第%1/%2项</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -146,19 +164,47 @@
     </message>
 </context>
 <context>
+    <name>MarkdownBridge</name>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="37"/>
+        <source>Collapse code block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="38"/>
+        <source>Expand code block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="39"/>
+        <source>Copy code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="40"/>
+        <source>Expand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="42"/>
+        <source>%1 line(s) of code collapsed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PathSettingWgt</name>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="84"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="90"/>
         <source>Remember the last used path</source>
         <translation>Emlékezzen az utoljára használt útvonalra</translation>
     </message>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="85"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="91"/>
         <source>Same path as the current file</source>
         <translation>Ugyanaz az elérési út, mint az aktuális fájl</translation>
     </message>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="86"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="92"/>
         <source>Customize the default path</source>
         <translation>Az alapértelmezett elérési út testreszabása</translation>
     </message>
@@ -171,15 +217,20 @@
         <translation>Szövegszerkesztő</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="294"/>
-        <location filename="../src/editor/editwrapper.cpp" line="761"/>
-        <location filename="../src/editor/editwrapper.cpp" line="776"/>
-        <location filename="../src/widgets/window.cpp" line="1362"/>
-        <location filename="../src/widgets/window.cpp" line="1390"/>
-        <location filename="../src/widgets/window.cpp" line="1531"/>
-        <location filename="../src/widgets/window.cpp" line="1548"/>
+        <location filename="../src/editor/editwrapper.cpp" line="357"/>
+        <location filename="../src/editor/editwrapper.cpp" line="897"/>
+        <location filename="../src/editor/editwrapper.cpp" line="912"/>
+        <location filename="../src/widgets/window.cpp" line="1528"/>
+        <location filename="../src/widgets/window.cpp" line="1556"/>
+        <location filename="../src/widgets/window.cpp" line="1715"/>
+        <location filename="../src/widgets/window.cpp" line="1732"/>
         <source>Encoding</source>
         <translation>Kódolás</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="2001"/>
+        <source>视图模式</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="11"/>
@@ -215,7 +266,7 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="18"/>
         <location filename="../src/controls/settingsdialog.cpp" line="96"/>
-        <location filename="../src/widgets/window.cpp" line="2388"/>
+        <location filename="../src/widgets/window.cpp" line="2581"/>
         <source>Window</source>
         <translation>Ablak</translation>
     </message>
@@ -755,68 +806,68 @@
         <translation>Vietnámi</translation>
     </message>
     <message>
-        <location filename="../src/startmanager.cpp" line="971"/>
+        <location filename="../src/startmanager.cpp" line="1035"/>
         <source>File not saved</source>
         <translation>A fájl nincs elmentve</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1532"/>
-        <location filename="../src/widgets/window.cpp" line="1549"/>
+        <location filename="../src/widgets/window.cpp" line="1716"/>
+        <location filename="../src/widgets/window.cpp" line="1733"/>
         <source>Line Endings</source>
         <translation>Sorvégek</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="243"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="379"/>
         <source>Please install &apos;UOS AI&apos; from the App Store before using</source>
         <translation>Kérjük, telepítse a &apos;UOS AI&apos;-t az Alkalmazásboltból a használat előtt</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="245"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="381"/>
         <source>No audio input device detected. Please check and try again</source>
         <translation>Nincs észlelt audio bemeneti eszköz. Kérjük, ellenőrizze, és próbálja újra</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="247"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="383"/>
         <source>No audio output device detected. Please check and try again</source>
         <translation>Nincs észlelt audio kimeneti eszköz. Kérjük, ellenőrizze, és próbálja újra</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="69"/>
+        <location filename="../src/common/text_file_saver.cpp" line="74"/>
         <source>File path is empty</source>
         <translation>A fájl elérési útja üres</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="155"/>
+        <location filename="../src/common/text_file_saver.cpp" line="153"/>
         <source>Insufficient memory to load document content</source>
         <translation>Nem elég memória a dokumentum tartalmának betöltéséhez</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="177"/>
+        <location filename="../src/common/text_file_saver.cpp" line="178"/>
         <source>Insufficient memory for encoding conversion</source>
         <translation>Nem elég memória a kódolási átalakításhoz</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="183"/>
+        <location filename="../src/common/text_file_saver.cpp" line="184"/>
         <source>Encoding conversion failed</source>
         <translation>A kódolási átalakítás meghiúsult</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="189"/>
+        <location filename="../src/common/text_file_saver.cpp" line="190"/>
         <source>Converted content is empty</source>
         <translation>Az átalakított tartalom üres</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="207"/>
+        <location filename="../src/common/text_file_saver.cpp" line="208"/>
         <source>Memory allocation failed</source>
         <translation>A memóriaelosztás meghiúsult</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="211"/>
+        <location filename="../src/common/text_file_saver.cpp" line="212"/>
         <source>Error occurred: %1</source>
         <translation>Hiba történt: %1</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="215"/>
+        <location filename="../src/common/text_file_saver.cpp" line="216"/>
         <source>Unknown error occurred</source>
         <translation>Ismeretlen hiba történt</translation>
     </message>
@@ -829,27 +880,27 @@
         <translation>Találat</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="34"/>
+        <location filename="../src/controls/replacebar.cpp" line="36"/>
         <source>Replace With</source>
         <translation>Csere a </translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="36"/>
+        <location filename="../src/controls/replacebar.cpp" line="40"/>
         <source>Replace</source>
         <translation>Csere</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="37"/>
+        <location filename="../src/controls/replacebar.cpp" line="42"/>
         <source>Skip</source>
         <translation>Kihagyás</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="38"/>
+        <location filename="../src/controls/replacebar.cpp" line="44"/>
         <source>Replace Rest</source>
         <translation>Aktuális cseréje</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="39"/>
+        <location filename="../src/controls/replacebar.cpp" line="46"/>
         <source>Replace All</source>
         <translation>Összes cseréje</translation>
     </message>
@@ -858,9 +909,9 @@
     <name>S:</name>
     <message>
         <location filename="../third/libiconv-1.16/src/iconv.c" line="103"/>
-        <source/>
+        <source></source>
         <comment>The first line of the short usage message.</comment>
-        <translation type="unfinished"/>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -891,34 +942,34 @@
         <translation>Teljes képernyő</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="484"/>
+        <location filename="../src/common/settings.cpp" line="491"/>
         <source>This shortcut conflicts with system shortcut %1</source>
         <translation>Ez a gyorsbillentyű ütközik a %1 rendszer gyorsbillentyűvel</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="487"/>
+        <location filename="../src/common/settings.cpp" line="494"/>
         <source>This shortcut conflicts with %1, click on Replace to make this shortcut effective immediately</source>
         <translation>Ez a gyorsbillentyű ütközik a következővel: %1, kattintson a Csere gombra a gyorsbillentyű azonnali használatához</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="682"/>
-        <location filename="../src/common/settings.cpp" line="695"/>
-        <location filename="../src/common/settings.cpp" line="704"/>
+        <location filename="../src/common/settings.cpp" line="689"/>
+        <location filename="../src/common/settings.cpp" line="702"/>
+        <location filename="../src/common/settings.cpp" line="711"/>
         <source>The shortcut %1 is invalid, please set another one.</source>
         <translation>A %1 gyorsbillentyű érvénytelen, kérjük állítson be egy másikat.</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="736"/>
+        <location filename="../src/common/settings.cpp" line="743"/>
         <source>Cancel</source>
         <translation>Mégsem</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="737"/>
+        <location filename="../src/common/settings.cpp" line="744"/>
         <source>Replace</source>
         <translation>Csere</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="740"/>
+        <location filename="../src/common/settings.cpp" line="747"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
@@ -926,7 +977,7 @@
 <context>
     <name>StartManager</name>
     <message>
-        <location filename="../src/startmanager.cpp" line="411"/>
+        <location filename="../src/startmanager.cpp" line="425"/>
         <source>Untitled %1</source>
         <translation>Cím nélküli %1</translation>
     </message>
@@ -934,32 +985,32 @@
 <context>
     <name>Tabbar</name>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="641"/>
+        <location filename="../src/controls/tabbar.cpp" line="678"/>
         <source>Close tab</source>
         <translation>Lap bezárása</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="642"/>
+        <location filename="../src/controls/tabbar.cpp" line="680"/>
         <source>Close other tabs</source>
         <translation>Többi lap bezárása</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="643"/>
+        <location filename="../src/controls/tabbar.cpp" line="682"/>
         <source>More options</source>
         <translation>További beállítások</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="644"/>
+        <location filename="../src/controls/tabbar.cpp" line="684"/>
         <source>Close tabs to the left</source>
         <translation>Lapok balra zárása</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="645"/>
+        <location filename="../src/controls/tabbar.cpp" line="686"/>
         <source>Close tabs to the right</source>
         <translation>Lapok jobbra zárása</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="646"/>
+        <location filename="../src/controls/tabbar.cpp" line="688"/>
         <source>Close unmodified tabs</source>
         <translation>Módosítatlan lapok bezárása</translation>
     </message>
@@ -967,263 +1018,280 @@
 <context>
     <name>TextEdit</name>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="305"/>
+        <location filename="../src/editor/dtextedit.cpp" line="388"/>
         <source>Undo</source>
         <translation>Visszavonás</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="306"/>
+        <location filename="../src/editor/dtextedit.cpp" line="390"/>
         <source>Redo</source>
         <translation>Újra visszavonás</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="307"/>
+        <location filename="../src/editor/dtextedit.cpp" line="392"/>
         <source>Cut</source>
         <translation>Kivágás</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="308"/>
+        <location filename="../src/editor/dtextedit.cpp" line="394"/>
         <source>Copy</source>
         <translation>Másolás</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="309"/>
+        <location filename="../src/editor/dtextedit.cpp" line="396"/>
         <source>Paste</source>
         <translation>Beillesztés</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="310"/>
+        <location filename="../src/editor/dtextedit.cpp" line="398"/>
         <source>Delete</source>
         <translation>Törlés</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="311"/>
+        <location filename="../src/editor/dtextedit.cpp" line="400"/>
         <source>Select All</source>
         <translation>Összes kijelölése</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="312"/>
-        <location filename="../src/widgets/window.cpp" line="535"/>
+        <location filename="../src/editor/dtextedit.cpp" line="402"/>
+        <location filename="../src/widgets/window.cpp" line="556"/>
         <source>Find</source>
         <translation>Találat</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="313"/>
-        <location filename="../src/widgets/window.cpp" line="536"/>
+        <location filename="../src/editor/dtextedit.cpp" line="404"/>
+        <location filename="../src/widgets/window.cpp" line="558"/>
         <source>Replace</source>
         <translation>Csere</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="314"/>
+        <location filename="../src/editor/dtextedit.cpp" line="406"/>
         <source>Go to Line</source>
         <translation>Ugrás megadott sorra</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="315"/>
-        <source>Turn on Read-Only mode</source>
-        <translation>Csak olvasható mód bekapcsolása</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="316"/>
-        <source>Turn off Read-Only mode</source>
-        <translation>Csak olvasható mód kikapcsolása</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="317"/>
+        <location filename="../src/editor/dtextedit.cpp" line="415"/>
         <source>Fullscreen</source>
         <translation>Teljes képernyő</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="318"/>
+        <location filename="../src/editor/dtextedit.cpp" line="417"/>
         <source>Exit fullscreen</source>
         <translation>Kilépés a teljes képernyőből</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="319"/>
+        <location filename="../src/editor/dtextedit.cpp" line="419"/>
         <source>Display in file manager</source>
         <translation>Megjelenítés a fájlkezelőben</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="320"/>
-        <location filename="../src/editor/dtextedit.cpp" line="374"/>
+        <location filename="../src/editor/dtextedit.cpp" line="421"/>
+        <location filename="../src/editor/dtextedit.cpp" line="493"/>
         <source>Add Comment</source>
         <translation>Megjegyzés hozzáadása</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="321"/>
+        <location filename="../src/editor/dtextedit.cpp" line="423"/>
         <source>Text to Speech</source>
         <translation>Szövegből beszéd</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="322"/>
-        <source>Stop reading</source>
-        <translation>Olvasás megállítása</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="323"/>
+        <location filename="../src/editor/dtextedit.cpp" line="425"/>
         <source>Speech to Text</source>
         <translation>Beszédből szöveg</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="324"/>
+        <location filename="../src/editor/dtextedit.cpp" line="427"/>
         <source>Translate</source>
         <translation>Fordítás</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="325"/>
+        <location filename="../src/editor/dtextedit.cpp" line="429"/>
         <source>Column Mode</source>
         <translation>Oszlop mód</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="326"/>
+        <location filename="../src/editor/dtextedit.cpp" line="431"/>
         <source>Add bookmark</source>
         <translation>Könyvjelző hozzáadása</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="327"/>
+        <location filename="../src/editor/dtextedit.cpp" line="433"/>
         <source>Remove Bookmark</source>
         <translation>Könyvjelző eltávolítása</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="328"/>
+        <location filename="../src/editor/dtextedit.cpp" line="435"/>
         <source>Previous bookmark</source>
         <translation>Előző könyvjelző</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="329"/>
+        <location filename="../src/editor/dtextedit.cpp" line="437"/>
         <source>Next bookmark</source>
         <translation>Következő könyvjelző</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="330"/>
+        <location filename="../src/editor/dtextedit.cpp" line="439"/>
         <source>Remove All Bookmarks</source>
         <translation>Összes könyvjelző eltávolítása</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="331"/>
+        <location filename="../src/editor/dtextedit.cpp" line="441"/>
         <source>Fold All</source>
         <translation>Összes hajtogatása</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="332"/>
+        <location filename="../src/editor/dtextedit.cpp" line="443"/>
         <source>Fold Current Level</source>
         <translation>Jelenlegi szint hajtogatása</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="333"/>
+        <location filename="../src/editor/dtextedit.cpp" line="445"/>
         <source>Unfold All</source>
         <translation>Összes kihajtogatása</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="334"/>
+        <location filename="../src/editor/dtextedit.cpp" line="447"/>
         <source>Unfold Current Level</source>
         <translation>Jelenlegi szint kihajtogatása</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="339"/>
+        <location filename="../src/editor/dtextedit.cpp" line="453"/>
         <source>Color Mark</source>
         <translation>Színes jelölő</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="343"/>
+        <location filename="../src/editor/dtextedit.cpp" line="458"/>
         <source>Clear All Marks</source>
         <translation>Összes jelölő törlése</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="344"/>
+        <location filename="../src/editor/dtextedit.cpp" line="460"/>
         <source>Clear Last Mark</source>
         <translation>Utolsó jelölés törlése</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="353"/>
+        <location filename="../src/editor/dtextedit.cpp" line="470"/>
         <source>Mark</source>
         <translation>Jelölő</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="366"/>
+        <location filename="../src/editor/dtextedit.cpp" line="484"/>
         <source>Mark All</source>
         <translation>Összes jelölése</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="375"/>
+        <location filename="../src/editor/dtextedit.cpp" line="494"/>
         <source>Remove Comment</source>
         <translation>Megjegyzés eltávolítása</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3208"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3211"/>
+        <location filename="../src/editor/dtextedit.cpp" line="543"/>
+        <source>View Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="3531"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3534"/>
         <source>Copy failed: not enough memory</source>
         <translation>A másolás sikertelen: nincs elég memória</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3333"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3335"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3656"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3658"/>
         <source>Press ALT and click lines to edit in column mode</source>
         <translation>Nyomja meg az ALT gombot, és kattintson a sorokra az oszlop módban történő szerkesztéshez</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="418"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9574"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9576"/>
+        <source>No audio output device was detected. Please ensure your speakers or headphones are properly connected and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="9583"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9585"/>
+        <source>No audio input device was detected. Please ensure your speakers or headphones are properly connected and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="534"/>
         <source>Change Case</source>
         <translation>Kisbetű/nagybetű váltása</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="419"/>
+        <location filename="../src/editor/dtextedit.cpp" line="409"/>
+        <source>Edit Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="411"/>
+        <source>Read View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="413"/>
+        <source>Live Preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="535"/>
         <source>Upper Case</source>
         <translation>Nagybetűs</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="420"/>
+        <location filename="../src/editor/dtextedit.cpp" line="536"/>
         <source>Lower Case</source>
         <translation>Kisbetűs</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="421"/>
+        <location filename="../src/editor/dtextedit.cpp" line="537"/>
         <source>Capitalize</source>
         <translation>Kapitális</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="78"/>
+        <location filename="../src/widgets/bottombar.cpp" line="110"/>
         <source>None</source>
         <translation>Semmi</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1363"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1490"/>
         <source>Selected line(s) copied</source>
         <translation>A kijelölt sor(ok) átmásolva</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1370"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1497"/>
         <source>Current line copied</source>
         <translation>A jelenlegi sor átmásolva</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1400"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1527"/>
         <source>Selected line(s) clipped</source>
         <translation>A kijelölt sor(ok) kivágva</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1412"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1539"/>
         <source>Current line clipped</source>
         <translation>A jelenlegi sor kivágva</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3227"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3230"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3550"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3553"/>
         <source>Paste failed: not enough memory</source>
         <translation>A beillesztés sikertelen: Nincs elegendő memória</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="4548"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4873"/>
         <source>Read-Only mode is off</source>
         <translation>Csak olvasható mód kikapcsolva</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="4560"/>
-        <location filename="../src/editor/dtextedit.cpp" line="4584"/>
-        <location filename="../src/editor/dtextedit.cpp" line="7896"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8007"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8015"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8026"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4885"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4909"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8236"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8347"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8355"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8366"/>
         <source>Read-Only mode is on</source>
         <translation>Csak olvasható mód bekapcsolva</translation>
     </message>
@@ -1231,138 +1299,175 @@
 <context>
     <name>WarningNotices</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="24"/>
+        <location filename="../src/controls/warningnotices.cpp" line="25"/>
         <source>Reload</source>
         <translation>Újratöltés</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/warningnotices.cpp" line="29"/>
+        <source>Edit Anyway</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>Window</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="25"/>
-        <location filename="../src/widgets/window.cpp" line="531"/>
+        <location filename="../src/controls/warningnotices.cpp" line="27"/>
+        <location filename="../src/widgets/window.cpp" line="548"/>
         <source>Save as</source>
         <translation>Mentés másként</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="527"/>
+        <location filename="../src/widgets/window.cpp" line="540"/>
         <source>New window</source>
         <translation>Új ablak</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="528"/>
+        <location filename="../src/widgets/window.cpp" line="542"/>
         <source>New tab</source>
         <translation>Új lap</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="529"/>
+        <location filename="../src/widgets/window.cpp" line="544"/>
         <source>Open file</source>
         <translation>Fájl megnyitása</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="530"/>
-        <location filename="../src/widgets/window.cpp" line="3545"/>
+        <location filename="../src/widgets/window.cpp" line="546"/>
+        <location filename="../src/widgets/window.cpp" line="3950"/>
         <source>Save</source>
         <translation>Mentés</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="532"/>
+        <location filename="../src/widgets/window.cpp" line="550"/>
         <source>Print</source>
         <translation>Nyomtatás</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="533"/>
+        <location filename="../src/widgets/window.cpp" line="552"/>
         <source>Switch theme</source>
         <translation>Téma váltása</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="534"/>
-        <location filename="../src/widgets/window.cpp" line="2448"/>
+        <location filename="../src/widgets/window.cpp" line="554"/>
+        <location filename="../src/widgets/window.cpp" line="2641"/>
         <source>Settings</source>
         <translation>Beállítások</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="666"/>
-        <location filename="../src/widgets/window.cpp" line="3845"/>
+        <location filename="../src/widgets/window.cpp" line="696"/>
+        <location filename="../src/widgets/window.cpp" line="4250"/>
         <source>Read-Only</source>
         <translation>Csak olvasható</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="687"/>
+        <location filename="../src/widgets/window.cpp" line="719"/>
         <source>You do not have permission to open %1</source>
         <translation>Nincs engedélye a %1 megnyitásához</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="738"/>
-        <location filename="../src/widgets/window.cpp" line="2963"/>
+        <location filename="../src/widgets/window.cpp" line="773"/>
+        <location filename="../src/widgets/window.cpp" line="3266"/>
         <source>Invalid file: %1</source>
         <translation>Érvénytelen fájl: %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="903"/>
-        <location filename="../src/widgets/window.cpp" line="956"/>
+        <location filename="../src/widgets/window.cpp" line="957"/>
+        <location filename="../src/widgets/window.cpp" line="1050"/>
+        <location filename="../src/widgets/window.cpp" line="3217"/>
         <source>Do you want to save this file?</source>
         <translation>El akarja menteni ezt a fájlt?</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1290"/>
+        <location filename="../src/widgets/window.cpp" line="1381"/>
+        <source>Invalid characters detected while saving &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1382"/>
+        <source>If you force save this file, it may cause file corruption. Still want to save?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1386"/>
+        <source>Don&apos;t Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1387"/>
+        <source>Save As</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1388"/>
+        <source>Save Anyway</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1456"/>
         <source>You do not have permission to save %1</source>
         <translation>Nincs engedélye a %1 mentéséhez</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1312"/>
+        <location filename="../src/widgets/window.cpp" line="1428"/>
+        <location filename="../src/widgets/window.cpp" line="1478"/>
         <source>Saved successfully</source>
         <translation>A mentés sikeres</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1354"/>
-        <location filename="../src/widgets/window.cpp" line="1481"/>
-        <location filename="../src/widgets/window.cpp" line="1529"/>
+        <location filename="../src/widgets/window.cpp" line="1520"/>
+        <location filename="../src/widgets/window.cpp" line="1665"/>
+        <location filename="../src/widgets/window.cpp" line="1713"/>
         <source>Save File</source>
         <translation>Fájl mentése</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1483"/>
+        <location filename="../src/widgets/window.cpp" line="1569"/>
+        <source>Cannot save as the original file in preview mode. Please choose a different path.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1667"/>
         <source>Encoding</source>
         <translation>Kódolás</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1773"/>
+        <location filename="../src/widgets/window.cpp" line="1957"/>
         <source>Read-Only mode is on</source>
         <translation>Csak olvasható mód bekapcsolva</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2322"/>
+        <location filename="../src/widgets/window.cpp" line="2511"/>
         <source>Current location remembered</source>
         <translation>A jelenlegi hely megjegyezve</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2398"/>
+        <location filename="../src/widgets/window.cpp" line="2591"/>
         <source>Ctrl+&apos;=&apos;</source>
         <translation>Ctrl+&apos;=&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2401"/>
+        <location filename="../src/widgets/window.cpp" line="2594"/>
         <source>Ctrl+&apos;-&apos;</source>
         <translation>Ctrl+&apos;-&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2430"/>
+        <location filename="../src/widgets/window.cpp" line="2623"/>
         <source>Editor</source>
         <translation>Szerkesztő</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3061"/>
+        <location filename="../src/widgets/window.cpp" line="3436"/>
         <source>Untitled %1</source>
         <translation>Cím nélküli %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3543"/>
+        <location filename="../src/widgets/window.cpp" line="3948"/>
         <source>Cancel</source>
         <translation>Mégsem</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3544"/>
+        <location filename="../src/widgets/window.cpp" line="3949"/>
         <source>Discard</source>
         <translation>Elvetés</translation>
     </message>

--- a/translations/deepin-editor_id.ts
+++ b/translations/deepin-editor_id.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="id">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="id">
 <context>
     <name>BottomBar</name>
     <message>
@@ -17,17 +19,36 @@
         <translation>Karakter %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="44"/>
+        <location filename="../src/widgets/bottombar.cpp" line="47"/>
         <source>Loading:</source>
         <translation>Memuat:</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="73"/>
+        <location filename="../src/widgets/bottombar.cpp" line="91"/>
+        <location filename="../src/widgets/bottombar.cpp" line="499"/>
+        <source>Edit Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="74"/>
+        <location filename="../src/widgets/bottombar.cpp" line="489"/>
+        <source>Read View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="75"/>
+        <location filename="../src/widgets/bottombar.cpp" line="493"/>
+        <source>Live Preview</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DDropdownMenu</name>
     <message>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="362"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="420"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="425"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="363"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="421"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="426"/>
         <source>None</source>
         <translation>Tidak ada</translation>
     </message>
@@ -35,68 +56,57 @@
 <context>
     <name>EditWrapper</name>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="292"/>
-        <location filename="../src/editor/editwrapper.cpp" line="365"/>
-        <location filename="../src/editor/editwrapper.cpp" line="521"/>
-        <location filename="../src/editor/editwrapper.cpp" line="751"/>
+        <location filename="../src/editor/editwrapper.cpp" line="355"/>
+        <location filename="../src/editor/editwrapper.cpp" line="429"/>
+        <location filename="../src/editor/editwrapper.cpp" line="595"/>
+        <location filename="../src/editor/editwrapper.cpp" line="887"/>
         <source>Save</source>
         <translation>Simpan</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="516"/>
+        <location filename="../src/editor/editwrapper.cpp" line="590"/>
         <source>Do you want to save this file?</source>
         <translation>Apakah anda ingin menyimpan berkas ini?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="363"/>
-        <location filename="../src/editor/editwrapper.cpp" line="519"/>
+        <location filename="../src/editor/editwrapper.cpp" line="427"/>
+        <location filename="../src/editor/editwrapper.cpp" line="593"/>
         <source>Cancel</source>
         <translation>Batal</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="360"/>
+        <location filename="../src/editor/editwrapper.cpp" line="424"/>
         <source>Encoding changed. Do you want to save the file now?</source>
         <translation>Mengubah encoding. Apakah anda ingin menyimpan berkas sekarang?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="520"/>
+        <location filename="../src/editor/editwrapper.cpp" line="594"/>
         <source>Discard</source>
         <translation>Membuang</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="274"/>
-        <location filename="../src/editor/editwrapper.cpp" line="620"/>
+        <location filename="../src/editor/editwrapper.cpp" line="1121"/>
+        <source>The file contains invalid characters (NUL). Preview mode is read-only.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="337"/>
+        <location filename="../src/editor/editwrapper.cpp" line="705"/>
         <source>You do not have permission to save %1</source>
         <translation>Anda tidak mempunyai ijin untuk simpan %1</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="836"/>
+        <location filename="../src/editor/editwrapper.cpp" line="987"/>
         <source>File removed on the disk. Save it now?</source>
         <translation>Berkas didisk sudah dihapus. Simpan sekarang?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="842"/>
+        <location filename="../src/editor/editwrapper.cpp" line="993"/>
         <source>File has changed on disk. Reload?</source>
         <translation>Berkas didisk sudah berubah, muat ulang?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="884"/>
-        <location filename="../src/widgets/bottombar.cpp" line="74"/>
-        <source>INSERT</source>
-        <translation>MASUK</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="888"/>
-        <source>OVERWRITE</source>
-        <translation>TULIS ULANG</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="892"/>
-        <source>R/O</source>
-        <translation>R/O</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="1618"/>
+        <location filename="../src/editor/editwrapper.cpp" line="1806"/>
         <source>The file cannot be read, which may be too large or has been damaged!</source>
         <translation>Berkas tidak dapat dibaca, yang mungkin terlalu besar atau telah rusak!</translation>
     </message>
@@ -109,17 +119,17 @@
         <translation>Cari</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="36"/>
+        <location filename="../src/controls/findbar.cpp" line="38"/>
         <source>Previous</source>
         <translation>Sebelum</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="37"/>
+        <location filename="../src/controls/findbar.cpp" line="40"/>
         <source>Next</source>
         <translation>Lanjut</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="38"/>
+        <location filename="../src/controls/findbar.cpp" line="42"/>
         <source>Replace</source>
         <translation>Ganti</translation>
     </message>
@@ -127,9 +137,17 @@
 <context>
     <name>JumpLineBar</name>
     <message>
-        <location filename="../src/controls/jumplinebar.cpp" line="45"/>
+        <location filename="../src/controls/jumplinebar.cpp" line="46"/>
         <source>Go to Line: </source>
         <translation>Pergi ke Baris:</translation>
+    </message>
+</context>
+<context>
+    <name>LineBar</name>
+    <message>
+        <location filename="../src/controls/linebar.cpp" line="144"/>
+        <source>第%1/%2项</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -146,19 +164,47 @@
     </message>
 </context>
 <context>
+    <name>MarkdownBridge</name>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="37"/>
+        <source>Collapse code block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="38"/>
+        <source>Expand code block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="39"/>
+        <source>Copy code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="40"/>
+        <source>Expand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="42"/>
+        <source>%1 line(s) of code collapsed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PathSettingWgt</name>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="84"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="90"/>
         <source>Remember the last used path</source>
         <translation>Ingat jalur yang terakhir digunakan</translation>
     </message>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="85"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="91"/>
         <source>Same path as the current file</source>
         <translation>Jalur yang sama dengan berkas saat ini</translation>
     </message>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="86"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="92"/>
         <source>Customize the default path</source>
         <translation>Menyesuaikan jalur bawaan</translation>
     </message>
@@ -171,15 +217,20 @@
         <translation>Text Editor</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="294"/>
-        <location filename="../src/editor/editwrapper.cpp" line="761"/>
-        <location filename="../src/editor/editwrapper.cpp" line="776"/>
-        <location filename="../src/widgets/window.cpp" line="1362"/>
-        <location filename="../src/widgets/window.cpp" line="1390"/>
-        <location filename="../src/widgets/window.cpp" line="1531"/>
-        <location filename="../src/widgets/window.cpp" line="1548"/>
+        <location filename="../src/editor/editwrapper.cpp" line="357"/>
+        <location filename="../src/editor/editwrapper.cpp" line="897"/>
+        <location filename="../src/editor/editwrapper.cpp" line="912"/>
+        <location filename="../src/widgets/window.cpp" line="1528"/>
+        <location filename="../src/widgets/window.cpp" line="1556"/>
+        <location filename="../src/widgets/window.cpp" line="1715"/>
+        <location filename="../src/widgets/window.cpp" line="1732"/>
         <source>Encoding</source>
         <translation>Mengencode</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="2001"/>
+        <source>视图模式</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="11"/>
@@ -215,7 +266,7 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="18"/>
         <location filename="../src/controls/settingsdialog.cpp" line="96"/>
-        <location filename="../src/widgets/window.cpp" line="2388"/>
+        <location filename="../src/widgets/window.cpp" line="2581"/>
         <source>Window</source>
         <translation>Jendela</translation>
     </message>
@@ -755,68 +806,68 @@
         <translation>Vietnam</translation>
     </message>
     <message>
-        <location filename="../src/startmanager.cpp" line="971"/>
+        <location filename="../src/startmanager.cpp" line="1035"/>
         <source>File not saved</source>
         <translation>Berkas tidak disimpan</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1532"/>
-        <location filename="../src/widgets/window.cpp" line="1549"/>
+        <location filename="../src/widgets/window.cpp" line="1716"/>
+        <location filename="../src/widgets/window.cpp" line="1733"/>
         <source>Line Endings</source>
         <translation>Akhir Baris</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="243"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="379"/>
         <source>Please install &apos;UOS AI&apos; from the App Store before using</source>
         <translation>Silakan instal &apos;UOS AI&apos; dari App Store sebelum menggunakan</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="245"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="381"/>
         <source>No audio input device detected. Please check and try again</source>
         <translation>Tidak ada perangkat masukan audio terdeteksi. Silakan periksa dan coba lagi</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="247"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="383"/>
         <source>No audio output device detected. Please check and try again</source>
         <translation>Tidak ada perangkat keluaran audio terdeteksi. Silakan periksa dan coba lagi</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="69"/>
+        <location filename="../src/common/text_file_saver.cpp" line="74"/>
         <source>File path is empty</source>
         <translation>Jalur berkas kosong</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="155"/>
+        <location filename="../src/common/text_file_saver.cpp" line="153"/>
         <source>Insufficient memory to load document content</source>
         <translation>Memori tidak cukup untuk memuat konten dokumen</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="177"/>
+        <location filename="../src/common/text_file_saver.cpp" line="178"/>
         <source>Insufficient memory for encoding conversion</source>
         <translation>Memori tidak cukup untuk konversi encoding</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="183"/>
+        <location filename="../src/common/text_file_saver.cpp" line="184"/>
         <source>Encoding conversion failed</source>
         <translation>Konversi encoding gagal</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="189"/>
+        <location filename="../src/common/text_file_saver.cpp" line="190"/>
         <source>Converted content is empty</source>
         <translation>Konten yang telah dikonversi kosong</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="207"/>
+        <location filename="../src/common/text_file_saver.cpp" line="208"/>
         <source>Memory allocation failed</source>
         <translation>Pengalokasian memori gagal</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="211"/>
+        <location filename="../src/common/text_file_saver.cpp" line="212"/>
         <source>Error occurred: %1</source>
         <translation>Terjadi kesalahan: %1</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="215"/>
+        <location filename="../src/common/text_file_saver.cpp" line="216"/>
         <source>Unknown error occurred</source>
         <translation>Terjadi kesalahan yang tidak diketahui</translation>
     </message>
@@ -829,27 +880,27 @@
         <translation>Cari</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="34"/>
+        <location filename="../src/controls/replacebar.cpp" line="36"/>
         <source>Replace With</source>
         <translation>Ganti dengan</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="36"/>
+        <location filename="../src/controls/replacebar.cpp" line="40"/>
         <source>Replace</source>
         <translation>Ganti</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="37"/>
+        <location filename="../src/controls/replacebar.cpp" line="42"/>
         <source>Skip</source>
         <translation>Lewati</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="38"/>
+        <location filename="../src/controls/replacebar.cpp" line="44"/>
         <source>Replace Rest</source>
         <translation>Ganti sisanya</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="39"/>
+        <location filename="../src/controls/replacebar.cpp" line="46"/>
         <source>Replace All</source>
         <translation>Ganti semua</translation>
     </message>
@@ -858,9 +909,9 @@
     <name>S:</name>
     <message>
         <location filename="../third/libiconv-1.16/src/iconv.c" line="103"/>
-        <source/>
+        <source></source>
         <comment>The first line of the short usage message.</comment>
-        <translation type="unfinished"/>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -891,34 +942,34 @@
         <translation>Layarpenuh</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="484"/>
+        <location filename="../src/common/settings.cpp" line="491"/>
         <source>This shortcut conflicts with system shortcut %1</source>
         <translation>Pintasan ini bertentangan dengan pintasan sistem %1</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="487"/>
+        <location filename="../src/common/settings.cpp" line="494"/>
         <source>This shortcut conflicts with %1, click on Replace to make this shortcut effective immediately</source>
         <translation>Pintasan ini bertentangan dengan %1, klik Ganti untuk membuat pintasan ini efektif segera</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="682"/>
-        <location filename="../src/common/settings.cpp" line="695"/>
-        <location filename="../src/common/settings.cpp" line="704"/>
+        <location filename="../src/common/settings.cpp" line="689"/>
+        <location filename="../src/common/settings.cpp" line="702"/>
+        <location filename="../src/common/settings.cpp" line="711"/>
         <source>The shortcut %1 is invalid, please set another one.</source>
         <translation>Pintasan %1 tidak valid, silakan atur yang lainnya.</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="736"/>
+        <location filename="../src/common/settings.cpp" line="743"/>
         <source>Cancel</source>
         <translation>Batal</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="737"/>
+        <location filename="../src/common/settings.cpp" line="744"/>
         <source>Replace</source>
         <translation>Ganti</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="740"/>
+        <location filename="../src/common/settings.cpp" line="747"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
@@ -926,7 +977,7 @@
 <context>
     <name>StartManager</name>
     <message>
-        <location filename="../src/startmanager.cpp" line="411"/>
+        <location filename="../src/startmanager.cpp" line="425"/>
         <source>Untitled %1</source>
         <translation>Tanpa Judul %1</translation>
     </message>
@@ -934,32 +985,32 @@
 <context>
     <name>Tabbar</name>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="641"/>
+        <location filename="../src/controls/tabbar.cpp" line="678"/>
         <source>Close tab</source>
         <translation>Tutup tab</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="642"/>
+        <location filename="../src/controls/tabbar.cpp" line="680"/>
         <source>Close other tabs</source>
         <translation>Tutup tab lainnya</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="643"/>
+        <location filename="../src/controls/tabbar.cpp" line="682"/>
         <source>More options</source>
         <translation>Pilihan lainnya</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="644"/>
+        <location filename="../src/controls/tabbar.cpp" line="684"/>
         <source>Close tabs to the left</source>
         <translation>Tutup tab ke kiri</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="645"/>
+        <location filename="../src/controls/tabbar.cpp" line="686"/>
         <source>Close tabs to the right</source>
         <translation>Tutup tab ke kanan</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="646"/>
+        <location filename="../src/controls/tabbar.cpp" line="688"/>
         <source>Close unmodified tabs</source>
         <translation>Tutup tab yang tidak diubah</translation>
     </message>
@@ -967,263 +1018,280 @@
 <context>
     <name>TextEdit</name>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="305"/>
+        <location filename="../src/editor/dtextedit.cpp" line="388"/>
         <source>Undo</source>
         <translation>Sebelum</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="306"/>
+        <location filename="../src/editor/dtextedit.cpp" line="390"/>
         <source>Redo</source>
         <translation>Sesudah</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="307"/>
+        <location filename="../src/editor/dtextedit.cpp" line="392"/>
         <source>Cut</source>
         <translation>Potong</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="308"/>
+        <location filename="../src/editor/dtextedit.cpp" line="394"/>
         <source>Copy</source>
         <translation>Salin</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="309"/>
+        <location filename="../src/editor/dtextedit.cpp" line="396"/>
         <source>Paste</source>
         <translation>Tempel</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="310"/>
+        <location filename="../src/editor/dtextedit.cpp" line="398"/>
         <source>Delete</source>
         <translation>Hapus</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="311"/>
+        <location filename="../src/editor/dtextedit.cpp" line="400"/>
         <source>Select All</source>
         <translation>Pilih Semua</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="312"/>
-        <location filename="../src/widgets/window.cpp" line="535"/>
+        <location filename="../src/editor/dtextedit.cpp" line="402"/>
+        <location filename="../src/widgets/window.cpp" line="556"/>
         <source>Find</source>
         <translation>Cari</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="313"/>
-        <location filename="../src/widgets/window.cpp" line="536"/>
+        <location filename="../src/editor/dtextedit.cpp" line="404"/>
+        <location filename="../src/widgets/window.cpp" line="558"/>
         <source>Replace</source>
         <translation>Ganti</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="314"/>
+        <location filename="../src/editor/dtextedit.cpp" line="406"/>
         <source>Go to Line</source>
         <translation>Pergi ke baris</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="315"/>
-        <source>Turn on Read-Only mode</source>
-        <translation>Nyalakan mode Hanya-Baca</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="316"/>
-        <source>Turn off Read-Only mode</source>
-        <translation>Matikan mode Hanya-Baca</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="317"/>
+        <location filename="../src/editor/dtextedit.cpp" line="415"/>
         <source>Fullscreen</source>
         <translation>Layar Penuh</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="318"/>
+        <location filename="../src/editor/dtextedit.cpp" line="417"/>
         <source>Exit fullscreen</source>
         <translation>Keluar Layar Penuh</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="319"/>
+        <location filename="../src/editor/dtextedit.cpp" line="419"/>
         <source>Display in file manager</source>
         <translation>Tampilkan di manajer berkas</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="320"/>
-        <location filename="../src/editor/dtextedit.cpp" line="374"/>
+        <location filename="../src/editor/dtextedit.cpp" line="421"/>
+        <location filename="../src/editor/dtextedit.cpp" line="493"/>
         <source>Add Comment</source>
         <translation>Tambahkan Komentar</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="321"/>
+        <location filename="../src/editor/dtextedit.cpp" line="423"/>
         <source>Text to Speech</source>
         <translation>Teks ke Suara</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="322"/>
-        <source>Stop reading</source>
-        <translation>Berhenti membaca</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="323"/>
+        <location filename="../src/editor/dtextedit.cpp" line="425"/>
         <source>Speech to Text</source>
         <translation>Suara ke Teks</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="324"/>
+        <location filename="../src/editor/dtextedit.cpp" line="427"/>
         <source>Translate</source>
         <translation>Terjemahkan</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="325"/>
+        <location filename="../src/editor/dtextedit.cpp" line="429"/>
         <source>Column Mode</source>
         <translation>Mode Kolom</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="326"/>
+        <location filename="../src/editor/dtextedit.cpp" line="431"/>
         <source>Add bookmark</source>
         <translation>Tambahkan markah</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="327"/>
+        <location filename="../src/editor/dtextedit.cpp" line="433"/>
         <source>Remove Bookmark</source>
         <translation>Hapus Markah</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="328"/>
+        <location filename="../src/editor/dtextedit.cpp" line="435"/>
         <source>Previous bookmark</source>
         <translation>Markah sebelumnya</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="329"/>
+        <location filename="../src/editor/dtextedit.cpp" line="437"/>
         <source>Next bookmark</source>
         <translation>Markah selanjutnya</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="330"/>
+        <location filename="../src/editor/dtextedit.cpp" line="439"/>
         <source>Remove All Bookmarks</source>
         <translation>Hapus Semua Markah</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="331"/>
+        <location filename="../src/editor/dtextedit.cpp" line="441"/>
         <source>Fold All</source>
         <translation>Gulung Semua</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="332"/>
+        <location filename="../src/editor/dtextedit.cpp" line="443"/>
         <source>Fold Current Level</source>
         <translation>Gulung Level Saat Ini</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="333"/>
+        <location filename="../src/editor/dtextedit.cpp" line="445"/>
         <source>Unfold All</source>
         <translation>Buka Semua</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="334"/>
+        <location filename="../src/editor/dtextedit.cpp" line="447"/>
         <source>Unfold Current Level</source>
         <translation>Buka Level Saat Ini</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="339"/>
+        <location filename="../src/editor/dtextedit.cpp" line="453"/>
         <source>Color Mark</source>
         <translation>Warna Markah</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="343"/>
+        <location filename="../src/editor/dtextedit.cpp" line="458"/>
         <source>Clear All Marks</source>
         <translation>Bersihkan Semua Markah</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="344"/>
+        <location filename="../src/editor/dtextedit.cpp" line="460"/>
         <source>Clear Last Mark</source>
         <translation>Bersihkan Markah Terakhir</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="353"/>
+        <location filename="../src/editor/dtextedit.cpp" line="470"/>
         <source>Mark</source>
         <translation>Tandai</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="366"/>
+        <location filename="../src/editor/dtextedit.cpp" line="484"/>
         <source>Mark All</source>
         <translation>Tandai Semua</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="375"/>
+        <location filename="../src/editor/dtextedit.cpp" line="494"/>
         <source>Remove Comment</source>
         <translation>Hapus Komentar</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3208"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3211"/>
+        <location filename="../src/editor/dtextedit.cpp" line="543"/>
+        <source>View Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="3531"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3534"/>
         <source>Copy failed: not enough memory</source>
         <translation>Salin gagal: tidak cukup memori</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3333"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3335"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3656"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3658"/>
         <source>Press ALT and click lines to edit in column mode</source>
         <translation>Tekan ALT dan klik baris untuk mengedit dalam mode kolom</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="418"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9574"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9576"/>
+        <source>No audio output device was detected. Please ensure your speakers or headphones are properly connected and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="9583"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9585"/>
+        <source>No audio input device was detected. Please ensure your speakers or headphones are properly connected and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="534"/>
         <source>Change Case</source>
         <translation>Ganti Huruf</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="419"/>
+        <location filename="../src/editor/dtextedit.cpp" line="409"/>
+        <source>Edit Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="411"/>
+        <source>Read View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="413"/>
+        <source>Live Preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="535"/>
         <source>Upper Case</source>
         <translation>Huruf Besar</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="420"/>
+        <location filename="../src/editor/dtextedit.cpp" line="536"/>
         <source>Lower Case</source>
         <translation>Huruf Kecil</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="421"/>
+        <location filename="../src/editor/dtextedit.cpp" line="537"/>
         <source>Capitalize</source>
         <translation>Kapital</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="78"/>
+        <location filename="../src/widgets/bottombar.cpp" line="110"/>
         <source>None</source>
         <translation>Tidak ada</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1363"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1490"/>
         <source>Selected line(s) copied</source>
         <translation>Baris yang dipilih disalin</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1370"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1497"/>
         <source>Current line copied</source>
         <translation>Baris saat ini disalin</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1400"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1527"/>
         <source>Selected line(s) clipped</source>
         <translation>Baris yang dipilih dipotong</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1412"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1539"/>
         <source>Current line clipped</source>
         <translation>Baris saat ini dipotong</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3227"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3230"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3550"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3553"/>
         <source>Paste failed: not enough memory</source>
         <translation>Tempel gagal: tidak cukup memori</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="4548"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4873"/>
         <source>Read-Only mode is off</source>
         <translation>Mode Hanya-Baca sudah dimatikan</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="4560"/>
-        <location filename="../src/editor/dtextedit.cpp" line="4584"/>
-        <location filename="../src/editor/dtextedit.cpp" line="7896"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8007"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8015"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8026"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4885"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4909"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8236"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8347"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8355"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8366"/>
         <source>Read-Only mode is on</source>
         <translation>Mode Hanya-Baca sudah dinyalakan</translation>
     </message>
@@ -1231,138 +1299,175 @@
 <context>
     <name>WarningNotices</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="24"/>
+        <location filename="../src/controls/warningnotices.cpp" line="25"/>
         <source>Reload</source>
         <translation>Muat Ulang</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/warningnotices.cpp" line="29"/>
+        <source>Edit Anyway</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>Window</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="25"/>
-        <location filename="../src/widgets/window.cpp" line="531"/>
+        <location filename="../src/controls/warningnotices.cpp" line="27"/>
+        <location filename="../src/widgets/window.cpp" line="548"/>
         <source>Save as</source>
         <translation>Simpan bagai</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="527"/>
+        <location filename="../src/widgets/window.cpp" line="540"/>
         <source>New window</source>
         <translation>Jendela baru</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="528"/>
+        <location filename="../src/widgets/window.cpp" line="542"/>
         <source>New tab</source>
         <translation>Tab baru</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="529"/>
+        <location filename="../src/widgets/window.cpp" line="544"/>
         <source>Open file</source>
         <translation>Buka berkas</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="530"/>
-        <location filename="../src/widgets/window.cpp" line="3545"/>
+        <location filename="../src/widgets/window.cpp" line="546"/>
+        <location filename="../src/widgets/window.cpp" line="3950"/>
         <source>Save</source>
         <translation>Simpan</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="532"/>
+        <location filename="../src/widgets/window.cpp" line="550"/>
         <source>Print</source>
         <translation>Cetak</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="533"/>
+        <location filename="../src/widgets/window.cpp" line="552"/>
         <source>Switch theme</source>
         <translation>Beralih tema</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="534"/>
-        <location filename="../src/widgets/window.cpp" line="2448"/>
+        <location filename="../src/widgets/window.cpp" line="554"/>
+        <location filename="../src/widgets/window.cpp" line="2641"/>
         <source>Settings</source>
         <translation>Pengaturan</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="666"/>
-        <location filename="../src/widgets/window.cpp" line="3845"/>
+        <location filename="../src/widgets/window.cpp" line="696"/>
+        <location filename="../src/widgets/window.cpp" line="4250"/>
         <source>Read-Only</source>
         <translation>Hanya-Baca</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="687"/>
+        <location filename="../src/widgets/window.cpp" line="719"/>
         <source>You do not have permission to open %1</source>
         <translation>Anda tidak mempunyai ijin untuk buka %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="738"/>
-        <location filename="../src/widgets/window.cpp" line="2963"/>
+        <location filename="../src/widgets/window.cpp" line="773"/>
+        <location filename="../src/widgets/window.cpp" line="3266"/>
         <source>Invalid file: %1</source>
         <translation>Berkas tidak valid: %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="903"/>
-        <location filename="../src/widgets/window.cpp" line="956"/>
+        <location filename="../src/widgets/window.cpp" line="957"/>
+        <location filename="../src/widgets/window.cpp" line="1050"/>
+        <location filename="../src/widgets/window.cpp" line="3217"/>
         <source>Do you want to save this file?</source>
         <translation>Apakah anda ingin menyimpan berkas ini?</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1290"/>
+        <location filename="../src/widgets/window.cpp" line="1381"/>
+        <source>Invalid characters detected while saving &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1382"/>
+        <source>If you force save this file, it may cause file corruption. Still want to save?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1386"/>
+        <source>Don&apos;t Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1387"/>
+        <source>Save As</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1388"/>
+        <source>Save Anyway</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1456"/>
         <source>You do not have permission to save %1</source>
         <translation>Anda tidak mempunyai ijin untuk simpan %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1312"/>
+        <location filename="../src/widgets/window.cpp" line="1428"/>
+        <location filename="../src/widgets/window.cpp" line="1478"/>
         <source>Saved successfully</source>
         <translation>Berhasil disimpan</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1354"/>
-        <location filename="../src/widgets/window.cpp" line="1481"/>
-        <location filename="../src/widgets/window.cpp" line="1529"/>
+        <location filename="../src/widgets/window.cpp" line="1520"/>
+        <location filename="../src/widgets/window.cpp" line="1665"/>
+        <location filename="../src/widgets/window.cpp" line="1713"/>
         <source>Save File</source>
         <translation>Simpan Berkas</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1483"/>
+        <location filename="../src/widgets/window.cpp" line="1569"/>
+        <source>Cannot save as the original file in preview mode. Please choose a different path.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1667"/>
         <source>Encoding</source>
         <translation>Mengencode</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1773"/>
+        <location filename="../src/widgets/window.cpp" line="1957"/>
         <source>Read-Only mode is on</source>
         <translation>Mode Hanya-Baca sudah dinyalakan</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2322"/>
+        <location filename="../src/widgets/window.cpp" line="2511"/>
         <source>Current location remembered</source>
         <translation>Lokasi saat ini diingat</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2398"/>
+        <location filename="../src/widgets/window.cpp" line="2591"/>
         <source>Ctrl+&apos;=&apos;</source>
         <translation>Ctrl+&apos;=&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2401"/>
+        <location filename="../src/widgets/window.cpp" line="2594"/>
         <source>Ctrl+&apos;-&apos;</source>
         <translation>Ctrl+&apos;-&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2430"/>
+        <location filename="../src/widgets/window.cpp" line="2623"/>
         <source>Editor</source>
         <translation>Penyunting</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3061"/>
+        <location filename="../src/widgets/window.cpp" line="3436"/>
         <source>Untitled %1</source>
         <translation>Tanpa Judul %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3543"/>
+        <location filename="../src/widgets/window.cpp" line="3948"/>
         <source>Cancel</source>
         <translation>Batal</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3544"/>
+        <location filename="../src/widgets/window.cpp" line="3949"/>
         <source>Discard</source>
         <translation>Membuang</translation>
     </message>

--- a/translations/deepin-editor_it.ts
+++ b/translations/deepin-editor_it.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="it">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="it">
 <context>
     <name>BottomBar</name>
     <message>
@@ -17,17 +19,36 @@
         <translation>Caratteri %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="44"/>
+        <location filename="../src/widgets/bottombar.cpp" line="47"/>
         <source>Loading:</source>
         <translation>Caricamento:</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="73"/>
+        <location filename="../src/widgets/bottombar.cpp" line="91"/>
+        <location filename="../src/widgets/bottombar.cpp" line="499"/>
+        <source>Edit Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="74"/>
+        <location filename="../src/widgets/bottombar.cpp" line="489"/>
+        <source>Read View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="75"/>
+        <location filename="../src/widgets/bottombar.cpp" line="493"/>
+        <source>Live Preview</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DDropdownMenu</name>
     <message>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="362"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="420"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="425"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="363"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="421"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="426"/>
         <source>None</source>
         <translation>No</translation>
     </message>
@@ -35,69 +56,58 @@
 <context>
     <name>EditWrapper</name>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="292"/>
-        <location filename="../src/editor/editwrapper.cpp" line="365"/>
-        <location filename="../src/editor/editwrapper.cpp" line="521"/>
-        <location filename="../src/editor/editwrapper.cpp" line="751"/>
+        <location filename="../src/editor/editwrapper.cpp" line="355"/>
+        <location filename="../src/editor/editwrapper.cpp" line="429"/>
+        <location filename="../src/editor/editwrapper.cpp" line="595"/>
+        <location filename="../src/editor/editwrapper.cpp" line="887"/>
         <source>Save</source>
         <translation>Salva</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="516"/>
+        <location filename="../src/editor/editwrapper.cpp" line="590"/>
         <source>Do you want to save this file?</source>
         <translation>Desideri salvare questo file?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="363"/>
-        <location filename="../src/editor/editwrapper.cpp" line="519"/>
+        <location filename="../src/editor/editwrapper.cpp" line="427"/>
+        <location filename="../src/editor/editwrapper.cpp" line="593"/>
         <source>Cancel</source>
         <translation>Annulla</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="360"/>
+        <location filename="../src/editor/editwrapper.cpp" line="424"/>
         <source>Encoding changed. Do you want to save the file now?</source>
-        <translation> 
+        <translation>&#xa0;
 La codifica è cambiata. Vuoi salvare il file ora?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="520"/>
+        <location filename="../src/editor/editwrapper.cpp" line="594"/>
         <source>Discard</source>
         <translation>Scarta</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="274"/>
-        <location filename="../src/editor/editwrapper.cpp" line="620"/>
+        <location filename="../src/editor/editwrapper.cpp" line="1121"/>
+        <source>The file contains invalid characters (NUL). Preview mode is read-only.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="337"/>
+        <location filename="../src/editor/editwrapper.cpp" line="705"/>
         <source>You do not have permission to save %1</source>
         <translation>Non hai i permessi per salvare %1</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="836"/>
+        <location filename="../src/editor/editwrapper.cpp" line="987"/>
         <source>File removed on the disk. Save it now?</source>
         <translation>File rimosso dal disco, salvarlo ora?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="842"/>
+        <location filename="../src/editor/editwrapper.cpp" line="993"/>
         <source>File has changed on disk. Reload?</source>
         <translation>File modificato sul Disco, ricaricarlo?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="884"/>
-        <location filename="../src/widgets/bottombar.cpp" line="74"/>
-        <source>INSERT</source>
-        <translation>INSERT</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="888"/>
-        <source>OVERWRITE</source>
-        <translation>OVERWRITE</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="892"/>
-        <source>R/O</source>
-        <translation>R/O</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="1618"/>
+        <location filename="../src/editor/editwrapper.cpp" line="1806"/>
         <source>The file cannot be read, which may be too large or has been damaged!</source>
         <translation>Il file non può essere letto, potrebbe essere troppo grande o danneggiato!</translation>
     </message>
@@ -110,17 +120,17 @@ La codifica è cambiata. Vuoi salvare il file ora?</translation>
         <translation>Trova</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="36"/>
+        <location filename="../src/controls/findbar.cpp" line="38"/>
         <source>Previous</source>
         <translation>Precedente</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="37"/>
+        <location filename="../src/controls/findbar.cpp" line="40"/>
         <source>Next</source>
         <translation>Prossima</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="38"/>
+        <location filename="../src/controls/findbar.cpp" line="42"/>
         <source>Replace</source>
         <translation>Sostituisci</translation>
     </message>
@@ -128,9 +138,17 @@ La codifica è cambiata. Vuoi salvare il file ora?</translation>
 <context>
     <name>JumpLineBar</name>
     <message>
-        <location filename="../src/controls/jumplinebar.cpp" line="45"/>
+        <location filename="../src/controls/jumplinebar.cpp" line="46"/>
         <source>Go to Line: </source>
         <translation>Vai alla linea: </translation>
+    </message>
+</context>
+<context>
+    <name>LineBar</name>
+    <message>
+        <location filename="../src/controls/linebar.cpp" line="144"/>
+        <source>第%1/%2项</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -148,19 +166,47 @@ Localizzazione italiana a cura di Massimo A. Carofano.</translation>
     </message>
 </context>
 <context>
+    <name>MarkdownBridge</name>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="37"/>
+        <source>Collapse code block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="38"/>
+        <source>Expand code block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="39"/>
+        <source>Copy code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="40"/>
+        <source>Expand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="42"/>
+        <source>%1 line(s) of code collapsed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PathSettingWgt</name>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="84"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="90"/>
         <source>Remember the last used path</source>
         <translation>Ricorda l&apos;ultimo percorso usato</translation>
     </message>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="85"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="91"/>
         <source>Same path as the current file</source>
         <translation>Stesso percorso del file corrente</translation>
     </message>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="86"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="92"/>
         <source>Customize the default path</source>
         <translation>Personalizza il percorso predefinito</translation>
     </message>
@@ -173,15 +219,20 @@ Localizzazione italiana a cura di Massimo A. Carofano.</translation>
         <translation>Editor di Testo</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="294"/>
-        <location filename="../src/editor/editwrapper.cpp" line="761"/>
-        <location filename="../src/editor/editwrapper.cpp" line="776"/>
-        <location filename="../src/widgets/window.cpp" line="1362"/>
-        <location filename="../src/widgets/window.cpp" line="1390"/>
-        <location filename="../src/widgets/window.cpp" line="1531"/>
-        <location filename="../src/widgets/window.cpp" line="1548"/>
+        <location filename="../src/editor/editwrapper.cpp" line="357"/>
+        <location filename="../src/editor/editwrapper.cpp" line="897"/>
+        <location filename="../src/editor/editwrapper.cpp" line="912"/>
+        <location filename="../src/widgets/window.cpp" line="1528"/>
+        <location filename="../src/widgets/window.cpp" line="1556"/>
+        <location filename="../src/widgets/window.cpp" line="1715"/>
+        <location filename="../src/widgets/window.cpp" line="1732"/>
         <source>Encoding</source>
         <translation>Codifica</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="2001"/>
+        <source>视图模式</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="11"/>
@@ -217,7 +268,7 @@ Localizzazione italiana a cura di Massimo A. Carofano.</translation>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="18"/>
         <location filename="../src/controls/settingsdialog.cpp" line="96"/>
-        <location filename="../src/widgets/window.cpp" line="2388"/>
+        <location filename="../src/widgets/window.cpp" line="2581"/>
         <source>Window</source>
         <translation>Finestra</translation>
     </message>
@@ -757,68 +808,68 @@ Localizzazione italiana a cura di Massimo A. Carofano.</translation>
         <translation>Vietnamese</translation>
     </message>
     <message>
-        <location filename="../src/startmanager.cpp" line="971"/>
+        <location filename="../src/startmanager.cpp" line="1035"/>
         <source>File not saved</source>
         <translation>File non salvato</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1532"/>
-        <location filename="../src/widgets/window.cpp" line="1549"/>
+        <location filename="../src/widgets/window.cpp" line="1716"/>
+        <location filename="../src/widgets/window.cpp" line="1733"/>
         <source>Line Endings</source>
         <translation>Fine delle righe</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="243"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="379"/>
         <source>Please install &apos;UOS AI&apos; from the App Store before using</source>
         <translation>Installa &apos;UOS AI&apos; dall&apos;App Store prima di usarlo</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="245"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="381"/>
         <source>No audio input device detected. Please check and try again</source>
         <translation>Nessun dispositivo di input audio rilevato. Controlla e prova di nuovo</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="247"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="383"/>
         <source>No audio output device detected. Please check and try again</source>
         <translation>Nessun dispositivo di output audio rilevato. Controlla e prova di nuovo</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="69"/>
+        <location filename="../src/common/text_file_saver.cpp" line="74"/>
         <source>File path is empty</source>
         <translation>Il percorso del file è vuoto</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="155"/>
+        <location filename="../src/common/text_file_saver.cpp" line="153"/>
         <source>Insufficient memory to load document content</source>
         <translation>Memoria insufficiente per caricare il contenuto del documento</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="177"/>
+        <location filename="../src/common/text_file_saver.cpp" line="178"/>
         <source>Insufficient memory for encoding conversion</source>
         <translation>Memoria insufficiente per la conversione di codifica</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="183"/>
+        <location filename="../src/common/text_file_saver.cpp" line="184"/>
         <source>Encoding conversion failed</source>
         <translation>Conversione di codifica fallita</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="189"/>
+        <location filename="../src/common/text_file_saver.cpp" line="190"/>
         <source>Converted content is empty</source>
         <translation>Il contenuto convertito è vuoto</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="207"/>
+        <location filename="../src/common/text_file_saver.cpp" line="208"/>
         <source>Memory allocation failed</source>
         <translation>Allocazione della memoria fallita</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="211"/>
+        <location filename="../src/common/text_file_saver.cpp" line="212"/>
         <source>Error occurred: %1</source>
         <translation>Si è verificato un errore: %1</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="215"/>
+        <location filename="../src/common/text_file_saver.cpp" line="216"/>
         <source>Unknown error occurred</source>
         <translation>Si è verificato un errore sconosciuto</translation>
     </message>
@@ -831,27 +882,27 @@ Localizzazione italiana a cura di Massimo A. Carofano.</translation>
         <translation>Trova</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="34"/>
+        <location filename="../src/controls/replacebar.cpp" line="36"/>
         <source>Replace With</source>
         <translation>Sostituisci con</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="36"/>
+        <location filename="../src/controls/replacebar.cpp" line="40"/>
         <source>Replace</source>
         <translation>Sostituisci</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="37"/>
+        <location filename="../src/controls/replacebar.cpp" line="42"/>
         <source>Skip</source>
         <translation>Salta</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="38"/>
+        <location filename="../src/controls/replacebar.cpp" line="44"/>
         <source>Replace Rest</source>
         <translation>Sostituisci il resto</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="39"/>
+        <location filename="../src/controls/replacebar.cpp" line="46"/>
         <source>Replace All</source>
         <translation>Sostituisci tutto</translation>
     </message>
@@ -860,9 +911,9 @@ Localizzazione italiana a cura di Massimo A. Carofano.</translation>
     <name>S:</name>
     <message>
         <location filename="../third/libiconv-1.16/src/iconv.c" line="103"/>
-        <source/>
+        <source></source>
         <comment>The first line of the short usage message.</comment>
-        <translation type="unfinished"/>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -893,34 +944,34 @@ Localizzazione italiana a cura di Massimo A. Carofano.</translation>
         <translation>Pieno schermo</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="484"/>
+        <location filename="../src/common/settings.cpp" line="491"/>
         <source>This shortcut conflicts with system shortcut %1</source>
         <translation>Questa scorciatoia è in conflitto con la scorciatoia di sistema %1</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="487"/>
+        <location filename="../src/common/settings.cpp" line="494"/>
         <source>This shortcut conflicts with %1, click on Replace to make this shortcut effective immediately</source>
         <translation>Questa scorciatoia è in conflitto con %1, clicca su Sostituisci per rendere questa come effettiva</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="682"/>
-        <location filename="../src/common/settings.cpp" line="695"/>
-        <location filename="../src/common/settings.cpp" line="704"/>
+        <location filename="../src/common/settings.cpp" line="689"/>
+        <location filename="../src/common/settings.cpp" line="702"/>
+        <location filename="../src/common/settings.cpp" line="711"/>
         <source>The shortcut %1 is invalid, please set another one.</source>
         <translation>La scorciatoia %1 non è valida, inseriscine una nuova.</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="736"/>
+        <location filename="../src/common/settings.cpp" line="743"/>
         <source>Cancel</source>
         <translation>Annulla</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="737"/>
+        <location filename="../src/common/settings.cpp" line="744"/>
         <source>Replace</source>
         <translation>Sostituisci</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="740"/>
+        <location filename="../src/common/settings.cpp" line="747"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
@@ -928,7 +979,7 @@ Localizzazione italiana a cura di Massimo A. Carofano.</translation>
 <context>
     <name>StartManager</name>
     <message>
-        <location filename="../src/startmanager.cpp" line="411"/>
+        <location filename="../src/startmanager.cpp" line="425"/>
         <source>Untitled %1</source>
         <translation>%1 senza titolo</translation>
     </message>
@@ -936,32 +987,32 @@ Localizzazione italiana a cura di Massimo A. Carofano.</translation>
 <context>
     <name>Tabbar</name>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="641"/>
+        <location filename="../src/controls/tabbar.cpp" line="678"/>
         <source>Close tab</source>
         <translation>Chiudi scheda</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="642"/>
+        <location filename="../src/controls/tabbar.cpp" line="680"/>
         <source>Close other tabs</source>
         <translation>Chiudi le altre schede</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="643"/>
+        <location filename="../src/controls/tabbar.cpp" line="682"/>
         <source>More options</source>
         <translation>Ulteriori opzioni</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="644"/>
+        <location filename="../src/controls/tabbar.cpp" line="684"/>
         <source>Close tabs to the left</source>
         <translation>Chiudi le schede sulla sinistra</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="645"/>
+        <location filename="../src/controls/tabbar.cpp" line="686"/>
         <source>Close tabs to the right</source>
         <translation>Chiudi le schede sulla destra</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="646"/>
+        <location filename="../src/controls/tabbar.cpp" line="688"/>
         <source>Close unmodified tabs</source>
         <translation>Chiudi schede non modificate</translation>
     </message>
@@ -969,263 +1020,280 @@ Localizzazione italiana a cura di Massimo A. Carofano.</translation>
 <context>
     <name>TextEdit</name>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="305"/>
+        <location filename="../src/editor/dtextedit.cpp" line="388"/>
         <source>Undo</source>
         <translation>Annulla</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="306"/>
+        <location filename="../src/editor/dtextedit.cpp" line="390"/>
         <source>Redo</source>
         <translation>Ripeti</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="307"/>
+        <location filename="../src/editor/dtextedit.cpp" line="392"/>
         <source>Cut</source>
         <translation>Taglia</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="308"/>
+        <location filename="../src/editor/dtextedit.cpp" line="394"/>
         <source>Copy</source>
         <translation>Copia</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="309"/>
+        <location filename="../src/editor/dtextedit.cpp" line="396"/>
         <source>Paste</source>
         <translation>Incolla</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="310"/>
+        <location filename="../src/editor/dtextedit.cpp" line="398"/>
         <source>Delete</source>
         <translation>Elimina</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="311"/>
+        <location filename="../src/editor/dtextedit.cpp" line="400"/>
         <source>Select All</source>
         <translation>Seleziona tutto</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="312"/>
-        <location filename="../src/widgets/window.cpp" line="535"/>
+        <location filename="../src/editor/dtextedit.cpp" line="402"/>
+        <location filename="../src/widgets/window.cpp" line="556"/>
         <source>Find</source>
         <translation>Trova</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="313"/>
-        <location filename="../src/widgets/window.cpp" line="536"/>
+        <location filename="../src/editor/dtextedit.cpp" line="404"/>
+        <location filename="../src/widgets/window.cpp" line="558"/>
         <source>Replace</source>
         <translation>Sostituisci</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="314"/>
+        <location filename="../src/editor/dtextedit.cpp" line="406"/>
         <source>Go to Line</source>
         <translation>Vai alla linea</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="315"/>
-        <source>Turn on Read-Only mode</source>
-        <translation>Attiva la modalità Sola Lettura</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="316"/>
-        <source>Turn off Read-Only mode</source>
-        <translation>Disattiva la modalità Sola Lettura</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="317"/>
+        <location filename="../src/editor/dtextedit.cpp" line="415"/>
         <source>Fullscreen</source>
         <translation>Schermo intero</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="318"/>
+        <location filename="../src/editor/dtextedit.cpp" line="417"/>
         <source>Exit fullscreen</source>
         <translation>Esci dallo schermo intero</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="319"/>
+        <location filename="../src/editor/dtextedit.cpp" line="419"/>
         <source>Display in file manager</source>
         <translation>Visualizza nel gestore file</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="320"/>
-        <location filename="../src/editor/dtextedit.cpp" line="374"/>
+        <location filename="../src/editor/dtextedit.cpp" line="421"/>
+        <location filename="../src/editor/dtextedit.cpp" line="493"/>
         <source>Add Comment</source>
         <translation>Aggiungi commento</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="321"/>
+        <location filename="../src/editor/dtextedit.cpp" line="423"/>
         <source>Text to Speech</source>
         <translation>Da testo a voce</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="322"/>
-        <source>Stop reading</source>
-        <translation>Interrompi lettura</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="323"/>
+        <location filename="../src/editor/dtextedit.cpp" line="425"/>
         <source>Speech to Text</source>
         <translation>Da voce a testo</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="324"/>
+        <location filename="../src/editor/dtextedit.cpp" line="427"/>
         <source>Translate</source>
         <translation>Traduci</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="325"/>
+        <location filename="../src/editor/dtextedit.cpp" line="429"/>
         <source>Column Mode</source>
         <translation>Modlità colonna</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="326"/>
+        <location filename="../src/editor/dtextedit.cpp" line="431"/>
         <source>Add bookmark</source>
         <translation>Aggiungi segnalibro</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="327"/>
+        <location filename="../src/editor/dtextedit.cpp" line="433"/>
         <source>Remove Bookmark</source>
         <translation>Rimuovi segnalibro</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="328"/>
+        <location filename="../src/editor/dtextedit.cpp" line="435"/>
         <source>Previous bookmark</source>
         <translation>Segnalibro precedente</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="329"/>
+        <location filename="../src/editor/dtextedit.cpp" line="437"/>
         <source>Next bookmark</source>
         <translation>Prossimo segnalibro</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="330"/>
+        <location filename="../src/editor/dtextedit.cpp" line="439"/>
         <source>Remove All Bookmarks</source>
         <translation>Rimuovi tutti i segnalibri</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="331"/>
+        <location filename="../src/editor/dtextedit.cpp" line="441"/>
         <source>Fold All</source>
         <translation>Collassa tutti i livelli</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="332"/>
+        <location filename="../src/editor/dtextedit.cpp" line="443"/>
         <source>Fold Current Level</source>
         <translation>Collassa l&apos;attuale livello</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="333"/>
+        <location filename="../src/editor/dtextedit.cpp" line="445"/>
         <source>Unfold All</source>
         <translation>Espandi tutti i livelli</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="334"/>
+        <location filename="../src/editor/dtextedit.cpp" line="447"/>
         <source>Unfold Current Level</source>
         <translation>Espandi il livello corrente</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="339"/>
+        <location filename="../src/editor/dtextedit.cpp" line="453"/>
         <source>Color Mark</source>
         <translation>Colori come marcatori</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="343"/>
+        <location filename="../src/editor/dtextedit.cpp" line="458"/>
         <source>Clear All Marks</source>
         <translation>Rimuovi le evidenziazioni</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="344"/>
+        <location filename="../src/editor/dtextedit.cpp" line="460"/>
         <source>Clear Last Mark</source>
         <translation>Rimuovi ultima evidenziazione</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="353"/>
+        <location filename="../src/editor/dtextedit.cpp" line="470"/>
         <source>Mark</source>
         <translation>Evidenzia</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="366"/>
+        <location filename="../src/editor/dtextedit.cpp" line="484"/>
         <source>Mark All</source>
         <translation>Evidenzia tutto</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="375"/>
+        <location filename="../src/editor/dtextedit.cpp" line="494"/>
         <source>Remove Comment</source>
         <translation>Rimuovi commenti</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3208"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3211"/>
+        <location filename="../src/editor/dtextedit.cpp" line="543"/>
+        <source>View Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="3531"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3534"/>
         <source>Copy failed: not enough memory</source>
         <translation>Copia fallita: memoria non sufficiente</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3333"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3335"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3656"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3658"/>
         <source>Press ALT and click lines to edit in column mode</source>
         <translation>Premi ALT e clicca sulle linee per editare in modalità colonna</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="418"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9574"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9576"/>
+        <source>No audio output device was detected. Please ensure your speakers or headphones are properly connected and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="9583"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9585"/>
+        <source>No audio input device was detected. Please ensure your speakers or headphones are properly connected and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="534"/>
         <source>Change Case</source>
         <translation>Cambia maiuscole</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="419"/>
+        <location filename="../src/editor/dtextedit.cpp" line="409"/>
+        <source>Edit Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="411"/>
+        <source>Read View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="413"/>
+        <source>Live Preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="535"/>
         <source>Upper Case</source>
         <translation>Maiuscolo</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="420"/>
+        <location filename="../src/editor/dtextedit.cpp" line="536"/>
         <source>Lower Case</source>
         <translation>Minuscolo</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="421"/>
+        <location filename="../src/editor/dtextedit.cpp" line="537"/>
         <source>Capitalize</source>
         <translation>Maiuscola iniziale</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="78"/>
+        <location filename="../src/widgets/bottombar.cpp" line="110"/>
         <source>None</source>
         <translation>No</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1363"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1490"/>
         <source>Selected line(s) copied</source>
         <translation>Linea(e) selezionate copiate</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1370"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1497"/>
         <source>Current line copied</source>
         <translation>Linea corrente copiata</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1400"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1527"/>
         <source>Selected line(s) clipped</source>
         <translation>Linea(e) selezionate copiate negli appunti</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1412"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1539"/>
         <source>Current line clipped</source>
         <translation>Linea corrente copiata negli appunti</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3227"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3230"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3550"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3553"/>
         <source>Paste failed: not enough memory</source>
         <translation>Copia fallita: memoria non sufficiente</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="4548"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4873"/>
         <source>Read-Only mode is off</source>
         <translation>La modalità sola lettura è disattivata</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="4560"/>
-        <location filename="../src/editor/dtextedit.cpp" line="4584"/>
-        <location filename="../src/editor/dtextedit.cpp" line="7896"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8007"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8015"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8026"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4885"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4909"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8236"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8347"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8355"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8366"/>
         <source>Read-Only mode is on</source>
         <translation>La modalità sola lettura è attiva</translation>
     </message>
@@ -1233,138 +1301,175 @@ Localizzazione italiana a cura di Massimo A. Carofano.</translation>
 <context>
     <name>WarningNotices</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="24"/>
+        <location filename="../src/controls/warningnotices.cpp" line="25"/>
         <source>Reload</source>
         <translation>Ricarica</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/warningnotices.cpp" line="29"/>
+        <source>Edit Anyway</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>Window</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="25"/>
-        <location filename="../src/widgets/window.cpp" line="531"/>
+        <location filename="../src/controls/warningnotices.cpp" line="27"/>
+        <location filename="../src/widgets/window.cpp" line="548"/>
         <source>Save as</source>
         <translation>Salva con nome</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="527"/>
+        <location filename="../src/widgets/window.cpp" line="540"/>
         <source>New window</source>
         <translation>Nuova finestra</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="528"/>
+        <location filename="../src/widgets/window.cpp" line="542"/>
         <source>New tab</source>
         <translation>Nuova scheda</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="529"/>
+        <location filename="../src/widgets/window.cpp" line="544"/>
         <source>Open file</source>
         <translation>Apri file</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="530"/>
-        <location filename="../src/widgets/window.cpp" line="3545"/>
+        <location filename="../src/widgets/window.cpp" line="546"/>
+        <location filename="../src/widgets/window.cpp" line="3950"/>
         <source>Save</source>
         <translation>Salva</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="532"/>
+        <location filename="../src/widgets/window.cpp" line="550"/>
         <source>Print</source>
         <translation>Stampa</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="533"/>
+        <location filename="../src/widgets/window.cpp" line="552"/>
         <source>Switch theme</source>
         <translation>Cambia tema</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="534"/>
-        <location filename="../src/widgets/window.cpp" line="2448"/>
+        <location filename="../src/widgets/window.cpp" line="554"/>
+        <location filename="../src/widgets/window.cpp" line="2641"/>
         <source>Settings</source>
         <translation>Impostazioni</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="666"/>
-        <location filename="../src/widgets/window.cpp" line="3845"/>
+        <location filename="../src/widgets/window.cpp" line="696"/>
+        <location filename="../src/widgets/window.cpp" line="4250"/>
         <source>Read-Only</source>
         <translation>Sola lettura</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="687"/>
+        <location filename="../src/widgets/window.cpp" line="719"/>
         <source>You do not have permission to open %1</source>
         <translation>Non hai i permessi per aprire %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="738"/>
-        <location filename="../src/widgets/window.cpp" line="2963"/>
+        <location filename="../src/widgets/window.cpp" line="773"/>
+        <location filename="../src/widgets/window.cpp" line="3266"/>
         <source>Invalid file: %1</source>
         <translation>File non valido: %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="903"/>
-        <location filename="../src/widgets/window.cpp" line="956"/>
+        <location filename="../src/widgets/window.cpp" line="957"/>
+        <location filename="../src/widgets/window.cpp" line="1050"/>
+        <location filename="../src/widgets/window.cpp" line="3217"/>
         <source>Do you want to save this file?</source>
         <translation>Desideri salvare questo file?</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1290"/>
+        <location filename="../src/widgets/window.cpp" line="1381"/>
+        <source>Invalid characters detected while saving &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1382"/>
+        <source>If you force save this file, it may cause file corruption. Still want to save?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1386"/>
+        <source>Don&apos;t Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1387"/>
+        <source>Save As</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1388"/>
+        <source>Save Anyway</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1456"/>
         <source>You do not have permission to save %1</source>
         <translation>Non hai i permessi per salvare %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1312"/>
+        <location filename="../src/widgets/window.cpp" line="1428"/>
+        <location filename="../src/widgets/window.cpp" line="1478"/>
         <source>Saved successfully</source>
         <translation>Salvato con successo</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1354"/>
-        <location filename="../src/widgets/window.cpp" line="1481"/>
-        <location filename="../src/widgets/window.cpp" line="1529"/>
+        <location filename="../src/widgets/window.cpp" line="1520"/>
+        <location filename="../src/widgets/window.cpp" line="1665"/>
+        <location filename="../src/widgets/window.cpp" line="1713"/>
         <source>Save File</source>
         <translation>Salva file</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1483"/>
+        <location filename="../src/widgets/window.cpp" line="1569"/>
+        <source>Cannot save as the original file in preview mode. Please choose a different path.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1667"/>
         <source>Encoding</source>
         <translation>Codifica</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1773"/>
+        <location filename="../src/widgets/window.cpp" line="1957"/>
         <source>Read-Only mode is on</source>
         <translation>La modalità sola lettura è attiva</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2322"/>
+        <location filename="../src/widgets/window.cpp" line="2511"/>
         <source>Current location remembered</source>
         <translation>Locazione corrente memorizzata</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2398"/>
+        <location filename="../src/widgets/window.cpp" line="2591"/>
         <source>Ctrl+&apos;=&apos;</source>
         <translation>Ctrl+&apos;=&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2401"/>
+        <location filename="../src/widgets/window.cpp" line="2594"/>
         <source>Ctrl+&apos;-&apos;</source>
         <translation>Ctrl+&apos;-&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2430"/>
+        <location filename="../src/widgets/window.cpp" line="2623"/>
         <source>Editor</source>
         <translation>Editor</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3061"/>
+        <location filename="../src/widgets/window.cpp" line="3436"/>
         <source>Untitled %1</source>
         <translation>%1 senza titolo</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3543"/>
+        <location filename="../src/widgets/window.cpp" line="3948"/>
         <source>Cancel</source>
         <translation>Annulla</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3544"/>
+        <location filename="../src/widgets/window.cpp" line="3949"/>
         <source>Discard</source>
         <translation>Scarta</translation>
     </message>

--- a/translations/deepin-editor_ja.ts
+++ b/translations/deepin-editor_ja.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ja">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ja">
 <context>
     <name>BottomBar</name>
     <message>
@@ -17,17 +19,36 @@
         <translation>%1文字</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="44"/>
+        <location filename="../src/widgets/bottombar.cpp" line="47"/>
         <source>Loading:</source>
         <translation>読み込み中:</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="73"/>
+        <location filename="../src/widgets/bottombar.cpp" line="91"/>
+        <location filename="../src/widgets/bottombar.cpp" line="499"/>
+        <source>Edit Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="74"/>
+        <location filename="../src/widgets/bottombar.cpp" line="489"/>
+        <source>Read View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="75"/>
+        <location filename="../src/widgets/bottombar.cpp" line="493"/>
+        <source>Live Preview</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DDropdownMenu</name>
     <message>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="362"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="420"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="425"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="363"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="421"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="426"/>
         <source>None</source>
         <translation>なし</translation>
     </message>
@@ -35,68 +56,57 @@
 <context>
     <name>EditWrapper</name>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="292"/>
-        <location filename="../src/editor/editwrapper.cpp" line="365"/>
-        <location filename="../src/editor/editwrapper.cpp" line="521"/>
-        <location filename="../src/editor/editwrapper.cpp" line="751"/>
+        <location filename="../src/editor/editwrapper.cpp" line="355"/>
+        <location filename="../src/editor/editwrapper.cpp" line="429"/>
+        <location filename="../src/editor/editwrapper.cpp" line="595"/>
+        <location filename="../src/editor/editwrapper.cpp" line="887"/>
         <source>Save</source>
         <translation>保存</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="516"/>
+        <location filename="../src/editor/editwrapper.cpp" line="590"/>
         <source>Do you want to save this file?</source>
         <translation>ファイルを保存しますか？</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="363"/>
-        <location filename="../src/editor/editwrapper.cpp" line="519"/>
+        <location filename="../src/editor/editwrapper.cpp" line="427"/>
+        <location filename="../src/editor/editwrapper.cpp" line="593"/>
         <source>Cancel</source>
         <translation>キャンセル</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="360"/>
+        <location filename="../src/editor/editwrapper.cpp" line="424"/>
         <source>Encoding changed. Do you want to save the file now?</source>
         <translation>エンコードが変更されました。ファイルを保存しますか？</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="520"/>
+        <location filename="../src/editor/editwrapper.cpp" line="594"/>
         <source>Discard</source>
         <translation>破棄</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="274"/>
-        <location filename="../src/editor/editwrapper.cpp" line="620"/>
+        <location filename="../src/editor/editwrapper.cpp" line="1121"/>
+        <source>The file contains invalid characters (NUL). Preview mode is read-only.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="337"/>
+        <location filename="../src/editor/editwrapper.cpp" line="705"/>
         <source>You do not have permission to save %1</source>
         <translation>%1を保存する権限がありません</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="836"/>
+        <location filename="../src/editor/editwrapper.cpp" line="987"/>
         <source>File removed on the disk. Save it now?</source>
         <translation>ファイルが削除されました。保存しますか？</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="842"/>
+        <location filename="../src/editor/editwrapper.cpp" line="993"/>
         <source>File has changed on disk. Reload?</source>
         <translation>ファイルが変更されました。更新しますか？</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="884"/>
-        <location filename="../src/widgets/bottombar.cpp" line="74"/>
-        <source>INSERT</source>
-        <translation>挿入</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="888"/>
-        <source>OVERWRITE</source>
-        <translation>上書き</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="892"/>
-        <source>R/O</source>
-        <translation>R/O</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="1618"/>
+        <location filename="../src/editor/editwrapper.cpp" line="1806"/>
         <source>The file cannot be read, which may be too large or has been damaged!</source>
         <translation>ファイルのサイズが大き過ぎるか破損しているため、読み込めませんでした。</translation>
     </message>
@@ -109,17 +119,17 @@
         <translation>検索</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="36"/>
+        <location filename="../src/controls/findbar.cpp" line="38"/>
         <source>Previous</source>
         <translation>前へ</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="37"/>
+        <location filename="../src/controls/findbar.cpp" line="40"/>
         <source>Next</source>
         <translation>次へ</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="38"/>
+        <location filename="../src/controls/findbar.cpp" line="42"/>
         <source>Replace</source>
         <translation>置換</translation>
     </message>
@@ -127,9 +137,17 @@
 <context>
     <name>JumpLineBar</name>
     <message>
-        <location filename="../src/controls/jumplinebar.cpp" line="45"/>
+        <location filename="../src/controls/jumplinebar.cpp" line="46"/>
         <source>Go to Line: </source>
         <translation>移動先: </translation>
+    </message>
+</context>
+<context>
+    <name>LineBar</name>
+    <message>
+        <location filename="../src/controls/linebar.cpp" line="144"/>
+        <source>第%1/%2项</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -146,19 +164,47 @@
     </message>
 </context>
 <context>
+    <name>MarkdownBridge</name>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="37"/>
+        <source>Collapse code block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="38"/>
+        <source>Expand code block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="39"/>
+        <source>Copy code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="40"/>
+        <source>Expand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="42"/>
+        <source>%1 line(s) of code collapsed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PathSettingWgt</name>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="84"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="90"/>
         <source>Remember the last used path</source>
         <translation>最後に使用したパスを記憶する</translation>
     </message>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="85"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="91"/>
         <source>Same path as the current file</source>
         <translation>現在のファイルと同じパスを指定する</translation>
     </message>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="86"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="92"/>
         <source>Customize the default path</source>
         <translation>デフォルトのパスを指定する</translation>
     </message>
@@ -171,15 +217,20 @@
         <translation>テキストエディタ</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="294"/>
-        <location filename="../src/editor/editwrapper.cpp" line="761"/>
-        <location filename="../src/editor/editwrapper.cpp" line="776"/>
-        <location filename="../src/widgets/window.cpp" line="1362"/>
-        <location filename="../src/widgets/window.cpp" line="1390"/>
-        <location filename="../src/widgets/window.cpp" line="1531"/>
-        <location filename="../src/widgets/window.cpp" line="1548"/>
+        <location filename="../src/editor/editwrapper.cpp" line="357"/>
+        <location filename="../src/editor/editwrapper.cpp" line="897"/>
+        <location filename="../src/editor/editwrapper.cpp" line="912"/>
+        <location filename="../src/widgets/window.cpp" line="1528"/>
+        <location filename="../src/widgets/window.cpp" line="1556"/>
+        <location filename="../src/widgets/window.cpp" line="1715"/>
+        <location filename="../src/widgets/window.cpp" line="1732"/>
         <source>Encoding</source>
         <translation>エンコーディング</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="2001"/>
+        <source>视图模式</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="11"/>
@@ -215,7 +266,7 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="18"/>
         <location filename="../src/controls/settingsdialog.cpp" line="96"/>
-        <location filename="../src/widgets/window.cpp" line="2388"/>
+        <location filename="../src/widgets/window.cpp" line="2581"/>
         <source>Window</source>
         <translation>ウインドウ</translation>
     </message>
@@ -472,22 +523,22 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="69"/>
         <source>Move to line indentation</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="70"/>
         <source>Upper case</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="71"/>
         <source>Lower case</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="72"/>
         <source>Capitalize</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="73"/>
@@ -502,12 +553,12 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="75"/>
         <source>Forward over a pair</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="76"/>
         <source>Backward over a pair</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="77"/>
@@ -532,7 +583,7 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="81"/>
         <source>Transpose character</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="82"/>
@@ -542,7 +593,7 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="83"/>
         <source>Unmark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="84"/>
@@ -557,7 +608,7 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="86"/>
         <source>Merge lines</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="87"/>
@@ -755,68 +806,68 @@
         <translation>ベトナム語</translation>
     </message>
     <message>
-        <location filename="../src/startmanager.cpp" line="971"/>
+        <location filename="../src/startmanager.cpp" line="1035"/>
         <source>File not saved</source>
         <translation>ファイルが保存されていません</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1532"/>
-        <location filename="../src/widgets/window.cpp" line="1549"/>
+        <location filename="../src/widgets/window.cpp" line="1716"/>
+        <location filename="../src/widgets/window.cpp" line="1733"/>
         <source>Line Endings</source>
         <translation>改行文字</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="243"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="379"/>
         <source>Please install &apos;UOS AI&apos; from the App Store before using</source>
         <translation>この機能を使用する前に、&quot;UOS AI&quot;をアプリストアからインストールしてください。</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="245"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="381"/>
         <source>No audio input device detected. Please check and try again</source>
         <translation>オーディオ入力デバイスが見つかりませんでした。接続を確認して、もう一度お試しください。</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="247"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="383"/>
         <source>No audio output device detected. Please check and try again</source>
         <translation>オーディオ出力デバイスが見つかりませんでした。接続を確認して、もう一度お試しください。</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="69"/>
+        <location filename="../src/common/text_file_saver.cpp" line="74"/>
         <source>File path is empty</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="155"/>
+        <location filename="../src/common/text_file_saver.cpp" line="153"/>
         <source>Insufficient memory to load document content</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="177"/>
+        <location filename="../src/common/text_file_saver.cpp" line="178"/>
         <source>Insufficient memory for encoding conversion</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="183"/>
+        <location filename="../src/common/text_file_saver.cpp" line="184"/>
         <source>Encoding conversion failed</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="189"/>
+        <location filename="../src/common/text_file_saver.cpp" line="190"/>
         <source>Converted content is empty</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="207"/>
+        <location filename="../src/common/text_file_saver.cpp" line="208"/>
         <source>Memory allocation failed</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="211"/>
+        <location filename="../src/common/text_file_saver.cpp" line="212"/>
         <source>Error occurred: %1</source>
         <translation>エラーが発生しました: %1</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="215"/>
+        <location filename="../src/common/text_file_saver.cpp" line="216"/>
         <source>Unknown error occurred</source>
         <translation>不明なエラーが発生しました</translation>
     </message>
@@ -829,27 +880,27 @@
         <translation>検索</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="34"/>
+        <location filename="../src/controls/replacebar.cpp" line="36"/>
         <source>Replace With</source>
         <translation>置換する文字列</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="36"/>
+        <location filename="../src/controls/replacebar.cpp" line="40"/>
         <source>Replace</source>
         <translation>置換</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="37"/>
+        <location filename="../src/controls/replacebar.cpp" line="42"/>
         <source>Skip</source>
         <translation>スキップ</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="38"/>
+        <location filename="../src/controls/replacebar.cpp" line="44"/>
         <source>Replace Rest</source>
         <translation>選択箇所より後を置換</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="39"/>
+        <location filename="../src/controls/replacebar.cpp" line="46"/>
         <source>Replace All</source>
         <translation>すべて置換</translation>
     </message>
@@ -858,9 +909,9 @@
     <name>S:</name>
     <message>
         <location filename="../third/libiconv-1.16/src/iconv.c" line="103"/>
-        <source/>
+        <source></source>
         <comment>The first line of the short usage message.</comment>
-        <translation type="unfinished"/>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -868,7 +919,7 @@
     <message>
         <location filename="../src/common/settings.cpp" line="141"/>
         <source>Standard</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/common/settings.cpp" line="141"/>
@@ -891,34 +942,34 @@
         <translation>フルスクリーン</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="484"/>
+        <location filename="../src/common/settings.cpp" line="491"/>
         <source>This shortcut conflicts with system shortcut %1</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="487"/>
+        <location filename="../src/common/settings.cpp" line="494"/>
         <source>This shortcut conflicts with %1, click on Replace to make this shortcut effective immediately</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="682"/>
-        <location filename="../src/common/settings.cpp" line="695"/>
-        <location filename="../src/common/settings.cpp" line="704"/>
+        <location filename="../src/common/settings.cpp" line="689"/>
+        <location filename="../src/common/settings.cpp" line="702"/>
+        <location filename="../src/common/settings.cpp" line="711"/>
         <source>The shortcut %1 is invalid, please set another one.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="736"/>
+        <location filename="../src/common/settings.cpp" line="743"/>
         <source>Cancel</source>
         <translation>キャンセル</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="737"/>
+        <location filename="../src/common/settings.cpp" line="744"/>
         <source>Replace</source>
         <translation>置き換え</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="740"/>
+        <location filename="../src/common/settings.cpp" line="747"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
@@ -926,7 +977,7 @@
 <context>
     <name>StartManager</name>
     <message>
-        <location filename="../src/startmanager.cpp" line="411"/>
+        <location filename="../src/startmanager.cpp" line="425"/>
         <source>Untitled %1</source>
         <translation>無題%1</translation>
     </message>
@@ -934,32 +985,32 @@
 <context>
     <name>Tabbar</name>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="641"/>
+        <location filename="../src/controls/tabbar.cpp" line="678"/>
         <source>Close tab</source>
         <translation>タブを閉じる</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="642"/>
+        <location filename="../src/controls/tabbar.cpp" line="680"/>
         <source>Close other tabs</source>
         <translation>他のタブを閉じる</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="643"/>
+        <location filename="../src/controls/tabbar.cpp" line="682"/>
         <source>More options</source>
         <translation>さらにオプションを表示</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="644"/>
+        <location filename="../src/controls/tabbar.cpp" line="684"/>
         <source>Close tabs to the left</source>
         <translation>左のタブを閉じる</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="645"/>
+        <location filename="../src/controls/tabbar.cpp" line="686"/>
         <source>Close tabs to the right</source>
         <translation>右のタブを閉じる</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="646"/>
+        <location filename="../src/controls/tabbar.cpp" line="688"/>
         <source>Close unmodified tabs</source>
         <translation>未編集のタブを閉じる</translation>
     </message>
@@ -967,263 +1018,280 @@
 <context>
     <name>TextEdit</name>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="305"/>
+        <location filename="../src/editor/dtextedit.cpp" line="388"/>
         <source>Undo</source>
         <translation>元に戻す</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="306"/>
+        <location filename="../src/editor/dtextedit.cpp" line="390"/>
         <source>Redo</source>
         <translation>やり直す</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="307"/>
+        <location filename="../src/editor/dtextedit.cpp" line="392"/>
         <source>Cut</source>
         <translation>切り取り</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="308"/>
+        <location filename="../src/editor/dtextedit.cpp" line="394"/>
         <source>Copy</source>
         <translation>コピー</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="309"/>
+        <location filename="../src/editor/dtextedit.cpp" line="396"/>
         <source>Paste</source>
         <translation>貼り付け</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="310"/>
+        <location filename="../src/editor/dtextedit.cpp" line="398"/>
         <source>Delete</source>
         <translation>削除</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="311"/>
+        <location filename="../src/editor/dtextedit.cpp" line="400"/>
         <source>Select All</source>
         <translation>全選択</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="312"/>
-        <location filename="../src/widgets/window.cpp" line="535"/>
+        <location filename="../src/editor/dtextedit.cpp" line="402"/>
+        <location filename="../src/widgets/window.cpp" line="556"/>
         <source>Find</source>
         <translation>検索</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="313"/>
-        <location filename="../src/widgets/window.cpp" line="536"/>
+        <location filename="../src/editor/dtextedit.cpp" line="404"/>
+        <location filename="../src/widgets/window.cpp" line="558"/>
         <source>Replace</source>
         <translation>置き換え</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="314"/>
+        <location filename="../src/editor/dtextedit.cpp" line="406"/>
         <source>Go to Line</source>
         <translation>指定行へ移動</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="315"/>
-        <source>Turn on Read-Only mode</source>
-        <translation>読み取り専用モードに入る</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="316"/>
-        <source>Turn off Read-Only mode</source>
-        <translation>読み取り専用モードを終了</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="317"/>
+        <location filename="../src/editor/dtextedit.cpp" line="415"/>
         <source>Fullscreen</source>
         <translation>全画面表示</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="318"/>
+        <location filename="../src/editor/dtextedit.cpp" line="417"/>
         <source>Exit fullscreen</source>
         <translation>フルスクリーンを解除</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="319"/>
+        <location filename="../src/editor/dtextedit.cpp" line="419"/>
         <source>Display in file manager</source>
         <translation>ファイルマネージャーで表示</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="320"/>
-        <location filename="../src/editor/dtextedit.cpp" line="374"/>
+        <location filename="../src/editor/dtextedit.cpp" line="421"/>
+        <location filename="../src/editor/dtextedit.cpp" line="493"/>
         <source>Add Comment</source>
         <translation>コメントを追加</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="321"/>
+        <location filename="../src/editor/dtextedit.cpp" line="423"/>
         <source>Text to Speech</source>
         <translation>音声読み上げ</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="322"/>
-        <source>Stop reading</source>
-        <translation>読み上げを停止</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="323"/>
+        <location filename="../src/editor/dtextedit.cpp" line="425"/>
         <source>Speech to Text</source>
         <translation>音声入力</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="324"/>
+        <location filename="../src/editor/dtextedit.cpp" line="427"/>
         <source>Translate</source>
         <translation>翻訳</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="325"/>
+        <location filename="../src/editor/dtextedit.cpp" line="429"/>
         <source>Column Mode</source>
         <translation>コラムモード</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="326"/>
+        <location filename="../src/editor/dtextedit.cpp" line="431"/>
         <source>Add bookmark</source>
         <translation>ブックマークを追加</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="327"/>
+        <location filename="../src/editor/dtextedit.cpp" line="433"/>
         <source>Remove Bookmark</source>
         <translation>ブックマークを削除</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="328"/>
+        <location filename="../src/editor/dtextedit.cpp" line="435"/>
         <source>Previous bookmark</source>
         <translation>前のブックマーク</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="329"/>
+        <location filename="../src/editor/dtextedit.cpp" line="437"/>
         <source>Next bookmark</source>
         <translation>次のブックマーク</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="330"/>
+        <location filename="../src/editor/dtextedit.cpp" line="439"/>
         <source>Remove All Bookmarks</source>
         <translation>すべてのブックマークを削除</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="331"/>
+        <location filename="../src/editor/dtextedit.cpp" line="441"/>
         <source>Fold All</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="332"/>
+        <location filename="../src/editor/dtextedit.cpp" line="443"/>
         <source>Fold Current Level</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="333"/>
+        <location filename="../src/editor/dtextedit.cpp" line="445"/>
         <source>Unfold All</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="334"/>
+        <location filename="../src/editor/dtextedit.cpp" line="447"/>
         <source>Unfold Current Level</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="339"/>
+        <location filename="../src/editor/dtextedit.cpp" line="453"/>
         <source>Color Mark</source>
         <translation>カラーマーキング</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="343"/>
+        <location filename="../src/editor/dtextedit.cpp" line="458"/>
         <source>Clear All Marks</source>
         <translation>すべてのマーキングを削除</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="344"/>
+        <location filename="../src/editor/dtextedit.cpp" line="460"/>
         <source>Clear Last Mark</source>
         <translation>最後のマーキングを削除</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="353"/>
+        <location filename="../src/editor/dtextedit.cpp" line="470"/>
         <source>Mark</source>
         <translation>マーキング</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="366"/>
+        <location filename="../src/editor/dtextedit.cpp" line="484"/>
         <source>Mark All</source>
         <translation>すべてマーキング</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="375"/>
+        <location filename="../src/editor/dtextedit.cpp" line="494"/>
         <source>Remove Comment</source>
         <translation>コメントを削除</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3208"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3211"/>
+        <location filename="../src/editor/dtextedit.cpp" line="543"/>
+        <source>View Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="3531"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3534"/>
         <source>Copy failed: not enough memory</source>
         <translation>コピーできませんでした : メモリが不足しています</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3333"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3335"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3656"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3658"/>
         <source>Press ALT and click lines to edit in column mode</source>
         <translation>ALTを押しながら行を選択して、コラムモードで編集します</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="418"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9574"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9576"/>
+        <source>No audio output device was detected. Please ensure your speakers or headphones are properly connected and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="9583"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9585"/>
+        <source>No audio input device was detected. Please ensure your speakers or headphones are properly connected and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="534"/>
         <source>Change Case</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="419"/>
+        <location filename="../src/editor/dtextedit.cpp" line="409"/>
+        <source>Edit Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="411"/>
+        <source>Read View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="413"/>
+        <source>Live Preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="535"/>
         <source>Upper Case</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="420"/>
+        <location filename="../src/editor/dtextedit.cpp" line="536"/>
         <source>Lower Case</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="421"/>
+        <location filename="../src/editor/dtextedit.cpp" line="537"/>
         <source>Capitalize</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="78"/>
+        <location filename="../src/widgets/bottombar.cpp" line="110"/>
         <source>None</source>
         <translation>なし</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1363"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1490"/>
         <source>Selected line(s) copied</source>
         <translation>選択した行をコピーしました</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1370"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1497"/>
         <source>Current line copied</source>
         <translation>現在の行をコピーしました</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1400"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1527"/>
         <source>Selected line(s) clipped</source>
         <translation>選択した行を切り取りました</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1412"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1539"/>
         <source>Current line clipped</source>
         <translation>現在の行を切り取りました</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3227"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3230"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3550"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3553"/>
         <source>Paste failed: not enough memory</source>
         <translation>貼り付けできませんでした : メモリが不足しています</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="4548"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4873"/>
         <source>Read-Only mode is off</source>
         <translation>読み取り専用モードはOFFです</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="4560"/>
-        <location filename="../src/editor/dtextedit.cpp" line="4584"/>
-        <location filename="../src/editor/dtextedit.cpp" line="7896"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8007"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8015"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8026"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4885"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4909"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8236"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8347"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8355"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8366"/>
         <source>Read-Only mode is on</source>
         <translation>読み込み専用モードがONです</translation>
     </message>
@@ -1231,138 +1299,175 @@
 <context>
     <name>WarningNotices</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="24"/>
+        <location filename="../src/controls/warningnotices.cpp" line="25"/>
         <source>Reload</source>
         <translation>再読込み</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/warningnotices.cpp" line="29"/>
+        <source>Edit Anyway</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>Window</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="25"/>
-        <location filename="../src/widgets/window.cpp" line="531"/>
+        <location filename="../src/controls/warningnotices.cpp" line="27"/>
+        <location filename="../src/widgets/window.cpp" line="548"/>
         <source>Save as</source>
         <translation>名前をつけて保存</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="527"/>
+        <location filename="../src/widgets/window.cpp" line="540"/>
         <source>New window</source>
         <translation>新しいウィンドウ</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="528"/>
+        <location filename="../src/widgets/window.cpp" line="542"/>
         <source>New tab</source>
         <translation>新しいタブ</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="529"/>
+        <location filename="../src/widgets/window.cpp" line="544"/>
         <source>Open file</source>
         <translation>ファイルを開く</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="530"/>
-        <location filename="../src/widgets/window.cpp" line="3545"/>
+        <location filename="../src/widgets/window.cpp" line="546"/>
+        <location filename="../src/widgets/window.cpp" line="3950"/>
         <source>Save</source>
         <translation>保存</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="532"/>
+        <location filename="../src/widgets/window.cpp" line="550"/>
         <source>Print</source>
         <translation>印刷</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="533"/>
+        <location filename="../src/widgets/window.cpp" line="552"/>
         <source>Switch theme</source>
         <translation>テーマ切替</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="534"/>
-        <location filename="../src/widgets/window.cpp" line="2448"/>
+        <location filename="../src/widgets/window.cpp" line="554"/>
+        <location filename="../src/widgets/window.cpp" line="2641"/>
         <source>Settings</source>
         <translation>設定</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="666"/>
-        <location filename="../src/widgets/window.cpp" line="3845"/>
+        <location filename="../src/widgets/window.cpp" line="696"/>
+        <location filename="../src/widgets/window.cpp" line="4250"/>
         <source>Read-Only</source>
         <translation>読み取り専用</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="687"/>
+        <location filename="../src/widgets/window.cpp" line="719"/>
         <source>You do not have permission to open %1</source>
         <translation>%1を開く権限がありません</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="738"/>
-        <location filename="../src/widgets/window.cpp" line="2963"/>
+        <location filename="../src/widgets/window.cpp" line="773"/>
+        <location filename="../src/widgets/window.cpp" line="3266"/>
         <source>Invalid file: %1</source>
         <translation>無効なファイル: %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="903"/>
-        <location filename="../src/widgets/window.cpp" line="956"/>
+        <location filename="../src/widgets/window.cpp" line="957"/>
+        <location filename="../src/widgets/window.cpp" line="1050"/>
+        <location filename="../src/widgets/window.cpp" line="3217"/>
         <source>Do you want to save this file?</source>
         <translation>ファイルを保存しますか？</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1290"/>
+        <location filename="../src/widgets/window.cpp" line="1381"/>
+        <source>Invalid characters detected while saving &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1382"/>
+        <source>If you force save this file, it may cause file corruption. Still want to save?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1386"/>
+        <source>Don&apos;t Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1387"/>
+        <source>Save As</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1388"/>
+        <source>Save Anyway</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1456"/>
         <source>You do not have permission to save %1</source>
         <translation>%1を保存する権限がありません</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1312"/>
+        <location filename="../src/widgets/window.cpp" line="1428"/>
+        <location filename="../src/widgets/window.cpp" line="1478"/>
         <source>Saved successfully</source>
         <translation>保存しました</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1354"/>
-        <location filename="../src/widgets/window.cpp" line="1481"/>
-        <location filename="../src/widgets/window.cpp" line="1529"/>
+        <location filename="../src/widgets/window.cpp" line="1520"/>
+        <location filename="../src/widgets/window.cpp" line="1665"/>
+        <location filename="../src/widgets/window.cpp" line="1713"/>
         <source>Save File</source>
         <translation>ファイルを保存する</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1483"/>
+        <location filename="../src/widgets/window.cpp" line="1569"/>
+        <source>Cannot save as the original file in preview mode. Please choose a different path.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1667"/>
         <source>Encoding</source>
         <translation>エンコーディング</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1773"/>
+        <location filename="../src/widgets/window.cpp" line="1957"/>
         <source>Read-Only mode is on</source>
         <translation>読み込み専用モードが有効です</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2322"/>
+        <location filename="../src/widgets/window.cpp" line="2511"/>
         <source>Current location remembered</source>
         <translation>現在の位置を記憶しました</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2398"/>
+        <location filename="../src/widgets/window.cpp" line="2591"/>
         <source>Ctrl+&apos;=&apos;</source>
         <translation>Ctrl+&apos;=&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2401"/>
+        <location filename="../src/widgets/window.cpp" line="2594"/>
         <source>Ctrl+&apos;-&apos;</source>
         <translation>Ctrl+&apos;-&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2430"/>
+        <location filename="../src/widgets/window.cpp" line="2623"/>
         <source>Editor</source>
         <translation>エディター</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3061"/>
+        <location filename="../src/widgets/window.cpp" line="3436"/>
         <source>Untitled %1</source>
         <translation>無題%1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3543"/>
+        <location filename="../src/widgets/window.cpp" line="3948"/>
         <source>Cancel</source>
         <translation>キャンセル</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3544"/>
+        <location filename="../src/widgets/window.cpp" line="3949"/>
         <source>Discard</source>
         <translation>破棄</translation>
     </message>

--- a/translations/deepin-editor_ko.ts
+++ b/translations/deepin-editor_ko.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ko">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ko">
 <context>
     <name>BottomBar</name>
     <message>
@@ -17,17 +19,36 @@
         <translation>문자 %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="44"/>
+        <location filename="../src/widgets/bottombar.cpp" line="47"/>
         <source>Loading:</source>
         <translation>로딩:</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="73"/>
+        <location filename="../src/widgets/bottombar.cpp" line="91"/>
+        <location filename="../src/widgets/bottombar.cpp" line="499"/>
+        <source>Edit Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="74"/>
+        <location filename="../src/widgets/bottombar.cpp" line="489"/>
+        <source>Read View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="75"/>
+        <location filename="../src/widgets/bottombar.cpp" line="493"/>
+        <source>Live Preview</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DDropdownMenu</name>
     <message>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="362"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="420"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="425"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="363"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="421"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="426"/>
         <source>None</source>
         <translation>없음</translation>
     </message>
@@ -35,68 +56,57 @@
 <context>
     <name>EditWrapper</name>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="292"/>
-        <location filename="../src/editor/editwrapper.cpp" line="365"/>
-        <location filename="../src/editor/editwrapper.cpp" line="521"/>
-        <location filename="../src/editor/editwrapper.cpp" line="751"/>
+        <location filename="../src/editor/editwrapper.cpp" line="355"/>
+        <location filename="../src/editor/editwrapper.cpp" line="429"/>
+        <location filename="../src/editor/editwrapper.cpp" line="595"/>
+        <location filename="../src/editor/editwrapper.cpp" line="887"/>
         <source>Save</source>
         <translation>저장</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="516"/>
+        <location filename="../src/editor/editwrapper.cpp" line="590"/>
         <source>Do you want to save this file?</source>
         <translation>이 파일을 저장하시겠습니까?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="363"/>
-        <location filename="../src/editor/editwrapper.cpp" line="519"/>
+        <location filename="../src/editor/editwrapper.cpp" line="427"/>
+        <location filename="../src/editor/editwrapper.cpp" line="593"/>
         <source>Cancel</source>
         <translation>취소</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="360"/>
+        <location filename="../src/editor/editwrapper.cpp" line="424"/>
         <source>Encoding changed. Do you want to save the file now?</source>
         <translation>인코딩이 변경되었습니다. 지금 파일을 저장하시겠습니까?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="520"/>
+        <location filename="../src/editor/editwrapper.cpp" line="594"/>
         <source>Discard</source>
         <translation>폐기</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="274"/>
-        <location filename="../src/editor/editwrapper.cpp" line="620"/>
+        <location filename="../src/editor/editwrapper.cpp" line="1121"/>
+        <source>The file contains invalid characters (NUL). Preview mode is read-only.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="337"/>
+        <location filename="../src/editor/editwrapper.cpp" line="705"/>
         <source>You do not have permission to save %1</source>
         <translation>%1을(를) 저장할 권한이 없습니다</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="836"/>
+        <location filename="../src/editor/editwrapper.cpp" line="987"/>
         <source>File removed on the disk. Save it now?</source>
         <translation>디스크에서 파일이 제거되었습니다. 지금 저장 하시겠습니까?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="842"/>
+        <location filename="../src/editor/editwrapper.cpp" line="993"/>
         <source>File has changed on disk. Reload?</source>
         <translation>디스크의 파일이 변경되었습니다. 다시 불러오시겠습니까?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="884"/>
-        <location filename="../src/widgets/bottombar.cpp" line="74"/>
-        <source>INSERT</source>
-        <translation>삽입</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="888"/>
-        <source>OVERWRITE</source>
-        <translation>덮어쓰기</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="892"/>
-        <source>R/O</source>
-        <translation>읽기 전용</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="1618"/>
+        <location filename="../src/editor/editwrapper.cpp" line="1806"/>
         <source>The file cannot be read, which may be too large or has been damaged!</source>
         <translation>파일을 읽을 수 없습니다. 너무 크거나 손상되었을 수 있습니다!</translation>
     </message>
@@ -109,17 +119,17 @@
         <translation>찾기</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="36"/>
+        <location filename="../src/controls/findbar.cpp" line="38"/>
         <source>Previous</source>
         <translation>이전</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="37"/>
+        <location filename="../src/controls/findbar.cpp" line="40"/>
         <source>Next</source>
         <translation>다음</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="38"/>
+        <location filename="../src/controls/findbar.cpp" line="42"/>
         <source>Replace</source>
         <translation>바꾸기</translation>
     </message>
@@ -127,9 +137,17 @@
 <context>
     <name>JumpLineBar</name>
     <message>
-        <location filename="../src/controls/jumplinebar.cpp" line="45"/>
+        <location filename="../src/controls/jumplinebar.cpp" line="46"/>
         <source>Go to Line: </source>
         <translation>줄로 이동:</translation>
+    </message>
+</context>
+<context>
+    <name>LineBar</name>
+    <message>
+        <location filename="../src/controls/linebar.cpp" line="144"/>
+        <source>第%1/%2项</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -146,19 +164,47 @@
     </message>
 </context>
 <context>
+    <name>MarkdownBridge</name>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="37"/>
+        <source>Collapse code block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="38"/>
+        <source>Expand code block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="39"/>
+        <source>Copy code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="40"/>
+        <source>Expand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="42"/>
+        <source>%1 line(s) of code collapsed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PathSettingWgt</name>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="84"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="90"/>
         <source>Remember the last used path</source>
         <translation>마지막으로 사용한 경로 기억</translation>
     </message>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="85"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="91"/>
         <source>Same path as the current file</source>
         <translation>현재 파일과 동일한 경로</translation>
     </message>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="86"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="92"/>
         <source>Customize the default path</source>
         <translation>기본 경로 사용자 지정</translation>
     </message>
@@ -171,15 +217,20 @@
         <translation>텍스트 편집기</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="294"/>
-        <location filename="../src/editor/editwrapper.cpp" line="761"/>
-        <location filename="../src/editor/editwrapper.cpp" line="776"/>
-        <location filename="../src/widgets/window.cpp" line="1362"/>
-        <location filename="../src/widgets/window.cpp" line="1390"/>
-        <location filename="../src/widgets/window.cpp" line="1531"/>
-        <location filename="../src/widgets/window.cpp" line="1548"/>
+        <location filename="../src/editor/editwrapper.cpp" line="357"/>
+        <location filename="../src/editor/editwrapper.cpp" line="897"/>
+        <location filename="../src/editor/editwrapper.cpp" line="912"/>
+        <location filename="../src/widgets/window.cpp" line="1528"/>
+        <location filename="../src/widgets/window.cpp" line="1556"/>
+        <location filename="../src/widgets/window.cpp" line="1715"/>
+        <location filename="../src/widgets/window.cpp" line="1732"/>
         <source>Encoding</source>
         <translation>인코딩</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="2001"/>
+        <source>视图模式</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="11"/>
@@ -215,7 +266,7 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="18"/>
         <location filename="../src/controls/settingsdialog.cpp" line="96"/>
-        <location filename="../src/widgets/window.cpp" line="2388"/>
+        <location filename="../src/widgets/window.cpp" line="2581"/>
         <source>Window</source>
         <translation>창</translation>
     </message>
@@ -755,68 +806,68 @@
         <translation>베트남어</translation>
     </message>
     <message>
-        <location filename="../src/startmanager.cpp" line="971"/>
+        <location filename="../src/startmanager.cpp" line="1035"/>
         <source>File not saved</source>
         <translation>파일이 저장되지 않음</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1532"/>
-        <location filename="../src/widgets/window.cpp" line="1549"/>
+        <location filename="../src/widgets/window.cpp" line="1716"/>
+        <location filename="../src/widgets/window.cpp" line="1733"/>
         <source>Line Endings</source>
         <translation>줄 끝</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="243"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="379"/>
         <source>Please install &apos;UOS AI&apos; from the App Store before using</source>
         <translation>사용하기 전에 &apos;UOS AI&apos;를 앱 스토어에서 설치하십시오</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="245"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="381"/>
         <source>No audio input device detected. Please check and try again</source>
         <translation>오디오 입력 장치를 감지할 수 없습니다. 다시 확인하고 시도하십시오</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="247"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="383"/>
         <source>No audio output device detected. Please check and try again</source>
         <translation>오디오 출력 장치를 감지할 수 없습니다. 다시 확인하고 시도하십시오</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="69"/>
+        <location filename="../src/common/text_file_saver.cpp" line="74"/>
         <source>File path is empty</source>
         <translation>파일 경로가 비어 있습니다</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="155"/>
+        <location filename="../src/common/text_file_saver.cpp" line="153"/>
         <source>Insufficient memory to load document content</source>
         <translation>문서 내용을 로드하기에 메모리가 부족합니다</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="177"/>
+        <location filename="../src/common/text_file_saver.cpp" line="178"/>
         <source>Insufficient memory for encoding conversion</source>
         <translation>인코딩 변환에 메모리가 부족합니다</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="183"/>
+        <location filename="../src/common/text_file_saver.cpp" line="184"/>
         <source>Encoding conversion failed</source>
         <translation>인코딩 변환에 실패했습니다</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="189"/>
+        <location filename="../src/common/text_file_saver.cpp" line="190"/>
         <source>Converted content is empty</source>
         <translation>변환된 내용이 비어 있습니다</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="207"/>
+        <location filename="../src/common/text_file_saver.cpp" line="208"/>
         <source>Memory allocation failed</source>
         <translation>메모리 할당에 실패했습니다</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="211"/>
+        <location filename="../src/common/text_file_saver.cpp" line="212"/>
         <source>Error occurred: %1</source>
         <translation>오류가 발생했습니다: %1</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="215"/>
+        <location filename="../src/common/text_file_saver.cpp" line="216"/>
         <source>Unknown error occurred</source>
         <translation>알 수 없는 오류가 발생했습니다</translation>
     </message>
@@ -829,27 +880,27 @@
         <translation>찾기</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="34"/>
+        <location filename="../src/controls/replacebar.cpp" line="36"/>
         <source>Replace With</source>
         <translation>바꿀 대상</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="36"/>
+        <location filename="../src/controls/replacebar.cpp" line="40"/>
         <source>Replace</source>
         <translation>바꾸기</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="37"/>
+        <location filename="../src/controls/replacebar.cpp" line="42"/>
         <source>Skip</source>
         <translation>건너뛰기</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="38"/>
+        <location filename="../src/controls/replacebar.cpp" line="44"/>
         <source>Replace Rest</source>
         <translation>나머지 바꾸기</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="39"/>
+        <location filename="../src/controls/replacebar.cpp" line="46"/>
         <source>Replace All</source>
         <translation>모두 바꾸기</translation>
     </message>
@@ -858,9 +909,9 @@
     <name>S:</name>
     <message>
         <location filename="../third/libiconv-1.16/src/iconv.c" line="103"/>
-        <source/>
+        <source></source>
         <comment>The first line of the short usage message.</comment>
-        <translation type="unfinished"/>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -891,34 +942,34 @@
         <translation>전체 화면</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="484"/>
+        <location filename="../src/common/settings.cpp" line="491"/>
         <source>This shortcut conflicts with system shortcut %1</source>
         <translation>이 단축키는 시스템 단축키 %1와 충돌합니다</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="487"/>
+        <location filename="../src/common/settings.cpp" line="494"/>
         <source>This shortcut conflicts with %1, click on Replace to make this shortcut effective immediately</source>
         <translation>이 단축키는 %1과 충돌합니다. 이 단축키를 즉시 적용하려면 바꾸기를 클릭하십시오.</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="682"/>
-        <location filename="../src/common/settings.cpp" line="695"/>
-        <location filename="../src/common/settings.cpp" line="704"/>
+        <location filename="../src/common/settings.cpp" line="689"/>
+        <location filename="../src/common/settings.cpp" line="702"/>
+        <location filename="../src/common/settings.cpp" line="711"/>
         <source>The shortcut %1 is invalid, please set another one.</source>
         <translation>단축키 %1이 잘못되었습니다. 다른 단축키를 설정하십시오.</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="736"/>
+        <location filename="../src/common/settings.cpp" line="743"/>
         <source>Cancel</source>
         <translation>취소</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="737"/>
+        <location filename="../src/common/settings.cpp" line="744"/>
         <source>Replace</source>
         <translation>바꾸기</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="740"/>
+        <location filename="../src/common/settings.cpp" line="747"/>
         <source>OK</source>
         <translation>확인</translation>
     </message>
@@ -926,7 +977,7 @@
 <context>
     <name>StartManager</name>
     <message>
-        <location filename="../src/startmanager.cpp" line="411"/>
+        <location filename="../src/startmanager.cpp" line="425"/>
         <source>Untitled %1</source>
         <translation>제목 없음 %1</translation>
     </message>
@@ -934,32 +985,32 @@
 <context>
     <name>Tabbar</name>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="641"/>
+        <location filename="../src/controls/tabbar.cpp" line="678"/>
         <source>Close tab</source>
         <translation>탭 닫기</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="642"/>
+        <location filename="../src/controls/tabbar.cpp" line="680"/>
         <source>Close other tabs</source>
         <translation>다른 탭 닫기</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="643"/>
+        <location filename="../src/controls/tabbar.cpp" line="682"/>
         <source>More options</source>
         <translation>더보기</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="644"/>
+        <location filename="../src/controls/tabbar.cpp" line="684"/>
         <source>Close tabs to the left</source>
         <translation>왼쪽으로 탭 닫기</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="645"/>
+        <location filename="../src/controls/tabbar.cpp" line="686"/>
         <source>Close tabs to the right</source>
         <translation>오른쪽으로 탭 닫기</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="646"/>
+        <location filename="../src/controls/tabbar.cpp" line="688"/>
         <source>Close unmodified tabs</source>
         <translation>수정되지 않은 탭 닫기</translation>
     </message>
@@ -967,263 +1018,280 @@
 <context>
     <name>TextEdit</name>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="305"/>
+        <location filename="../src/editor/dtextedit.cpp" line="388"/>
         <source>Undo</source>
         <translation>되돌리기</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="306"/>
+        <location filename="../src/editor/dtextedit.cpp" line="390"/>
         <source>Redo</source>
         <translation>재실행</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="307"/>
+        <location filename="../src/editor/dtextedit.cpp" line="392"/>
         <source>Cut</source>
         <translation>잘라내기</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="308"/>
+        <location filename="../src/editor/dtextedit.cpp" line="394"/>
         <source>Copy</source>
         <translation>복사하기</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="309"/>
+        <location filename="../src/editor/dtextedit.cpp" line="396"/>
         <source>Paste</source>
         <translation>붙여넣기</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="310"/>
+        <location filename="../src/editor/dtextedit.cpp" line="398"/>
         <source>Delete</source>
         <translation>삭제하기</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="311"/>
+        <location filename="../src/editor/dtextedit.cpp" line="400"/>
         <source>Select All</source>
         <translation>모두 선택</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="312"/>
-        <location filename="../src/widgets/window.cpp" line="535"/>
+        <location filename="../src/editor/dtextedit.cpp" line="402"/>
+        <location filename="../src/widgets/window.cpp" line="556"/>
         <source>Find</source>
         <translation>찾기</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="313"/>
-        <location filename="../src/widgets/window.cpp" line="536"/>
+        <location filename="../src/editor/dtextedit.cpp" line="404"/>
+        <location filename="../src/widgets/window.cpp" line="558"/>
         <source>Replace</source>
         <translation>바꾸기</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="314"/>
+        <location filename="../src/editor/dtextedit.cpp" line="406"/>
         <source>Go to Line</source>
         <translation>줄로 이동</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="315"/>
-        <source>Turn on Read-Only mode</source>
-        <translation>읽기 전용 모드 켜기</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="316"/>
-        <source>Turn off Read-Only mode</source>
-        <translation>읽기 전용 모드 끄기</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="317"/>
+        <location filename="../src/editor/dtextedit.cpp" line="415"/>
         <source>Fullscreen</source>
         <translation>전체 화면</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="318"/>
+        <location filename="../src/editor/dtextedit.cpp" line="417"/>
         <source>Exit fullscreen</source>
         <translation>전체 화면 종료</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="319"/>
+        <location filename="../src/editor/dtextedit.cpp" line="419"/>
         <source>Display in file manager</source>
         <translation>파일 관리자에 표시</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="320"/>
-        <location filename="../src/editor/dtextedit.cpp" line="374"/>
+        <location filename="../src/editor/dtextedit.cpp" line="421"/>
+        <location filename="../src/editor/dtextedit.cpp" line="493"/>
         <source>Add Comment</source>
         <translation>주석 추가하기</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="321"/>
+        <location filename="../src/editor/dtextedit.cpp" line="423"/>
         <source>Text to Speech</source>
         <translation>텍스트 음성 변환</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="322"/>
-        <source>Stop reading</source>
-        <translation>읽기 중지</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="323"/>
+        <location filename="../src/editor/dtextedit.cpp" line="425"/>
         <source>Speech to Text</source>
         <translation>음성 텍스트 변환</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="324"/>
+        <location filename="../src/editor/dtextedit.cpp" line="427"/>
         <source>Translate</source>
         <translation>번역</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="325"/>
+        <location filename="../src/editor/dtextedit.cpp" line="429"/>
         <source>Column Mode</source>
         <translation>열 모드</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="326"/>
+        <location filename="../src/editor/dtextedit.cpp" line="431"/>
         <source>Add bookmark</source>
         <translation>책갈피 추가</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="327"/>
+        <location filename="../src/editor/dtextedit.cpp" line="433"/>
         <source>Remove Bookmark</source>
         <translation>책갈피 제거</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="328"/>
+        <location filename="../src/editor/dtextedit.cpp" line="435"/>
         <source>Previous bookmark</source>
         <translation>이전 책갈피</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="329"/>
+        <location filename="../src/editor/dtextedit.cpp" line="437"/>
         <source>Next bookmark</source>
         <translation>다음 책갈피</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="330"/>
+        <location filename="../src/editor/dtextedit.cpp" line="439"/>
         <source>Remove All Bookmarks</source>
         <translation>모든 책갈피 제거</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="331"/>
+        <location filename="../src/editor/dtextedit.cpp" line="441"/>
         <source>Fold All</source>
         <translation>모두 접기</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="332"/>
+        <location filename="../src/editor/dtextedit.cpp" line="443"/>
         <source>Fold Current Level</source>
         <translation>현재 레벨 접기</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="333"/>
+        <location filename="../src/editor/dtextedit.cpp" line="445"/>
         <source>Unfold All</source>
         <translation>모두 펼치기</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="334"/>
+        <location filename="../src/editor/dtextedit.cpp" line="447"/>
         <source>Unfold Current Level</source>
         <translation>현재 레벨 펼치기</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="339"/>
+        <location filename="../src/editor/dtextedit.cpp" line="453"/>
         <source>Color Mark</source>
         <translation>색상 표시</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="343"/>
+        <location filename="../src/editor/dtextedit.cpp" line="458"/>
         <source>Clear All Marks</source>
         <translation>모든 표시 지우기</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="344"/>
+        <location filename="../src/editor/dtextedit.cpp" line="460"/>
         <source>Clear Last Mark</source>
         <translation>마지막 표시 지우기</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="353"/>
+        <location filename="../src/editor/dtextedit.cpp" line="470"/>
         <source>Mark</source>
         <translation>선택표시 시작</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="366"/>
+        <location filename="../src/editor/dtextedit.cpp" line="484"/>
         <source>Mark All</source>
         <translation>모두 표시하기</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="375"/>
+        <location filename="../src/editor/dtextedit.cpp" line="494"/>
         <source>Remove Comment</source>
         <translation>주석 제거하기</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3208"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3211"/>
+        <location filename="../src/editor/dtextedit.cpp" line="543"/>
+        <source>View Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="3531"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3534"/>
         <source>Copy failed: not enough memory</source>
         <translation>복사 실패: 메모리가 부족합니다</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3333"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3335"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3656"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3658"/>
         <source>Press ALT and click lines to edit in column mode</source>
         <translation>열 모드에서 편집하려면 ALT를 누르고 줄을 클릭하십시오</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="418"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9574"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9576"/>
+        <source>No audio output device was detected. Please ensure your speakers or headphones are properly connected and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="9583"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9585"/>
+        <source>No audio input device was detected. Please ensure your speakers or headphones are properly connected and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="534"/>
         <source>Change Case</source>
         <translation>대/소문자 변경</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="419"/>
+        <location filename="../src/editor/dtextedit.cpp" line="409"/>
+        <source>Edit Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="411"/>
+        <source>Read View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="413"/>
+        <source>Live Preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="535"/>
         <source>Upper Case</source>
         <translation>대문자</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="420"/>
+        <location filename="../src/editor/dtextedit.cpp" line="536"/>
         <source>Lower Case</source>
         <translation>소문자</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="421"/>
+        <location filename="../src/editor/dtextedit.cpp" line="537"/>
         <source>Capitalize</source>
         <translation>대문자로 쓰기</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="78"/>
+        <location filename="../src/widgets/bottombar.cpp" line="110"/>
         <source>None</source>
         <translation>없음</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1363"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1490"/>
         <source>Selected line(s) copied</source>
         <translation>선택된 줄 복사됨</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1370"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1497"/>
         <source>Current line copied</source>
         <translation>현재 줄 복사됨</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1400"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1527"/>
         <source>Selected line(s) clipped</source>
         <translation>선택된 줄 복사됨</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1412"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1539"/>
         <source>Current line clipped</source>
         <translation>현재 줄 복사됨</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3227"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3230"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3550"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3553"/>
         <source>Paste failed: not enough memory</source>
         <translation>붙여넣기 실패: 메모리가 부족합니다</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="4548"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4873"/>
         <source>Read-Only mode is off</source>
         <translation>읽기 전용 모드가 꺼져 있음</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="4560"/>
-        <location filename="../src/editor/dtextedit.cpp" line="4584"/>
-        <location filename="../src/editor/dtextedit.cpp" line="7896"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8007"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8015"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8026"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4885"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4909"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8236"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8347"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8355"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8366"/>
         <source>Read-Only mode is on</source>
         <translation>읽기 전용 모드가 켜져 있음</translation>
     </message>
@@ -1231,138 +1299,175 @@
 <context>
     <name>WarningNotices</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="24"/>
+        <location filename="../src/controls/warningnotices.cpp" line="25"/>
         <source>Reload</source>
         <translation>새로고침</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/warningnotices.cpp" line="29"/>
+        <source>Edit Anyway</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>Window</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="25"/>
-        <location filename="../src/widgets/window.cpp" line="531"/>
+        <location filename="../src/controls/warningnotices.cpp" line="27"/>
+        <location filename="../src/widgets/window.cpp" line="548"/>
         <source>Save as</source>
         <translation>다른 이름으로 저장</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="527"/>
+        <location filename="../src/widgets/window.cpp" line="540"/>
         <source>New window</source>
         <translation>새 창</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="528"/>
+        <location filename="../src/widgets/window.cpp" line="542"/>
         <source>New tab</source>
         <translation>새 탭</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="529"/>
+        <location filename="../src/widgets/window.cpp" line="544"/>
         <source>Open file</source>
         <translation>파일 열기</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="530"/>
-        <location filename="../src/widgets/window.cpp" line="3545"/>
+        <location filename="../src/widgets/window.cpp" line="546"/>
+        <location filename="../src/widgets/window.cpp" line="3950"/>
         <source>Save</source>
         <translation>저장</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="532"/>
+        <location filename="../src/widgets/window.cpp" line="550"/>
         <source>Print</source>
         <translation>인쇄</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="533"/>
+        <location filename="../src/widgets/window.cpp" line="552"/>
         <source>Switch theme</source>
         <translation>테마 전환</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="534"/>
-        <location filename="../src/widgets/window.cpp" line="2448"/>
+        <location filename="../src/widgets/window.cpp" line="554"/>
+        <location filename="../src/widgets/window.cpp" line="2641"/>
         <source>Settings</source>
         <translation>설정</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="666"/>
-        <location filename="../src/widgets/window.cpp" line="3845"/>
+        <location filename="../src/widgets/window.cpp" line="696"/>
+        <location filename="../src/widgets/window.cpp" line="4250"/>
         <source>Read-Only</source>
         <translation>읽기 전용</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="687"/>
+        <location filename="../src/widgets/window.cpp" line="719"/>
         <source>You do not have permission to open %1</source>
         <translation>%1을(를) 열 수 있는 권한이 없음</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="738"/>
-        <location filename="../src/widgets/window.cpp" line="2963"/>
+        <location filename="../src/widgets/window.cpp" line="773"/>
+        <location filename="../src/widgets/window.cpp" line="3266"/>
         <source>Invalid file: %1</source>
         <translation>잘못된 파일: %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="903"/>
-        <location filename="../src/widgets/window.cpp" line="956"/>
+        <location filename="../src/widgets/window.cpp" line="957"/>
+        <location filename="../src/widgets/window.cpp" line="1050"/>
+        <location filename="../src/widgets/window.cpp" line="3217"/>
         <source>Do you want to save this file?</source>
         <translation>이 파일을 저장하시겠습니까?</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1290"/>
+        <location filename="../src/widgets/window.cpp" line="1381"/>
+        <source>Invalid characters detected while saving &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1382"/>
+        <source>If you force save this file, it may cause file corruption. Still want to save?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1386"/>
+        <source>Don&apos;t Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1387"/>
+        <source>Save As</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1388"/>
+        <source>Save Anyway</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1456"/>
         <source>You do not have permission to save %1</source>
         <translation>%1을(를) 저장할 권한이 없습니다</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1312"/>
+        <location filename="../src/widgets/window.cpp" line="1428"/>
+        <location filename="../src/widgets/window.cpp" line="1478"/>
         <source>Saved successfully</source>
         <translation>성공적으로 저장됨</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1354"/>
-        <location filename="../src/widgets/window.cpp" line="1481"/>
-        <location filename="../src/widgets/window.cpp" line="1529"/>
+        <location filename="../src/widgets/window.cpp" line="1520"/>
+        <location filename="../src/widgets/window.cpp" line="1665"/>
+        <location filename="../src/widgets/window.cpp" line="1713"/>
         <source>Save File</source>
         <translation>파일 저장</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1483"/>
+        <location filename="../src/widgets/window.cpp" line="1569"/>
+        <source>Cannot save as the original file in preview mode. Please choose a different path.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1667"/>
         <source>Encoding</source>
         <translation>인코딩</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1773"/>
+        <location filename="../src/widgets/window.cpp" line="1957"/>
         <source>Read-Only mode is on</source>
         <translation>읽기 전용 모드가 켜져 있음</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2322"/>
+        <location filename="../src/widgets/window.cpp" line="2511"/>
         <source>Current location remembered</source>
         <translation>기억된 현재 위치</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2398"/>
+        <location filename="../src/widgets/window.cpp" line="2591"/>
         <source>Ctrl+&apos;=&apos;</source>
         <translation>Ctrl+&apos;=&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2401"/>
+        <location filename="../src/widgets/window.cpp" line="2594"/>
         <source>Ctrl+&apos;-&apos;</source>
         <translation>Ctrl+&apos;-&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2430"/>
+        <location filename="../src/widgets/window.cpp" line="2623"/>
         <source>Editor</source>
         <translation>편집기</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3061"/>
+        <location filename="../src/widgets/window.cpp" line="3436"/>
         <source>Untitled %1</source>
         <translation>제목 없음 %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3543"/>
+        <location filename="../src/widgets/window.cpp" line="3948"/>
         <source>Cancel</source>
         <translation>취소</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3544"/>
+        <location filename="../src/widgets/window.cpp" line="3949"/>
         <source>Discard</source>
         <translation>폐기</translation>
     </message>

--- a/translations/deepin-editor_lo.ts
+++ b/translations/deepin-editor_lo.ts
@@ -19,17 +19,36 @@
         <translation>ຕັວອັກສະ %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="44"/>
+        <location filename="../src/widgets/bottombar.cpp" line="47"/>
         <source>Loading:</source>
         <translation>ກຳລາການດຳເນີນການ:</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="73"/>
+        <location filename="../src/widgets/bottombar.cpp" line="91"/>
+        <location filename="../src/widgets/bottombar.cpp" line="499"/>
+        <source>Edit Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="74"/>
+        <location filename="../src/widgets/bottombar.cpp" line="489"/>
+        <source>Read View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="75"/>
+        <location filename="../src/widgets/bottombar.cpp" line="493"/>
+        <source>Live Preview</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DDropdownMenu</name>
     <message>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="362"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="420"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="425"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="363"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="421"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="426"/>
         <source>None</source>
         <translation>ບໍ່ມີ</translation>
     </message>
@@ -37,68 +56,57 @@
 <context>
     <name>EditWrapper</name>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="292"/>
-        <location filename="../src/editor/editwrapper.cpp" line="365"/>
-        <location filename="../src/editor/editwrapper.cpp" line="521"/>
-        <location filename="../src/editor/editwrapper.cpp" line="751"/>
+        <location filename="../src/editor/editwrapper.cpp" line="355"/>
+        <location filename="../src/editor/editwrapper.cpp" line="429"/>
+        <location filename="../src/editor/editwrapper.cpp" line="595"/>
+        <location filename="../src/editor/editwrapper.cpp" line="887"/>
         <source>Save</source>
         <translation>ບັນທຶກ</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="516"/>
+        <location filename="../src/editor/editwrapper.cpp" line="590"/>
         <source>Do you want to save this file?</source>
         <translation>ທ່ານຕ້ອງການບັນທຶກຂໍ້ມູນນີ້ຫຍັງ?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="363"/>
-        <location filename="../src/editor/editwrapper.cpp" line="519"/>
+        <location filename="../src/editor/editwrapper.cpp" line="427"/>
+        <location filename="../src/editor/editwrapper.cpp" line="593"/>
         <source>Cancel</source>
         <translation>ຢກເລີກ</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="360"/>
+        <location filename="../src/editor/editwrapper.cpp" line="424"/>
         <source>Encoding changed. Do you want to save the file now?</source>
         <translation>ດັດຊະນີຂໍ້ມູນນີ້ຫຍັງ? ທ່ານຕ້ອງການບັນທຶກຂໍ້ມູນນີ້ຫຍັງ?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="520"/>
+        <location filename="../src/editor/editwrapper.cpp" line="594"/>
         <source>Discard</source>
         <translation>ລົບ</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="274"/>
-        <location filename="../src/editor/editwrapper.cpp" line="620"/>
+        <location filename="../src/editor/editwrapper.cpp" line="1121"/>
+        <source>The file contains invalid characters (NUL). Preview mode is read-only.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="337"/>
+        <location filename="../src/editor/editwrapper.cpp" line="705"/>
         <source>You do not have permission to save %1</source>
         <translation>ທ່ານບໍ່ມີສິທາງການບັນທຶກ %1</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="836"/>
+        <location filename="../src/editor/editwrapper.cpp" line="987"/>
         <source>File removed on the disk. Save it now?</source>
         <translation>ໄຟລ໌ຖືກລຶບອອກຈາກດິສ. ທ່ານຕ້ອງການບັນທຶກມັນດຽວນີ້ບໍ?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="842"/>
+        <location filename="../src/editor/editwrapper.cpp" line="993"/>
         <source>File has changed on disk. Reload?</source>
         <translation>ໄຟລ໌ຖືກດັດຊະນີອອກຈາກດິສ. ທ່ານຕ້ອງການບັນທຶກມັນດຽວນີ້ບໍ?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="884"/>
-        <location filename="../src/widgets/bottombar.cpp" line="74"/>
-        <source>INSERT</source>
-        <translation>ປ້ອນ</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="888"/>
-        <source>OVERWRITE</source>
-        <translation>ປ່ອຍປ່ອຍ</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="892"/>
-        <source>R/O</source>
-        <translation>ອ່ານ/ປ້ອນ</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="1618"/>
+        <location filename="../src/editor/editwrapper.cpp" line="1806"/>
         <source>The file cannot be read, which may be too large or has been damaged!</source>
         <translation>ບໍ່ສາມາດອ່ານໄຟລ໌ໄດ້, ອາດຈະໃຫຍ່ເກີນໄປ ຫຼື ໄດ້ຮັບຄວາມເສຍຫາຍ!</translation>
     </message>
@@ -111,17 +119,17 @@
         <translation>ຄີດຊອກ</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="36"/>
+        <location filename="../src/controls/findbar.cpp" line="38"/>
         <source>Previous</source>
         <translation>ຫົວ້ອງກ່ອນຫົວ້ອງ</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="37"/>
+        <location filename="../src/controls/findbar.cpp" line="40"/>
         <source>Next</source>
         <translation>ຫົວ້ອງຕໍ່ໄປ</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="38"/>
+        <location filename="../src/controls/findbar.cpp" line="42"/>
         <source>Replace</source>
         <translation>ປ່ຽນແທນ</translation>
     </message>
@@ -129,9 +137,17 @@
 <context>
     <name>JumpLineBar</name>
     <message>
-        <location filename="../src/controls/jumplinebar.cpp" line="45"/>
+        <location filename="../src/controls/jumplinebar.cpp" line="46"/>
         <source>Go to Line: </source>
         <translation>ໄປຫາບຣາວຊາດ: </translation>
+    </message>
+</context>
+<context>
+    <name>LineBar</name>
+    <message>
+        <location filename="../src/controls/linebar.cpp" line="144"/>
+        <source>第%1/%2项</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -148,19 +164,47 @@
     </message>
 </context>
 <context>
+    <name>MarkdownBridge</name>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="37"/>
+        <source>Collapse code block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="38"/>
+        <source>Expand code block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="39"/>
+        <source>Copy code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="40"/>
+        <source>Expand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="42"/>
+        <source>%1 line(s) of code collapsed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PathSettingWgt</name>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="84"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="90"/>
         <source>Remember the last used path</source>
         <translation>ການນຳໃຊ້ເສີມ</translation>
     </message>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="85"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="91"/>
         <source>Same path as the current file</source>
         <translation>ຈຸດທີ່ໄດ້ໃຊ້ກ່ອນ</translation>
     </message>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="86"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="92"/>
         <source>Customize the default path</source>
         <translation>ຄຸ້ມຄອບມາດຕະຖານ</translation>
     </message>
@@ -173,15 +217,20 @@
         <translation>ຕົວເລີ່ມຕົ້ນສຳລັບດູແລະປ່ອຍປ່ອຍຂໍ້ມູນນີ້ຫຍັງ.</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="294"/>
-        <location filename="../src/editor/editwrapper.cpp" line="761"/>
-        <location filename="../src/editor/editwrapper.cpp" line="776"/>
-        <location filename="../src/widgets/window.cpp" line="1362"/>
-        <location filename="../src/widgets/window.cpp" line="1390"/>
-        <location filename="../src/widgets/window.cpp" line="1531"/>
-        <location filename="../src/widgets/window.cpp" line="1548"/>
+        <location filename="../src/editor/editwrapper.cpp" line="357"/>
+        <location filename="../src/editor/editwrapper.cpp" line="897"/>
+        <location filename="../src/editor/editwrapper.cpp" line="912"/>
+        <location filename="../src/widgets/window.cpp" line="1528"/>
+        <location filename="../src/widgets/window.cpp" line="1556"/>
+        <location filename="../src/widgets/window.cpp" line="1715"/>
+        <location filename="../src/widgets/window.cpp" line="1732"/>
         <source>Encoding</source>
         <translation>ລະຫັດສະແດງ</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="2001"/>
+        <source>视图模式</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="11"/>
@@ -217,7 +266,7 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="18"/>
         <location filename="../src/controls/settingsdialog.cpp" line="96"/>
-        <location filename="../src/widgets/window.cpp" line="2388"/>
+        <location filename="../src/widgets/window.cpp" line="2581"/>
         <source>Window</source>
         <translation>ຫນ້າທີ່</translation>
     </message>
@@ -757,68 +806,68 @@
         <translation>ອາຣາບິກ</translation>
     </message>
     <message>
-        <location filename="../src/startmanager.cpp" line="971"/>
+        <location filename="../src/startmanager.cpp" line="1035"/>
         <source>File not saved</source>
         <translation>ບໍ່ໄດ້ບີ້້</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1532"/>
-        <location filename="../src/widgets/window.cpp" line="1549"/>
+        <location filename="../src/widgets/window.cpp" line="1716"/>
+        <location filename="../src/widgets/window.cpp" line="1733"/>
         <source>Line Endings</source>
         <translation>ເສົ້າທື່</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="243"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="379"/>
         <source>Please install &apos;UOS AI&apos; from the App Store before using</source>
         <translation>ກະລູນາຕິດຕັ້ງ &apos;UOS AI&apos; ຈາກ App Store ກ່ອນໃຊ້ງານ</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="245"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="381"/>
         <source>No audio input device detected. Please check and try again</source>
         <translation>ບໍ່ພົບອຸປະກອນຮັບສຽງ. ກະລຸນາກວດສອບ ແລະ ລອງໃໝ່ອີກຄັ້ງ</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="247"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="383"/>
         <source>No audio output device detected. Please check and try again</source>
         <translation>ບໍ່ພົບອຸປະກອນອອກສຽງ. ກະລຸນາກວດສອບ ແລະ ລອງໃໝ່ອີກຄັ້ງ</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="69"/>
+        <location filename="../src/common/text_file_saver.cpp" line="74"/>
         <source>File path is empty</source>
         <translation>ເຄື່ອງມຸງລະຫ຤ຸ້ນເປັນຫວ່າງເຫດ</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="155"/>
+        <location filename="../src/common/text_file_saver.cpp" line="153"/>
         <source>Insufficient memory to load document content</source>
         <translation>ບໍ່ພີ້ນພ້ອມພໍເພື່ອອົບຮົມເນື່ອງໃນເນື່ອງຂອງບໍ່ພີ້ນພ້ອມພໍ</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="177"/>
+        <location filename="../src/common/text_file_saver.cpp" line="178"/>
         <source>Insufficient memory for encoding conversion</source>
         <translation>ບໍ່ພີ້ນພ້ອມພໍສື່ຂໍ້າງກຳນຳເພື່ອການປ່ອງແລະການແປກ</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="183"/>
+        <location filename="../src/common/text_file_saver.cpp" line="184"/>
         <source>Encoding conversion failed</source>
         <translation>ລోຫຼາຍກວດການປ້ອມແປບ້ານບ່າຍກຳນຳໃຊ້ບໍ່ໄດ້</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="189"/>
+        <location filename="../src/common/text_file_saver.cpp" line="190"/>
         <source>Converted content is empty</source>
         <translation>ແປບ້ານທຳເລັດມີເນື້ອໃນເປັນຫວ່າງ</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="207"/>
+        <location filename="../src/common/text_file_saver.cpp" line="208"/>
         <source>Memory allocation failed</source>
         <translation>ຈົ່ງການຈັດເຈົ້າມີບັນຫາ</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="211"/>
+        <location filename="../src/common/text_file_saver.cpp" line="212"/>
         <source>Error occurred: %1</source>
         <translation>ເກີດຂ້ອງຫນ້າ: %1</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="215"/>
+        <location filename="../src/common/text_file_saver.cpp" line="216"/>
         <source>Unknown error occurred</source>
         <translation>ບ່າຍຂ້ອງຫນ້າທີ່ບໍ່ຮັບຮູ້ເກີດຂຶ້ນ</translation>
     </message>
@@ -831,27 +880,27 @@
         <translation>ຊອກຫາ</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="34"/>
+        <location filename="../src/controls/replacebar.cpp" line="36"/>
         <source>Replace With</source>
         <translation>ແບ່ງແຍ່ງໃຫ້ພັນທຳ</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="36"/>
+        <location filename="../src/controls/replacebar.cpp" line="40"/>
         <source>Replace</source>
         <translation>ແບ່ງແຍ່ງ</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="37"/>
+        <location filename="../src/controls/replacebar.cpp" line="42"/>
         <source>Skip</source>
         <translation>ຜ່ອຍວາງ</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="38"/>
+        <location filename="../src/controls/replacebar.cpp" line="44"/>
         <source>Replace Rest</source>
         <translation>ແບ່ງແຍ່ງເຫຼົ່າອື່ນ້ອຍ</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="39"/>
+        <location filename="../src/controls/replacebar.cpp" line="46"/>
         <source>Replace All</source>
         <translation>ແບ່ງແຍ່ງທີ່ງານ</translation>
     </message>
@@ -893,34 +942,34 @@
         <translation>ລະຄອມສູງສຸດ</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="484"/>
+        <location filename="../src/common/settings.cpp" line="491"/>
         <source>This shortcut conflicts with system shortcut %1</source>
         <translation>ປຸ່ມລັດນີ້ຂັດແຍ່ງກັບປຸ່ມລັດລະບົບ %1</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="487"/>
+        <location filename="../src/common/settings.cpp" line="494"/>
         <source>This shortcut conflicts with %1, click on Replace to make this shortcut effective immediately</source>
         <translation>ປຸ່ມລັດນີ້ຂັດແຍ່ງກັບ %1, ກົດທີ່ ແທນທີ່ ເພື່ອເຮັດໃຫ້ປຸ່ມລັດນີ້ມີຜົນທັນທີ</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="682"/>
-        <location filename="../src/common/settings.cpp" line="695"/>
-        <location filename="../src/common/settings.cpp" line="704"/>
+        <location filename="../src/common/settings.cpp" line="689"/>
+        <location filename="../src/common/settings.cpp" line="702"/>
+        <location filename="../src/common/settings.cpp" line="711"/>
         <source>The shortcut %1 is invalid, please set another one.</source>
         <translation>ປຸ່ມລັດ %1 ບໍ່ຖືກຕ້ອງ, ກະລຸນາຕັ້ງຄ່າປຸ່ມລັດອື່ນ.</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="736"/>
+        <location filename="../src/common/settings.cpp" line="743"/>
         <source>Cancel</source>
         <translation>ຍົກເລື່ອງ</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="737"/>
+        <location filename="../src/common/settings.cpp" line="744"/>
         <source>Replace</source>
         <translation>ແທນທີ້</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="740"/>
+        <location filename="../src/common/settings.cpp" line="747"/>
         <source>OK</source>
         <translation>ຕິດຕາມ</translation>
     </message>
@@ -928,7 +977,7 @@
 <context>
     <name>StartManager</name>
     <message>
-        <location filename="../src/startmanager.cpp" line="411"/>
+        <location filename="../src/startmanager.cpp" line="425"/>
         <source>Untitled %1</source>
         <translation>ບໍ່ມີຊື່ %1</translation>
     </message>
@@ -936,32 +985,32 @@
 <context>
     <name>Tabbar</name>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="641"/>
+        <location filename="../src/controls/tabbar.cpp" line="678"/>
         <source>Close tab</source>
         <translation>ປຸງປະດີງ མົງ</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="642"/>
+        <location filename="../src/controls/tabbar.cpp" line="680"/>
         <source>Close other tabs</source>
         <translation>ປຸງປະດີງ མົງອື່ນ</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="643"/>
+        <location filename="../src/controls/tabbar.cpp" line="682"/>
         <source>More options</source>
         <translation>ອີ້ນີ້ມີຫຼາຍວົງຢານ</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="644"/>
+        <location filename="../src/controls/tabbar.cpp" line="684"/>
         <source>Close tabs to the left</source>
         <translation>ປຸງປະດີງ མົງທີ່ຢັນຂວາ</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="645"/>
+        <location filename="../src/controls/tabbar.cpp" line="686"/>
         <source>Close tabs to the right</source>
         <translation>ປຸງປະດີງ མົງທີ່ຢັນຊ່ວງການ</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="646"/>
+        <location filename="../src/controls/tabbar.cpp" line="688"/>
         <source>Close unmodified tabs</source>
         <translation>ປຸງປະດີງ མົງທີ່ບໍ່ຖືກແກນແລ້ງ</translation>
     </message>
@@ -969,263 +1018,280 @@
 <context>
     <name>TextEdit</name>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="305"/>
+        <location filename="../src/editor/dtextedit.cpp" line="388"/>
         <source>Undo</source>
         <translation>ຍົກກລັບ</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="306"/>
+        <location filename="../src/editor/dtextedit.cpp" line="390"/>
         <source>Redo</source>
         <translation>ຍົກກລັບອີກຄັ້ງ</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="307"/>
+        <location filename="../src/editor/dtextedit.cpp" line="392"/>
         <source>Cut</source>
         <translation>ຕັດ</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="308"/>
+        <location filename="../src/editor/dtextedit.cpp" line="394"/>
         <source>Copy</source>
         <translation>ຄຸນມາ</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="309"/>
+        <location filename="../src/editor/dtextedit.cpp" line="396"/>
         <source>Paste</source>
         <translation>ຫຼືອົງ</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="310"/>
+        <location filename="../src/editor/dtextedit.cpp" line="398"/>
         <source>Delete</source>
         <translation>ລກງ</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="311"/>
+        <location filename="../src/editor/dtextedit.cpp" line="400"/>
         <source>Select All</source>
         <translation>ເລັ້ງທີ່ງ້າ</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="312"/>
-        <location filename="../src/widgets/window.cpp" line="535"/>
+        <location filename="../src/editor/dtextedit.cpp" line="402"/>
+        <location filename="../src/widgets/window.cpp" line="556"/>
         <source>Find</source>
         <translation>ຊອກຫາ</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="313"/>
-        <location filename="../src/widgets/window.cpp" line="536"/>
+        <location filename="../src/editor/dtextedit.cpp" line="404"/>
+        <location filename="../src/widgets/window.cpp" line="558"/>
         <source>Replace</source>
         <translation>ແທນທີ່</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="314"/>
+        <location filename="../src/editor/dtextedit.cpp" line="406"/>
         <source>Go to Line</source>
         <translation>ປະ້ອງແຖບ</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="315"/>
-        <source>Turn on Read-Only mode</source>
-        <translation>ເປີດໂໝດອ່ານຢ່າງດຽວ</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="316"/>
-        <source>Turn off Read-Only mode</source>
-        <translation>ປິດໂໝດອ່ານຢ່າງດຽວ</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="317"/>
+        <location filename="../src/editor/dtextedit.cpp" line="415"/>
         <source>Fullscreen</source>
         <translation>ລະບົງຮັບ</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="318"/>
+        <location filename="../src/editor/dtextedit.cpp" line="417"/>
         <source>Exit fullscreen</source>
         <translation>ອອກຈາກລະບົງຮັບ</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="319"/>
+        <location filename="../src/editor/dtextedit.cpp" line="419"/>
         <source>Display in file manager</source>
         <translation>ສະແດງໃນໂຕຈັດການໄຟລ໌</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="320"/>
-        <location filename="../src/editor/dtextedit.cpp" line="374"/>
+        <location filename="../src/editor/dtextedit.cpp" line="421"/>
+        <location filename="../src/editor/dtextedit.cpp" line="493"/>
         <source>Add Comment</source>
         <translation>ເພີ່ມຄວາມຄິດເຫັນ</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="321"/>
+        <location filename="../src/editor/dtextedit.cpp" line="423"/>
         <source>Text to Speech</source>
         <translation>ຂໍ້ຄວາມເປັນສຽງ</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="322"/>
-        <source>Stop reading</source>
-        <translation>ຫຢຸດອ່ານ</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="323"/>
+        <location filename="../src/editor/dtextedit.cpp" line="425"/>
         <source>Speech to Text</source>
         <translation>ສຽງເປັນຂໍ້ຄວາມ</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="324"/>
+        <location filename="../src/editor/dtextedit.cpp" line="427"/>
         <source>Translate</source>
         <translation>ຖອດຕັດ</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="325"/>
+        <location filename="../src/editor/dtextedit.cpp" line="429"/>
         <source>Column Mode</source>
         <translation>ສະແດງໃນໂຕຈັດການໄຟລ໌</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="326"/>
+        <location filename="../src/editor/dtextedit.cpp" line="431"/>
         <source>Add bookmark</source>
         <translation>ເພີ່ມການຕິດປ້າຍ</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="327"/>
+        <location filename="../src/editor/dtextedit.cpp" line="433"/>
         <source>Remove Bookmark</source>
         <translation>ລບການຕິດປ້າຍ</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="328"/>
+        <location filename="../src/editor/dtextedit.cpp" line="435"/>
         <source>Previous bookmark</source>
         <translation>ປ້າຍກ່ອນຫນ້າ</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="329"/>
+        <location filename="../src/editor/dtextedit.cpp" line="437"/>
         <source>Next bookmark</source>
         <translation>ປ້າຍຖັດໄປ</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="330"/>
+        <location filename="../src/editor/dtextedit.cpp" line="439"/>
         <source>Remove All Bookmarks</source>
         <translation>ລບທັງຫມືການຕິດປ້າຍ</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="331"/>
+        <location filename="../src/editor/dtextedit.cpp" line="441"/>
         <source>Fold All</source>
         <translation>ຢັບຢອງທັງຫມື</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="332"/>
+        <location filename="../src/editor/dtextedit.cpp" line="443"/>
         <source>Fold Current Level</source>
         <translation>ຢັບຢອງຣະດັບປັຈຈຸບັນ</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="333"/>
+        <location filename="../src/editor/dtextedit.cpp" line="445"/>
         <source>Unfold All</source>
         <translation>ຂຢັບຢອງທັງຫມື</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="334"/>
+        <location filename="../src/editor/dtextedit.cpp" line="447"/>
         <source>Unfold Current Level</source>
         <translation>ຂຢັບຢອງຣະດັບປັຈຈຸບັນ</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="339"/>
+        <location filename="../src/editor/dtextedit.cpp" line="453"/>
         <source>Color Mark</source>
         <translation>ກຳນົດສີ</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="343"/>
+        <location filename="../src/editor/dtextedit.cpp" line="458"/>
         <source>Clear All Marks</source>
         <translation>ລບທັງຫມືການຕິດປ້າຍ</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="344"/>
+        <location filename="../src/editor/dtextedit.cpp" line="460"/>
         <source>Clear Last Mark</source>
         <translation>ລບການຕິດປ້າຍສ້າງລົບ</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="353"/>
+        <location filename="../src/editor/dtextedit.cpp" line="470"/>
         <source>Mark</source>
         <translation>ກຳນົດ</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="366"/>
+        <location filename="../src/editor/dtextedit.cpp" line="484"/>
         <source>Mark All</source>
         <translation>ກຳນົດທັງຫມື</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="375"/>
+        <location filename="../src/editor/dtextedit.cpp" line="494"/>
         <source>Remove Comment</source>
         <translation>ລບຄວາມຄິດເຫັນ</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3208"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3211"/>
+        <location filename="../src/editor/dtextedit.cpp" line="543"/>
+        <source>View Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="3531"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3534"/>
         <source>Copy failed: not enough memory</source>
         <translation>ການຄັດລອກບໍ່ສຳເລັດ: ຫມື່ມີຄວາມຈຸ່ມວາງ</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3333"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3335"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3656"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3658"/>
         <source>Press ALT and click lines to edit in column mode</source>
         <translation>ກົດ ALT ແລະຄລິກບຣາບາບສຳລັບການແກ້ໄຂໃນສະແດງໃນໂຕຈັດການໄຟລ໌</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="418"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9574"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9576"/>
+        <source>No audio output device was detected. Please ensure your speakers or headphones are properly connected and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="9583"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9585"/>
+        <source>No audio input device was detected. Please ensure your speakers or headphones are properly connected and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="534"/>
         <source>Change Case</source>
         <translation>ປ່ຽນກໍລະນີ</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="419"/>
+        <location filename="../src/editor/dtextedit.cpp" line="409"/>
+        <source>Edit Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="411"/>
+        <source>Read View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="413"/>
+        <source>Live Preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="535"/>
         <source>Upper Case</source>
         <translation>ຕັດຕັວຫມືພິມ</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="420"/>
+        <location filename="../src/editor/dtextedit.cpp" line="536"/>
         <source>Lower Case</source>
         <translation>ຕັດຕັວຫມືພິມ</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="421"/>
+        <location filename="../src/editor/dtextedit.cpp" line="537"/>
         <source>Capitalize</source>
         <translation>ຕັດຕັວຫມືພິມ</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="78"/>
+        <location filename="../src/widgets/bottombar.cpp" line="110"/>
         <source>None</source>
         <translation>ບໍ່ມີ</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1363"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1490"/>
         <source>Selected line(s) copied</source>
         <translation>ແຖວທີ່ເລືອກໄວ້ຖືກສຳເນົາແລ້ວ</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1370"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1497"/>
         <source>Current line copied</source>
         <translation>ສຳເນົາບຣາບາບປັຈຈຸບັນແລ້ວ</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1400"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1527"/>
         <source>Selected line(s) clipped</source>
         <translation>ລອຫາດທີ່ເລືອກໄວ້ຖືກລອຫາດແລ້ວ</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1412"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1539"/>
         <source>Current line clipped</source>
         <translation>ລອຫາດທີ່ເລືອກໄວ້ຖືກລອຫາດແລ້ວ</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3227"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3230"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3550"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3553"/>
         <source>Paste failed: not enough memory</source>
         <translation>ການລອຫາດບໍ່ສຳເລັດ: ຫມື່ມີຄວາມຈຸ່ມວາງ</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="4548"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4873"/>
         <source>Read-Only mode is off</source>
         <translation>ໂໝດອ່ານຢ່າງດຽວຖືກປິດ</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="4560"/>
-        <location filename="../src/editor/dtextedit.cpp" line="4584"/>
-        <location filename="../src/editor/dtextedit.cpp" line="7896"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8007"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8015"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8026"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4885"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4909"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8236"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8347"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8355"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8366"/>
         <source>Read-Only mode is on</source>
         <translation>ໂໝດອ່ານຢ່າງດຽວຖືກເປີດ</translation>
     </message>
@@ -1233,138 +1299,175 @@
 <context>
     <name>WarningNotices</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="24"/>
+        <location filename="../src/controls/warningnotices.cpp" line="25"/>
         <source>Reload</source>
         <translation>ຕັດສຽງມາກກວ່ານີ້</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/warningnotices.cpp" line="29"/>
+        <source>Edit Anyway</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>Window</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="25"/>
-        <location filename="../src/widgets/window.cpp" line="531"/>
+        <location filename="../src/controls/warningnotices.cpp" line="27"/>
+        <location filename="../src/widgets/window.cpp" line="548"/>
         <source>Save as</source>
         <translation>ບັນທຶກຕົວຢ່າງ</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="527"/>
+        <location filename="../src/widgets/window.cpp" line="540"/>
         <source>New window</source>
         <translation>ຫນ້າທີ່ໃຫມ່</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="528"/>
+        <location filename="../src/widgets/window.cpp" line="542"/>
         <source>New tab</source>
         <translation>ຫນ້າທີ່ໃຫມ່</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="529"/>
+        <location filename="../src/widgets/window.cpp" line="544"/>
         <source>Open file</source>
         <translation>ເປີດໄຟລ໌</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="530"/>
-        <location filename="../src/widgets/window.cpp" line="3545"/>
+        <location filename="../src/widgets/window.cpp" line="546"/>
+        <location filename="../src/widgets/window.cpp" line="3950"/>
         <source>Save</source>
         <translation>ບັນທຶກ</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="532"/>
+        <location filename="../src/widgets/window.cpp" line="550"/>
         <source>Print</source>
         <translation>ພິມ</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="533"/>
+        <location filename="../src/widgets/window.cpp" line="552"/>
         <source>Switch theme</source>
         <translation>ປ່ຽນສີສັນ</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="534"/>
-        <location filename="../src/widgets/window.cpp" line="2448"/>
+        <location filename="../src/widgets/window.cpp" line="554"/>
+        <location filename="../src/widgets/window.cpp" line="2641"/>
         <source>Settings</source>
         <translation>ຕັດສຽງມາກກວ່ານີ້</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="666"/>
-        <location filename="../src/widgets/window.cpp" line="3845"/>
+        <location filename="../src/widgets/window.cpp" line="696"/>
+        <location filename="../src/widgets/window.cpp" line="4250"/>
         <source>Read-Only</source>
         <translation>ອ່ານຢ່າງດຽວ</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="687"/>
+        <location filename="../src/widgets/window.cpp" line="719"/>
         <source>You do not have permission to open %1</source>
         <translation>ທ່ານບໍ່ມີສິດທິໃນການເປີດ %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="738"/>
-        <location filename="../src/widgets/window.cpp" line="2963"/>
+        <location filename="../src/widgets/window.cpp" line="773"/>
+        <location filename="../src/widgets/window.cpp" line="3266"/>
         <source>Invalid file: %1</source>
         <translation>ໄຟລ໌ບໍ່ຖືກຕ້ອງ: %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="903"/>
-        <location filename="../src/widgets/window.cpp" line="956"/>
+        <location filename="../src/widgets/window.cpp" line="957"/>
+        <location filename="../src/widgets/window.cpp" line="1050"/>
+        <location filename="../src/widgets/window.cpp" line="3217"/>
         <source>Do you want to save this file?</source>
         <translation>ທ່ານຕ້ອງການບັນທຶກໄຟລ໌ນີ້ຫມືບໍ່?</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1290"/>
+        <location filename="../src/widgets/window.cpp" line="1381"/>
+        <source>Invalid characters detected while saving &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1382"/>
+        <source>If you force save this file, it may cause file corruption. Still want to save?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1386"/>
+        <source>Don&apos;t Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1387"/>
+        <source>Save As</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1388"/>
+        <source>Save Anyway</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1456"/>
         <source>You do not have permission to save %1</source>
         <translation>ທ່ານບໍ່ມີສິດທິໃນການບັນທຶກ %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1312"/>
+        <location filename="../src/widgets/window.cpp" line="1428"/>
+        <location filename="../src/widgets/window.cpp" line="1478"/>
         <source>Saved successfully</source>
         <translation>ບັນທຶກສຳເລັດແລ້ວ</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1354"/>
-        <location filename="../src/widgets/window.cpp" line="1481"/>
-        <location filename="../src/widgets/window.cpp" line="1529"/>
+        <location filename="../src/widgets/window.cpp" line="1520"/>
+        <location filename="../src/widgets/window.cpp" line="1665"/>
+        <location filename="../src/widgets/window.cpp" line="1713"/>
         <source>Save File</source>
         <translation>ບັນທຶກໄຟລ໌</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1483"/>
+        <location filename="../src/widgets/window.cpp" line="1569"/>
+        <source>Cannot save as the original file in preview mode. Please choose a different path.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1667"/>
         <source>Encoding</source>
         <translation>ການດັດສຽງ</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1773"/>
+        <location filename="../src/widgets/window.cpp" line="1957"/>
         <source>Read-Only mode is on</source>
         <translation>ໂໝດອ່ານຢ່າງດຽວຖືກເປີດ</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2322"/>
+        <location filename="../src/widgets/window.cpp" line="2511"/>
         <source>Current location remembered</source>
         <translation>ຕຳລາທີ່ເລືອກໄວ້ຖືກຈັດສຳເລັດແລ້ວ</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2398"/>
+        <location filename="../src/widgets/window.cpp" line="2591"/>
         <source>Ctrl+&apos;=&apos;</source>
         <translation>Ctrl+&apos;=&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2401"/>
+        <location filename="../src/widgets/window.cpp" line="2594"/>
         <source>Ctrl+&apos;-&apos;</source>
         <translation>Ctrl+&apos;-&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2430"/>
+        <location filename="../src/widgets/window.cpp" line="2623"/>
         <source>Editor</source>
         <translation>ຕັດສຽງມາກກວ່ານີ້</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3061"/>
+        <location filename="../src/widgets/window.cpp" line="3436"/>
         <source>Untitled %1</source>
         <translation>ບໍ່ມີຊື່ %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3543"/>
+        <location filename="../src/widgets/window.cpp" line="3948"/>
         <source>Cancel</source>
         <translation>ຢກເລີກ</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3544"/>
+        <location filename="../src/widgets/window.cpp" line="3949"/>
         <source>Discard</source>
         <translation>ລົບລາຍການ</translation>
     </message>

--- a/translations/deepin-editor_lt.ts
+++ b/translations/deepin-editor_lt.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="lt">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="lt">
 <context>
     <name>BottomBar</name>
     <message>
@@ -17,17 +19,36 @@
         <translation>Simboliai %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="44"/>
+        <location filename="../src/widgets/bottombar.cpp" line="47"/>
         <source>Loading:</source>
         <translation>Įkelti:</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="73"/>
+        <location filename="../src/widgets/bottombar.cpp" line="91"/>
+        <location filename="../src/widgets/bottombar.cpp" line="499"/>
+        <source>Edit Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="74"/>
+        <location filename="../src/widgets/bottombar.cpp" line="489"/>
+        <source>Read View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="75"/>
+        <location filename="../src/widgets/bottombar.cpp" line="493"/>
+        <source>Live Preview</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DDropdownMenu</name>
     <message>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="362"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="420"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="425"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="363"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="421"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="426"/>
         <source>None</source>
         <translation>Nėra</translation>
     </message>
@@ -35,68 +56,57 @@
 <context>
     <name>EditWrapper</name>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="292"/>
-        <location filename="../src/editor/editwrapper.cpp" line="365"/>
-        <location filename="../src/editor/editwrapper.cpp" line="521"/>
-        <location filename="../src/editor/editwrapper.cpp" line="751"/>
+        <location filename="../src/editor/editwrapper.cpp" line="355"/>
+        <location filename="../src/editor/editwrapper.cpp" line="429"/>
+        <location filename="../src/editor/editwrapper.cpp" line="595"/>
+        <location filename="../src/editor/editwrapper.cpp" line="887"/>
         <source>Save</source>
         <translation>Įrašyti</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="516"/>
+        <location filename="../src/editor/editwrapper.cpp" line="590"/>
         <source>Do you want to save this file?</source>
         <translation>Ar norite įrašyti šį failą?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="363"/>
-        <location filename="../src/editor/editwrapper.cpp" line="519"/>
+        <location filename="../src/editor/editwrapper.cpp" line="427"/>
+        <location filename="../src/editor/editwrapper.cpp" line="593"/>
         <source>Cancel</source>
         <translation>Atsisakyti</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="360"/>
+        <location filename="../src/editor/editwrapper.cpp" line="424"/>
         <source>Encoding changed. Do you want to save the file now?</source>
         <translation>Pasikeitė koduotė. Ar norite dabar įrašyti failą?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="520"/>
+        <location filename="../src/editor/editwrapper.cpp" line="594"/>
         <source>Discard</source>
         <translation>Atmesti</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="274"/>
-        <location filename="../src/editor/editwrapper.cpp" line="620"/>
+        <location filename="../src/editor/editwrapper.cpp" line="1121"/>
+        <source>The file contains invalid characters (NUL). Preview mode is read-only.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="337"/>
+        <location filename="../src/editor/editwrapper.cpp" line="705"/>
         <source>You do not have permission to save %1</source>
         <translation>Jūs neturite leidimo įrašyti %1</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="836"/>
+        <location filename="../src/editor/editwrapper.cpp" line="987"/>
         <source>File removed on the disk. Save it now?</source>
         <translation>Failas diske buvo pašalintas. Įrašyti jį dabar?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="842"/>
+        <location filename="../src/editor/editwrapper.cpp" line="993"/>
         <source>File has changed on disk. Reload?</source>
         <translation>Failas diske pasikeitė. Įkelti jį iš naujo?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="884"/>
-        <location filename="../src/widgets/bottombar.cpp" line="74"/>
-        <source>INSERT</source>
-        <translation>ĮTERPTI</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="888"/>
-        <source>OVERWRITE</source>
-        <translation>PERRAŠYTI</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="892"/>
-        <source>R/O</source>
-        <translation>TIK SKAITYMUI</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="1618"/>
+        <location filename="../src/editor/editwrapper.cpp" line="1806"/>
         <source>The file cannot be read, which may be too large or has been damaged!</source>
         <translation>Failas negali būti atsiverstas, gali būti per didelis ar sugadintas!</translation>
     </message>
@@ -109,17 +119,17 @@
         <translation>Rasti</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="36"/>
+        <location filename="../src/controls/findbar.cpp" line="38"/>
         <source>Previous</source>
         <translation>Ankstesnis</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="37"/>
+        <location filename="../src/controls/findbar.cpp" line="40"/>
         <source>Next</source>
         <translation>Kitas</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="38"/>
+        <location filename="../src/controls/findbar.cpp" line="42"/>
         <source>Replace</source>
         <translation>Pakeisti</translation>
     </message>
@@ -127,9 +137,17 @@
 <context>
     <name>JumpLineBar</name>
     <message>
-        <location filename="../src/controls/jumplinebar.cpp" line="45"/>
+        <location filename="../src/controls/jumplinebar.cpp" line="46"/>
         <source>Go to Line: </source>
         <translation>Pereiti į eilutę: </translation>
+    </message>
+</context>
+<context>
+    <name>LineBar</name>
+    <message>
+        <location filename="../src/controls/linebar.cpp" line="144"/>
+        <source>第%1/%2项</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -146,19 +164,47 @@
     </message>
 </context>
 <context>
+    <name>MarkdownBridge</name>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="37"/>
+        <source>Collapse code block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="38"/>
+        <source>Expand code block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="39"/>
+        <source>Copy code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="40"/>
+        <source>Expand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="42"/>
+        <source>%1 line(s) of code collapsed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PathSettingWgt</name>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="84"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="90"/>
         <source>Remember the last used path</source>
         <translation>Atsiminti paskutinį naudotą kelią</translation>
     </message>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="85"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="91"/>
         <source>Same path as the current file</source>
         <translation>Tas pats kelias kaip esamas failas</translation>
     </message>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="86"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="92"/>
         <source>Customize the default path</source>
         <translation>Pritaikyti numatytąjį kelį</translation>
     </message>
@@ -171,15 +217,20 @@
         <translation>Tekstų redaktorius</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="294"/>
-        <location filename="../src/editor/editwrapper.cpp" line="761"/>
-        <location filename="../src/editor/editwrapper.cpp" line="776"/>
-        <location filename="../src/widgets/window.cpp" line="1362"/>
-        <location filename="../src/widgets/window.cpp" line="1390"/>
-        <location filename="../src/widgets/window.cpp" line="1531"/>
-        <location filename="../src/widgets/window.cpp" line="1548"/>
+        <location filename="../src/editor/editwrapper.cpp" line="357"/>
+        <location filename="../src/editor/editwrapper.cpp" line="897"/>
+        <location filename="../src/editor/editwrapper.cpp" line="912"/>
+        <location filename="../src/widgets/window.cpp" line="1528"/>
+        <location filename="../src/widgets/window.cpp" line="1556"/>
+        <location filename="../src/widgets/window.cpp" line="1715"/>
+        <location filename="../src/widgets/window.cpp" line="1732"/>
         <source>Encoding</source>
         <translation>Koduotė</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="2001"/>
+        <source>视图模式</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="11"/>
@@ -215,7 +266,7 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="18"/>
         <location filename="../src/controls/settingsdialog.cpp" line="96"/>
-        <location filename="../src/widgets/window.cpp" line="2388"/>
+        <location filename="../src/widgets/window.cpp" line="2581"/>
         <source>Window</source>
         <translation>Langas</translation>
     </message>
@@ -755,68 +806,68 @@
         <translation>Vietnamas</translation>
     </message>
     <message>
-        <location filename="../src/startmanager.cpp" line="971"/>
+        <location filename="../src/startmanager.cpp" line="1035"/>
         <source>File not saved</source>
         <translation>Failas neįrašytas</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1532"/>
-        <location filename="../src/widgets/window.cpp" line="1549"/>
+        <location filename="../src/widgets/window.cpp" line="1716"/>
+        <location filename="../src/widgets/window.cpp" line="1733"/>
         <source>Line Endings</source>
         <translation>Eilučių pabaigos</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="243"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="379"/>
         <source>Please install &apos;UOS AI&apos; from the App Store before using</source>
         <translation>Įdiekite &apos;UOS AI&apos; Pirkimų platformoje prieš naudodami</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="245"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="381"/>
         <source>No audio input device detected. Please check and try again</source>
         <translation>Nepavyko aptikti garsų įvedimo įrenginio. Patikrinkite ir bandykite dar kartą</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="247"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="383"/>
         <source>No audio output device detected. Please check and try again</source>
         <translation>Nepavyko aptikti garsų išvedimo įrenginio. Patikrinkite ir bandykite dar kartą</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="69"/>
+        <location filename="../src/common/text_file_saver.cpp" line="74"/>
         <source>File path is empty</source>
         <translation>Failo kelių nėra</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="155"/>
+        <location filename="../src/common/text_file_saver.cpp" line="153"/>
         <source>Insufficient memory to load document content</source>
         <translation>Nepakankamai atminties, kad būtų galima įkelti dokumento turinį</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="177"/>
+        <location filename="../src/common/text_file_saver.cpp" line="178"/>
         <source>Insufficient memory for encoding conversion</source>
         <translation>Nepakankamai atminties kodavimo konvertavimui</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="183"/>
+        <location filename="../src/common/text_file_saver.cpp" line="184"/>
         <source>Encoding conversion failed</source>
         <translation>Kodavimo konvertavimas nepavyko</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="189"/>
+        <location filename="../src/common/text_file_saver.cpp" line="190"/>
         <source>Converted content is empty</source>
         <translation>Konvertuoto turinio nėra</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="207"/>
+        <location filename="../src/common/text_file_saver.cpp" line="208"/>
         <source>Memory allocation failed</source>
         <translation>Atminties priskyrimas nepavyko</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="211"/>
+        <location filename="../src/common/text_file_saver.cpp" line="212"/>
         <source>Error occurred: %1</source>
         <translation>Klaida: %1</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="215"/>
+        <location filename="../src/common/text_file_saver.cpp" line="216"/>
         <source>Unknown error occurred</source>
         <translation>Nežinoma klaida</translation>
     </message>
@@ -829,27 +880,27 @@
         <translation>Rasti</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="34"/>
+        <location filename="../src/controls/replacebar.cpp" line="36"/>
         <source>Replace With</source>
         <translation>Kuo pakeisti</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="36"/>
+        <location filename="../src/controls/replacebar.cpp" line="40"/>
         <source>Replace</source>
         <translation>Pakeisti</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="37"/>
+        <location filename="../src/controls/replacebar.cpp" line="42"/>
         <source>Skip</source>
         <translation>Praleisti</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="38"/>
+        <location filename="../src/controls/replacebar.cpp" line="44"/>
         <source>Replace Rest</source>
         <translation>Pakeisti likusius</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="39"/>
+        <location filename="../src/controls/replacebar.cpp" line="46"/>
         <source>Replace All</source>
         <translation>Pakeisti visus</translation>
     </message>
@@ -858,9 +909,9 @@
     <name>S:</name>
     <message>
         <location filename="../third/libiconv-1.16/src/iconv.c" line="103"/>
-        <source/>
+        <source></source>
         <comment>The first line of the short usage message.</comment>
-        <translation type="unfinished"/>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -891,34 +942,34 @@
         <translation>Visas ekranas</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="484"/>
+        <location filename="../src/common/settings.cpp" line="491"/>
         <source>This shortcut conflicts with system shortcut %1</source>
         <translation>Šis trumpinys konfliktuoja su sistemos trumpiniu %1</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="487"/>
+        <location filename="../src/common/settings.cpp" line="494"/>
         <source>This shortcut conflicts with %1, click on Replace to make this shortcut effective immediately</source>
         <translation>Šis trumpinys konfliktuoja su %1, spustelėkite „Pakeisti“, kad šis trumpinys būtų aktyvus nedelsiant</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="682"/>
-        <location filename="../src/common/settings.cpp" line="695"/>
-        <location filename="../src/common/settings.cpp" line="704"/>
+        <location filename="../src/common/settings.cpp" line="689"/>
+        <location filename="../src/common/settings.cpp" line="702"/>
+        <location filename="../src/common/settings.cpp" line="711"/>
         <source>The shortcut %1 is invalid, please set another one.</source>
         <translation>Trumpinys %1 yra neteisingas, prašome nustatyti kitą.</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="736"/>
+        <location filename="../src/common/settings.cpp" line="743"/>
         <source>Cancel</source>
         <translation>Atsisakyti</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="737"/>
+        <location filename="../src/common/settings.cpp" line="744"/>
         <source>Replace</source>
         <translation>Pakeisti</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="740"/>
+        <location filename="../src/common/settings.cpp" line="747"/>
         <source>OK</source>
         <translation>GERAI</translation>
     </message>
@@ -926,7 +977,7 @@
 <context>
     <name>StartManager</name>
     <message>
-        <location filename="../src/startmanager.cpp" line="411"/>
+        <location filename="../src/startmanager.cpp" line="425"/>
         <source>Untitled %1</source>
         <translation>Be pavadinimo %1</translation>
     </message>
@@ -934,32 +985,32 @@
 <context>
     <name>Tabbar</name>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="641"/>
+        <location filename="../src/controls/tabbar.cpp" line="678"/>
         <source>Close tab</source>
         <translation>Užverti kortelę</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="642"/>
+        <location filename="../src/controls/tabbar.cpp" line="680"/>
         <source>Close other tabs</source>
         <translation>Užverti kitas korteles</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="643"/>
+        <location filename="../src/controls/tabbar.cpp" line="682"/>
         <source>More options</source>
         <translation>Daugiau parinkčių</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="644"/>
+        <location filename="../src/controls/tabbar.cpp" line="684"/>
         <source>Close tabs to the left</source>
         <translation>Uždaryti lankstus kairėje</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="645"/>
+        <location filename="../src/controls/tabbar.cpp" line="686"/>
         <source>Close tabs to the right</source>
         <translation>Uždaryti lankstus dešinėje</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="646"/>
+        <location filename="../src/controls/tabbar.cpp" line="688"/>
         <source>Close unmodified tabs</source>
         <translation>Uždaryti nesamdytus lankstus</translation>
     </message>
@@ -967,263 +1018,280 @@
 <context>
     <name>TextEdit</name>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="305"/>
+        <location filename="../src/editor/dtextedit.cpp" line="388"/>
         <source>Undo</source>
         <translation>Atšaukti</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="306"/>
+        <location filename="../src/editor/dtextedit.cpp" line="390"/>
         <source>Redo</source>
         <translation>Grąžinti</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="307"/>
+        <location filename="../src/editor/dtextedit.cpp" line="392"/>
         <source>Cut</source>
         <translation>Iškirpti</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="308"/>
+        <location filename="../src/editor/dtextedit.cpp" line="394"/>
         <source>Copy</source>
         <translation>Kopijuoti</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="309"/>
+        <location filename="../src/editor/dtextedit.cpp" line="396"/>
         <source>Paste</source>
         <translation>Įdėti</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="310"/>
+        <location filename="../src/editor/dtextedit.cpp" line="398"/>
         <source>Delete</source>
         <translation>Ištrinti</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="311"/>
+        <location filename="../src/editor/dtextedit.cpp" line="400"/>
         <source>Select All</source>
         <translation>Žymėti viską</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="312"/>
-        <location filename="../src/widgets/window.cpp" line="535"/>
+        <location filename="../src/editor/dtextedit.cpp" line="402"/>
+        <location filename="../src/widgets/window.cpp" line="556"/>
         <source>Find</source>
         <translation>Rasti</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="313"/>
-        <location filename="../src/widgets/window.cpp" line="536"/>
+        <location filename="../src/editor/dtextedit.cpp" line="404"/>
+        <location filename="../src/widgets/window.cpp" line="558"/>
         <source>Replace</source>
         <translation>Pakeisti</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="314"/>
+        <location filename="../src/editor/dtextedit.cpp" line="406"/>
         <source>Go to Line</source>
         <translation>Pereiti į eilutę</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="315"/>
-        <source>Turn on Read-Only mode</source>
-        <translation>Įjungti tik skaitymo veikseną</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="316"/>
-        <source>Turn off Read-Only mode</source>
-        <translation>Išjungti tik skaitymo veikseną</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="317"/>
+        <location filename="../src/editor/dtextedit.cpp" line="415"/>
         <source>Fullscreen</source>
         <translation>Visas ekranas</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="318"/>
+        <location filename="../src/editor/dtextedit.cpp" line="417"/>
         <source>Exit fullscreen</source>
         <translation>Išeiti iš viso ekrano</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="319"/>
+        <location filename="../src/editor/dtextedit.cpp" line="419"/>
         <source>Display in file manager</source>
         <translation>Rodyti failų tvarkytuvėje</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="320"/>
-        <location filename="../src/editor/dtextedit.cpp" line="374"/>
+        <location filename="../src/editor/dtextedit.cpp" line="421"/>
+        <location filename="../src/editor/dtextedit.cpp" line="493"/>
         <source>Add Comment</source>
         <translation>Pridėti komentą</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="321"/>
+        <location filename="../src/editor/dtextedit.cpp" line="423"/>
         <source>Text to Speech</source>
         <translation>Tekstas į kalbą</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="322"/>
-        <source>Stop reading</source>
-        <translation>Stabdikai skaitymą</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="323"/>
+        <location filename="../src/editor/dtextedit.cpp" line="425"/>
         <source>Speech to Text</source>
         <translation>Kalba į tekstą</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="324"/>
+        <location filename="../src/editor/dtextedit.cpp" line="427"/>
         <source>Translate</source>
         <translation>Perversti</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="325"/>
+        <location filename="../src/editor/dtextedit.cpp" line="429"/>
         <source>Column Mode</source>
         <translation>Stulpų režimas</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="326"/>
+        <location filename="../src/editor/dtextedit.cpp" line="431"/>
         <source>Add bookmark</source>
         <translation>Pridėti žymę</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="327"/>
+        <location filename="../src/editor/dtextedit.cpp" line="433"/>
         <source>Remove Bookmark</source>
         <translation>Pašalinti žymę</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="328"/>
+        <location filename="../src/editor/dtextedit.cpp" line="435"/>
         <source>Previous bookmark</source>
         <translation>Ankstesnė žymė</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="329"/>
+        <location filename="../src/editor/dtextedit.cpp" line="437"/>
         <source>Next bookmark</source>
         <translation>Sekanti žymė</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="330"/>
+        <location filename="../src/editor/dtextedit.cpp" line="439"/>
         <source>Remove All Bookmarks</source>
         <translation>Pašalinti visas žymes</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="331"/>
+        <location filename="../src/editor/dtextedit.cpp" line="441"/>
         <source>Fold All</source>
         <translation>Sukrauti viską</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="332"/>
+        <location filename="../src/editor/dtextedit.cpp" line="443"/>
         <source>Fold Current Level</source>
         <translation>Sukrauti šį lygį</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="333"/>
+        <location filename="../src/editor/dtextedit.cpp" line="445"/>
         <source>Unfold All</source>
         <translation>Atsukti viską</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="334"/>
+        <location filename="../src/editor/dtextedit.cpp" line="447"/>
         <source>Unfold Current Level</source>
         <translation>Atsukti šį lygį</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="339"/>
+        <location filename="../src/editor/dtextedit.cpp" line="453"/>
         <source>Color Mark</source>
         <translation>Spalvoti žymę</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="343"/>
+        <location filename="../src/editor/dtextedit.cpp" line="458"/>
         <source>Clear All Marks</source>
         <translation>Ištrinti visas žymes</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="344"/>
+        <location filename="../src/editor/dtextedit.cpp" line="460"/>
         <source>Clear Last Mark</source>
         <translation>Ištrinti paskutinę žymę</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="353"/>
+        <location filename="../src/editor/dtextedit.cpp" line="470"/>
         <source>Mark</source>
         <translation>Žymėti</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="366"/>
+        <location filename="../src/editor/dtextedit.cpp" line="484"/>
         <source>Mark All</source>
         <translation>Žymėti viską</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="375"/>
+        <location filename="../src/editor/dtextedit.cpp" line="494"/>
         <source>Remove Comment</source>
         <translation>Pašalinti komentą</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3208"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3211"/>
+        <location filename="../src/editor/dtextedit.cpp" line="543"/>
+        <source>View Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="3531"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3534"/>
         <source>Copy failed: not enough memory</source>
         <translation>Kopijavimas nepavyko: nepakankama atmintis</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3333"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3335"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3656"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3658"/>
         <source>Press ALT and click lines to edit in column mode</source>
         <translation>Spustelėkite ALT ir spustelėkite eilutes, kad redaguotumėte stulpų režime</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="418"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9574"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9576"/>
+        <source>No audio output device was detected. Please ensure your speakers or headphones are properly connected and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="9583"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9585"/>
+        <source>No audio input device was detected. Please ensure your speakers or headphones are properly connected and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="534"/>
         <source>Change Case</source>
         <translation>Keisti raidžių dydį</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="419"/>
+        <location filename="../src/editor/dtextedit.cpp" line="409"/>
+        <source>Edit Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="411"/>
+        <source>Read View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="413"/>
+        <source>Live Preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="535"/>
         <source>Upper Case</source>
         <translation>Didžiosios raidės</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="420"/>
+        <location filename="../src/editor/dtextedit.cpp" line="536"/>
         <source>Lower Case</source>
         <translation>Mažosios raidės</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="421"/>
+        <location filename="../src/editor/dtextedit.cpp" line="537"/>
         <source>Capitalize</source>
         <translation>Iš didžiosios raidės</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="78"/>
+        <location filename="../src/widgets/bottombar.cpp" line="110"/>
         <source>None</source>
         <translation>Nėra</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1363"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1490"/>
         <source>Selected line(s) copied</source>
         <translation>Pasirinktos eilutės (eilutė) kopijuotos</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1370"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1497"/>
         <source>Current line copied</source>
         <translation>Dabartinė eilutė nukopijuota</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1400"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1527"/>
         <source>Selected line(s) clipped</source>
         <translation>Pasirinktos eilutės (eilutė) iškliptos</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1412"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1539"/>
         <source>Current line clipped</source>
         <translation>Ši eilutė išklipta</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3227"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3230"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3550"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3553"/>
         <source>Paste failed: not enough memory</source>
         <translation>Įklejimas nepavyko: nepakankama atmintis</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="4548"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4873"/>
         <source>Read-Only mode is off</source>
         <translation>Tik skaitymo veiksena yra išjungta</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="4560"/>
-        <location filename="../src/editor/dtextedit.cpp" line="4584"/>
-        <location filename="../src/editor/dtextedit.cpp" line="7896"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8007"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8015"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8026"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4885"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4909"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8236"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8347"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8355"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8366"/>
         <source>Read-Only mode is on</source>
         <translation>Tik skaitymo veiksena yra įjungta</translation>
     </message>
@@ -1231,138 +1299,175 @@
 <context>
     <name>WarningNotices</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="24"/>
+        <location filename="../src/controls/warningnotices.cpp" line="25"/>
         <source>Reload</source>
         <translation>Įkelti iš naujo</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/warningnotices.cpp" line="29"/>
+        <source>Edit Anyway</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>Window</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="25"/>
-        <location filename="../src/widgets/window.cpp" line="531"/>
+        <location filename="../src/controls/warningnotices.cpp" line="27"/>
+        <location filename="../src/widgets/window.cpp" line="548"/>
         <source>Save as</source>
         <translation>Įrašyti kaip</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="527"/>
+        <location filename="../src/widgets/window.cpp" line="540"/>
         <source>New window</source>
         <translation>Naujas langas</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="528"/>
+        <location filename="../src/widgets/window.cpp" line="542"/>
         <source>New tab</source>
         <translation>Nauja kortelė</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="529"/>
+        <location filename="../src/widgets/window.cpp" line="544"/>
         <source>Open file</source>
         <translation>Atverti failą</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="530"/>
-        <location filename="../src/widgets/window.cpp" line="3545"/>
+        <location filename="../src/widgets/window.cpp" line="546"/>
+        <location filename="../src/widgets/window.cpp" line="3950"/>
         <source>Save</source>
         <translation>Įrašyti</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="532"/>
+        <location filename="../src/widgets/window.cpp" line="550"/>
         <source>Print</source>
         <translation>Spausdinti</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="533"/>
+        <location filename="../src/widgets/window.cpp" line="552"/>
         <source>Switch theme</source>
         <translation>Perjungti temą</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="534"/>
-        <location filename="../src/widgets/window.cpp" line="2448"/>
+        <location filename="../src/widgets/window.cpp" line="554"/>
+        <location filename="../src/widgets/window.cpp" line="2641"/>
         <source>Settings</source>
         <translation>Nustatymai</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="666"/>
-        <location filename="../src/widgets/window.cpp" line="3845"/>
+        <location filename="../src/widgets/window.cpp" line="696"/>
+        <location filename="../src/widgets/window.cpp" line="4250"/>
         <source>Read-Only</source>
         <translation>Tik skaitymui</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="687"/>
+        <location filename="../src/widgets/window.cpp" line="719"/>
         <source>You do not have permission to open %1</source>
         <translation>Jūs neturite leidimo atverti %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="738"/>
-        <location filename="../src/widgets/window.cpp" line="2963"/>
+        <location filename="../src/widgets/window.cpp" line="773"/>
+        <location filename="../src/widgets/window.cpp" line="3266"/>
         <source>Invalid file: %1</source>
         <translation>Neteisingas failas: %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="903"/>
-        <location filename="../src/widgets/window.cpp" line="956"/>
+        <location filename="../src/widgets/window.cpp" line="957"/>
+        <location filename="../src/widgets/window.cpp" line="1050"/>
+        <location filename="../src/widgets/window.cpp" line="3217"/>
         <source>Do you want to save this file?</source>
         <translation>Ar norite įrašyti šį failą?</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1290"/>
+        <location filename="../src/widgets/window.cpp" line="1381"/>
+        <source>Invalid characters detected while saving &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1382"/>
+        <source>If you force save this file, it may cause file corruption. Still want to save?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1386"/>
+        <source>Don&apos;t Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1387"/>
+        <source>Save As</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1388"/>
+        <source>Save Anyway</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1456"/>
         <source>You do not have permission to save %1</source>
         <translation>Jūs neturite leidimo įrašyti %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1312"/>
+        <location filename="../src/widgets/window.cpp" line="1428"/>
+        <location filename="../src/widgets/window.cpp" line="1478"/>
         <source>Saved successfully</source>
         <translation>Sėkmingai įrašyta</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1354"/>
-        <location filename="../src/widgets/window.cpp" line="1481"/>
-        <location filename="../src/widgets/window.cpp" line="1529"/>
+        <location filename="../src/widgets/window.cpp" line="1520"/>
+        <location filename="../src/widgets/window.cpp" line="1665"/>
+        <location filename="../src/widgets/window.cpp" line="1713"/>
         <source>Save File</source>
         <translation>Įrašyti failą</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1483"/>
+        <location filename="../src/widgets/window.cpp" line="1569"/>
+        <source>Cannot save as the original file in preview mode. Please choose a different path.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1667"/>
         <source>Encoding</source>
         <translation>Koduotė</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1773"/>
+        <location filename="../src/widgets/window.cpp" line="1957"/>
         <source>Read-Only mode is on</source>
         <translation>Tik skaitymo veiksena yra įjungta</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2322"/>
+        <location filename="../src/widgets/window.cpp" line="2511"/>
         <source>Current location remembered</source>
         <translation>Pažymėta esama pozicija</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2398"/>
+        <location filename="../src/widgets/window.cpp" line="2591"/>
         <source>Ctrl+&apos;=&apos;</source>
         <translation>Ctrl+=&apos; </translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2401"/>
+        <location filename="../src/widgets/window.cpp" line="2594"/>
         <source>Ctrl+&apos;-&apos;</source>
         <translation>Ctrl+=&apos;-</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2430"/>
+        <location filename="../src/widgets/window.cpp" line="2623"/>
         <source>Editor</source>
         <translation>Redaktorius</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3061"/>
+        <location filename="../src/widgets/window.cpp" line="3436"/>
         <source>Untitled %1</source>
         <translation>Be pavadinimo %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3543"/>
+        <location filename="../src/widgets/window.cpp" line="3948"/>
         <source>Cancel</source>
         <translation>Atsisakyti</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3544"/>
+        <location filename="../src/widgets/window.cpp" line="3949"/>
         <source>Discard</source>
         <translation>Atmesti</translation>
     </message>

--- a/translations/deepin-editor_ms.ts
+++ b/translations/deepin-editor_ms.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ms">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ms">
 <context>
     <name>BottomBar</name>
     <message>
@@ -17,17 +19,36 @@
         <translation>Aksara %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="44"/>
+        <location filename="../src/widgets/bottombar.cpp" line="47"/>
         <source>Loading:</source>
         <translation>Memuatkan:</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="73"/>
+        <location filename="../src/widgets/bottombar.cpp" line="91"/>
+        <location filename="../src/widgets/bottombar.cpp" line="499"/>
+        <source>Edit Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="74"/>
+        <location filename="../src/widgets/bottombar.cpp" line="489"/>
+        <source>Read View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="75"/>
+        <location filename="../src/widgets/bottombar.cpp" line="493"/>
+        <source>Live Preview</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DDropdownMenu</name>
     <message>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="362"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="420"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="425"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="363"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="421"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="426"/>
         <source>None</source>
         <translation>Tiada</translation>
     </message>
@@ -35,68 +56,57 @@
 <context>
     <name>EditWrapper</name>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="292"/>
-        <location filename="../src/editor/editwrapper.cpp" line="365"/>
-        <location filename="../src/editor/editwrapper.cpp" line="521"/>
-        <location filename="../src/editor/editwrapper.cpp" line="751"/>
+        <location filename="../src/editor/editwrapper.cpp" line="355"/>
+        <location filename="../src/editor/editwrapper.cpp" line="429"/>
+        <location filename="../src/editor/editwrapper.cpp" line="595"/>
+        <location filename="../src/editor/editwrapper.cpp" line="887"/>
         <source>Save</source>
         <translation>Simpan</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="516"/>
+        <location filename="../src/editor/editwrapper.cpp" line="590"/>
         <source>Do you want to save this file?</source>
         <translation>Anda mahu menyimpan fail ini?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="363"/>
-        <location filename="../src/editor/editwrapper.cpp" line="519"/>
+        <location filename="../src/editor/editwrapper.cpp" line="427"/>
+        <location filename="../src/editor/editwrapper.cpp" line="593"/>
         <source>Cancel</source>
         <translation>Batal</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="360"/>
+        <location filename="../src/editor/editwrapper.cpp" line="424"/>
         <source>Encoding changed. Do you want to save the file now?</source>
         <translation>Pengekodan berubah. Anda mahu menyimpan fail sekarang?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="520"/>
+        <location filename="../src/editor/editwrapper.cpp" line="594"/>
         <source>Discard</source>
         <translation>Singkir</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="274"/>
-        <location filename="../src/editor/editwrapper.cpp" line="620"/>
+        <location filename="../src/editor/editwrapper.cpp" line="1121"/>
+        <source>The file contains invalid characters (NUL). Preview mode is read-only.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="337"/>
+        <location filename="../src/editor/editwrapper.cpp" line="705"/>
         <source>You do not have permission to save %1</source>
         <translation>Anda tidak mempunyai keizinan untuk menyimpan %1</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="836"/>
+        <location filename="../src/editor/editwrapper.cpp" line="987"/>
         <source>File removed on the disk. Save it now?</source>
         <translation>Fail dalam cakera telah dibuang. Simpan ia sekarang?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="842"/>
+        <location filename="../src/editor/editwrapper.cpp" line="993"/>
         <source>File has changed on disk. Reload?</source>
         <translation>Fail telah berubah di dalam cakera. Muat semula?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="884"/>
-        <location filename="../src/widgets/bottombar.cpp" line="74"/>
-        <source>INSERT</source>
-        <translation>SISIP</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="888"/>
-        <source>OVERWRITE</source>
-        <translation>TULISGANTI</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="892"/>
-        <source>R/O</source>
-        <translation>R/O</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="1618"/>
+        <location filename="../src/editor/editwrapper.cpp" line="1806"/>
         <source>The file cannot be read, which may be too large or has been damaged!</source>
         <translation>Fail tidak boleh dibaca, mungkin saiznya terlalu besar atau sudah rosak!</translation>
     </message>
@@ -109,17 +119,17 @@
         <translation>Cari</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="36"/>
+        <location filename="../src/controls/findbar.cpp" line="38"/>
         <source>Previous</source>
         <translation>Terdahulu</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="37"/>
+        <location filename="../src/controls/findbar.cpp" line="40"/>
         <source>Next</source>
         <translation>Berikutnya</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="38"/>
+        <location filename="../src/controls/findbar.cpp" line="42"/>
         <source>Replace</source>
         <translation>Ganti</translation>
     </message>
@@ -127,9 +137,17 @@
 <context>
     <name>JumpLineBar</name>
     <message>
-        <location filename="../src/controls/jumplinebar.cpp" line="45"/>
+        <location filename="../src/controls/jumplinebar.cpp" line="46"/>
         <source>Go to Line: </source>
         <translation>Pergi ke Baris:</translation>
+    </message>
+</context>
+<context>
+    <name>LineBar</name>
+    <message>
+        <location filename="../src/controls/linebar.cpp" line="144"/>
+        <source>第%1/%2项</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -146,19 +164,47 @@
     </message>
 </context>
 <context>
+    <name>MarkdownBridge</name>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="37"/>
+        <source>Collapse code block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="38"/>
+        <source>Expand code block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="39"/>
+        <source>Copy code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="40"/>
+        <source>Expand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="42"/>
+        <source>%1 line(s) of code collapsed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PathSettingWgt</name>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="84"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="90"/>
         <source>Remember the last used path</source>
         <translation>Ingat laluan yang terakhir digunakan</translation>
     </message>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="85"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="91"/>
         <source>Same path as the current file</source>
         <translation>Laluan serupa sebagai fail semasa</translation>
     </message>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="86"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="92"/>
         <source>Customize the default path</source>
         <translation>Suai laluan lalai</translation>
     </message>
@@ -171,15 +217,20 @@
         <translation>Penyunting Teks</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="294"/>
-        <location filename="../src/editor/editwrapper.cpp" line="761"/>
-        <location filename="../src/editor/editwrapper.cpp" line="776"/>
-        <location filename="../src/widgets/window.cpp" line="1362"/>
-        <location filename="../src/widgets/window.cpp" line="1390"/>
-        <location filename="../src/widgets/window.cpp" line="1531"/>
-        <location filename="../src/widgets/window.cpp" line="1548"/>
+        <location filename="../src/editor/editwrapper.cpp" line="357"/>
+        <location filename="../src/editor/editwrapper.cpp" line="897"/>
+        <location filename="../src/editor/editwrapper.cpp" line="912"/>
+        <location filename="../src/widgets/window.cpp" line="1528"/>
+        <location filename="../src/widgets/window.cpp" line="1556"/>
+        <location filename="../src/widgets/window.cpp" line="1715"/>
+        <location filename="../src/widgets/window.cpp" line="1732"/>
         <source>Encoding</source>
         <translation>Pengekodan</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="2001"/>
+        <source>视图模式</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="11"/>
@@ -215,7 +266,7 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="18"/>
         <location filename="../src/controls/settingsdialog.cpp" line="96"/>
-        <location filename="../src/widgets/window.cpp" line="2388"/>
+        <location filename="../src/widgets/window.cpp" line="2581"/>
         <source>Window</source>
         <translation>Tetingkap</translation>
     </message>
@@ -755,68 +806,68 @@
         <translation>Vietnam</translation>
     </message>
     <message>
-        <location filename="../src/startmanager.cpp" line="971"/>
+        <location filename="../src/startmanager.cpp" line="1035"/>
         <source>File not saved</source>
         <translation>Fail tidak disimpan</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1532"/>
-        <location filename="../src/widgets/window.cpp" line="1549"/>
+        <location filename="../src/widgets/window.cpp" line="1716"/>
+        <location filename="../src/widgets/window.cpp" line="1733"/>
         <source>Line Endings</source>
         <translation>Penghujung Baris</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="243"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="379"/>
         <source>Please install &apos;UOS AI&apos; from the App Store before using</source>
         <translation>Sila pasang &apos;UOS AI&apos; dari App Store sebelum menggunakannya</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="245"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="381"/>
         <source>No audio input device detected. Please check and try again</source>
         <translation>Tiada peranti input audio terkena. Sila semak dan cuba lagi</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="247"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="383"/>
         <source>No audio output device detected. Please check and try again</source>
         <translation>Tiada peranti output audio terkena. Sila semak dan cuba lagi</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="69"/>
+        <location filename="../src/common/text_file_saver.cpp" line="74"/>
         <source>File path is empty</source>
         <translation>Laluan fail kosong</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="155"/>
+        <location filename="../src/common/text_file_saver.cpp" line="153"/>
         <source>Insufficient memory to load document content</source>
         <translation>Memori tidak mencukupi untuk memuatkan kandungan dokumen</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="177"/>
+        <location filename="../src/common/text_file_saver.cpp" line="178"/>
         <source>Insufficient memory for encoding conversion</source>
         <translation>Memori tidak mencukupi untuk penukaran pengkodan</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="183"/>
+        <location filename="../src/common/text_file_saver.cpp" line="184"/>
         <source>Encoding conversion failed</source>
         <translation>Penukaran pengkodan gagal</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="189"/>
+        <location filename="../src/common/text_file_saver.cpp" line="190"/>
         <source>Converted content is empty</source>
         <translation>Kandungan yang ditukar kosong</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="207"/>
+        <location filename="../src/common/text_file_saver.cpp" line="208"/>
         <source>Memory allocation failed</source>
         <translation>Pengalokasian memori gagal</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="211"/>
+        <location filename="../src/common/text_file_saver.cpp" line="212"/>
         <source>Error occurred: %1</source>
         <translation>Ralat berlaku: %1</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="215"/>
+        <location filename="../src/common/text_file_saver.cpp" line="216"/>
         <source>Unknown error occurred</source>
         <translation>Ralat tidak diketahui berlaku</translation>
     </message>
@@ -829,27 +880,27 @@
         <translation>Cari</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="34"/>
+        <location filename="../src/controls/replacebar.cpp" line="36"/>
         <source>Replace With</source>
         <translation>Ganti Dengan</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="36"/>
+        <location filename="../src/controls/replacebar.cpp" line="40"/>
         <source>Replace</source>
         <translation>Ganti</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="37"/>
+        <location filename="../src/controls/replacebar.cpp" line="42"/>
         <source>Skip</source>
         <translation>Langkau</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="38"/>
+        <location filename="../src/controls/replacebar.cpp" line="44"/>
         <source>Replace Rest</source>
         <translation>Ganti Selebihnya</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="39"/>
+        <location filename="../src/controls/replacebar.cpp" line="46"/>
         <source>Replace All</source>
         <translation>Ganti Semua</translation>
     </message>
@@ -858,9 +909,9 @@
     <name>S:</name>
     <message>
         <location filename="../third/libiconv-1.16/src/iconv.c" line="103"/>
-        <source/>
+        <source></source>
         <comment>The first line of the short usage message.</comment>
-        <translation type="unfinished"/>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -891,34 +942,34 @@
         <translation>Skrin Penuh</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="484"/>
+        <location filename="../src/common/settings.cpp" line="491"/>
         <source>This shortcut conflicts with system shortcut %1</source>
         <translation>Pintasan ini berkonflik dengan pintasan sistem %1</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="487"/>
+        <location filename="../src/common/settings.cpp" line="494"/>
         <source>This shortcut conflicts with %1, click on Replace to make this shortcut effective immediately</source>
         <translation>Pintasan ini berkonflik dengan %1, klik Ganti untuk menjadikan pintasan ini berkesan serta-merta</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="682"/>
-        <location filename="../src/common/settings.cpp" line="695"/>
-        <location filename="../src/common/settings.cpp" line="704"/>
+        <location filename="../src/common/settings.cpp" line="689"/>
+        <location filename="../src/common/settings.cpp" line="702"/>
+        <location filename="../src/common/settings.cpp" line="711"/>
         <source>The shortcut %1 is invalid, please set another one.</source>
         <translation>Pintasan %1 tidak sah, sila tetapkan yang lain.</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="736"/>
+        <location filename="../src/common/settings.cpp" line="743"/>
         <source>Cancel</source>
         <translation>Batal</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="737"/>
+        <location filename="../src/common/settings.cpp" line="744"/>
         <source>Replace</source>
         <translation>Ganti</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="740"/>
+        <location filename="../src/common/settings.cpp" line="747"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
@@ -926,7 +977,7 @@
 <context>
     <name>StartManager</name>
     <message>
-        <location filename="../src/startmanager.cpp" line="411"/>
+        <location filename="../src/startmanager.cpp" line="425"/>
         <source>Untitled %1</source>
         <translation>%1 Tidak Bertajuk</translation>
     </message>
@@ -934,32 +985,32 @@
 <context>
     <name>Tabbar</name>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="641"/>
+        <location filename="../src/controls/tabbar.cpp" line="678"/>
         <source>Close tab</source>
         <translation>Tutup tab</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="642"/>
+        <location filename="../src/controls/tabbar.cpp" line="680"/>
         <source>Close other tabs</source>
         <translation>Tutup tab lain</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="643"/>
+        <location filename="../src/controls/tabbar.cpp" line="682"/>
         <source>More options</source>
         <translation>Lagi pilihan</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="644"/>
+        <location filename="../src/controls/tabbar.cpp" line="684"/>
         <source>Close tabs to the left</source>
         <translation>Tutup tab di sebelah kiri</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="645"/>
+        <location filename="../src/controls/tabbar.cpp" line="686"/>
         <source>Close tabs to the right</source>
         <translation>Tutup tab di sebelah kanan</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="646"/>
+        <location filename="../src/controls/tabbar.cpp" line="688"/>
         <source>Close unmodified tabs</source>
         <translation>Tutup tab yang tidak diubah suai</translation>
     </message>
@@ -967,263 +1018,280 @@
 <context>
     <name>TextEdit</name>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="305"/>
+        <location filename="../src/editor/dtextedit.cpp" line="388"/>
         <source>Undo</source>
         <translation>Buat Asal</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="306"/>
+        <location filename="../src/editor/dtextedit.cpp" line="390"/>
         <source>Redo</source>
         <translation>Buat Semula</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="307"/>
+        <location filename="../src/editor/dtextedit.cpp" line="392"/>
         <source>Cut</source>
         <translation>Potong</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="308"/>
+        <location filename="../src/editor/dtextedit.cpp" line="394"/>
         <source>Copy</source>
         <translation>Salin</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="309"/>
+        <location filename="../src/editor/dtextedit.cpp" line="396"/>
         <source>Paste</source>
         <translation>Tampal</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="310"/>
+        <location filename="../src/editor/dtextedit.cpp" line="398"/>
         <source>Delete</source>
         <translation>Padam</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="311"/>
+        <location filename="../src/editor/dtextedit.cpp" line="400"/>
         <source>Select All</source>
         <translation>Pilih Semua</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="312"/>
-        <location filename="../src/widgets/window.cpp" line="535"/>
+        <location filename="../src/editor/dtextedit.cpp" line="402"/>
+        <location filename="../src/widgets/window.cpp" line="556"/>
         <source>Find</source>
         <translation>Cari</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="313"/>
-        <location filename="../src/widgets/window.cpp" line="536"/>
+        <location filename="../src/editor/dtextedit.cpp" line="404"/>
+        <location filename="../src/widgets/window.cpp" line="558"/>
         <source>Replace</source>
         <translation>Ganti</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="314"/>
+        <location filename="../src/editor/dtextedit.cpp" line="406"/>
         <source>Go to Line</source>
         <translation>Pergi ke Baris</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="315"/>
-        <source>Turn on Read-Only mode</source>
-        <translation>Hidupkan mod Baca-Sahaja</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="316"/>
-        <source>Turn off Read-Only mode</source>
-        <translation>Matikan mod Baca-Sahaja</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="317"/>
+        <location filename="../src/editor/dtextedit.cpp" line="415"/>
         <source>Fullscreen</source>
         <translation>Skrin Penuh</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="318"/>
+        <location filename="../src/editor/dtextedit.cpp" line="417"/>
         <source>Exit fullscreen</source>
         <translation>Keluar dari skrin penuh</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="319"/>
+        <location filename="../src/editor/dtextedit.cpp" line="419"/>
         <source>Display in file manager</source>
         <translation>Papar dalam pengurus fail</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="320"/>
-        <location filename="../src/editor/dtextedit.cpp" line="374"/>
+        <location filename="../src/editor/dtextedit.cpp" line="421"/>
+        <location filename="../src/editor/dtextedit.cpp" line="493"/>
         <source>Add Comment</source>
         <translation>Tambah Ulasan</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="321"/>
+        <location filename="../src/editor/dtextedit.cpp" line="423"/>
         <source>Text to Speech</source>
         <translation>Teks ke Pertuturan</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="322"/>
-        <source>Stop reading</source>
-        <translation>Berhenti membaca</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="323"/>
+        <location filename="../src/editor/dtextedit.cpp" line="425"/>
         <source>Speech to Text</source>
         <translation>Pertuturan ke Teks</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="324"/>
+        <location filename="../src/editor/dtextedit.cpp" line="427"/>
         <source>Translate</source>
         <translation>Terjemah</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="325"/>
+        <location filename="../src/editor/dtextedit.cpp" line="429"/>
         <source>Column Mode</source>
         <translation>Mod Lajur</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="326"/>
+        <location filename="../src/editor/dtextedit.cpp" line="431"/>
         <source>Add bookmark</source>
         <translation>Tambah tanda buku</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="327"/>
+        <location filename="../src/editor/dtextedit.cpp" line="433"/>
         <source>Remove Bookmark</source>
         <translation>Buang Tanda Buku</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="328"/>
+        <location filename="../src/editor/dtextedit.cpp" line="435"/>
         <source>Previous bookmark</source>
         <translation>Tanda buku terdahulu</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="329"/>
+        <location filename="../src/editor/dtextedit.cpp" line="437"/>
         <source>Next bookmark</source>
         <translation>Tanda buku berikutnya</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="330"/>
+        <location filename="../src/editor/dtextedit.cpp" line="439"/>
         <source>Remove All Bookmarks</source>
         <translation>Buang Semua Tanda Buku</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="331"/>
+        <location filename="../src/editor/dtextedit.cpp" line="441"/>
         <source>Fold All</source>
         <translation>Lipat Semua</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="332"/>
+        <location filename="../src/editor/dtextedit.cpp" line="443"/>
         <source>Fold Current Level</source>
         <translation>Lipat Aras Semasa</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="333"/>
+        <location filename="../src/editor/dtextedit.cpp" line="445"/>
         <source>Unfold All</source>
         <translation>Nyahlipat Semua</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="334"/>
+        <location filename="../src/editor/dtextedit.cpp" line="447"/>
         <source>Unfold Current Level</source>
         <translation>Nyahlipat Aras Semasa</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="339"/>
+        <location filename="../src/editor/dtextedit.cpp" line="453"/>
         <source>Color Mark</source>
         <translation>Tanda Warna</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="343"/>
+        <location filename="../src/editor/dtextedit.cpp" line="458"/>
         <source>Clear All Marks</source>
         <translation>Kosongkan Semua Tanda</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="344"/>
+        <location filename="../src/editor/dtextedit.cpp" line="460"/>
         <source>Clear Last Mark</source>
         <translation>Kosongkan Tanda Terakhir</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="353"/>
+        <location filename="../src/editor/dtextedit.cpp" line="470"/>
         <source>Mark</source>
         <translation>Tanda</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="366"/>
+        <location filename="../src/editor/dtextedit.cpp" line="484"/>
         <source>Mark All</source>
         <translation>Tanda Semua</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="375"/>
+        <location filename="../src/editor/dtextedit.cpp" line="494"/>
         <source>Remove Comment</source>
         <translation>Buang Ulasan</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3208"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3211"/>
+        <location filename="../src/editor/dtextedit.cpp" line="543"/>
+        <source>View Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="3531"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3534"/>
         <source>Copy failed: not enough memory</source>
         <translation>Gagal salin: ingatan tidak mencukupi</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3333"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3335"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3656"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3658"/>
         <source>Press ALT and click lines to edit in column mode</source>
         <translation>Tekan ALT dan klik baris untuk menyunting dalam mod lajur</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="418"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9574"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9576"/>
+        <source>No audio output device was detected. Please ensure your speakers or headphones are properly connected and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="9583"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9585"/>
+        <source>No audio input device was detected. Please ensure your speakers or headphones are properly connected and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="534"/>
         <source>Change Case</source>
         <translation>Ubah Kata</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="419"/>
+        <location filename="../src/editor/dtextedit.cpp" line="409"/>
+        <source>Edit Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="411"/>
+        <source>Read View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="413"/>
+        <source>Live Preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="535"/>
         <source>Upper Case</source>
         <translation>Huruf Besar</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="420"/>
+        <location filename="../src/editor/dtextedit.cpp" line="536"/>
         <source>Lower Case</source>
         <translation>Huruf Kecil</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="421"/>
+        <location filename="../src/editor/dtextedit.cpp" line="537"/>
         <source>Capitalize</source>
         <translation>Huruf Besarkan</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="78"/>
+        <location filename="../src/widgets/bottombar.cpp" line="110"/>
         <source>None</source>
         <translation>Tiada</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1363"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1490"/>
         <source>Selected line(s) copied</source>
         <translation>Baris terpilih disalin</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1370"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1497"/>
         <source>Current line copied</source>
         <translation>Baris semasa disalin</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1400"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1527"/>
         <source>Selected line(s) clipped</source>
         <translation>Baris terpilih dikerat</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1412"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1539"/>
         <source>Current line clipped</source>
         <translation>Baris semasa dikerat</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3227"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3230"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3550"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3553"/>
         <source>Paste failed: not enough memory</source>
         <translation>Gagal tampal: ingatan tidak mencukupi</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="4548"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4873"/>
         <source>Read-Only mode is off</source>
         <translation>Mod Baca-Sahaja dimatikan</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="4560"/>
-        <location filename="../src/editor/dtextedit.cpp" line="4584"/>
-        <location filename="../src/editor/dtextedit.cpp" line="7896"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8007"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8015"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8026"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4885"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4909"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8236"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8347"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8355"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8366"/>
         <source>Read-Only mode is on</source>
         <translation>Mod Baca-Sahaja dihidupkan</translation>
     </message>
@@ -1231,138 +1299,175 @@
 <context>
     <name>WarningNotices</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="24"/>
+        <location filename="../src/controls/warningnotices.cpp" line="25"/>
         <source>Reload</source>
         <translation>Muat Semula</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/warningnotices.cpp" line="29"/>
+        <source>Edit Anyway</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>Window</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="25"/>
-        <location filename="../src/widgets/window.cpp" line="531"/>
+        <location filename="../src/controls/warningnotices.cpp" line="27"/>
+        <location filename="../src/widgets/window.cpp" line="548"/>
         <source>Save as</source>
         <translation>Simpan sebagai</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="527"/>
+        <location filename="../src/widgets/window.cpp" line="540"/>
         <source>New window</source>
         <translation>Tetingkap baharu</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="528"/>
+        <location filename="../src/widgets/window.cpp" line="542"/>
         <source>New tab</source>
         <translation>Tab baharu</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="529"/>
+        <location filename="../src/widgets/window.cpp" line="544"/>
         <source>Open file</source>
         <translation>Buka fail</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="530"/>
-        <location filename="../src/widgets/window.cpp" line="3545"/>
+        <location filename="../src/widgets/window.cpp" line="546"/>
+        <location filename="../src/widgets/window.cpp" line="3950"/>
         <source>Save</source>
         <translation>Simpan</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="532"/>
+        <location filename="../src/widgets/window.cpp" line="550"/>
         <source>Print</source>
         <translation>Cetak</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="533"/>
+        <location filename="../src/widgets/window.cpp" line="552"/>
         <source>Switch theme</source>
         <translation>Tukar tema</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="534"/>
-        <location filename="../src/widgets/window.cpp" line="2448"/>
+        <location filename="../src/widgets/window.cpp" line="554"/>
+        <location filename="../src/widgets/window.cpp" line="2641"/>
         <source>Settings</source>
         <translation>Tetapan</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="666"/>
-        <location filename="../src/widgets/window.cpp" line="3845"/>
+        <location filename="../src/widgets/window.cpp" line="696"/>
+        <location filename="../src/widgets/window.cpp" line="4250"/>
         <source>Read-Only</source>
         <translation>Baca-Sahaja</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="687"/>
+        <location filename="../src/widgets/window.cpp" line="719"/>
         <source>You do not have permission to open %1</source>
         <translation>Anda tidak mempunyai keizinan untuk membuka %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="738"/>
-        <location filename="../src/widgets/window.cpp" line="2963"/>
+        <location filename="../src/widgets/window.cpp" line="773"/>
+        <location filename="../src/widgets/window.cpp" line="3266"/>
         <source>Invalid file: %1</source>
         <translation>Fail tidak sah: %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="903"/>
-        <location filename="../src/widgets/window.cpp" line="956"/>
+        <location filename="../src/widgets/window.cpp" line="957"/>
+        <location filename="../src/widgets/window.cpp" line="1050"/>
+        <location filename="../src/widgets/window.cpp" line="3217"/>
         <source>Do you want to save this file?</source>
         <translation>Anda mahu menyimpan fail ini?</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1290"/>
+        <location filename="../src/widgets/window.cpp" line="1381"/>
+        <source>Invalid characters detected while saving &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1382"/>
+        <source>If you force save this file, it may cause file corruption. Still want to save?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1386"/>
+        <source>Don&apos;t Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1387"/>
+        <source>Save As</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1388"/>
+        <source>Save Anyway</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1456"/>
         <source>You do not have permission to save %1</source>
         <translation>Anda tidak mempunyai keizinan untuk menyimpan %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1312"/>
+        <location filename="../src/widgets/window.cpp" line="1428"/>
+        <location filename="../src/widgets/window.cpp" line="1478"/>
         <source>Saved successfully</source>
         <translation>Berjaya disimpan</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1354"/>
-        <location filename="../src/widgets/window.cpp" line="1481"/>
-        <location filename="../src/widgets/window.cpp" line="1529"/>
+        <location filename="../src/widgets/window.cpp" line="1520"/>
+        <location filename="../src/widgets/window.cpp" line="1665"/>
+        <location filename="../src/widgets/window.cpp" line="1713"/>
         <source>Save File</source>
         <translation>Simpan Fail</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1483"/>
+        <location filename="../src/widgets/window.cpp" line="1569"/>
+        <source>Cannot save as the original file in preview mode. Please choose a different path.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1667"/>
         <source>Encoding</source>
         <translation>Pengekodan</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1773"/>
+        <location filename="../src/widgets/window.cpp" line="1957"/>
         <source>Read-Only mode is on</source>
         <translation>Mod Baca-Sahaja dihidupkan</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2322"/>
+        <location filename="../src/widgets/window.cpp" line="2511"/>
         <source>Current location remembered</source>
         <translation>Lokasi semasa diingati</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2398"/>
+        <location filename="../src/widgets/window.cpp" line="2591"/>
         <source>Ctrl+&apos;=&apos;</source>
         <translation>Ctrl+&apos;=&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2401"/>
+        <location filename="../src/widgets/window.cpp" line="2594"/>
         <source>Ctrl+&apos;-&apos;</source>
         <translation>Ctrl+&apos;-&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2430"/>
+        <location filename="../src/widgets/window.cpp" line="2623"/>
         <source>Editor</source>
         <translation>Penyunting</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3061"/>
+        <location filename="../src/widgets/window.cpp" line="3436"/>
         <source>Untitled %1</source>
         <translation>%1 Tidak Bertajuk</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3543"/>
+        <location filename="../src/widgets/window.cpp" line="3948"/>
         <source>Cancel</source>
         <translation>Batal</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3544"/>
+        <location filename="../src/widgets/window.cpp" line="3949"/>
         <source>Discard</source>
         <translation>Singkir</translation>
     </message>

--- a/translations/deepin-editor_nb.ts
+++ b/translations/deepin-editor_nb.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="nb">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="nb">
 <context>
     <name>BottomBar</name>
     <message>
@@ -17,17 +19,36 @@
         <translation>Tegn %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="44"/>
+        <location filename="../src/widgets/bottombar.cpp" line="47"/>
         <source>Loading:</source>
         <translation>Laster inn:</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="73"/>
+        <location filename="../src/widgets/bottombar.cpp" line="91"/>
+        <location filename="../src/widgets/bottombar.cpp" line="499"/>
+        <source>Edit Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="74"/>
+        <location filename="../src/widgets/bottombar.cpp" line="489"/>
+        <source>Read View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="75"/>
+        <location filename="../src/widgets/bottombar.cpp" line="493"/>
+        <source>Live Preview</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DDropdownMenu</name>
     <message>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="362"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="420"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="425"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="363"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="421"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="426"/>
         <source>None</source>
         <translation>Ingen</translation>
     </message>
@@ -35,68 +56,57 @@
 <context>
     <name>EditWrapper</name>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="292"/>
-        <location filename="../src/editor/editwrapper.cpp" line="365"/>
-        <location filename="../src/editor/editwrapper.cpp" line="521"/>
-        <location filename="../src/editor/editwrapper.cpp" line="751"/>
+        <location filename="../src/editor/editwrapper.cpp" line="355"/>
+        <location filename="../src/editor/editwrapper.cpp" line="429"/>
+        <location filename="../src/editor/editwrapper.cpp" line="595"/>
+        <location filename="../src/editor/editwrapper.cpp" line="887"/>
         <source>Save</source>
         <translation>Lagre</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="516"/>
+        <location filename="../src/editor/editwrapper.cpp" line="590"/>
         <source>Do you want to save this file?</source>
         <translation>Vil du lagre denne filen? </translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="363"/>
-        <location filename="../src/editor/editwrapper.cpp" line="519"/>
+        <location filename="../src/editor/editwrapper.cpp" line="427"/>
+        <location filename="../src/editor/editwrapper.cpp" line="593"/>
         <source>Cancel</source>
         <translation>Avbryt</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="360"/>
+        <location filename="../src/editor/editwrapper.cpp" line="424"/>
         <source>Encoding changed. Do you want to save the file now?</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="520"/>
+        <location filename="../src/editor/editwrapper.cpp" line="594"/>
         <source>Discard</source>
         <translation>Forkast</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="274"/>
-        <location filename="../src/editor/editwrapper.cpp" line="620"/>
+        <location filename="../src/editor/editwrapper.cpp" line="1121"/>
+        <source>The file contains invalid characters (NUL). Preview mode is read-only.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="337"/>
+        <location filename="../src/editor/editwrapper.cpp" line="705"/>
         <source>You do not have permission to save %1</source>
         <translation>Du har ikke rettigheter til å lagre %1</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="836"/>
+        <location filename="../src/editor/editwrapper.cpp" line="987"/>
         <source>File removed on the disk. Save it now?</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="842"/>
+        <location filename="../src/editor/editwrapper.cpp" line="993"/>
         <source>File has changed on disk. Reload?</source>
         <translation>Filen har blitt endret på disk. Laste inn på nytt? </translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="884"/>
-        <location filename="../src/widgets/bottombar.cpp" line="74"/>
-        <source>INSERT</source>
-        <translation>SETT INN</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="888"/>
-        <source>OVERWRITE</source>
-        <translation>OVERSKRIV</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="892"/>
-        <source>R/O</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="1618"/>
+        <location filename="../src/editor/editwrapper.cpp" line="1806"/>
         <source>The file cannot be read, which may be too large or has been damaged!</source>
         <translation>Filen kan ikke leses, den kan være for stor eller skadet. </translation>
     </message>
@@ -109,17 +119,17 @@
         <translation>Finn</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="36"/>
+        <location filename="../src/controls/findbar.cpp" line="38"/>
         <source>Previous</source>
         <translation>Forrige</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="37"/>
+        <location filename="../src/controls/findbar.cpp" line="40"/>
         <source>Next</source>
         <translation>Neste</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="38"/>
+        <location filename="../src/controls/findbar.cpp" line="42"/>
         <source>Replace</source>
         <translation>Erstatt</translation>
     </message>
@@ -127,9 +137,17 @@
 <context>
     <name>JumpLineBar</name>
     <message>
-        <location filename="../src/controls/jumplinebar.cpp" line="45"/>
+        <location filename="../src/controls/jumplinebar.cpp" line="46"/>
         <source>Go to Line: </source>
         <translation>Gå til linje:</translation>
+    </message>
+</context>
+<context>
+    <name>LineBar</name>
+    <message>
+        <location filename="../src/controls/linebar.cpp" line="144"/>
+        <source>第%1/%2项</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -137,7 +155,7 @@
     <message>
         <location filename="../src/editorapplication.cpp" line="12"/>
         <source>Text Editor is a powerful tool for viewing and editing text files.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/editorapplication.cpp" line="34"/>
@@ -146,21 +164,49 @@
     </message>
 </context>
 <context>
+    <name>MarkdownBridge</name>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="37"/>
+        <source>Collapse code block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="38"/>
+        <source>Expand code block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="39"/>
+        <source>Copy code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="40"/>
+        <source>Expand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="42"/>
+        <source>%1 line(s) of code collapsed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PathSettingWgt</name>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="84"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="90"/>
         <source>Remember the last used path</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="85"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="91"/>
         <source>Same path as the current file</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="86"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="92"/>
         <source>Customize the default path</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -171,15 +217,20 @@
         <translation>Tekstrederingsverktøy</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="294"/>
-        <location filename="../src/editor/editwrapper.cpp" line="761"/>
-        <location filename="../src/editor/editwrapper.cpp" line="776"/>
-        <location filename="../src/widgets/window.cpp" line="1362"/>
-        <location filename="../src/widgets/window.cpp" line="1390"/>
-        <location filename="../src/widgets/window.cpp" line="1531"/>
-        <location filename="../src/widgets/window.cpp" line="1548"/>
+        <location filename="../src/editor/editwrapper.cpp" line="357"/>
+        <location filename="../src/editor/editwrapper.cpp" line="897"/>
+        <location filename="../src/editor/editwrapper.cpp" line="912"/>
+        <location filename="../src/widgets/window.cpp" line="1528"/>
+        <location filename="../src/widgets/window.cpp" line="1556"/>
+        <location filename="../src/widgets/window.cpp" line="1715"/>
+        <location filename="../src/widgets/window.cpp" line="1732"/>
         <source>Encoding</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="2001"/>
+        <source>视图模式</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="11"/>
@@ -189,7 +240,7 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="12"/>
         <source>Font Style</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="13"/>
@@ -210,12 +261,12 @@
         <location filename="../src/controls/settingsdialog.cpp" line="16"/>
         <location filename="../src/controls/settingsdialog.cpp" line="17"/>
         <source>Keymap</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="18"/>
         <location filename="../src/controls/settingsdialog.cpp" line="96"/>
-        <location filename="../src/widgets/window.cpp" line="2388"/>
+        <location filename="../src/widgets/window.cpp" line="2581"/>
         <source>Window</source>
         <translation>Vindu</translation>
     </message>
@@ -272,12 +323,12 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="29"/>
         <source>Increment font size</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="30"/>
         <source>Decrement font size</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="31"/>
@@ -292,7 +343,7 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="33"/>
         <source>Toggle fullscreen</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="34"/>
@@ -302,12 +353,12 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="35"/>
         <source>Find Next</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="36"/>
         <source>Find Previous</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="37"/>
@@ -317,17 +368,17 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="38"/>
         <source>Go to line</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="39"/>
         <source>Save cursor position</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="40"/>
         <source>Reset cursor position</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="41"/>
@@ -342,42 +393,42 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="43"/>
         <source>Print</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="44"/>
         <source>Editor</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="45"/>
         <source>Increase indent</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="46"/>
         <source>Decrease indent</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="47"/>
         <source>Forward character</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="48"/>
         <source>Backward character</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="49"/>
         <source>Forward word</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="50"/>
         <source>Backward word</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="51"/>
@@ -397,12 +448,12 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="54"/>
         <source>New line above</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="55"/>
         <source>New line below</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="56"/>
@@ -412,102 +463,102 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="57"/>
         <source>Delete to end of line</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="58"/>
         <source>Delete current line</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="59"/>
         <source>Swap line up</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="60"/>
         <source>Swap line down</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="61"/>
         <source>Scroll up one line</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="62"/>
         <source>Scroll down one line</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="63"/>
         <source>Page up</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="64"/>
         <source>Page down</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="65"/>
         <source>Move to end of line</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="66"/>
         <source>Move to start of line</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="67"/>
         <source>Move to end of text</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="68"/>
         <source>Move to start of text</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="69"/>
         <source>Move to line indentation</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="70"/>
         <source>Upper case</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="71"/>
         <source>Lower case</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="72"/>
         <source>Capitalize</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="73"/>
         <source>Delete backward word</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="74"/>
         <source>Delete forward word</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="75"/>
         <source>Forward over a pair</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="76"/>
         <source>Backward over a pair</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="77"/>
@@ -532,47 +583,47 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="81"/>
         <source>Transpose character</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="82"/>
         <source>Mark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="83"/>
         <source>Unmark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="84"/>
         <source>Copy line</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="85"/>
         <source>Cut line</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="86"/>
         <source>Merge lines</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="87"/>
         <source>Read-Only mode</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="88"/>
         <source>Add comment</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="89"/>
         <source>Remove comment</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="90"/>
@@ -587,238 +638,238 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="92"/>
         <source>Add/Remove bookmark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="93"/>
         <source>Move to previous bookmark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="94"/>
         <source>Move to next bookmark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="95"/>
         <source>Advanced</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="97"/>
         <source>Window size</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="98"/>
         <source>Tab width</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="99"/>
         <source>Paste by pressing a middle mouse button</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="101"/>
         <source>Startup</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="102"/>
         <source>Reopen last closed tabs</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="104"/>
         <source>Open/Save Settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="106"/>
         <source>Word wrap</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="107"/>
         <source>Code folding flag</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="108"/>
         <source>Show line numbers</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="109"/>
         <source>Show bookmarks icon</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="110"/>
         <source>Show whitespaces and tabs</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="111"/>
         <source>Highlight current line</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="112"/>
         <source>Color mark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="115"/>
         <source>Unicode</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="116"/>
         <source>WesternEuropean</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="117"/>
         <source>CentralEuropean</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="118"/>
         <source>Baltic</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="119"/>
         <source>Cyrillic</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="120"/>
         <source>Arabic</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="125"/>
         <source>Celtic</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="126"/>
         <source>SouthEasternEuropean</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="121"/>
         <source>Greek</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="122"/>
         <source>Hebrew</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="127"/>
         <source>ChineseSimplified</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="128"/>
         <source>ChineseTraditional</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="129"/>
         <source>Japanese</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="130"/>
         <source>Korean</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="124"/>
         <source>Thai</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="123"/>
         <source>Turkish</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="131"/>
         <source>Vietnamese</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/startmanager.cpp" line="971"/>
+        <location filename="../src/startmanager.cpp" line="1035"/>
         <source>File not saved</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1532"/>
-        <location filename="../src/widgets/window.cpp" line="1549"/>
+        <location filename="../src/widgets/window.cpp" line="1716"/>
+        <location filename="../src/widgets/window.cpp" line="1733"/>
         <source>Line Endings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="243"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="379"/>
         <source>Please install &apos;UOS AI&apos; from the App Store before using</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="245"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="381"/>
         <source>No audio input device detected. Please check and try again</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="247"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="383"/>
         <source>No audio output device detected. Please check and try again</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="69"/>
+        <location filename="../src/common/text_file_saver.cpp" line="74"/>
         <source>File path is empty</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="155"/>
+        <location filename="../src/common/text_file_saver.cpp" line="153"/>
         <source>Insufficient memory to load document content</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="177"/>
+        <location filename="../src/common/text_file_saver.cpp" line="178"/>
         <source>Insufficient memory for encoding conversion</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="183"/>
+        <location filename="../src/common/text_file_saver.cpp" line="184"/>
         <source>Encoding conversion failed</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="189"/>
+        <location filename="../src/common/text_file_saver.cpp" line="190"/>
         <source>Converted content is empty</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="207"/>
+        <location filename="../src/common/text_file_saver.cpp" line="208"/>
         <source>Memory allocation failed</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="211"/>
+        <location filename="../src/common/text_file_saver.cpp" line="212"/>
         <source>Error occurred: %1</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="215"/>
+        <location filename="../src/common/text_file_saver.cpp" line="216"/>
         <source>Unknown error occurred</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -829,38 +880,38 @@
         <translation>Finn</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="34"/>
+        <location filename="../src/controls/replacebar.cpp" line="36"/>
         <source>Replace With</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="36"/>
+        <location filename="../src/controls/replacebar.cpp" line="40"/>
         <source>Replace</source>
         <translation>Erstatt</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="37"/>
+        <location filename="../src/controls/replacebar.cpp" line="42"/>
         <source>Skip</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="38"/>
+        <location filename="../src/controls/replacebar.cpp" line="44"/>
         <source>Replace Rest</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="39"/>
+        <location filename="../src/controls/replacebar.cpp" line="46"/>
         <source>Replace All</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>S:</name>
     <message>
         <location filename="../third/libiconv-1.16/src/iconv.c" line="103"/>
-        <source/>
+        <source></source>
         <comment>The first line of the short usage message.</comment>
-        <translation type="unfinished"/>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -868,22 +919,22 @@
     <message>
         <location filename="../src/common/settings.cpp" line="141"/>
         <source>Standard</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/common/settings.cpp" line="141"/>
         <source>Customize</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/common/settings.cpp" line="154"/>
         <source>Normal</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/common/settings.cpp" line="154"/>
         <source>Maximum</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/common/settings.cpp" line="154"/>
@@ -891,478 +942,532 @@
         <translation>Fullskjerm</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="484"/>
+        <location filename="../src/common/settings.cpp" line="491"/>
         <source>This shortcut conflicts with system shortcut %1</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="487"/>
+        <location filename="../src/common/settings.cpp" line="494"/>
         <source>This shortcut conflicts with %1, click on Replace to make this shortcut effective immediately</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="682"/>
-        <location filename="../src/common/settings.cpp" line="695"/>
-        <location filename="../src/common/settings.cpp" line="704"/>
+        <location filename="../src/common/settings.cpp" line="689"/>
+        <location filename="../src/common/settings.cpp" line="702"/>
+        <location filename="../src/common/settings.cpp" line="711"/>
         <source>The shortcut %1 is invalid, please set another one.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="736"/>
+        <location filename="../src/common/settings.cpp" line="743"/>
         <source>Cancel</source>
         <translation>Avbryt</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="737"/>
+        <location filename="../src/common/settings.cpp" line="744"/>
         <source>Replace</source>
         <translation>Erstatt</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="740"/>
+        <location filename="../src/common/settings.cpp" line="747"/>
         <source>OK</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>StartManager</name>
     <message>
-        <location filename="../src/startmanager.cpp" line="411"/>
+        <location filename="../src/startmanager.cpp" line="425"/>
         <source>Untitled %1</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>Tabbar</name>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="641"/>
+        <location filename="../src/controls/tabbar.cpp" line="678"/>
         <source>Close tab</source>
         <translation>Lukk fane</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="642"/>
+        <location filename="../src/controls/tabbar.cpp" line="680"/>
         <source>Close other tabs</source>
         <translation>Lukk alle andre faner</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="643"/>
+        <location filename="../src/controls/tabbar.cpp" line="682"/>
         <source>More options</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="644"/>
+        <location filename="../src/controls/tabbar.cpp" line="684"/>
         <source>Close tabs to the left</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="645"/>
+        <location filename="../src/controls/tabbar.cpp" line="686"/>
         <source>Close tabs to the right</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="646"/>
+        <location filename="../src/controls/tabbar.cpp" line="688"/>
         <source>Close unmodified tabs</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>TextEdit</name>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="305"/>
+        <location filename="../src/editor/dtextedit.cpp" line="388"/>
         <source>Undo</source>
         <translation>Angre</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="306"/>
+        <location filename="../src/editor/dtextedit.cpp" line="390"/>
         <source>Redo</source>
         <translation>Gjør om</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="307"/>
+        <location filename="../src/editor/dtextedit.cpp" line="392"/>
         <source>Cut</source>
         <translation>Klipp ut</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="308"/>
+        <location filename="../src/editor/dtextedit.cpp" line="394"/>
         <source>Copy</source>
         <translation>Kopier</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="309"/>
+        <location filename="../src/editor/dtextedit.cpp" line="396"/>
         <source>Paste</source>
         <translation>Lim inn</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="310"/>
+        <location filename="../src/editor/dtextedit.cpp" line="398"/>
         <source>Delete</source>
         <translation>Slett</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="311"/>
+        <location filename="../src/editor/dtextedit.cpp" line="400"/>
         <source>Select All</source>
         <translation>Merk alle</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="312"/>
-        <location filename="../src/widgets/window.cpp" line="535"/>
+        <location filename="../src/editor/dtextedit.cpp" line="402"/>
+        <location filename="../src/widgets/window.cpp" line="556"/>
         <source>Find</source>
         <translation>Finn</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="313"/>
-        <location filename="../src/widgets/window.cpp" line="536"/>
+        <location filename="../src/editor/dtextedit.cpp" line="404"/>
+        <location filename="../src/widgets/window.cpp" line="558"/>
         <source>Replace</source>
         <translation>Erstatt</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="314"/>
+        <location filename="../src/editor/dtextedit.cpp" line="406"/>
         <source>Go to Line</source>
         <translation>Gå til linje</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="315"/>
-        <source>Turn on Read-Only mode</source>
-        <translation>Skru på skrivebeskyttelse</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="316"/>
-        <source>Turn off Read-Only mode</source>
-        <translation>Skru av skrivebeskyttelse</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="317"/>
+        <location filename="../src/editor/dtextedit.cpp" line="415"/>
         <source>Fullscreen</source>
         <translation>Fullskjerm</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="318"/>
+        <location filename="../src/editor/dtextedit.cpp" line="417"/>
         <source>Exit fullscreen</source>
         <translation>Avslutt fullskjerm</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="319"/>
-        <source>Display in file manager</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="320"/>
-        <location filename="../src/editor/dtextedit.cpp" line="374"/>
-        <source>Add Comment</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="321"/>
-        <source>Text to Speech</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="322"/>
-        <source>Stop reading</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="323"/>
-        <source>Speech to Text</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="324"/>
-        <source>Translate</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="325"/>
-        <source>Column Mode</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="326"/>
-        <source>Add bookmark</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="327"/>
-        <source>Remove Bookmark</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="328"/>
-        <source>Previous bookmark</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="329"/>
-        <source>Next bookmark</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="330"/>
-        <source>Remove All Bookmarks</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="331"/>
-        <source>Fold All</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="332"/>
-        <source>Fold Current Level</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="333"/>
-        <source>Unfold All</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="334"/>
-        <source>Unfold Current Level</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="339"/>
-        <source>Color Mark</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="343"/>
-        <source>Clear All Marks</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="344"/>
-        <source>Clear Last Mark</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="353"/>
-        <source>Mark</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="366"/>
-        <source>Mark All</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="375"/>
-        <source>Remove Comment</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3208"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3211"/>
-        <source>Copy failed: not enough memory</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3333"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3335"/>
-        <source>Press ALT and click lines to edit in column mode</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="418"/>
-        <source>Change Case</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
         <location filename="../src/editor/dtextedit.cpp" line="419"/>
+        <source>Display in file manager</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="421"/>
+        <location filename="../src/editor/dtextedit.cpp" line="493"/>
+        <source>Add Comment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="423"/>
+        <source>Text to Speech</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="425"/>
+        <source>Speech to Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="427"/>
+        <source>Translate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="429"/>
+        <source>Column Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="431"/>
+        <source>Add bookmark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="433"/>
+        <source>Remove Bookmark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="435"/>
+        <source>Previous bookmark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="437"/>
+        <source>Next bookmark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="439"/>
+        <source>Remove All Bookmarks</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="441"/>
+        <source>Fold All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="443"/>
+        <source>Fold Current Level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="445"/>
+        <source>Unfold All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="447"/>
+        <source>Unfold Current Level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="453"/>
+        <source>Color Mark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="458"/>
+        <source>Clear All Marks</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="460"/>
+        <source>Clear Last Mark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="470"/>
+        <source>Mark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="484"/>
+        <source>Mark All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="494"/>
+        <source>Remove Comment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="543"/>
+        <source>View Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="3531"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3534"/>
+        <source>Copy failed: not enough memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="3656"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3658"/>
+        <source>Press ALT and click lines to edit in column mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="9574"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9576"/>
+        <source>No audio output device was detected. Please ensure your speakers or headphones are properly connected and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="9583"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9585"/>
+        <source>No audio input device was detected. Please ensure your speakers or headphones are properly connected and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="534"/>
+        <source>Change Case</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="409"/>
+        <source>Edit Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="411"/>
+        <source>Read View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="413"/>
+        <source>Live Preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="535"/>
         <source>Upper Case</source>
         <translation>Store bokstaver</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="420"/>
+        <location filename="../src/editor/dtextedit.cpp" line="536"/>
         <source>Lower Case</source>
         <translation>Små bokstaver</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="421"/>
+        <location filename="../src/editor/dtextedit.cpp" line="537"/>
         <source>Capitalize</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="78"/>
+        <location filename="../src/widgets/bottombar.cpp" line="110"/>
         <source>None</source>
         <translation>Ingen</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1363"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1490"/>
         <source>Selected line(s) copied</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1370"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1497"/>
         <source>Current line copied</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1400"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1527"/>
         <source>Selected line(s) clipped</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1412"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1539"/>
         <source>Current line clipped</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3227"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3230"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3550"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3553"/>
         <source>Paste failed: not enough memory</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="4548"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4873"/>
         <source>Read-Only mode is off</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="4560"/>
-        <location filename="../src/editor/dtextedit.cpp" line="4584"/>
-        <location filename="../src/editor/dtextedit.cpp" line="7896"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8007"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8015"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8026"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4885"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4909"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8236"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8347"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8355"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8366"/>
         <source>Read-Only mode is on</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>WarningNotices</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="24"/>
+        <location filename="../src/controls/warningnotices.cpp" line="25"/>
         <source>Reload</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/controls/warningnotices.cpp" line="29"/>
+        <source>Edit Anyway</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>Window</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="25"/>
-        <location filename="../src/widgets/window.cpp" line="531"/>
+        <location filename="../src/controls/warningnotices.cpp" line="27"/>
+        <location filename="../src/widgets/window.cpp" line="548"/>
         <source>Save as</source>
         <translation>Lagre som</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="527"/>
+        <location filename="../src/widgets/window.cpp" line="540"/>
         <source>New window</source>
         <translation>Nytt vindu</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="528"/>
+        <location filename="../src/widgets/window.cpp" line="542"/>
         <source>New tab</source>
         <translation>Ny fane</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="529"/>
+        <location filename="../src/widgets/window.cpp" line="544"/>
         <source>Open file</source>
         <translation>Åpne fil</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="530"/>
-        <location filename="../src/widgets/window.cpp" line="3545"/>
+        <location filename="../src/widgets/window.cpp" line="546"/>
+        <location filename="../src/widgets/window.cpp" line="3950"/>
         <source>Save</source>
         <translation>Lagre</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="532"/>
+        <location filename="../src/widgets/window.cpp" line="550"/>
         <source>Print</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="533"/>
+        <location filename="../src/widgets/window.cpp" line="552"/>
         <source>Switch theme</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="534"/>
-        <location filename="../src/widgets/window.cpp" line="2448"/>
+        <location filename="../src/widgets/window.cpp" line="554"/>
+        <location filename="../src/widgets/window.cpp" line="2641"/>
         <source>Settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="666"/>
-        <location filename="../src/widgets/window.cpp" line="3845"/>
+        <location filename="../src/widgets/window.cpp" line="696"/>
+        <location filename="../src/widgets/window.cpp" line="4250"/>
         <source>Read-Only</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="687"/>
+        <location filename="../src/widgets/window.cpp" line="719"/>
         <source>You do not have permission to open %1</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="738"/>
-        <location filename="../src/widgets/window.cpp" line="2963"/>
+        <location filename="../src/widgets/window.cpp" line="773"/>
+        <location filename="../src/widgets/window.cpp" line="3266"/>
         <source>Invalid file: %1</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="903"/>
-        <location filename="../src/widgets/window.cpp" line="956"/>
+        <location filename="../src/widgets/window.cpp" line="957"/>
+        <location filename="../src/widgets/window.cpp" line="1050"/>
+        <location filename="../src/widgets/window.cpp" line="3217"/>
         <source>Do you want to save this file?</source>
         <translation>Vil du lagre denne filen? </translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1290"/>
+        <location filename="../src/widgets/window.cpp" line="1381"/>
+        <source>Invalid characters detected while saving &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1382"/>
+        <source>If you force save this file, it may cause file corruption. Still want to save?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1386"/>
+        <source>Don&apos;t Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1387"/>
+        <source>Save As</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1388"/>
+        <source>Save Anyway</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1456"/>
         <source>You do not have permission to save %1</source>
         <translation>Du har ikke rettigheter til å lagre %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1312"/>
+        <location filename="../src/widgets/window.cpp" line="1428"/>
+        <location filename="../src/widgets/window.cpp" line="1478"/>
         <source>Saved successfully</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1354"/>
-        <location filename="../src/widgets/window.cpp" line="1481"/>
-        <location filename="../src/widgets/window.cpp" line="1529"/>
+        <location filename="../src/widgets/window.cpp" line="1520"/>
+        <location filename="../src/widgets/window.cpp" line="1665"/>
+        <location filename="../src/widgets/window.cpp" line="1713"/>
         <source>Save File</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1483"/>
+        <location filename="../src/widgets/window.cpp" line="1569"/>
+        <source>Cannot save as the original file in preview mode. Please choose a different path.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1667"/>
         <source>Encoding</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1773"/>
+        <location filename="../src/widgets/window.cpp" line="1957"/>
         <source>Read-Only mode is on</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2322"/>
+        <location filename="../src/widgets/window.cpp" line="2511"/>
         <source>Current location remembered</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2398"/>
+        <location filename="../src/widgets/window.cpp" line="2591"/>
         <source>Ctrl+&apos;=&apos;</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2401"/>
+        <location filename="../src/widgets/window.cpp" line="2594"/>
         <source>Ctrl+&apos;-&apos;</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2430"/>
+        <location filename="../src/widgets/window.cpp" line="2623"/>
         <source>Editor</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3061"/>
+        <location filename="../src/widgets/window.cpp" line="3436"/>
         <source>Untitled %1</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3543"/>
+        <location filename="../src/widgets/window.cpp" line="3948"/>
         <source>Cancel</source>
         <translation>Avbryt</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3544"/>
+        <location filename="../src/widgets/window.cpp" line="3949"/>
         <source>Discard</source>
         <translation>Forkast</translation>
     </message>

--- a/translations/deepin-editor_ne.ts
+++ b/translations/deepin-editor_ne.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ne">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ne">
 <context>
     <name>BottomBar</name>
     <message>
@@ -17,17 +19,36 @@
         <translation>क्यारेक्टर% 1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="44"/>
+        <location filename="../src/widgets/bottombar.cpp" line="47"/>
         <source>Loading:</source>
         <translation>୬୪ଦାନ୍ତା</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="73"/>
+        <location filename="../src/widgets/bottombar.cpp" line="91"/>
+        <location filename="../src/widgets/bottombar.cpp" line="499"/>
+        <source>Edit Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="74"/>
+        <location filename="../src/widgets/bottombar.cpp" line="489"/>
+        <source>Read View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="75"/>
+        <location filename="../src/widgets/bottombar.cpp" line="493"/>
+        <source>Live Preview</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DDropdownMenu</name>
     <message>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="362"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="420"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="425"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="363"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="421"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="426"/>
         <source>None</source>
         <translation>कुनै पनि होइन</translation>
     </message>
@@ -35,68 +56,57 @@
 <context>
     <name>EditWrapper</name>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="292"/>
-        <location filename="../src/editor/editwrapper.cpp" line="365"/>
-        <location filename="../src/editor/editwrapper.cpp" line="521"/>
-        <location filename="../src/editor/editwrapper.cpp" line="751"/>
+        <location filename="../src/editor/editwrapper.cpp" line="355"/>
+        <location filename="../src/editor/editwrapper.cpp" line="429"/>
+        <location filename="../src/editor/editwrapper.cpp" line="595"/>
+        <location filename="../src/editor/editwrapper.cpp" line="887"/>
         <source>Save</source>
         <translation>सुरक्षित गर्नु</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="516"/>
+        <location filename="../src/editor/editwrapper.cpp" line="590"/>
         <source>Do you want to save this file?</source>
         <translation>के तपाइँ यो फाईल सुरक्षित गर्न चाहनुहुन्छ?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="363"/>
-        <location filename="../src/editor/editwrapper.cpp" line="519"/>
+        <location filename="../src/editor/editwrapper.cpp" line="427"/>
+        <location filename="../src/editor/editwrapper.cpp" line="593"/>
         <source>Cancel</source>
         <translation>रद्द गर्नुहोस्</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="360"/>
+        <location filename="../src/editor/editwrapper.cpp" line="424"/>
         <source>Encoding changed. Do you want to save the file now?</source>
         <translation>एन्कोडिंग परिवर्तन भयो। के तपाईं अब फाईल बचत गर्न चाहानुहुन्छ?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="520"/>
+        <location filename="../src/editor/editwrapper.cpp" line="594"/>
         <source>Discard</source>
         <translation>त्याग्नुहोस्</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="274"/>
-        <location filename="../src/editor/editwrapper.cpp" line="620"/>
+        <location filename="../src/editor/editwrapper.cpp" line="1121"/>
+        <source>The file contains invalid characters (NUL). Preview mode is read-only.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="337"/>
+        <location filename="../src/editor/editwrapper.cpp" line="705"/>
         <source>You do not have permission to save %1</source>
         <translation>तपाईंसँग% 1 सुरक्षित गर्न अनुमति छैन</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="836"/>
+        <location filename="../src/editor/editwrapper.cpp" line="987"/>
         <source>File removed on the disk. Save it now?</source>
         <translation>डिस्कबाट फाइल हटाइयो सुरक्षित गर्नुहोस्।</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="842"/>
+        <location filename="../src/editor/editwrapper.cpp" line="993"/>
         <source>File has changed on disk. Reload?</source>
         <translation>डिस्कमा फाइल परिवर्तन भएको छ। पुन: लोड गर्नुहोस?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="884"/>
-        <location filename="../src/widgets/bottombar.cpp" line="74"/>
-        <source>INSERT</source>
-        <translation>हाल्नु</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="888"/>
-        <source>OVERWRITE</source>
-        <translation>त्योमाथि</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="892"/>
-        <source>R/O</source>
-        <translation>आर / ओ</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="1618"/>
+        <location filename="../src/editor/editwrapper.cpp" line="1806"/>
         <source>The file cannot be read, which may be too large or has been damaged!</source>
         <translation>ଫାଇଲ୍ ପଢ଼ିବା ଯାଇପାରେ ନାହିଁ, ଯାହା ଅତ୍ୟଧିକ ବଡ଼ ହୋଇଥାଏ ବା କ୍ଷତିଗ୍ରସ୍ଥ ହୋଇଥାଏ!</translation>
     </message>
@@ -109,17 +119,17 @@
         <translation>खोज्नुहोस्</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="36"/>
+        <location filename="../src/controls/findbar.cpp" line="38"/>
         <source>Previous</source>
         <translation>अघिल्लो</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="37"/>
+        <location filename="../src/controls/findbar.cpp" line="40"/>
         <source>Next</source>
         <translation>अर्को</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="38"/>
+        <location filename="../src/controls/findbar.cpp" line="42"/>
         <source>Replace</source>
         <translation>बदल्नुहोस्</translation>
     </message>
@@ -127,9 +137,17 @@
 <context>
     <name>JumpLineBar</name>
     <message>
-        <location filename="../src/controls/jumplinebar.cpp" line="45"/>
+        <location filename="../src/controls/jumplinebar.cpp" line="46"/>
         <source>Go to Line: </source>
         <translation>रेखामा जानुहोस्</translation>
+    </message>
+</context>
+<context>
+    <name>LineBar</name>
+    <message>
+        <location filename="../src/controls/linebar.cpp" line="144"/>
+        <source>第%1/%2项</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -146,19 +164,47 @@
     </message>
 </context>
 <context>
+    <name>MarkdownBridge</name>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="37"/>
+        <source>Collapse code block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="38"/>
+        <source>Expand code block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="39"/>
+        <source>Copy code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="40"/>
+        <source>Expand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="42"/>
+        <source>%1 line(s) of code collapsed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PathSettingWgt</name>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="84"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="90"/>
         <source>Remember the last used path</source>
         <translation>ଅକ୍ଷତ ବ୍ୟବହାର କରାଯାଇଥବା ପଥ ରଖନ୍ତୁ</translation>
     </message>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="85"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="91"/>
         <source>Same path as the current file</source>
         <translation>ବର୍ତ୍ତମାନ ଫାଇଲ୍ ର ଅକ୍ଷତ ପଥ</translation>
     </message>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="86"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="92"/>
         <source>Customize the default path</source>
         <translation>ଅକ୍ଷତ ପଥ ପ୍ରାଥମିକ ପଥ ପରିବର୍ତ୍ତନ କରନ୍ତୁ</translation>
     </message>
@@ -171,15 +217,20 @@
         <translation>पाठ सम्पादक</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="294"/>
-        <location filename="../src/editor/editwrapper.cpp" line="761"/>
-        <location filename="../src/editor/editwrapper.cpp" line="776"/>
-        <location filename="../src/widgets/window.cpp" line="1362"/>
-        <location filename="../src/widgets/window.cpp" line="1390"/>
-        <location filename="../src/widgets/window.cpp" line="1531"/>
-        <location filename="../src/widgets/window.cpp" line="1548"/>
+        <location filename="../src/editor/editwrapper.cpp" line="357"/>
+        <location filename="../src/editor/editwrapper.cpp" line="897"/>
+        <location filename="../src/editor/editwrapper.cpp" line="912"/>
+        <location filename="../src/widgets/window.cpp" line="1528"/>
+        <location filename="../src/widgets/window.cpp" line="1556"/>
+        <location filename="../src/widgets/window.cpp" line="1715"/>
+        <location filename="../src/widgets/window.cpp" line="1732"/>
         <source>Encoding</source>
         <translation>सङ्केतन</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="2001"/>
+        <source>视图模式</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="11"/>
@@ -215,7 +266,7 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="18"/>
         <location filename="../src/controls/settingsdialog.cpp" line="96"/>
-        <location filename="../src/widgets/window.cpp" line="2388"/>
+        <location filename="../src/widgets/window.cpp" line="2581"/>
         <source>Window</source>
         <translation>विन्डो</translation>
     </message>
@@ -755,68 +806,68 @@
         <translation>वियतनामी</translation>
     </message>
     <message>
-        <location filename="../src/startmanager.cpp" line="971"/>
+        <location filename="../src/startmanager.cpp" line="1035"/>
         <source>File not saved</source>
         <translation>फाइल बचत भएन</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1532"/>
-        <location filename="../src/widgets/window.cpp" line="1549"/>
+        <location filename="../src/widgets/window.cpp" line="1716"/>
+        <location filename="../src/widgets/window.cpp" line="1733"/>
         <source>Line Endings</source>
         <translation>रेखा समाप्ति</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="243"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="379"/>
         <source>Please install &apos;UOS AI&apos; from the App Store before using</source>
         <translation>कृपया उपयोग करने से पहले &apos;UOS AI&apos; को एप्प स्टोर से स्थापित करें</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="245"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="381"/>
         <source>No audio input device detected. Please check and try again</source>
         <translation>कोई ऑडियो इनपुट डिवाइस नहीं डिटेक्ट किया गया। कृपया जांच करें और फिर से प्रयास करें</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="247"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="383"/>
         <source>No audio output device detected. Please check and try again</source>
         <translation>कोई ऑडियो आउटपुट डिवाइस नहीं डिटेक्ट किया गया। कृपया जांच करें और फिर से प्रयास करें</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="69"/>
+        <location filename="../src/common/text_file_saver.cpp" line="74"/>
         <source>File path is empty</source>
         <translation>फाइल पथ खाली है</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="155"/>
+        <location filename="../src/common/text_file_saver.cpp" line="153"/>
         <source>Insufficient memory to load document content</source>
         <translation>दस्तावेज़ सामग्री लोड करने के लिए अपर्याप्त स्मृति</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="177"/>
+        <location filename="../src/common/text_file_saver.cpp" line="178"/>
         <source>Insufficient memory for encoding conversion</source>
         <translation>एन्कोडिंग कनवर्ज़न के लिए अपर्याप्त स्मृति</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="183"/>
+        <location filename="../src/common/text_file_saver.cpp" line="184"/>
         <source>Encoding conversion failed</source>
         <translation>एन्कोडिंग कनवर्ज़न में विफलता</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="189"/>
+        <location filename="../src/common/text_file_saver.cpp" line="190"/>
         <source>Converted content is empty</source>
         <translation>कनवर्ट की गई सामग्री खाली है</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="207"/>
+        <location filename="../src/common/text_file_saver.cpp" line="208"/>
         <source>Memory allocation failed</source>
         <translation>स्मृति आवंटन में विफलता</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="211"/>
+        <location filename="../src/common/text_file_saver.cpp" line="212"/>
         <source>Error occurred: %1</source>
         <translation>त्रुटि हुई: %1</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="215"/>
+        <location filename="../src/common/text_file_saver.cpp" line="216"/>
         <source>Unknown error occurred</source>
         <translation>अज्ञात त्रुटि हुई</translation>
     </message>
@@ -829,27 +880,27 @@
         <translation>खोज्नुहोस्</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="34"/>
+        <location filename="../src/controls/replacebar.cpp" line="36"/>
         <source>Replace With</source>
         <translation> संग बदल्नुहोस्</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="36"/>
+        <location filename="../src/controls/replacebar.cpp" line="40"/>
         <source>Replace</source>
         <translation>बदल्नुहोस्</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="37"/>
+        <location filename="../src/controls/replacebar.cpp" line="42"/>
         <source>Skip</source>
         <translation>छोड्नुहोस्</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="38"/>
+        <location filename="../src/controls/replacebar.cpp" line="44"/>
         <source>Replace Rest</source>
         <translation>पुन: बदल्नुहोस्</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="39"/>
+        <location filename="../src/controls/replacebar.cpp" line="46"/>
         <source>Replace All</source>
         <translation>सबै बदल्नुहोस्</translation>
     </message>
@@ -858,9 +909,9 @@
     <name>S:</name>
     <message>
         <location filename="../third/libiconv-1.16/src/iconv.c" line="103"/>
-        <source/>
+        <source></source>
         <comment>The first line of the short usage message.</comment>
-        <translation type="unfinished"/>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -891,34 +942,34 @@
         <translation>पूरा स्क्रीन</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="484"/>
+        <location filename="../src/common/settings.cpp" line="491"/>
         <source>This shortcut conflicts with system shortcut %1</source>
         <translation>यह शॉर्टकट सिस्टम शॉर्टकट %1 के साथ टकराता है</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="487"/>
+        <location filename="../src/common/settings.cpp" line="494"/>
         <source>This shortcut conflicts with %1, click on Replace to make this shortcut effective immediately</source>
         <translation>यह शॉर्टकट %1 के साथ टकराता है, इस शॉर्टकट को तुरंत प्रभावी बनाने के लिए Replace पर क्लिक करें</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="682"/>
-        <location filename="../src/common/settings.cpp" line="695"/>
-        <location filename="../src/common/settings.cpp" line="704"/>
+        <location filename="../src/common/settings.cpp" line="689"/>
+        <location filename="../src/common/settings.cpp" line="702"/>
+        <location filename="../src/common/settings.cpp" line="711"/>
         <source>The shortcut %1 is invalid, please set another one.</source>
         <translation>शॉर्टकट %1 अमान्य है, कृपया दूसरा निर्धारित करें।</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="736"/>
+        <location filename="../src/common/settings.cpp" line="743"/>
         <source>Cancel</source>
         <translation>रद्द गर्नुहोस्</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="737"/>
+        <location filename="../src/common/settings.cpp" line="744"/>
         <source>Replace</source>
         <translation>बदल्नुहोस्</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="740"/>
+        <location filename="../src/common/settings.cpp" line="747"/>
         <source>OK</source>
         <translation>ठीक है</translation>
     </message>
@@ -926,7 +977,7 @@
 <context>
     <name>StartManager</name>
     <message>
-        <location filename="../src/startmanager.cpp" line="411"/>
+        <location filename="../src/startmanager.cpp" line="425"/>
         <source>Untitled %1</source>
         <translation>शीर्षकविहिन% 1</translation>
     </message>
@@ -934,32 +985,32 @@
 <context>
     <name>Tabbar</name>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="641"/>
+        <location filename="../src/controls/tabbar.cpp" line="678"/>
         <source>Close tab</source>
         <translation>ट्याब बन्द गर्नुहोस्</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="642"/>
+        <location filename="../src/controls/tabbar.cpp" line="680"/>
         <source>Close other tabs</source>
         <translation>अन्य ट्याबहरू बन्द गर्नुहोस्</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="643"/>
+        <location filename="../src/controls/tabbar.cpp" line="682"/>
         <source>More options</source>
         <translation>अधिक विकल्प</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="644"/>
+        <location filename="../src/controls/tabbar.cpp" line="684"/>
         <source>Close tabs to the left</source>
         <translation>बाईं ओर टैब बंद करें</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="645"/>
+        <location filename="../src/controls/tabbar.cpp" line="686"/>
         <source>Close tabs to the right</source>
         <translation>दाईं ओर टैब बंद करें</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="646"/>
+        <location filename="../src/controls/tabbar.cpp" line="688"/>
         <source>Close unmodified tabs</source>
         <translation>अपरिवर्तित टैब बंद करें</translation>
     </message>
@@ -967,263 +1018,280 @@
 <context>
     <name>TextEdit</name>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="305"/>
+        <location filename="../src/editor/dtextedit.cpp" line="388"/>
         <source>Undo</source>
         <translation>पूर्ववत गर्नुहोस्</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="306"/>
+        <location filename="../src/editor/dtextedit.cpp" line="390"/>
         <source>Redo</source>
         <translation>फेरि गर्नुहोस्</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="307"/>
+        <location filename="../src/editor/dtextedit.cpp" line="392"/>
         <source>Cut</source>
         <translation>काट्नुहोस्</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="308"/>
+        <location filename="../src/editor/dtextedit.cpp" line="394"/>
         <source>Copy</source>
         <translation>कपी</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="309"/>
+        <location filename="../src/editor/dtextedit.cpp" line="396"/>
         <source>Paste</source>
         <translation>टाँस्नुहोस्</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="310"/>
+        <location filename="../src/editor/dtextedit.cpp" line="398"/>
         <source>Delete</source>
         <translation>मेटाउनुहोस्</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="311"/>
+        <location filename="../src/editor/dtextedit.cpp" line="400"/>
         <source>Select All</source>
         <translation>सबै छान्नु</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="312"/>
-        <location filename="../src/widgets/window.cpp" line="535"/>
+        <location filename="../src/editor/dtextedit.cpp" line="402"/>
+        <location filename="../src/widgets/window.cpp" line="556"/>
         <source>Find</source>
         <translation>खोज्नुहोस्</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="313"/>
-        <location filename="../src/widgets/window.cpp" line="536"/>
+        <location filename="../src/editor/dtextedit.cpp" line="404"/>
+        <location filename="../src/widgets/window.cpp" line="558"/>
         <source>Replace</source>
         <translation>बदल्नुहोस्</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="314"/>
+        <location filename="../src/editor/dtextedit.cpp" line="406"/>
         <source>Go to Line</source>
         <translation>रेखामा जानुहोस्</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="315"/>
-        <source>Turn on Read-Only mode</source>
-        <translation>पढ्ने-मात्र मोड खोल्नुहोस्</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="316"/>
-        <source>Turn off Read-Only mode</source>
-        <translation>पढ्ने-मात्र मोड बन्द गर्नुहोस्</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="317"/>
+        <location filename="../src/editor/dtextedit.cpp" line="415"/>
         <source>Fullscreen</source>
         <translation>पूरा स्क्रीन</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="318"/>
+        <location filename="../src/editor/dtextedit.cpp" line="417"/>
         <source>Exit fullscreen</source>
         <translation>पूरा स्क्रिनबाट निस्कनुहोस्</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="319"/>
+        <location filename="../src/editor/dtextedit.cpp" line="419"/>
         <source>Display in file manager</source>
         <translation>फाईल प्रबन्धकमा प्रदर्शन गर्नुहोस्</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="320"/>
-        <location filename="../src/editor/dtextedit.cpp" line="374"/>
+        <location filename="../src/editor/dtextedit.cpp" line="421"/>
+        <location filename="../src/editor/dtextedit.cpp" line="493"/>
         <source>Add Comment</source>
         <translation>टिप्पणी जोड़ें</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="321"/>
+        <location filename="../src/editor/dtextedit.cpp" line="423"/>
         <source>Text to Speech</source>
         <translation>टेक्स्ट तु स्पीच </translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="322"/>
-        <source>Stop reading</source>
-        <translation>ढुल्न छोड्नुहोस्</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="323"/>
+        <location filename="../src/editor/dtextedit.cpp" line="425"/>
         <source>Speech to Text</source>
         <translation>स्पीच  तु  टेक्स्ट </translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="324"/>
+        <location filename="../src/editor/dtextedit.cpp" line="427"/>
         <source>Translate</source>
         <translation>अनुवाद गर्नुहोस्</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="325"/>
+        <location filename="../src/editor/dtextedit.cpp" line="429"/>
         <source>Column Mode</source>
         <translation>कोलम मोड</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="326"/>
+        <location filename="../src/editor/dtextedit.cpp" line="431"/>
         <source>Add bookmark</source>
         <translation>बुकमार्क थप्नुहोस्</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="327"/>
+        <location filename="../src/editor/dtextedit.cpp" line="433"/>
         <source>Remove Bookmark</source>
         <translation>बुकमार्क हटाउन</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="328"/>
+        <location filename="../src/editor/dtextedit.cpp" line="435"/>
         <source>Previous bookmark</source>
         <translation>पिछलो बुकमार्क</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="329"/>
+        <location filename="../src/editor/dtextedit.cpp" line="437"/>
         <source>Next bookmark</source>
         <translation>अगलो बुकमार्क</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="330"/>
+        <location filename="../src/editor/dtextedit.cpp" line="439"/>
         <source>Remove All Bookmarks</source>
         <translation>सबै बुकमार्क हटाउन</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="331"/>
+        <location filename="../src/editor/dtextedit.cpp" line="441"/>
         <source>Fold All</source>
         <translation>सबै बन्द गर्नुहोस्</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="332"/>
+        <location filename="../src/editor/dtextedit.cpp" line="443"/>
         <source>Fold Current Level</source>
         <translation>समान स्तर बन्द गर्नुहोस्</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="333"/>
+        <location filename="../src/editor/dtextedit.cpp" line="445"/>
         <source>Unfold All</source>
         <translation>सबै खुलाउन</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="334"/>
+        <location filename="../src/editor/dtextedit.cpp" line="447"/>
         <source>Unfold Current Level</source>
         <translation>समान स्तर खुलाउन</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="339"/>
+        <location filename="../src/editor/dtextedit.cpp" line="453"/>
         <source>Color Mark</source>
         <translation>रंग चिह्न</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="343"/>
+        <location filename="../src/editor/dtextedit.cpp" line="458"/>
         <source>Clear All Marks</source>
         <translation>सबै चिह्न हटाउन</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="344"/>
+        <location filename="../src/editor/dtextedit.cpp" line="460"/>
         <source>Clear Last Mark</source>
         <translation>अन्तिम चिह्न हटाउन</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="353"/>
+        <location filename="../src/editor/dtextedit.cpp" line="470"/>
         <source>Mark</source>
         <translation>चिन्ह लगाउनुहोस्</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="366"/>
+        <location filename="../src/editor/dtextedit.cpp" line="484"/>
         <source>Mark All</source>
         <translation>सबै चिह्न गर्नुहोस्</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="375"/>
+        <location filename="../src/editor/dtextedit.cpp" line="494"/>
         <source>Remove Comment</source>
         <translation>कमेन्ट हटाउन</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3208"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3211"/>
+        <location filename="../src/editor/dtextedit.cpp" line="543"/>
+        <source>View Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="3531"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3534"/>
         <source>Copy failed: not enough memory</source>
         <translation>काट्न असफल: सामाग्री अप्याद छ</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3333"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3335"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3656"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3658"/>
         <source>Press ALT and click lines to edit in column mode</source>
         <translation>ALT दबाउँदा रेखा क्लिक गर्नुहोस् कोलम मोडमा सम्पादन गर्न</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="418"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9574"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9576"/>
+        <source>No audio output device was detected. Please ensure your speakers or headphones are properly connected and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="9583"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9585"/>
+        <source>No audio input device was detected. Please ensure your speakers or headphones are properly connected and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="534"/>
         <source>Change Case</source>
         <translation>केस परिवर्तन गर्नुहोस्</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="419"/>
+        <location filename="../src/editor/dtextedit.cpp" line="409"/>
+        <source>Edit Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="411"/>
+        <source>Read View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="413"/>
+        <source>Live Preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="535"/>
         <source>Upper Case</source>
         <translation>माथिल्लो केस</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="420"/>
+        <location filename="../src/editor/dtextedit.cpp" line="536"/>
         <source>Lower Case</source>
         <translation>तल्लो केस</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="421"/>
+        <location filename="../src/editor/dtextedit.cpp" line="537"/>
         <source>Capitalize</source>
         <translation>क्यापिटलिज गर्नुहोस्</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="78"/>
+        <location filename="../src/widgets/bottombar.cpp" line="110"/>
         <source>None</source>
         <translation>कुनै पनि होइन</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1363"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1490"/>
         <source>Selected line(s) copied</source>
         <translation>चयनित लाइन (हरू) प्रतिलिपि गरियो</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1370"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1497"/>
         <source>Current line copied</source>
         <translation>हालको लाइन प्रतिलिपि गरियो</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1400"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1527"/>
         <source>Selected line(s) clipped</source>
         <translation>चयनित लाइन (हरू) क्लिप गरियो</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1412"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1539"/>
         <source>Current line clipped</source>
         <translation>हालको लाइन क्लिप गरियो</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3227"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3230"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3550"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3553"/>
         <source>Paste failed: not enough memory</source>
         <translation>पेस्ट असफल: सामाग्री अप्याद छ</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="4548"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4873"/>
         <source>Read-Only mode is off</source>
         <translation>पढ्ने मात्र मोड बन्द छ</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="4560"/>
-        <location filename="../src/editor/dtextedit.cpp" line="4584"/>
-        <location filename="../src/editor/dtextedit.cpp" line="7896"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8007"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8015"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8026"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4885"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4909"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8236"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8347"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8355"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8366"/>
         <source>Read-Only mode is on</source>
         <translation>पढ्ने मात्र मोड चालू छ</translation>
     </message>
@@ -1231,138 +1299,175 @@
 <context>
     <name>WarningNotices</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="24"/>
+        <location filename="../src/controls/warningnotices.cpp" line="25"/>
         <source>Reload</source>
         <translation>पुन: लोड गर्नुहोस्</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/warningnotices.cpp" line="29"/>
+        <source>Edit Anyway</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>Window</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="25"/>
-        <location filename="../src/widgets/window.cpp" line="531"/>
+        <location filename="../src/controls/warningnotices.cpp" line="27"/>
+        <location filename="../src/widgets/window.cpp" line="548"/>
         <source>Save as</source>
         <translation>यसरी राख</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="527"/>
+        <location filename="../src/widgets/window.cpp" line="540"/>
         <source>New window</source>
         <translation>नयाँ विन्डो</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="528"/>
+        <location filename="../src/widgets/window.cpp" line="542"/>
         <source>New tab</source>
         <translation>नयाँ ट्याब</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="529"/>
+        <location filename="../src/widgets/window.cpp" line="544"/>
         <source>Open file</source>
         <translation>फाईल खोल्नुहोस्</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="530"/>
-        <location filename="../src/widgets/window.cpp" line="3545"/>
+        <location filename="../src/widgets/window.cpp" line="546"/>
+        <location filename="../src/widgets/window.cpp" line="3950"/>
         <source>Save</source>
         <translation>सुरक्षित गर्नु</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="532"/>
+        <location filename="../src/widgets/window.cpp" line="550"/>
         <source>Print</source>
         <translation>प्रिन्ट गर्नुहोस्</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="533"/>
+        <location filename="../src/widgets/window.cpp" line="552"/>
         <source>Switch theme</source>
         <translation>स्विच थेम</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="534"/>
-        <location filename="../src/widgets/window.cpp" line="2448"/>
+        <location filename="../src/widgets/window.cpp" line="554"/>
+        <location filename="../src/widgets/window.cpp" line="2641"/>
         <source>Settings</source>
         <translation>सेटिङ्हरू</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="666"/>
-        <location filename="../src/widgets/window.cpp" line="3845"/>
+        <location filename="../src/widgets/window.cpp" line="696"/>
+        <location filename="../src/widgets/window.cpp" line="4250"/>
         <source>Read-Only</source>
         <translation>पढ्ने मात्र </translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="687"/>
+        <location filename="../src/widgets/window.cpp" line="719"/>
         <source>You do not have permission to open %1</source>
         <translation>तपाईंसँग% 1 खोल्न अनुमति छैन</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="738"/>
-        <location filename="../src/widgets/window.cpp" line="2963"/>
+        <location filename="../src/widgets/window.cpp" line="773"/>
+        <location filename="../src/widgets/window.cpp" line="3266"/>
         <source>Invalid file: %1</source>
         <translation>अमान्य फाइल:% 1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="903"/>
-        <location filename="../src/widgets/window.cpp" line="956"/>
+        <location filename="../src/widgets/window.cpp" line="957"/>
+        <location filename="../src/widgets/window.cpp" line="1050"/>
+        <location filename="../src/widgets/window.cpp" line="3217"/>
         <source>Do you want to save this file?</source>
         <translation>के तपाइँ यो फाईल सुरक्षित गर्न चाहनुहुन्छ?</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1290"/>
+        <location filename="../src/widgets/window.cpp" line="1381"/>
+        <source>Invalid characters detected while saving &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1382"/>
+        <source>If you force save this file, it may cause file corruption. Still want to save?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1386"/>
+        <source>Don&apos;t Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1387"/>
+        <source>Save As</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1388"/>
+        <source>Save Anyway</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1456"/>
         <source>You do not have permission to save %1</source>
         <translation>तपाईंसँग% 1 सुरक्षित गर्न अनुमति छैन</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1312"/>
+        <location filename="../src/widgets/window.cpp" line="1428"/>
+        <location filename="../src/widgets/window.cpp" line="1478"/>
         <source>Saved successfully</source>
         <translation>सफलतापूर्वक सुरक्षित गरियो</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1354"/>
-        <location filename="../src/widgets/window.cpp" line="1481"/>
-        <location filename="../src/widgets/window.cpp" line="1529"/>
+        <location filename="../src/widgets/window.cpp" line="1520"/>
+        <location filename="../src/widgets/window.cpp" line="1665"/>
+        <location filename="../src/widgets/window.cpp" line="1713"/>
         <source>Save File</source>
         <translation>फाइल सुरक्षित गर्नु</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1483"/>
+        <location filename="../src/widgets/window.cpp" line="1569"/>
+        <source>Cannot save as the original file in preview mode. Please choose a different path.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1667"/>
         <source>Encoding</source>
         <translation>सङ्केतन</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1773"/>
+        <location filename="../src/widgets/window.cpp" line="1957"/>
         <source>Read-Only mode is on</source>
         <translation>पढ्ने मात्र मोड चालू छ</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2322"/>
+        <location filename="../src/widgets/window.cpp" line="2511"/>
         <source>Current location remembered</source>
         <translation>हालको स्थान सम्झियो</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2398"/>
+        <location filename="../src/widgets/window.cpp" line="2591"/>
         <source>Ctrl+&apos;=&apos;</source>
         <translation>Ctrl+=&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2401"/>
+        <location filename="../src/widgets/window.cpp" line="2594"/>
         <source>Ctrl+&apos;-&apos;</source>
         <translation>Ctrl+=&apos;-</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2430"/>
+        <location filename="../src/widgets/window.cpp" line="2623"/>
         <source>Editor</source>
         <translation>संपादक</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3061"/>
+        <location filename="../src/widgets/window.cpp" line="3436"/>
         <source>Untitled %1</source>
         <translation>शीर्षकविहिन% 1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3543"/>
+        <location filename="../src/widgets/window.cpp" line="3948"/>
         <source>Cancel</source>
         <translation>रद्द गर्नुहोस्</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3544"/>
+        <location filename="../src/widgets/window.cpp" line="3949"/>
         <source>Discard</source>
         <translation>त्याग्नुहोस्</translation>
     </message>

--- a/translations/deepin-editor_nl.ts
+++ b/translations/deepin-editor_nl.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="nl">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="nl">
 <context>
     <name>BottomBar</name>
     <message>
@@ -17,17 +19,36 @@
         <translation>%1 tekens</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="44"/>
+        <location filename="../src/widgets/bottombar.cpp" line="47"/>
         <source>Loading:</source>
         <translation>Bezig met laden van</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="73"/>
+        <location filename="../src/widgets/bottombar.cpp" line="91"/>
+        <location filename="../src/widgets/bottombar.cpp" line="499"/>
+        <source>Edit Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="74"/>
+        <location filename="../src/widgets/bottombar.cpp" line="489"/>
+        <source>Read View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="75"/>
+        <location filename="../src/widgets/bottombar.cpp" line="493"/>
+        <source>Live Preview</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DDropdownMenu</name>
     <message>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="362"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="420"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="425"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="363"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="421"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="426"/>
         <source>None</source>
         <translation>Geen</translation>
     </message>
@@ -35,68 +56,57 @@
 <context>
     <name>EditWrapper</name>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="292"/>
-        <location filename="../src/editor/editwrapper.cpp" line="365"/>
-        <location filename="../src/editor/editwrapper.cpp" line="521"/>
-        <location filename="../src/editor/editwrapper.cpp" line="751"/>
+        <location filename="../src/editor/editwrapper.cpp" line="355"/>
+        <location filename="../src/editor/editwrapper.cpp" line="429"/>
+        <location filename="../src/editor/editwrapper.cpp" line="595"/>
+        <location filename="../src/editor/editwrapper.cpp" line="887"/>
         <source>Save</source>
         <translation>Opslaan</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="516"/>
+        <location filename="../src/editor/editwrapper.cpp" line="590"/>
         <source>Do you want to save this file?</source>
         <translation>Wil je dit bestand opslaan?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="363"/>
-        <location filename="../src/editor/editwrapper.cpp" line="519"/>
+        <location filename="../src/editor/editwrapper.cpp" line="427"/>
+        <location filename="../src/editor/editwrapper.cpp" line="593"/>
         <source>Cancel</source>
         <translation>Annuleren</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="360"/>
+        <location filename="../src/editor/editwrapper.cpp" line="424"/>
         <source>Encoding changed. Do you want to save the file now?</source>
         <translation>De tekencodering is aangepast. Wil je het bestand opslaan?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="520"/>
+        <location filename="../src/editor/editwrapper.cpp" line="594"/>
         <source>Discard</source>
         <translation>Verwerpen</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="274"/>
-        <location filename="../src/editor/editwrapper.cpp" line="620"/>
+        <location filename="../src/editor/editwrapper.cpp" line="1121"/>
+        <source>The file contains invalid characters (NUL). Preview mode is read-only.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="337"/>
+        <location filename="../src/editor/editwrapper.cpp" line="705"/>
         <source>You do not have permission to save %1</source>
         <translation>Je bent niet gemachtigd om %1 op te slaan</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="836"/>
+        <location filename="../src/editor/editwrapper.cpp" line="987"/>
         <source>File removed on the disk. Save it now?</source>
         <translation>Het bestand is verwijderd van de schijf. Wil je het opslaan?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="842"/>
+        <location filename="../src/editor/editwrapper.cpp" line="993"/>
         <source>File has changed on disk. Reload?</source>
         <translation>Het bestand is aangepast op de schijf. Wil je het opnieuw laden?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="884"/>
-        <location filename="../src/widgets/bottombar.cpp" line="74"/>
-        <source>INSERT</source>
-        <translation>INSERT</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="888"/>
-        <source>OVERWRITE</source>
-        <translation>OVERSCHRIJVEN</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="892"/>
-        <source>R/O</source>
-        <translation>ALLEEN-LEZEN</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="1618"/>
+        <location filename="../src/editor/editwrapper.cpp" line="1806"/>
         <source>The file cannot be read, which may be too large or has been damaged!</source>
         <translation>Het bestand kan niet worden ingelezen omdat het te groot of beschadigd is!</translation>
     </message>
@@ -109,17 +119,17 @@
         <translation>Zoeken</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="36"/>
+        <location filename="../src/controls/findbar.cpp" line="38"/>
         <source>Previous</source>
         <translation>Vorige</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="37"/>
+        <location filename="../src/controls/findbar.cpp" line="40"/>
         <source>Next</source>
         <translation>Volgende</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="38"/>
+        <location filename="../src/controls/findbar.cpp" line="42"/>
         <source>Replace</source>
         <translation>Vervangen</translation>
     </message>
@@ -127,9 +137,17 @@
 <context>
     <name>JumpLineBar</name>
     <message>
-        <location filename="../src/controls/jumplinebar.cpp" line="45"/>
+        <location filename="../src/controls/jumplinebar.cpp" line="46"/>
         <source>Go to Line: </source>
         <translation>Ga naar regel:</translation>
+    </message>
+</context>
+<context>
+    <name>LineBar</name>
+    <message>
+        <location filename="../src/controls/linebar.cpp" line="144"/>
+        <source>第%1/%2项</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -146,19 +164,47 @@
     </message>
 </context>
 <context>
+    <name>MarkdownBridge</name>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="37"/>
+        <source>Collapse code block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="38"/>
+        <source>Expand code block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="39"/>
+        <source>Copy code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="40"/>
+        <source>Expand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="42"/>
+        <source>%1 line(s) of code collapsed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PathSettingWgt</name>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="84"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="90"/>
         <source>Remember the last used path</source>
         <translation>Laatstgebruikte locatie onthouden</translation>
     </message>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="85"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="91"/>
         <source>Same path as the current file</source>
         <translation>Dezelfde locatie als huidig bestand</translation>
     </message>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="86"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="92"/>
         <source>Customize the default path</source>
         <translation>Standaardlocatie wijzigen</translation>
     </message>
@@ -171,15 +217,20 @@
         <translation>Tekstbewerker</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="294"/>
-        <location filename="../src/editor/editwrapper.cpp" line="761"/>
-        <location filename="../src/editor/editwrapper.cpp" line="776"/>
-        <location filename="../src/widgets/window.cpp" line="1362"/>
-        <location filename="../src/widgets/window.cpp" line="1390"/>
-        <location filename="../src/widgets/window.cpp" line="1531"/>
-        <location filename="../src/widgets/window.cpp" line="1548"/>
+        <location filename="../src/editor/editwrapper.cpp" line="357"/>
+        <location filename="../src/editor/editwrapper.cpp" line="897"/>
+        <location filename="../src/editor/editwrapper.cpp" line="912"/>
+        <location filename="../src/widgets/window.cpp" line="1528"/>
+        <location filename="../src/widgets/window.cpp" line="1556"/>
+        <location filename="../src/widgets/window.cpp" line="1715"/>
+        <location filename="../src/widgets/window.cpp" line="1732"/>
         <source>Encoding</source>
         <translation>Tekencodering</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="2001"/>
+        <source>视图模式</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="11"/>
@@ -215,7 +266,7 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="18"/>
         <location filename="../src/controls/settingsdialog.cpp" line="96"/>
-        <location filename="../src/widgets/window.cpp" line="2388"/>
+        <location filename="../src/widgets/window.cpp" line="2581"/>
         <source>Window</source>
         <translation>Venster</translation>
     </message>
@@ -755,68 +806,68 @@
         <translation>Vietnamees</translation>
     </message>
     <message>
-        <location filename="../src/startmanager.cpp" line="971"/>
+        <location filename="../src/startmanager.cpp" line="1035"/>
         <source>File not saved</source>
         <translation>Bestand is niet opgeslagen</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1532"/>
-        <location filename="../src/widgets/window.cpp" line="1549"/>
+        <location filename="../src/widgets/window.cpp" line="1716"/>
+        <location filename="../src/widgets/window.cpp" line="1733"/>
         <source>Line Endings</source>
         <translation>Regeleindes</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="243"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="379"/>
         <source>Please install &apos;UOS AI&apos; from the App Store before using</source>
         <translation>Installeer &apos;UOS AI&apos; vanaf de App Store voordat u het gebruikt</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="245"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="381"/>
         <source>No audio input device detected. Please check and try again</source>
         <translation>Geen audio-inapparaat is gedetecteerd. Controleer en probeer opnieuw</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="247"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="383"/>
         <source>No audio output device detected. Please check and try again</source>
         <translation>Geen audio-outapparaat is gedetecteerd. Controleer en probeer opnieuw</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="69"/>
+        <location filename="../src/common/text_file_saver.cpp" line="74"/>
         <source>File path is empty</source>
         <translation>Bestandspad is leeg</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="155"/>
+        <location filename="../src/common/text_file_saver.cpp" line="153"/>
         <source>Insufficient memory to load document content</source>
         <translation>Onvoldoende geheugen om het documentinhoud te laden</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="177"/>
+        <location filename="../src/common/text_file_saver.cpp" line="178"/>
         <source>Insufficient memory for encoding conversion</source>
         <translation>Onvoldoende geheugen voor coderingconversie</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="183"/>
+        <location filename="../src/common/text_file_saver.cpp" line="184"/>
         <source>Encoding conversion failed</source>
         <translation>Coderingconversie is mislukt</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="189"/>
+        <location filename="../src/common/text_file_saver.cpp" line="190"/>
         <source>Converted content is empty</source>
         <translation>Geconverteerde inhoud is leeg</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="207"/>
+        <location filename="../src/common/text_file_saver.cpp" line="208"/>
         <source>Memory allocation failed</source>
         <translation>Geheugenallocatie is mislukt</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="211"/>
+        <location filename="../src/common/text_file_saver.cpp" line="212"/>
         <source>Error occurred: %1</source>
         <translation>Fout opgetreden: %1</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="215"/>
+        <location filename="../src/common/text_file_saver.cpp" line="216"/>
         <source>Unknown error occurred</source>
         <translation>Onbekende fout is opgetreden</translation>
     </message>
@@ -829,27 +880,27 @@
         <translation>Zoeken</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="34"/>
+        <location filename="../src/controls/replacebar.cpp" line="36"/>
         <source>Replace With</source>
         <translation>Vervangen door</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="36"/>
+        <location filename="../src/controls/replacebar.cpp" line="40"/>
         <source>Replace</source>
         <translation>Vervangen</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="37"/>
+        <location filename="../src/controls/replacebar.cpp" line="42"/>
         <source>Skip</source>
         <translation>Overslaan</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="38"/>
+        <location filename="../src/controls/replacebar.cpp" line="44"/>
         <source>Replace Rest</source>
         <translation>Overige vervangen</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="39"/>
+        <location filename="../src/controls/replacebar.cpp" line="46"/>
         <source>Replace All</source>
         <translation>Alles vervangen</translation>
     </message>
@@ -858,9 +909,9 @@
     <name>S:</name>
     <message>
         <location filename="../third/libiconv-1.16/src/iconv.c" line="103"/>
-        <source/>
+        <source></source>
         <comment>The first line of the short usage message.</comment>
-        <translation type="unfinished"/>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -891,34 +942,34 @@
         <translation>Beeldvullende modus</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="484"/>
+        <location filename="../src/common/settings.cpp" line="491"/>
         <source>This shortcut conflicts with system shortcut %1</source>
         <translation>Deze sneltoets is wordt al gebruikt door de algemene sneltoets %1</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="487"/>
+        <location filename="../src/common/settings.cpp" line="494"/>
         <source>This shortcut conflicts with %1, click on Replace to make this shortcut effective immediately</source>
         <translation>Deze sneltoets is al in gebruik door %1 - klik om deze sneltoets in plaats daarvan te gebruiken</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="682"/>
-        <location filename="../src/common/settings.cpp" line="695"/>
-        <location filename="../src/common/settings.cpp" line="704"/>
+        <location filename="../src/common/settings.cpp" line="689"/>
+        <location filename="../src/common/settings.cpp" line="702"/>
+        <location filename="../src/common/settings.cpp" line="711"/>
         <source>The shortcut %1 is invalid, please set another one.</source>
         <translation>De sneltoets &apos;%1&apos; is ongeldig. Stel een andere in.</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="736"/>
+        <location filename="../src/common/settings.cpp" line="743"/>
         <source>Cancel</source>
         <translation>Annuleren</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="737"/>
+        <location filename="../src/common/settings.cpp" line="744"/>
         <source>Replace</source>
         <translation>Vervangen</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="740"/>
+        <location filename="../src/common/settings.cpp" line="747"/>
         <source>OK</source>
         <translation>Oké</translation>
     </message>
@@ -926,7 +977,7 @@
 <context>
     <name>StartManager</name>
     <message>
-        <location filename="../src/startmanager.cpp" line="411"/>
+        <location filename="../src/startmanager.cpp" line="425"/>
         <source>Untitled %1</source>
         <translation>Naamloos %1</translation>
     </message>
@@ -934,32 +985,32 @@
 <context>
     <name>Tabbar</name>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="641"/>
+        <location filename="../src/controls/tabbar.cpp" line="678"/>
         <source>Close tab</source>
         <translation>Tabblad sluiten</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="642"/>
+        <location filename="../src/controls/tabbar.cpp" line="680"/>
         <source>Close other tabs</source>
         <translation>Overige tabbladen sluiten</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="643"/>
+        <location filename="../src/controls/tabbar.cpp" line="682"/>
         <source>More options</source>
         <translation>Meer opties</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="644"/>
+        <location filename="../src/controls/tabbar.cpp" line="684"/>
         <source>Close tabs to the left</source>
         <translation>Tabbladen links sluiten</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="645"/>
+        <location filename="../src/controls/tabbar.cpp" line="686"/>
         <source>Close tabs to the right</source>
         <translation>Tabbladen rechts sluiten</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="646"/>
+        <location filename="../src/controls/tabbar.cpp" line="688"/>
         <source>Close unmodified tabs</source>
         <translation>Onaangepaste tabbladen sluiten</translation>
     </message>
@@ -967,263 +1018,280 @@
 <context>
     <name>TextEdit</name>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="305"/>
+        <location filename="../src/editor/dtextedit.cpp" line="388"/>
         <source>Undo</source>
         <translation>Ongedaan maken</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="306"/>
+        <location filename="../src/editor/dtextedit.cpp" line="390"/>
         <source>Redo</source>
         <translation>Opnieuw</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="307"/>
+        <location filename="../src/editor/dtextedit.cpp" line="392"/>
         <source>Cut</source>
         <translation>Knippen</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="308"/>
+        <location filename="../src/editor/dtextedit.cpp" line="394"/>
         <source>Copy</source>
         <translation>Kopiëren</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="309"/>
+        <location filename="../src/editor/dtextedit.cpp" line="396"/>
         <source>Paste</source>
         <translation>Plakken</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="310"/>
+        <location filename="../src/editor/dtextedit.cpp" line="398"/>
         <source>Delete</source>
         <translation>Verwijderen</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="311"/>
+        <location filename="../src/editor/dtextedit.cpp" line="400"/>
         <source>Select All</source>
         <translation>Alles selecteren</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="312"/>
-        <location filename="../src/widgets/window.cpp" line="535"/>
+        <location filename="../src/editor/dtextedit.cpp" line="402"/>
+        <location filename="../src/widgets/window.cpp" line="556"/>
         <source>Find</source>
         <translation>Zoeken</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="313"/>
-        <location filename="../src/widgets/window.cpp" line="536"/>
+        <location filename="../src/editor/dtextedit.cpp" line="404"/>
+        <location filename="../src/widgets/window.cpp" line="558"/>
         <source>Replace</source>
         <translation>Vervangen</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="314"/>
+        <location filename="../src/editor/dtextedit.cpp" line="406"/>
         <source>Go to Line</source>
         <translation>Ga naar regel</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="315"/>
-        <source>Turn on Read-Only mode</source>
-        <translation>Alleen-lezenmodus inschakelen</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="316"/>
-        <source>Turn off Read-Only mode</source>
-        <translation>Alleen-lezenmodus uitschakelen</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="317"/>
+        <location filename="../src/editor/dtextedit.cpp" line="415"/>
         <source>Fullscreen</source>
         <translation>Beeldvullende modus</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="318"/>
+        <location filename="../src/editor/dtextedit.cpp" line="417"/>
         <source>Exit fullscreen</source>
         <translation>Beeldvullende modus verlaten</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="319"/>
+        <location filename="../src/editor/dtextedit.cpp" line="419"/>
         <source>Display in file manager</source>
         <translation>Tonen in bestandsbeheerder</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="320"/>
-        <location filename="../src/editor/dtextedit.cpp" line="374"/>
+        <location filename="../src/editor/dtextedit.cpp" line="421"/>
+        <location filename="../src/editor/dtextedit.cpp" line="493"/>
         <source>Add Comment</source>
         <translation>Opmerking toevoegen</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="321"/>
+        <location filename="../src/editor/dtextedit.cpp" line="423"/>
         <source>Text to Speech</source>
         <translation>Tekst-naar-spraak</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="322"/>
-        <source>Stop reading</source>
-        <translation>Stoppen met lezen</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="323"/>
+        <location filename="../src/editor/dtextedit.cpp" line="425"/>
         <source>Speech to Text</source>
         <translation>Spraak-naar-tekst</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="324"/>
+        <location filename="../src/editor/dtextedit.cpp" line="427"/>
         <source>Translate</source>
         <translation>Vertalen</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="325"/>
+        <location filename="../src/editor/dtextedit.cpp" line="429"/>
         <source>Column Mode</source>
         <translation>Kolommodus</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="326"/>
+        <location filename="../src/editor/dtextedit.cpp" line="431"/>
         <source>Add bookmark</source>
         <translation>Bladwijzer toevoegen</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="327"/>
+        <location filename="../src/editor/dtextedit.cpp" line="433"/>
         <source>Remove Bookmark</source>
         <translation>Bladwijzer verwijderen</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="328"/>
+        <location filename="../src/editor/dtextedit.cpp" line="435"/>
         <source>Previous bookmark</source>
         <translation>Vorige bladwijzer</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="329"/>
+        <location filename="../src/editor/dtextedit.cpp" line="437"/>
         <source>Next bookmark</source>
         <translation>Volgende bladwijzer</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="330"/>
+        <location filename="../src/editor/dtextedit.cpp" line="439"/>
         <source>Remove All Bookmarks</source>
         <translation>Alle bladwijzers verwijderen</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="331"/>
+        <location filename="../src/editor/dtextedit.cpp" line="441"/>
         <source>Fold All</source>
         <translation>Alles inklappen</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="332"/>
+        <location filename="../src/editor/dtextedit.cpp" line="443"/>
         <source>Fold Current Level</source>
         <translation>Huidig niveau inklappen</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="333"/>
+        <location filename="../src/editor/dtextedit.cpp" line="445"/>
         <source>Unfold All</source>
         <translation>Alles uitklappen</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="334"/>
+        <location filename="../src/editor/dtextedit.cpp" line="447"/>
         <source>Unfold Current Level</source>
         <translation>Huidig niveau uitklappen</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="339"/>
+        <location filename="../src/editor/dtextedit.cpp" line="453"/>
         <source>Color Mark</source>
         <translation>Markeerkleur</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="343"/>
+        <location filename="../src/editor/dtextedit.cpp" line="458"/>
         <source>Clear All Marks</source>
         <translation>Alle markeringen missen</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="344"/>
+        <location filename="../src/editor/dtextedit.cpp" line="460"/>
         <source>Clear Last Mark</source>
         <translation>Recentste markering demarkeren</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="353"/>
+        <location filename="../src/editor/dtextedit.cpp" line="470"/>
         <source>Mark</source>
         <translation>Markeren</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="366"/>
+        <location filename="../src/editor/dtextedit.cpp" line="484"/>
         <source>Mark All</source>
         <translation>Alles markeren</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="375"/>
+        <location filename="../src/editor/dtextedit.cpp" line="494"/>
         <source>Remove Comment</source>
         <translation>Opmerking verwijderen</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3208"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3211"/>
+        <location filename="../src/editor/dtextedit.cpp" line="543"/>
+        <source>View Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="3531"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3534"/>
         <source>Copy failed: not enough memory</source>
         <translation>Het kopiëren is mislukt omdat er onvoldoende vrij geheugen is</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3333"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3335"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3656"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3658"/>
         <source>Press ALT and click lines to edit in column mode</source>
         <translation>Druk op Alt en klik op regels om te bewerken in kolommodus</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="418"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9574"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9576"/>
+        <source>No audio output device was detected. Please ensure your speakers or headphones are properly connected and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="9583"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9585"/>
+        <source>No audio input device was detected. Please ensure your speakers or headphones are properly connected and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="534"/>
         <source>Change Case</source>
         <translation>Hoofdletters/Kleine letters</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="419"/>
+        <location filename="../src/editor/dtextedit.cpp" line="409"/>
+        <source>Edit Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="411"/>
+        <source>Read View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="413"/>
+        <source>Live Preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="535"/>
         <source>Upper Case</source>
         <translation>Hoofdletters</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="420"/>
+        <location filename="../src/editor/dtextedit.cpp" line="536"/>
         <source>Lower Case</source>
         <translation>Kleine letters</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="421"/>
+        <location filename="../src/editor/dtextedit.cpp" line="537"/>
         <source>Capitalize</source>
         <translation>Omzetten naar hoofdletters</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="78"/>
+        <location filename="../src/widgets/bottombar.cpp" line="110"/>
         <source>None</source>
         <translation>Geen</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1363"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1490"/>
         <source>Selected line(s) copied</source>
         <translation>De geselecteerde regel(s) is (zijn) gekopieerd</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1370"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1497"/>
         <source>Current line copied</source>
         <translation>De huidige regel is gekopieerd</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1400"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1527"/>
         <source>Selected line(s) clipped</source>
         <translation>De geselecteerde regel(s) is (zijn) ingekort</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1412"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1539"/>
         <source>Current line clipped</source>
         <translation>De huidige regel is ingekort</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3227"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3230"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3550"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3553"/>
         <source>Paste failed: not enough memory</source>
         <translation>Het plakken is mislukt omdat er onvoldoende vrij geheugen is</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="4548"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4873"/>
         <source>Read-Only mode is off</source>
         <translation>Alleen-lezenmodus is uitgeschakeld</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="4560"/>
-        <location filename="../src/editor/dtextedit.cpp" line="4584"/>
-        <location filename="../src/editor/dtextedit.cpp" line="7896"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8007"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8015"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8026"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4885"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4909"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8236"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8347"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8355"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8366"/>
         <source>Read-Only mode is on</source>
         <translation>Alleen-lezenmodus is ingeschakeld</translation>
     </message>
@@ -1231,138 +1299,175 @@
 <context>
     <name>WarningNotices</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="24"/>
+        <location filename="../src/controls/warningnotices.cpp" line="25"/>
         <source>Reload</source>
         <translation>Opnieuw laden</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/warningnotices.cpp" line="29"/>
+        <source>Edit Anyway</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>Window</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="25"/>
-        <location filename="../src/widgets/window.cpp" line="531"/>
+        <location filename="../src/controls/warningnotices.cpp" line="27"/>
+        <location filename="../src/widgets/window.cpp" line="548"/>
         <source>Save as</source>
         <translation>Opslaan als</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="527"/>
+        <location filename="../src/widgets/window.cpp" line="540"/>
         <source>New window</source>
         <translation>Nieuw venster</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="528"/>
+        <location filename="../src/widgets/window.cpp" line="542"/>
         <source>New tab</source>
         <translation>Nieuw tabblad</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="529"/>
+        <location filename="../src/widgets/window.cpp" line="544"/>
         <source>Open file</source>
         <translation>Bestand openen</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="530"/>
-        <location filename="../src/widgets/window.cpp" line="3545"/>
+        <location filename="../src/widgets/window.cpp" line="546"/>
+        <location filename="../src/widgets/window.cpp" line="3950"/>
         <source>Save</source>
         <translation>Opslaan</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="532"/>
+        <location filename="../src/widgets/window.cpp" line="550"/>
         <source>Print</source>
         <translation>Afdrukken</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="533"/>
+        <location filename="../src/widgets/window.cpp" line="552"/>
         <source>Switch theme</source>
         <translation>Thema wijzigen</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="534"/>
-        <location filename="../src/widgets/window.cpp" line="2448"/>
+        <location filename="../src/widgets/window.cpp" line="554"/>
+        <location filename="../src/widgets/window.cpp" line="2641"/>
         <source>Settings</source>
         <translation>Instellingen</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="666"/>
-        <location filename="../src/widgets/window.cpp" line="3845"/>
+        <location filename="../src/widgets/window.cpp" line="696"/>
+        <location filename="../src/widgets/window.cpp" line="4250"/>
         <source>Read-Only</source>
         <translation>Alleen-lezen</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="687"/>
+        <location filename="../src/widgets/window.cpp" line="719"/>
         <source>You do not have permission to open %1</source>
         <translation>Je bent niet gemachtigd om %1 te openen</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="738"/>
-        <location filename="../src/widgets/window.cpp" line="2963"/>
+        <location filename="../src/widgets/window.cpp" line="773"/>
+        <location filename="../src/widgets/window.cpp" line="3266"/>
         <source>Invalid file: %1</source>
         <translation>Ongeldig bestand: %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="903"/>
-        <location filename="../src/widgets/window.cpp" line="956"/>
+        <location filename="../src/widgets/window.cpp" line="957"/>
+        <location filename="../src/widgets/window.cpp" line="1050"/>
+        <location filename="../src/widgets/window.cpp" line="3217"/>
         <source>Do you want to save this file?</source>
         <translation>Wil je dit bestand opslaan?</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1290"/>
+        <location filename="../src/widgets/window.cpp" line="1381"/>
+        <source>Invalid characters detected while saving &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1382"/>
+        <source>If you force save this file, it may cause file corruption. Still want to save?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1386"/>
+        <source>Don&apos;t Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1387"/>
+        <source>Save As</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1388"/>
+        <source>Save Anyway</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1456"/>
         <source>You do not have permission to save %1</source>
         <translation>Je bent niet gemachtigd om %1 op te slaan</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1312"/>
+        <location filename="../src/widgets/window.cpp" line="1428"/>
+        <location filename="../src/widgets/window.cpp" line="1478"/>
         <source>Saved successfully</source>
         <translation>Opgeslagen</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1354"/>
-        <location filename="../src/widgets/window.cpp" line="1481"/>
-        <location filename="../src/widgets/window.cpp" line="1529"/>
+        <location filename="../src/widgets/window.cpp" line="1520"/>
+        <location filename="../src/widgets/window.cpp" line="1665"/>
+        <location filename="../src/widgets/window.cpp" line="1713"/>
         <source>Save File</source>
         <translation>Bestand opslaan</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1483"/>
+        <location filename="../src/widgets/window.cpp" line="1569"/>
+        <source>Cannot save as the original file in preview mode. Please choose a different path.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1667"/>
         <source>Encoding</source>
         <translation>Tekencodering</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1773"/>
+        <location filename="../src/widgets/window.cpp" line="1957"/>
         <source>Read-Only mode is on</source>
         <translation>Alleen-lezenmodus is ingeschakeld</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2322"/>
+        <location filename="../src/widgets/window.cpp" line="2511"/>
         <source>Current location remembered</source>
         <translation>De huidige locatie wordt onthouden</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2398"/>
+        <location filename="../src/widgets/window.cpp" line="2591"/>
         <source>Ctrl+&apos;=&apos;</source>
         <translation>Ctrl+&apos;=&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2401"/>
+        <location filename="../src/widgets/window.cpp" line="2594"/>
         <source>Ctrl+&apos;-&apos;</source>
         <translation>Ctrl+&apos;-&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2430"/>
+        <location filename="../src/widgets/window.cpp" line="2623"/>
         <source>Editor</source>
         <translation>Bewerker</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3061"/>
+        <location filename="../src/widgets/window.cpp" line="3436"/>
         <source>Untitled %1</source>
         <translation>Naamloos %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3543"/>
+        <location filename="../src/widgets/window.cpp" line="3948"/>
         <source>Cancel</source>
         <translation>Annuleren</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3544"/>
+        <location filename="../src/widgets/window.cpp" line="3949"/>
         <source>Discard</source>
         <translation>Verwerpen</translation>
     </message>

--- a/translations/deepin-editor_pl.ts
+++ b/translations/deepin-editor_pl.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="pl">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pl">
 <context>
     <name>BottomBar</name>
     <message>
@@ -17,17 +19,36 @@
         <translation>Znaki %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="44"/>
+        <location filename="../src/widgets/bottombar.cpp" line="47"/>
         <source>Loading:</source>
         <translation>Wczytywanie:</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="73"/>
+        <location filename="../src/widgets/bottombar.cpp" line="91"/>
+        <location filename="../src/widgets/bottombar.cpp" line="499"/>
+        <source>Edit Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="74"/>
+        <location filename="../src/widgets/bottombar.cpp" line="489"/>
+        <source>Read View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="75"/>
+        <location filename="../src/widgets/bottombar.cpp" line="493"/>
+        <source>Live Preview</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DDropdownMenu</name>
     <message>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="362"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="420"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="425"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="363"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="421"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="426"/>
         <source>None</source>
         <translation>Brak</translation>
     </message>
@@ -35,68 +56,57 @@
 <context>
     <name>EditWrapper</name>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="292"/>
-        <location filename="../src/editor/editwrapper.cpp" line="365"/>
-        <location filename="../src/editor/editwrapper.cpp" line="521"/>
-        <location filename="../src/editor/editwrapper.cpp" line="751"/>
+        <location filename="../src/editor/editwrapper.cpp" line="355"/>
+        <location filename="../src/editor/editwrapper.cpp" line="429"/>
+        <location filename="../src/editor/editwrapper.cpp" line="595"/>
+        <location filename="../src/editor/editwrapper.cpp" line="887"/>
         <source>Save</source>
         <translation>Zapisz</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="516"/>
+        <location filename="../src/editor/editwrapper.cpp" line="590"/>
         <source>Do you want to save this file?</source>
         <translation>Czy chcesz zapisać plik?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="363"/>
-        <location filename="../src/editor/editwrapper.cpp" line="519"/>
+        <location filename="../src/editor/editwrapper.cpp" line="427"/>
+        <location filename="../src/editor/editwrapper.cpp" line="593"/>
         <source>Cancel</source>
         <translation>Anuluj</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="360"/>
+        <location filename="../src/editor/editwrapper.cpp" line="424"/>
         <source>Encoding changed. Do you want to save the file now?</source>
         <translation>Kodowanie zostało zmienione. Czy chcesz teraz zapisać plik?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="520"/>
+        <location filename="../src/editor/editwrapper.cpp" line="594"/>
         <source>Discard</source>
         <translation>Odrzuć</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="274"/>
-        <location filename="../src/editor/editwrapper.cpp" line="620"/>
+        <location filename="../src/editor/editwrapper.cpp" line="1121"/>
+        <source>The file contains invalid characters (NUL). Preview mode is read-only.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="337"/>
+        <location filename="../src/editor/editwrapper.cpp" line="705"/>
         <source>You do not have permission to save %1</source>
         <translation>Nie posiadasz uprawnień do zapisania %1</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="836"/>
+        <location filename="../src/editor/editwrapper.cpp" line="987"/>
         <source>File removed on the disk. Save it now?</source>
         <translation>Plik został usunięty z dysku. Czy chcesz go zapisać?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="842"/>
+        <location filename="../src/editor/editwrapper.cpp" line="993"/>
         <source>File has changed on disk. Reload?</source>
         <translation>Plik został zmieniony na dysku. Czy chcesz go ponownie wczytać?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="884"/>
-        <location filename="../src/widgets/bottombar.cpp" line="74"/>
-        <source>INSERT</source>
-        <translation>WSTAWIANIE</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="888"/>
-        <source>OVERWRITE</source>
-        <translation>NADPISYWANIE</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="892"/>
-        <source>R/O</source>
-        <translation>TYLKO DO ODCZYTU</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="1618"/>
+        <location filename="../src/editor/editwrapper.cpp" line="1806"/>
         <source>The file cannot be read, which may be too large or has been damaged!</source>
         <translation>Nie można odczytać pliku, może być za duży lub jest uszkodzony!</translation>
     </message>
@@ -109,17 +119,17 @@
         <translation>Znajdź</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="36"/>
+        <location filename="../src/controls/findbar.cpp" line="38"/>
         <source>Previous</source>
         <translation>Poprzednie</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="37"/>
+        <location filename="../src/controls/findbar.cpp" line="40"/>
         <source>Next</source>
         <translation>Następne</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="38"/>
+        <location filename="../src/controls/findbar.cpp" line="42"/>
         <source>Replace</source>
         <translation>Zamień</translation>
     </message>
@@ -127,9 +137,17 @@
 <context>
     <name>JumpLineBar</name>
     <message>
-        <location filename="../src/controls/jumplinebar.cpp" line="45"/>
+        <location filename="../src/controls/jumplinebar.cpp" line="46"/>
         <source>Go to Line: </source>
         <translation>Przejdź do wiersza:</translation>
+    </message>
+</context>
+<context>
+    <name>LineBar</name>
+    <message>
+        <location filename="../src/controls/linebar.cpp" line="144"/>
+        <source>第%1/%2项</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -146,19 +164,47 @@
     </message>
 </context>
 <context>
+    <name>MarkdownBridge</name>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="37"/>
+        <source>Collapse code block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="38"/>
+        <source>Expand code block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="39"/>
+        <source>Copy code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="40"/>
+        <source>Expand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="42"/>
+        <source>%1 line(s) of code collapsed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PathSettingWgt</name>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="84"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="90"/>
         <source>Remember the last used path</source>
         <translation>Zapamiętaj ostatnio użytą ścieżkę</translation>
     </message>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="85"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="91"/>
         <source>Same path as the current file</source>
         <translation>Taka sama ścieżka jak bieżącego pliku</translation>
     </message>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="86"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="92"/>
         <source>Customize the default path</source>
         <translation>Dostosuj ścieżkę domyślną</translation>
     </message>
@@ -171,15 +217,20 @@
         <translation>Edytor tekstu</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="294"/>
-        <location filename="../src/editor/editwrapper.cpp" line="761"/>
-        <location filename="../src/editor/editwrapper.cpp" line="776"/>
-        <location filename="../src/widgets/window.cpp" line="1362"/>
-        <location filename="../src/widgets/window.cpp" line="1390"/>
-        <location filename="../src/widgets/window.cpp" line="1531"/>
-        <location filename="../src/widgets/window.cpp" line="1548"/>
+        <location filename="../src/editor/editwrapper.cpp" line="357"/>
+        <location filename="../src/editor/editwrapper.cpp" line="897"/>
+        <location filename="../src/editor/editwrapper.cpp" line="912"/>
+        <location filename="../src/widgets/window.cpp" line="1528"/>
+        <location filename="../src/widgets/window.cpp" line="1556"/>
+        <location filename="../src/widgets/window.cpp" line="1715"/>
+        <location filename="../src/widgets/window.cpp" line="1732"/>
         <source>Encoding</source>
         <translation>Kodowanie</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="2001"/>
+        <source>视图模式</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="11"/>
@@ -215,7 +266,7 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="18"/>
         <location filename="../src/controls/settingsdialog.cpp" line="96"/>
-        <location filename="../src/widgets/window.cpp" line="2388"/>
+        <location filename="../src/widgets/window.cpp" line="2581"/>
         <source>Window</source>
         <translation>Okno</translation>
     </message>
@@ -755,68 +806,68 @@
         <translation>Wietnamski</translation>
     </message>
     <message>
-        <location filename="../src/startmanager.cpp" line="971"/>
+        <location filename="../src/startmanager.cpp" line="1035"/>
         <source>File not saved</source>
         <translation>Plik nie został zapisany</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1532"/>
-        <location filename="../src/widgets/window.cpp" line="1549"/>
+        <location filename="../src/widgets/window.cpp" line="1716"/>
+        <location filename="../src/widgets/window.cpp" line="1733"/>
         <source>Line Endings</source>
         <translation>Zakończenia wiersza</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="243"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="379"/>
         <source>Please install &apos;UOS AI&apos; from the App Store before using</source>
         <translation>Proszę zainstalować &apos;UOS AI&apos; z sklepu z aplikacjami przed użyciem</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="245"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="381"/>
         <source>No audio input device detected. Please check and try again</source>
         <translation>Nie znaleziono urządzenia wejściowego dźwięku. Sprawdź i spróbuj ponownie</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="247"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="383"/>
         <source>No audio output device detected. Please check and try again</source>
         <translation>Nie znaleziono urządzenia wyjściowego dźwięku. Sprawdź i spróbuj ponownie</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="69"/>
+        <location filename="../src/common/text_file_saver.cpp" line="74"/>
         <source>File path is empty</source>
         <translation>Ścieżka pliku jest pusta</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="155"/>
+        <location filename="../src/common/text_file_saver.cpp" line="153"/>
         <source>Insufficient memory to load document content</source>
         <translation>Niewystarczająca pamięć do załadowania zawartości dokumentu</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="177"/>
+        <location filename="../src/common/text_file_saver.cpp" line="178"/>
         <source>Insufficient memory for encoding conversion</source>
         <translation>Niewystarczająca pamięć do konwersji kodowania</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="183"/>
+        <location filename="../src/common/text_file_saver.cpp" line="184"/>
         <source>Encoding conversion failed</source>
         <translation>Konwersja kodowania zakończyła się niepowodzeniem</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="189"/>
+        <location filename="../src/common/text_file_saver.cpp" line="190"/>
         <source>Converted content is empty</source>
         <translation>Za konwertowanym zawartością jest pusta</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="207"/>
+        <location filename="../src/common/text_file_saver.cpp" line="208"/>
         <source>Memory allocation failed</source>
         <translation>Alokacja pamięci zakończyła się niepowodzeniem</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="211"/>
+        <location filename="../src/common/text_file_saver.cpp" line="212"/>
         <source>Error occurred: %1</source>
         <translation>Wystąpił błąd: %1</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="215"/>
+        <location filename="../src/common/text_file_saver.cpp" line="216"/>
         <source>Unknown error occurred</source>
         <translation>Wystąpił nieznany błąd</translation>
     </message>
@@ -829,27 +880,27 @@
         <translation>Znajdź</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="34"/>
+        <location filename="../src/controls/replacebar.cpp" line="36"/>
         <source>Replace With</source>
         <translation>Zamień na</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="36"/>
+        <location filename="../src/controls/replacebar.cpp" line="40"/>
         <source>Replace</source>
         <translation>Zastąp</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="37"/>
+        <location filename="../src/controls/replacebar.cpp" line="42"/>
         <source>Skip</source>
         <translation>Pomiń</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="38"/>
+        <location filename="../src/controls/replacebar.cpp" line="44"/>
         <source>Replace Rest</source>
         <translation>Zastąp pozostałe</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="39"/>
+        <location filename="../src/controls/replacebar.cpp" line="46"/>
         <source>Replace All</source>
         <translation>Zastąp wszystkie</translation>
     </message>
@@ -858,9 +909,9 @@
     <name>S:</name>
     <message>
         <location filename="../third/libiconv-1.16/src/iconv.c" line="103"/>
-        <source/>
+        <source></source>
         <comment>The first line of the short usage message.</comment>
-        <translation type="unfinished"/>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -891,34 +942,34 @@
         <translation>Pełny ekran</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="484"/>
+        <location filename="../src/common/settings.cpp" line="491"/>
         <source>This shortcut conflicts with system shortcut %1</source>
         <translation>Ten skrót jest w konflikcie ze skrótem systemowym %1</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="487"/>
+        <location filename="../src/common/settings.cpp" line="494"/>
         <source>This shortcut conflicts with %1, click on Replace to make this shortcut effective immediately</source>
         <translation>Ten skrót jest w konflikcie z %1, kliknij Zastąp, aby go nadpisać</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="682"/>
-        <location filename="../src/common/settings.cpp" line="695"/>
-        <location filename="../src/common/settings.cpp" line="704"/>
+        <location filename="../src/common/settings.cpp" line="689"/>
+        <location filename="../src/common/settings.cpp" line="702"/>
+        <location filename="../src/common/settings.cpp" line="711"/>
         <source>The shortcut %1 is invalid, please set another one.</source>
         <translation>Skrót %1 jest nieprawidłowy, ustaw inny.</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="736"/>
+        <location filename="../src/common/settings.cpp" line="743"/>
         <source>Cancel</source>
         <translation>Anuluj</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="737"/>
+        <location filename="../src/common/settings.cpp" line="744"/>
         <source>Replace</source>
         <translation>Zamień</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="740"/>
+        <location filename="../src/common/settings.cpp" line="747"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
@@ -926,7 +977,7 @@
 <context>
     <name>StartManager</name>
     <message>
-        <location filename="../src/startmanager.cpp" line="411"/>
+        <location filename="../src/startmanager.cpp" line="425"/>
         <source>Untitled %1</source>
         <translation>Bez tytułu %1</translation>
     </message>
@@ -934,32 +985,32 @@
 <context>
     <name>Tabbar</name>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="641"/>
+        <location filename="../src/controls/tabbar.cpp" line="678"/>
         <source>Close tab</source>
         <translation>Zamknij kartę</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="642"/>
+        <location filename="../src/controls/tabbar.cpp" line="680"/>
         <source>Close other tabs</source>
         <translation>Zamknij pozostałe karty</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="643"/>
+        <location filename="../src/controls/tabbar.cpp" line="682"/>
         <source>More options</source>
         <translation>Więcej opcji</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="644"/>
+        <location filename="../src/controls/tabbar.cpp" line="684"/>
         <source>Close tabs to the left</source>
         <translation>Zamknij karty po lewej stronie</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="645"/>
+        <location filename="../src/controls/tabbar.cpp" line="686"/>
         <source>Close tabs to the right</source>
         <translation>Zamknij karty po prawej stronie</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="646"/>
+        <location filename="../src/controls/tabbar.cpp" line="688"/>
         <source>Close unmodified tabs</source>
         <translation>Zamknij niezmodyfikowane karty</translation>
     </message>
@@ -967,263 +1018,280 @@
 <context>
     <name>TextEdit</name>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="305"/>
+        <location filename="../src/editor/dtextedit.cpp" line="388"/>
         <source>Undo</source>
         <translation>Cofnij</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="306"/>
+        <location filename="../src/editor/dtextedit.cpp" line="390"/>
         <source>Redo</source>
         <translation>Ponów</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="307"/>
+        <location filename="../src/editor/dtextedit.cpp" line="392"/>
         <source>Cut</source>
         <translation>Wytnij</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="308"/>
+        <location filename="../src/editor/dtextedit.cpp" line="394"/>
         <source>Copy</source>
         <translation>Kopiuj</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="309"/>
+        <location filename="../src/editor/dtextedit.cpp" line="396"/>
         <source>Paste</source>
         <translation>Wklej</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="310"/>
+        <location filename="../src/editor/dtextedit.cpp" line="398"/>
         <source>Delete</source>
         <translation>Usuń</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="311"/>
+        <location filename="../src/editor/dtextedit.cpp" line="400"/>
         <source>Select All</source>
         <translation>Zaznacz wszystko</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="312"/>
-        <location filename="../src/widgets/window.cpp" line="535"/>
+        <location filename="../src/editor/dtextedit.cpp" line="402"/>
+        <location filename="../src/widgets/window.cpp" line="556"/>
         <source>Find</source>
         <translation>Znajdź</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="313"/>
-        <location filename="../src/widgets/window.cpp" line="536"/>
+        <location filename="../src/editor/dtextedit.cpp" line="404"/>
+        <location filename="../src/widgets/window.cpp" line="558"/>
         <source>Replace</source>
         <translation>Zamień</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="314"/>
+        <location filename="../src/editor/dtextedit.cpp" line="406"/>
         <source>Go to Line</source>
         <translation>Przejdź do wiersza</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="315"/>
-        <source>Turn on Read-Only mode</source>
-        <translation>Włącz tryb tylko-do-odczytu</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="316"/>
-        <source>Turn off Read-Only mode</source>
-        <translation>Wyłącz tryb tylko-do-odczytu</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="317"/>
+        <location filename="../src/editor/dtextedit.cpp" line="415"/>
         <source>Fullscreen</source>
         <translation>Pełny ekran</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="318"/>
+        <location filename="../src/editor/dtextedit.cpp" line="417"/>
         <source>Exit fullscreen</source>
         <translation>Opuść pełny ekran</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="319"/>
+        <location filename="../src/editor/dtextedit.cpp" line="419"/>
         <source>Display in file manager</source>
         <translation>Wyświetl w Menedżerze plików</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="320"/>
-        <location filename="../src/editor/dtextedit.cpp" line="374"/>
+        <location filename="../src/editor/dtextedit.cpp" line="421"/>
+        <location filename="../src/editor/dtextedit.cpp" line="493"/>
         <source>Add Comment</source>
         <translation>Dodaj komentarz</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="321"/>
+        <location filename="../src/editor/dtextedit.cpp" line="423"/>
         <source>Text to Speech</source>
         <translation>Tekst na mowę</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="322"/>
-        <source>Stop reading</source>
-        <translation>Przestań czytać</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="323"/>
+        <location filename="../src/editor/dtextedit.cpp" line="425"/>
         <source>Speech to Text</source>
         <translation>Mowa na tekst</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="324"/>
+        <location filename="../src/editor/dtextedit.cpp" line="427"/>
         <source>Translate</source>
         <translation>Przetłumacz</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="325"/>
+        <location filename="../src/editor/dtextedit.cpp" line="429"/>
         <source>Column Mode</source>
         <translation>Tryb kolumnowy</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="326"/>
+        <location filename="../src/editor/dtextedit.cpp" line="431"/>
         <source>Add bookmark</source>
         <translation>Dodaj zakładkę</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="327"/>
+        <location filename="../src/editor/dtextedit.cpp" line="433"/>
         <source>Remove Bookmark</source>
         <translation>Usuń zakładkę</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="328"/>
+        <location filename="../src/editor/dtextedit.cpp" line="435"/>
         <source>Previous bookmark</source>
         <translation>Poprzednia zakładka</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="329"/>
+        <location filename="../src/editor/dtextedit.cpp" line="437"/>
         <source>Next bookmark</source>
         <translation>Następna zakładka</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="330"/>
+        <location filename="../src/editor/dtextedit.cpp" line="439"/>
         <source>Remove All Bookmarks</source>
         <translation>Usuń wszystkie zakładki</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="331"/>
+        <location filename="../src/editor/dtextedit.cpp" line="441"/>
         <source>Fold All</source>
         <translation>Zwiń wszystko</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="332"/>
+        <location filename="../src/editor/dtextedit.cpp" line="443"/>
         <source>Fold Current Level</source>
         <translation>Zwiń bieżący poziom</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="333"/>
+        <location filename="../src/editor/dtextedit.cpp" line="445"/>
         <source>Unfold All</source>
         <translation>Rozwiń wszystko</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="334"/>
+        <location filename="../src/editor/dtextedit.cpp" line="447"/>
         <source>Unfold Current Level</source>
         <translation>Rozwiń bieżący poziom</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="339"/>
+        <location filename="../src/editor/dtextedit.cpp" line="453"/>
         <source>Color Mark</source>
         <translation>Kolor oznaczenia</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="343"/>
+        <location filename="../src/editor/dtextedit.cpp" line="458"/>
         <source>Clear All Marks</source>
         <translation>Wyczyść wszystkie oznaczenia</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="344"/>
+        <location filename="../src/editor/dtextedit.cpp" line="460"/>
         <source>Clear Last Mark</source>
         <translation>Wyczyść ostatnie oznaczenie</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="353"/>
+        <location filename="../src/editor/dtextedit.cpp" line="470"/>
         <source>Mark</source>
         <translation>Oznacz</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="366"/>
+        <location filename="../src/editor/dtextedit.cpp" line="484"/>
         <source>Mark All</source>
         <translation>Oznacz wszystko</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="375"/>
+        <location filename="../src/editor/dtextedit.cpp" line="494"/>
         <source>Remove Comment</source>
         <translation>Usuń komentarz</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3208"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3211"/>
+        <location filename="../src/editor/dtextedit.cpp" line="543"/>
+        <source>View Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="3531"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3534"/>
         <source>Copy failed: not enough memory</source>
         <translation>Kopiowanie nieudane: niewystarczająca ilość pamięci</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3333"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3335"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3656"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3658"/>
         <source>Press ALT and click lines to edit in column mode</source>
         <translation>Naciśnij ALT i kliknij wiersz, aby edytować w trybie kolumnowym</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="418"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9574"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9576"/>
+        <source>No audio output device was detected. Please ensure your speakers or headphones are properly connected and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="9583"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9585"/>
+        <source>No audio input device was detected. Please ensure your speakers or headphones are properly connected and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="534"/>
         <source>Change Case</source>
         <translation>Zmień wielkość znaków</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="419"/>
+        <location filename="../src/editor/dtextedit.cpp" line="409"/>
+        <source>Edit Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="411"/>
+        <source>Read View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="413"/>
+        <source>Live Preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="535"/>
         <source>Upper Case</source>
         <translation>Wielkie litery</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="420"/>
+        <location filename="../src/editor/dtextedit.cpp" line="536"/>
         <source>Lower Case</source>
         <translation>Małe litery</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="421"/>
+        <location filename="../src/editor/dtextedit.cpp" line="537"/>
         <source>Capitalize</source>
         <translation>Wielka litera</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="78"/>
+        <location filename="../src/widgets/bottombar.cpp" line="110"/>
         <source>None</source>
         <translation>Brak</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1363"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1490"/>
         <source>Selected line(s) copied</source>
         <translation>Skopiowano zaznaczone wiersz(e)</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1370"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1497"/>
         <source>Current line copied</source>
         <translation>Skopiowano bieżący wiersz</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1400"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1527"/>
         <source>Selected line(s) clipped</source>
         <translation>Wycięto zaznaczone wiersz(e)</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1412"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1539"/>
         <source>Current line clipped</source>
         <translation>Wycięto bieżący wiersz</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3227"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3230"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3550"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3553"/>
         <source>Paste failed: not enough memory</source>
         <translation>Wklejanie nieudane: niewystarczająca ilość pamięci</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="4548"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4873"/>
         <source>Read-Only mode is off</source>
         <translation>Tryb tylko-do-odczytu jest nieaktywny</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="4560"/>
-        <location filename="../src/editor/dtextedit.cpp" line="4584"/>
-        <location filename="../src/editor/dtextedit.cpp" line="7896"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8007"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8015"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8026"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4885"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4909"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8236"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8347"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8355"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8366"/>
         <source>Read-Only mode is on</source>
         <translation>Tryb tylko-do-odczytu jest aktywny</translation>
     </message>
@@ -1231,138 +1299,175 @@
 <context>
     <name>WarningNotices</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="24"/>
+        <location filename="../src/controls/warningnotices.cpp" line="25"/>
         <source>Reload</source>
         <translation>Przeładuj</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/warningnotices.cpp" line="29"/>
+        <source>Edit Anyway</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>Window</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="25"/>
-        <location filename="../src/widgets/window.cpp" line="531"/>
+        <location filename="../src/controls/warningnotices.cpp" line="27"/>
+        <location filename="../src/widgets/window.cpp" line="548"/>
         <source>Save as</source>
         <translation>Zapisz jako</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="527"/>
+        <location filename="../src/widgets/window.cpp" line="540"/>
         <source>New window</source>
         <translation>Nowe okno</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="528"/>
+        <location filename="../src/widgets/window.cpp" line="542"/>
         <source>New tab</source>
         <translation>Nowa karta</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="529"/>
+        <location filename="../src/widgets/window.cpp" line="544"/>
         <source>Open file</source>
         <translation>Otwórz plik</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="530"/>
-        <location filename="../src/widgets/window.cpp" line="3545"/>
+        <location filename="../src/widgets/window.cpp" line="546"/>
+        <location filename="../src/widgets/window.cpp" line="3950"/>
         <source>Save</source>
         <translation>Zapisz</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="532"/>
+        <location filename="../src/widgets/window.cpp" line="550"/>
         <source>Print</source>
         <translation>Drukuj</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="533"/>
+        <location filename="../src/widgets/window.cpp" line="552"/>
         <source>Switch theme</source>
         <translation>Przełącz motyw</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="534"/>
-        <location filename="../src/widgets/window.cpp" line="2448"/>
+        <location filename="../src/widgets/window.cpp" line="554"/>
+        <location filename="../src/widgets/window.cpp" line="2641"/>
         <source>Settings</source>
         <translation>Ustawienia</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="666"/>
-        <location filename="../src/widgets/window.cpp" line="3845"/>
+        <location filename="../src/widgets/window.cpp" line="696"/>
+        <location filename="../src/widgets/window.cpp" line="4250"/>
         <source>Read-Only</source>
         <translation>Tylko-do-odczytu</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="687"/>
+        <location filename="../src/widgets/window.cpp" line="719"/>
         <source>You do not have permission to open %1</source>
         <translation>Nie posiadasz uprawnień do otwarcia %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="738"/>
-        <location filename="../src/widgets/window.cpp" line="2963"/>
+        <location filename="../src/widgets/window.cpp" line="773"/>
+        <location filename="../src/widgets/window.cpp" line="3266"/>
         <source>Invalid file: %1</source>
         <translation>Nieprawidłowy plik: %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="903"/>
-        <location filename="../src/widgets/window.cpp" line="956"/>
+        <location filename="../src/widgets/window.cpp" line="957"/>
+        <location filename="../src/widgets/window.cpp" line="1050"/>
+        <location filename="../src/widgets/window.cpp" line="3217"/>
         <source>Do you want to save this file?</source>
         <translation>Czy chcesz zapisać ten plik?</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1290"/>
+        <location filename="../src/widgets/window.cpp" line="1381"/>
+        <source>Invalid characters detected while saving &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1382"/>
+        <source>If you force save this file, it may cause file corruption. Still want to save?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1386"/>
+        <source>Don&apos;t Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1387"/>
+        <source>Save As</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1388"/>
+        <source>Save Anyway</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1456"/>
         <source>You do not have permission to save %1</source>
         <translation>Nie posiadasz uprawnień do zapisania %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1312"/>
+        <location filename="../src/widgets/window.cpp" line="1428"/>
+        <location filename="../src/widgets/window.cpp" line="1478"/>
         <source>Saved successfully</source>
         <translation>Zapisano pomyślnie</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1354"/>
-        <location filename="../src/widgets/window.cpp" line="1481"/>
-        <location filename="../src/widgets/window.cpp" line="1529"/>
+        <location filename="../src/widgets/window.cpp" line="1520"/>
+        <location filename="../src/widgets/window.cpp" line="1665"/>
+        <location filename="../src/widgets/window.cpp" line="1713"/>
         <source>Save File</source>
         <translation>Zapisz plik</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1483"/>
+        <location filename="../src/widgets/window.cpp" line="1569"/>
+        <source>Cannot save as the original file in preview mode. Please choose a different path.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1667"/>
         <source>Encoding</source>
         <translation>Kodowanie</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1773"/>
+        <location filename="../src/widgets/window.cpp" line="1957"/>
         <source>Read-Only mode is on</source>
         <translation>Tryb tylko-do-odczytu jest aktywny</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2322"/>
+        <location filename="../src/widgets/window.cpp" line="2511"/>
         <source>Current location remembered</source>
         <translation>Bieżąca pozycja kursora została zapamiętana</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2398"/>
+        <location filename="../src/widgets/window.cpp" line="2591"/>
         <source>Ctrl+&apos;=&apos;</source>
         <translation>Ctrl+&apos;=&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2401"/>
+        <location filename="../src/widgets/window.cpp" line="2594"/>
         <source>Ctrl+&apos;-&apos;</source>
         <translation>Ctrl+&apos;-&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2430"/>
+        <location filename="../src/widgets/window.cpp" line="2623"/>
         <source>Editor</source>
         <translation>Edytor</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3061"/>
+        <location filename="../src/widgets/window.cpp" line="3436"/>
         <source>Untitled %1</source>
         <translation>Bez tytułu %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3543"/>
+        <location filename="../src/widgets/window.cpp" line="3948"/>
         <source>Cancel</source>
         <translation>Anuluj</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3544"/>
+        <location filename="../src/widgets/window.cpp" line="3949"/>
         <source>Discard</source>
         <translation>Odrzuć</translation>
     </message>

--- a/translations/deepin-editor_pt.ts
+++ b/translations/deepin-editor_pt.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="pt">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pt">
 <context>
     <name>BottomBar</name>
     <message>
@@ -17,17 +19,36 @@
         <translation>Caracteres %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="44"/>
+        <location filename="../src/widgets/bottombar.cpp" line="47"/>
         <source>Loading:</source>
         <translation>A carregar:</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="73"/>
+        <location filename="../src/widgets/bottombar.cpp" line="91"/>
+        <location filename="../src/widgets/bottombar.cpp" line="499"/>
+        <source>Edit Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="74"/>
+        <location filename="../src/widgets/bottombar.cpp" line="489"/>
+        <source>Read View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="75"/>
+        <location filename="../src/widgets/bottombar.cpp" line="493"/>
+        <source>Live Preview</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DDropdownMenu</name>
     <message>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="362"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="420"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="425"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="363"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="421"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="426"/>
         <source>None</source>
         <translation>Nenhum</translation>
     </message>
@@ -35,68 +56,57 @@
 <context>
     <name>EditWrapper</name>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="292"/>
-        <location filename="../src/editor/editwrapper.cpp" line="365"/>
-        <location filename="../src/editor/editwrapper.cpp" line="521"/>
-        <location filename="../src/editor/editwrapper.cpp" line="751"/>
+        <location filename="../src/editor/editwrapper.cpp" line="355"/>
+        <location filename="../src/editor/editwrapper.cpp" line="429"/>
+        <location filename="../src/editor/editwrapper.cpp" line="595"/>
+        <location filename="../src/editor/editwrapper.cpp" line="887"/>
         <source>Save</source>
         <translation>Guardar</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="516"/>
+        <location filename="../src/editor/editwrapper.cpp" line="590"/>
         <source>Do you want to save this file?</source>
         <translation>Quer guardar este ficheiro?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="363"/>
-        <location filename="../src/editor/editwrapper.cpp" line="519"/>
+        <location filename="../src/editor/editwrapper.cpp" line="427"/>
+        <location filename="../src/editor/editwrapper.cpp" line="593"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="360"/>
+        <location filename="../src/editor/editwrapper.cpp" line="424"/>
         <source>Encoding changed. Do you want to save the file now?</source>
         <translation>A codificação foi alterada. Deseja guardar o ficheiro agora?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="520"/>
+        <location filename="../src/editor/editwrapper.cpp" line="594"/>
         <source>Discard</source>
         <translation>Descartar</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="274"/>
-        <location filename="../src/editor/editwrapper.cpp" line="620"/>
+        <location filename="../src/editor/editwrapper.cpp" line="1121"/>
+        <source>The file contains invalid characters (NUL). Preview mode is read-only.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="337"/>
+        <location filename="../src/editor/editwrapper.cpp" line="705"/>
         <source>You do not have permission to save %1</source>
         <translation>Não possui permissões para guardar %1</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="836"/>
+        <location filename="../src/editor/editwrapper.cpp" line="987"/>
         <source>File removed on the disk. Save it now?</source>
         <translation>Ficheiro removido no disco. Guardar agora?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="842"/>
+        <location filename="../src/editor/editwrapper.cpp" line="993"/>
         <source>File has changed on disk. Reload?</source>
         <translation>Ficheiro foi alterado no disco. Recarregar?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="884"/>
-        <location filename="../src/widgets/bottombar.cpp" line="74"/>
-        <source>INSERT</source>
-        <translation>INSERIR</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="888"/>
-        <source>OVERWRITE</source>
-        <translation>SOBRESCREVER</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="892"/>
-        <source>R/O</source>
-        <translation>A/L</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="1618"/>
+        <location filename="../src/editor/editwrapper.cpp" line="1806"/>
         <source>The file cannot be read, which may be too large or has been damaged!</source>
         <translation>O ficheiro não pode ser lido, o mesmo pode ser demasiado grande ou ter sido danificado!</translation>
     </message>
@@ -109,17 +119,17 @@
         <translation>Procurar</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="36"/>
+        <location filename="../src/controls/findbar.cpp" line="38"/>
         <source>Previous</source>
         <translation>Anterior</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="37"/>
+        <location filename="../src/controls/findbar.cpp" line="40"/>
         <source>Next</source>
         <translation>Seguinte</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="38"/>
+        <location filename="../src/controls/findbar.cpp" line="42"/>
         <source>Replace</source>
         <translation>Substituir</translation>
     </message>
@@ -127,9 +137,17 @@
 <context>
     <name>JumpLineBar</name>
     <message>
-        <location filename="../src/controls/jumplinebar.cpp" line="45"/>
+        <location filename="../src/controls/jumplinebar.cpp" line="46"/>
         <source>Go to Line: </source>
         <translation>Ir para linha:</translation>
+    </message>
+</context>
+<context>
+    <name>LineBar</name>
+    <message>
+        <location filename="../src/controls/linebar.cpp" line="144"/>
+        <source>第%1/%2项</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -146,19 +164,47 @@
     </message>
 </context>
 <context>
+    <name>MarkdownBridge</name>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="37"/>
+        <source>Collapse code block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="38"/>
+        <source>Expand code block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="39"/>
+        <source>Copy code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="40"/>
+        <source>Expand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="42"/>
+        <source>%1 line(s) of code collapsed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PathSettingWgt</name>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="84"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="90"/>
         <source>Remember the last used path</source>
         <translation>Lembrar o último caminho usado</translation>
     </message>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="85"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="91"/>
         <source>Same path as the current file</source>
         <translation>O mesmo caminho que o ficheiro atual</translation>
     </message>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="86"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="92"/>
         <source>Customize the default path</source>
         <translation>Personalizar o caminho predefinido</translation>
     </message>
@@ -171,15 +217,20 @@
         <translation>Editor de texto</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="294"/>
-        <location filename="../src/editor/editwrapper.cpp" line="761"/>
-        <location filename="../src/editor/editwrapper.cpp" line="776"/>
-        <location filename="../src/widgets/window.cpp" line="1362"/>
-        <location filename="../src/widgets/window.cpp" line="1390"/>
-        <location filename="../src/widgets/window.cpp" line="1531"/>
-        <location filename="../src/widgets/window.cpp" line="1548"/>
+        <location filename="../src/editor/editwrapper.cpp" line="357"/>
+        <location filename="../src/editor/editwrapper.cpp" line="897"/>
+        <location filename="../src/editor/editwrapper.cpp" line="912"/>
+        <location filename="../src/widgets/window.cpp" line="1528"/>
+        <location filename="../src/widgets/window.cpp" line="1556"/>
+        <location filename="../src/widgets/window.cpp" line="1715"/>
+        <location filename="../src/widgets/window.cpp" line="1732"/>
         <source>Encoding</source>
         <translation>Codificação</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="2001"/>
+        <source>视图模式</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="11"/>
@@ -215,7 +266,7 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="18"/>
         <location filename="../src/controls/settingsdialog.cpp" line="96"/>
-        <location filename="../src/widgets/window.cpp" line="2388"/>
+        <location filename="../src/widgets/window.cpp" line="2581"/>
         <source>Window</source>
         <translation>Janela</translation>
     </message>
@@ -755,68 +806,68 @@
         <translation>Vietnamita</translation>
     </message>
     <message>
-        <location filename="../src/startmanager.cpp" line="971"/>
+        <location filename="../src/startmanager.cpp" line="1035"/>
         <source>File not saved</source>
         <translation>Ficheiro não guardado</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1532"/>
-        <location filename="../src/widgets/window.cpp" line="1549"/>
+        <location filename="../src/widgets/window.cpp" line="1716"/>
+        <location filename="../src/widgets/window.cpp" line="1733"/>
         <source>Line Endings</source>
         <translation>Terminações de linha</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="243"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="379"/>
         <source>Please install &apos;UOS AI&apos; from the App Store before using</source>
         <translation>Instale o &apos;UOS AI&apos; da Loja de Aplicativos antes de usar</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="245"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="381"/>
         <source>No audio input device detected. Please check and try again</source>
         <translation>Nenhum dispositivo de entrada de áudio detectado. Por favor, verifique e tente novamente</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="247"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="383"/>
         <source>No audio output device detected. Please check and try again</source>
         <translation>Nenhum dispositivo de saída de áudio detectado. Por favor, verifique e tente novamente</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="69"/>
+        <location filename="../src/common/text_file_saver.cpp" line="74"/>
         <source>File path is empty</source>
         <translation>O caminho do arquivo está vazio</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="155"/>
+        <location filename="../src/common/text_file_saver.cpp" line="153"/>
         <source>Insufficient memory to load document content</source>
         <translation>Memória insuficiente para carregar o conteúdo do documento</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="177"/>
+        <location filename="../src/common/text_file_saver.cpp" line="178"/>
         <source>Insufficient memory for encoding conversion</source>
         <translation>Memória insuficiente para conversão de codificação</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="183"/>
+        <location filename="../src/common/text_file_saver.cpp" line="184"/>
         <source>Encoding conversion failed</source>
         <translation>Conversão de codificação falhou</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="189"/>
+        <location filename="../src/common/text_file_saver.cpp" line="190"/>
         <source>Converted content is empty</source>
         <translation>O conteúdo convertido está vazio</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="207"/>
+        <location filename="../src/common/text_file_saver.cpp" line="208"/>
         <source>Memory allocation failed</source>
         <translation>Alocação de memória falhou</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="211"/>
+        <location filename="../src/common/text_file_saver.cpp" line="212"/>
         <source>Error occurred: %1</source>
         <translation>Ocorreu um erro: %1</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="215"/>
+        <location filename="../src/common/text_file_saver.cpp" line="216"/>
         <source>Unknown error occurred</source>
         <translation>Ocorreu um erro desconhecido</translation>
     </message>
@@ -829,27 +880,27 @@
         <translation>Localizar</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="34"/>
+        <location filename="../src/controls/replacebar.cpp" line="36"/>
         <source>Replace With</source>
         <translation>Substituir por</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="36"/>
+        <location filename="../src/controls/replacebar.cpp" line="40"/>
         <source>Replace</source>
         <translation>Substituir</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="37"/>
+        <location filename="../src/controls/replacebar.cpp" line="42"/>
         <source>Skip</source>
         <translation>Ignorar</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="38"/>
+        <location filename="../src/controls/replacebar.cpp" line="44"/>
         <source>Replace Rest</source>
         <translation>Substituir restantes</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="39"/>
+        <location filename="../src/controls/replacebar.cpp" line="46"/>
         <source>Replace All</source>
         <translation>Substituir todos</translation>
     </message>
@@ -858,9 +909,9 @@
     <name>S:</name>
     <message>
         <location filename="../third/libiconv-1.16/src/iconv.c" line="103"/>
-        <source/>
+        <source></source>
         <comment>The first line of the short usage message.</comment>
-        <translation type="unfinished"/>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -891,34 +942,34 @@
         <translation>Ecrã Inteiro</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="484"/>
+        <location filename="../src/common/settings.cpp" line="491"/>
         <source>This shortcut conflicts with system shortcut %1</source>
         <translation>Este atalho entra em conflito com o atalho do sistema %1</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="487"/>
+        <location filename="../src/common/settings.cpp" line="494"/>
         <source>This shortcut conflicts with %1, click on Replace to make this shortcut effective immediately</source>
         <translation>Esta tecla de atalho entra em conflito com %1, clique em Substituir para que esta tecla de atalho entre em vigor imediatamente</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="682"/>
-        <location filename="../src/common/settings.cpp" line="695"/>
-        <location filename="../src/common/settings.cpp" line="704"/>
+        <location filename="../src/common/settings.cpp" line="689"/>
+        <location filename="../src/common/settings.cpp" line="702"/>
+        <location filename="../src/common/settings.cpp" line="711"/>
         <source>The shortcut %1 is invalid, please set another one.</source>
         <translation>O atalho %1 é inválido, defina outro.</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="736"/>
+        <location filename="../src/common/settings.cpp" line="743"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="737"/>
+        <location filename="../src/common/settings.cpp" line="744"/>
         <source>Replace</source>
         <translation>Substituir</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="740"/>
+        <location filename="../src/common/settings.cpp" line="747"/>
         <source>OK</source>
         <translation>Aceitar</translation>
     </message>
@@ -926,7 +977,7 @@
 <context>
     <name>StartManager</name>
     <message>
-        <location filename="../src/startmanager.cpp" line="411"/>
+        <location filename="../src/startmanager.cpp" line="425"/>
         <source>Untitled %1</source>
         <translation>Sem título %1</translation>
     </message>
@@ -934,32 +985,32 @@
 <context>
     <name>Tabbar</name>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="641"/>
+        <location filename="../src/controls/tabbar.cpp" line="678"/>
         <source>Close tab</source>
         <translation>Fechar separador</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="642"/>
+        <location filename="../src/controls/tabbar.cpp" line="680"/>
         <source>Close other tabs</source>
         <translation>Fechar outros separadores</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="643"/>
+        <location filename="../src/controls/tabbar.cpp" line="682"/>
         <source>More options</source>
         <translation>Mais opções</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="644"/>
+        <location filename="../src/controls/tabbar.cpp" line="684"/>
         <source>Close tabs to the left</source>
         <translation>Fechar separadores à esquerda</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="645"/>
+        <location filename="../src/controls/tabbar.cpp" line="686"/>
         <source>Close tabs to the right</source>
         <translation>Fechar separadores à direita</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="646"/>
+        <location filename="../src/controls/tabbar.cpp" line="688"/>
         <source>Close unmodified tabs</source>
         <translation>Fechar separadores não modificados</translation>
     </message>
@@ -967,263 +1018,280 @@
 <context>
     <name>TextEdit</name>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="305"/>
+        <location filename="../src/editor/dtextedit.cpp" line="388"/>
         <source>Undo</source>
         <translation>Anular</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="306"/>
+        <location filename="../src/editor/dtextedit.cpp" line="390"/>
         <source>Redo</source>
         <translation>Refazer</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="307"/>
+        <location filename="../src/editor/dtextedit.cpp" line="392"/>
         <source>Cut</source>
         <translation>Cortar</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="308"/>
+        <location filename="../src/editor/dtextedit.cpp" line="394"/>
         <source>Copy</source>
         <translation>Copiar</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="309"/>
+        <location filename="../src/editor/dtextedit.cpp" line="396"/>
         <source>Paste</source>
         <translation>Colar</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="310"/>
+        <location filename="../src/editor/dtextedit.cpp" line="398"/>
         <source>Delete</source>
         <translation>Eliminar</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="311"/>
+        <location filename="../src/editor/dtextedit.cpp" line="400"/>
         <source>Select All</source>
         <translation>Selecionar tudo</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="312"/>
-        <location filename="../src/widgets/window.cpp" line="535"/>
+        <location filename="../src/editor/dtextedit.cpp" line="402"/>
+        <location filename="../src/widgets/window.cpp" line="556"/>
         <source>Find</source>
         <translation>Procurar</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="313"/>
-        <location filename="../src/widgets/window.cpp" line="536"/>
+        <location filename="../src/editor/dtextedit.cpp" line="404"/>
+        <location filename="../src/widgets/window.cpp" line="558"/>
         <source>Replace</source>
         <translation>Substituir</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="314"/>
+        <location filename="../src/editor/dtextedit.cpp" line="406"/>
         <source>Go to Line</source>
         <translation>Ir para linha</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="315"/>
-        <source>Turn on Read-Only mode</source>
-        <translation>Ativar modo de Apenas-Leitura</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="316"/>
-        <source>Turn off Read-Only mode</source>
-        <translation>Desativar modo de Apenas-Leitura</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="317"/>
+        <location filename="../src/editor/dtextedit.cpp" line="415"/>
         <source>Fullscreen</source>
         <translation>Ecrã inteiro</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="318"/>
+        <location filename="../src/editor/dtextedit.cpp" line="417"/>
         <source>Exit fullscreen</source>
         <translation>Sair de ecrã inteiro</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="319"/>
+        <location filename="../src/editor/dtextedit.cpp" line="419"/>
         <source>Display in file manager</source>
         <translation>Mostrar no gestor de ficheiros</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="320"/>
-        <location filename="../src/editor/dtextedit.cpp" line="374"/>
+        <location filename="../src/editor/dtextedit.cpp" line="421"/>
+        <location filename="../src/editor/dtextedit.cpp" line="493"/>
         <source>Add Comment</source>
         <translation>Adicionar comentário</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="321"/>
+        <location filename="../src/editor/dtextedit.cpp" line="423"/>
         <source>Text to Speech</source>
         <translation>Texto para voz</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="322"/>
-        <source>Stop reading</source>
-        <translation>Parar a leitura</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="323"/>
+        <location filename="../src/editor/dtextedit.cpp" line="425"/>
         <source>Speech to Text</source>
         <translation>Voz para texto</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="324"/>
+        <location filename="../src/editor/dtextedit.cpp" line="427"/>
         <source>Translate</source>
         <translation>Traduzir</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="325"/>
+        <location filename="../src/editor/dtextedit.cpp" line="429"/>
         <source>Column Mode</source>
         <translation>Modo de coluna</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="326"/>
+        <location filename="../src/editor/dtextedit.cpp" line="431"/>
         <source>Add bookmark</source>
         <translation>Adicionador marcador</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="327"/>
+        <location filename="../src/editor/dtextedit.cpp" line="433"/>
         <source>Remove Bookmark</source>
         <translation>Remover marcador</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="328"/>
+        <location filename="../src/editor/dtextedit.cpp" line="435"/>
         <source>Previous bookmark</source>
         <translation>Marcador anterior</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="329"/>
+        <location filename="../src/editor/dtextedit.cpp" line="437"/>
         <source>Next bookmark</source>
         <translation>Marcador seguinte</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="330"/>
+        <location filename="../src/editor/dtextedit.cpp" line="439"/>
         <source>Remove All Bookmarks</source>
         <translation>Remover todos os marcadores</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="331"/>
+        <location filename="../src/editor/dtextedit.cpp" line="441"/>
         <source>Fold All</source>
         <translation>Minimizar tudo</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="332"/>
+        <location filename="../src/editor/dtextedit.cpp" line="443"/>
         <source>Fold Current Level</source>
         <translation>Minimizar nível atual</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="333"/>
+        <location filename="../src/editor/dtextedit.cpp" line="445"/>
         <source>Unfold All</source>
         <translation>Mostrar tudo</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="334"/>
+        <location filename="../src/editor/dtextedit.cpp" line="447"/>
         <source>Unfold Current Level</source>
         <translation>Mostrar nível atual</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="339"/>
+        <location filename="../src/editor/dtextedit.cpp" line="453"/>
         <source>Color Mark</source>
         <translation>Marca de cor</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="343"/>
+        <location filename="../src/editor/dtextedit.cpp" line="458"/>
         <source>Clear All Marks</source>
         <translation>Limpar selecionados</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="344"/>
+        <location filename="../src/editor/dtextedit.cpp" line="460"/>
         <source>Clear Last Mark</source>
         <translation>Limpar último selecionado</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="353"/>
+        <location filename="../src/editor/dtextedit.cpp" line="470"/>
         <source>Mark</source>
         <translation>Marcar</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="366"/>
+        <location filename="../src/editor/dtextedit.cpp" line="484"/>
         <source>Mark All</source>
         <translation>Marcar tudo</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="375"/>
+        <location filename="../src/editor/dtextedit.cpp" line="494"/>
         <source>Remove Comment</source>
         <translation>Remover comentário</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3208"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3211"/>
+        <location filename="../src/editor/dtextedit.cpp" line="543"/>
+        <source>View Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="3531"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3534"/>
         <source>Copy failed: not enough memory</source>
         <translation>Falha ao copiar: não há memória suficiente</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3333"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3335"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3656"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3658"/>
         <source>Press ALT and click lines to edit in column mode</source>
         <translation>Prima ALT e clique em linhas para editar em modo de coluna</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="418"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9574"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9576"/>
+        <source>No audio output device was detected. Please ensure your speakers or headphones are properly connected and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="9583"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9585"/>
+        <source>No audio input device was detected. Please ensure your speakers or headphones are properly connected and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="534"/>
         <source>Change Case</source>
         <translation>Maiúsculas e Minúsculas</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="419"/>
+        <location filename="../src/editor/dtextedit.cpp" line="409"/>
+        <source>Edit Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="411"/>
+        <source>Read View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="413"/>
+        <source>Live Preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="535"/>
         <source>Upper Case</source>
         <translation>Maiúsculas</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="420"/>
+        <location filename="../src/editor/dtextedit.cpp" line="536"/>
         <source>Lower Case</source>
         <translation>Minúsculas</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="421"/>
+        <location filename="../src/editor/dtextedit.cpp" line="537"/>
         <source>Capitalize</source>
         <translation>Maiúsculas</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="78"/>
+        <location filename="../src/widgets/bottombar.cpp" line="110"/>
         <source>None</source>
         <translation>Nenhum</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1363"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1490"/>
         <source>Selected line(s) copied</source>
         <translation>Linha(s) selecionada(s) copiada(s)</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1370"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1497"/>
         <source>Current line copied</source>
         <translation>Linha atual copiada</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1400"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1527"/>
         <source>Selected line(s) clipped</source>
         <translation>Linha(s) selecionada(s) cortada(s)</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1412"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1539"/>
         <source>Current line clipped</source>
         <translation>Linha atual cortada</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3227"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3230"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3550"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3553"/>
         <source>Paste failed: not enough memory</source>
         <translation>Falha ao colar: memória insuficiente</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="4548"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4873"/>
         <source>Read-Only mode is off</source>
         <translation>O modo de Apenas-Leitura está desligado</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="4560"/>
-        <location filename="../src/editor/dtextedit.cpp" line="4584"/>
-        <location filename="../src/editor/dtextedit.cpp" line="7896"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8007"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8015"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8026"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4885"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4909"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8236"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8347"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8355"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8366"/>
         <source>Read-Only mode is on</source>
         <translation>O modo de Apenas-Leitura está ligado</translation>
     </message>
@@ -1231,138 +1299,175 @@
 <context>
     <name>WarningNotices</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="24"/>
+        <location filename="../src/controls/warningnotices.cpp" line="25"/>
         <source>Reload</source>
         <translation>Recarregar</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/warningnotices.cpp" line="29"/>
+        <source>Edit Anyway</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>Window</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="25"/>
-        <location filename="../src/widgets/window.cpp" line="531"/>
+        <location filename="../src/controls/warningnotices.cpp" line="27"/>
+        <location filename="../src/widgets/window.cpp" line="548"/>
         <source>Save as</source>
         <translation>Guardar como</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="527"/>
+        <location filename="../src/widgets/window.cpp" line="540"/>
         <source>New window</source>
         <translation>Nova janela</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="528"/>
+        <location filename="../src/widgets/window.cpp" line="542"/>
         <source>New tab</source>
         <translation>Novo separador</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="529"/>
+        <location filename="../src/widgets/window.cpp" line="544"/>
         <source>Open file</source>
         <translation>Abrir ficheiro</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="530"/>
-        <location filename="../src/widgets/window.cpp" line="3545"/>
+        <location filename="../src/widgets/window.cpp" line="546"/>
+        <location filename="../src/widgets/window.cpp" line="3950"/>
         <source>Save</source>
         <translation>Guardar</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="532"/>
+        <location filename="../src/widgets/window.cpp" line="550"/>
         <source>Print</source>
         <translation>Imprimir</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="533"/>
+        <location filename="../src/widgets/window.cpp" line="552"/>
         <source>Switch theme</source>
         <translation>Alterar tema</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="534"/>
-        <location filename="../src/widgets/window.cpp" line="2448"/>
+        <location filename="../src/widgets/window.cpp" line="554"/>
+        <location filename="../src/widgets/window.cpp" line="2641"/>
         <source>Settings</source>
         <translation>Definições</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="666"/>
-        <location filename="../src/widgets/window.cpp" line="3845"/>
+        <location filename="../src/widgets/window.cpp" line="696"/>
+        <location filename="../src/widgets/window.cpp" line="4250"/>
         <source>Read-Only</source>
         <translation>Apenas-Leitura</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="687"/>
+        <location filename="../src/widgets/window.cpp" line="719"/>
         <source>You do not have permission to open %1</source>
         <translation>Não possui permissões para abrir %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="738"/>
-        <location filename="../src/widgets/window.cpp" line="2963"/>
+        <location filename="../src/widgets/window.cpp" line="773"/>
+        <location filename="../src/widgets/window.cpp" line="3266"/>
         <source>Invalid file: %1</source>
         <translation>Ficheiro inválido: %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="903"/>
-        <location filename="../src/widgets/window.cpp" line="956"/>
+        <location filename="../src/widgets/window.cpp" line="957"/>
+        <location filename="../src/widgets/window.cpp" line="1050"/>
+        <location filename="../src/widgets/window.cpp" line="3217"/>
         <source>Do you want to save this file?</source>
         <translation>Quer guardar este ficheiro?</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1290"/>
+        <location filename="../src/widgets/window.cpp" line="1381"/>
+        <source>Invalid characters detected while saving &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1382"/>
+        <source>If you force save this file, it may cause file corruption. Still want to save?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1386"/>
+        <source>Don&apos;t Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1387"/>
+        <source>Save As</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1388"/>
+        <source>Save Anyway</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1456"/>
         <source>You do not have permission to save %1</source>
         <translation>Não possui permissões para guardar %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1312"/>
+        <location filename="../src/widgets/window.cpp" line="1428"/>
+        <location filename="../src/widgets/window.cpp" line="1478"/>
         <source>Saved successfully</source>
         <translation>Gravado com sucesso</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1354"/>
-        <location filename="../src/widgets/window.cpp" line="1481"/>
-        <location filename="../src/widgets/window.cpp" line="1529"/>
+        <location filename="../src/widgets/window.cpp" line="1520"/>
+        <location filename="../src/widgets/window.cpp" line="1665"/>
+        <location filename="../src/widgets/window.cpp" line="1713"/>
         <source>Save File</source>
         <translation>Guardar ficheiro</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1483"/>
+        <location filename="../src/widgets/window.cpp" line="1569"/>
+        <source>Cannot save as the original file in preview mode. Please choose a different path.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1667"/>
         <source>Encoding</source>
         <translation>Codificação</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1773"/>
+        <location filename="../src/widgets/window.cpp" line="1957"/>
         <source>Read-Only mode is on</source>
         <translation>O modo de Apenas-Leitura está ligado</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2322"/>
+        <location filename="../src/widgets/window.cpp" line="2511"/>
         <source>Current location remembered</source>
         <translation>Localização atual memorizada</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2398"/>
+        <location filename="../src/widgets/window.cpp" line="2591"/>
         <source>Ctrl+&apos;=&apos;</source>
         <translation>Ctrl+&apos;=&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2401"/>
+        <location filename="../src/widgets/window.cpp" line="2594"/>
         <source>Ctrl+&apos;-&apos;</source>
         <translation>Ctrl+&apos;-&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2430"/>
+        <location filename="../src/widgets/window.cpp" line="2623"/>
         <source>Editor</source>
         <translation>Editor</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3061"/>
+        <location filename="../src/widgets/window.cpp" line="3436"/>
         <source>Untitled %1</source>
         <translation>Sem título %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3543"/>
+        <location filename="../src/widgets/window.cpp" line="3948"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3544"/>
+        <location filename="../src/widgets/window.cpp" line="3949"/>
         <source>Discard</source>
         <translation>Descartar</translation>
     </message>

--- a/translations/deepin-editor_pt_BR.ts
+++ b/translations/deepin-editor_pt_BR.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="pt_BR">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pt_BR">
 <context>
     <name>BottomBar</name>
     <message>
@@ -17,17 +19,36 @@
         <translation>%1 Caracteres</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="44"/>
+        <location filename="../src/widgets/bottombar.cpp" line="47"/>
         <source>Loading:</source>
         <translation>Carregando:</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="73"/>
+        <location filename="../src/widgets/bottombar.cpp" line="91"/>
+        <location filename="../src/widgets/bottombar.cpp" line="499"/>
+        <source>Edit Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="74"/>
+        <location filename="../src/widgets/bottombar.cpp" line="489"/>
+        <source>Read View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="75"/>
+        <location filename="../src/widgets/bottombar.cpp" line="493"/>
+        <source>Live Preview</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DDropdownMenu</name>
     <message>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="362"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="420"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="425"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="363"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="421"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="426"/>
         <source>None</source>
         <translation>Nenhum</translation>
     </message>
@@ -35,68 +56,57 @@
 <context>
     <name>EditWrapper</name>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="292"/>
-        <location filename="../src/editor/editwrapper.cpp" line="365"/>
-        <location filename="../src/editor/editwrapper.cpp" line="521"/>
-        <location filename="../src/editor/editwrapper.cpp" line="751"/>
+        <location filename="../src/editor/editwrapper.cpp" line="355"/>
+        <location filename="../src/editor/editwrapper.cpp" line="429"/>
+        <location filename="../src/editor/editwrapper.cpp" line="595"/>
+        <location filename="../src/editor/editwrapper.cpp" line="887"/>
         <source>Save</source>
         <translation>Salvar</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="516"/>
+        <location filename="../src/editor/editwrapper.cpp" line="590"/>
         <source>Do you want to save this file?</source>
         <translation>Salvar este arquivo?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="363"/>
-        <location filename="../src/editor/editwrapper.cpp" line="519"/>
+        <location filename="../src/editor/editwrapper.cpp" line="427"/>
+        <location filename="../src/editor/editwrapper.cpp" line="593"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="360"/>
+        <location filename="../src/editor/editwrapper.cpp" line="424"/>
         <source>Encoding changed. Do you want to save the file now?</source>
         <translation>Codificação alterada. Salvar?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="520"/>
+        <location filename="../src/editor/editwrapper.cpp" line="594"/>
         <source>Discard</source>
         <translation>Descartar</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="274"/>
-        <location filename="../src/editor/editwrapper.cpp" line="620"/>
+        <location filename="../src/editor/editwrapper.cpp" line="1121"/>
+        <source>The file contains invalid characters (NUL). Preview mode is read-only.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="337"/>
+        <location filename="../src/editor/editwrapper.cpp" line="705"/>
         <source>You do not have permission to save %1</source>
         <translation>Você não tem permissão para salvar %1</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="836"/>
+        <location filename="../src/editor/editwrapper.cpp" line="987"/>
         <source>File removed on the disk. Save it now?</source>
         <translation>Arquivo removido no disco. Salvar agora?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="842"/>
+        <location filename="../src/editor/editwrapper.cpp" line="993"/>
         <source>File has changed on disk. Reload?</source>
         <translation>O arquivo foi alterado no disco. Recarregar?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="884"/>
-        <location filename="../src/widgets/bottombar.cpp" line="74"/>
-        <source>INSERT</source>
-        <translation>INSERIR</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="888"/>
-        <source>OVERWRITE</source>
-        <translation>SOBRESCREVER</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="892"/>
-        <source>R/O</source>
-        <translation>R/O</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="1618"/>
+        <location filename="../src/editor/editwrapper.cpp" line="1806"/>
         <source>The file cannot be read, which may be too large or has been damaged!</source>
         <translation>O arquivo não pode ser lido, ele pode ser muito grande ou está danificado!</translation>
     </message>
@@ -109,17 +119,17 @@
         <translation>Localizar</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="36"/>
+        <location filename="../src/controls/findbar.cpp" line="38"/>
         <source>Previous</source>
         <translation>Anterior</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="37"/>
+        <location filename="../src/controls/findbar.cpp" line="40"/>
         <source>Next</source>
         <translation>Próximo</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="38"/>
+        <location filename="../src/controls/findbar.cpp" line="42"/>
         <source>Replace</source>
         <translation>Substituir</translation>
     </message>
@@ -127,9 +137,17 @@
 <context>
     <name>JumpLineBar</name>
     <message>
-        <location filename="../src/controls/jumplinebar.cpp" line="45"/>
+        <location filename="../src/controls/jumplinebar.cpp" line="46"/>
         <source>Go to Line: </source>
         <translation>Ir para Linha:</translation>
+    </message>
+</context>
+<context>
+    <name>LineBar</name>
+    <message>
+        <location filename="../src/controls/linebar.cpp" line="144"/>
+        <source>第%1/%2项</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -146,19 +164,47 @@
     </message>
 </context>
 <context>
+    <name>MarkdownBridge</name>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="37"/>
+        <source>Collapse code block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="38"/>
+        <source>Expand code block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="39"/>
+        <source>Copy code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="40"/>
+        <source>Expand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="42"/>
+        <source>%1 line(s) of code collapsed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PathSettingWgt</name>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="84"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="90"/>
         <source>Remember the last used path</source>
         <translation>Lembrar a última pasta usada</translation>
     </message>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="85"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="91"/>
         <source>Same path as the current file</source>
         <translation>A mesma pasta do arquivo atual</translation>
     </message>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="86"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="92"/>
         <source>Customize the default path</source>
         <translation>Personalizar a pasta padrão</translation>
     </message>
@@ -171,15 +217,20 @@
         <translation>Editor de Textos</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="294"/>
-        <location filename="../src/editor/editwrapper.cpp" line="761"/>
-        <location filename="../src/editor/editwrapper.cpp" line="776"/>
-        <location filename="../src/widgets/window.cpp" line="1362"/>
-        <location filename="../src/widgets/window.cpp" line="1390"/>
-        <location filename="../src/widgets/window.cpp" line="1531"/>
-        <location filename="../src/widgets/window.cpp" line="1548"/>
+        <location filename="../src/editor/editwrapper.cpp" line="357"/>
+        <location filename="../src/editor/editwrapper.cpp" line="897"/>
+        <location filename="../src/editor/editwrapper.cpp" line="912"/>
+        <location filename="../src/widgets/window.cpp" line="1528"/>
+        <location filename="../src/widgets/window.cpp" line="1556"/>
+        <location filename="../src/widgets/window.cpp" line="1715"/>
+        <location filename="../src/widgets/window.cpp" line="1732"/>
         <source>Encoding</source>
         <translation>Codificação</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="2001"/>
+        <source>视图模式</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="11"/>
@@ -215,7 +266,7 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="18"/>
         <location filename="../src/controls/settingsdialog.cpp" line="96"/>
-        <location filename="../src/widgets/window.cpp" line="2388"/>
+        <location filename="../src/widgets/window.cpp" line="2581"/>
         <source>Window</source>
         <translation>Janela</translation>
     </message>
@@ -755,68 +806,68 @@
         <translation>Vietnamita</translation>
     </message>
     <message>
-        <location filename="../src/startmanager.cpp" line="971"/>
+        <location filename="../src/startmanager.cpp" line="1035"/>
         <source>File not saved</source>
         <translation>Arquivo não salvo</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1532"/>
-        <location filename="../src/widgets/window.cpp" line="1549"/>
+        <location filename="../src/widgets/window.cpp" line="1716"/>
+        <location filename="../src/widgets/window.cpp" line="1733"/>
         <source>Line Endings</source>
         <translation>Terminações de Linha</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="243"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="379"/>
         <source>Please install &apos;UOS AI&apos; from the App Store before using</source>
         <translation>Instale o &apos;UOS AI&apos; da Loja de Aplicativos antes de usar</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="245"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="381"/>
         <source>No audio input device detected. Please check and try again</source>
         <translation>Nenhum dispositivo de entrada de áudio detectado. Por favor, verifique e tente novamente</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="247"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="383"/>
         <source>No audio output device detected. Please check and try again</source>
         <translation>Nenhum dispositivo de saída de áudio detectado. Por favor, verifique e tente novamente</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="69"/>
+        <location filename="../src/common/text_file_saver.cpp" line="74"/>
         <source>File path is empty</source>
         <translation>O caminho do arquivo está vazio</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="155"/>
+        <location filename="../src/common/text_file_saver.cpp" line="153"/>
         <source>Insufficient memory to load document content</source>
         <translation>Memória insuficiente para carregar o conteúdo do documento</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="177"/>
+        <location filename="../src/common/text_file_saver.cpp" line="178"/>
         <source>Insufficient memory for encoding conversion</source>
         <translation>Memória insuficiente para conversão de codificação</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="183"/>
+        <location filename="../src/common/text_file_saver.cpp" line="184"/>
         <source>Encoding conversion failed</source>
         <translation>Conversão de codificação falhou</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="189"/>
+        <location filename="../src/common/text_file_saver.cpp" line="190"/>
         <source>Converted content is empty</source>
         <translation>O conteúdo convertido está vazio</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="207"/>
+        <location filename="../src/common/text_file_saver.cpp" line="208"/>
         <source>Memory allocation failed</source>
         <translation>Alocação de memória falhou</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="211"/>
+        <location filename="../src/common/text_file_saver.cpp" line="212"/>
         <source>Error occurred: %1</source>
         <translation>Ocorreu um erro: %1</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="215"/>
+        <location filename="../src/common/text_file_saver.cpp" line="216"/>
         <source>Unknown error occurred</source>
         <translation>Ocorreu um erro desconhecido</translation>
     </message>
@@ -829,27 +880,27 @@
         <translation>Localizar</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="34"/>
+        <location filename="../src/controls/replacebar.cpp" line="36"/>
         <source>Replace With</source>
         <translation>Substituir com</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="36"/>
+        <location filename="../src/controls/replacebar.cpp" line="40"/>
         <source>Replace</source>
         <translation>Substituir</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="37"/>
+        <location filename="../src/controls/replacebar.cpp" line="42"/>
         <source>Skip</source>
         <translation>Ignorar</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="38"/>
+        <location filename="../src/controls/replacebar.cpp" line="44"/>
         <source>Replace Rest</source>
         <translation>Substituir o Restante</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="39"/>
+        <location filename="../src/controls/replacebar.cpp" line="46"/>
         <source>Replace All</source>
         <translation>Substituir Tudo</translation>
     </message>
@@ -858,9 +909,9 @@
     <name>S:</name>
     <message>
         <location filename="../third/libiconv-1.16/src/iconv.c" line="103"/>
-        <source/>
+        <source></source>
         <comment>The first line of the short usage message.</comment>
-        <translation type="unfinished"/>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -891,34 +942,34 @@
         <translation>Tela Cheia</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="484"/>
+        <location filename="../src/common/settings.cpp" line="491"/>
         <source>This shortcut conflicts with system shortcut %1</source>
         <translation>Este atalho entra em conflito com o atalho %1 do sistema</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="487"/>
+        <location filename="../src/common/settings.cpp" line="494"/>
         <source>This shortcut conflicts with %1, click on Replace to make this shortcut effective immediately</source>
         <translation>Este atalho entra em conflito com %1; clique em Substituir para efetivar esse atalho imediatamente</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="682"/>
-        <location filename="../src/common/settings.cpp" line="695"/>
-        <location filename="../src/common/settings.cpp" line="704"/>
+        <location filename="../src/common/settings.cpp" line="689"/>
+        <location filename="../src/common/settings.cpp" line="702"/>
+        <location filename="../src/common/settings.cpp" line="711"/>
         <source>The shortcut %1 is invalid, please set another one.</source>
         <translation>O atalho %1 é inválido; defina outro.</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="736"/>
+        <location filename="../src/common/settings.cpp" line="743"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="737"/>
+        <location filename="../src/common/settings.cpp" line="744"/>
         <source>Replace</source>
         <translation>Substituir</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="740"/>
+        <location filename="../src/common/settings.cpp" line="747"/>
         <source>OK</source>
         <translation>Ok</translation>
     </message>
@@ -926,7 +977,7 @@
 <context>
     <name>StartManager</name>
     <message>
-        <location filename="../src/startmanager.cpp" line="411"/>
+        <location filename="../src/startmanager.cpp" line="425"/>
         <source>Untitled %1</source>
         <translation>Sem título %1</translation>
     </message>
@@ -934,32 +985,32 @@
 <context>
     <name>Tabbar</name>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="641"/>
+        <location filename="../src/controls/tabbar.cpp" line="678"/>
         <source>Close tab</source>
         <translation>Fechar Aba</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="642"/>
+        <location filename="../src/controls/tabbar.cpp" line="680"/>
         <source>Close other tabs</source>
         <translation>Fechar outras abas</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="643"/>
+        <location filename="../src/controls/tabbar.cpp" line="682"/>
         <source>More options</source>
         <translation>Mais opções</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="644"/>
+        <location filename="../src/controls/tabbar.cpp" line="684"/>
         <source>Close tabs to the left</source>
         <translation>Fechar as abas à esquerda</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="645"/>
+        <location filename="../src/controls/tabbar.cpp" line="686"/>
         <source>Close tabs to the right</source>
         <translation>Fechar as abas à direita</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="646"/>
+        <location filename="../src/controls/tabbar.cpp" line="688"/>
         <source>Close unmodified tabs</source>
         <translation>Fechar as abas não modificadas</translation>
     </message>
@@ -967,263 +1018,280 @@
 <context>
     <name>TextEdit</name>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="305"/>
+        <location filename="../src/editor/dtextedit.cpp" line="388"/>
         <source>Undo</source>
         <translation>Desfazer</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="306"/>
+        <location filename="../src/editor/dtextedit.cpp" line="390"/>
         <source>Redo</source>
         <translation>Refazer</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="307"/>
+        <location filename="../src/editor/dtextedit.cpp" line="392"/>
         <source>Cut</source>
         <translation>Recortar</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="308"/>
+        <location filename="../src/editor/dtextedit.cpp" line="394"/>
         <source>Copy</source>
         <translation>Copiar</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="309"/>
+        <location filename="../src/editor/dtextedit.cpp" line="396"/>
         <source>Paste</source>
         <translation>Colar</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="310"/>
+        <location filename="../src/editor/dtextedit.cpp" line="398"/>
         <source>Delete</source>
         <translation>Excluir</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="311"/>
+        <location filename="../src/editor/dtextedit.cpp" line="400"/>
         <source>Select All</source>
         <translation>Selecionar Tudo</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="312"/>
-        <location filename="../src/widgets/window.cpp" line="535"/>
+        <location filename="../src/editor/dtextedit.cpp" line="402"/>
+        <location filename="../src/widgets/window.cpp" line="556"/>
         <source>Find</source>
         <translation>Localizar</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="313"/>
-        <location filename="../src/widgets/window.cpp" line="536"/>
+        <location filename="../src/editor/dtextedit.cpp" line="404"/>
+        <location filename="../src/widgets/window.cpp" line="558"/>
         <source>Replace</source>
         <translation>Substituir</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="314"/>
+        <location filename="../src/editor/dtextedit.cpp" line="406"/>
         <source>Go to Line</source>
         <translation>Ir para Linha</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="315"/>
-        <source>Turn on Read-Only mode</source>
-        <translation>Ativar o modo Somente Leitura</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="316"/>
-        <source>Turn off Read-Only mode</source>
-        <translation>Desativar o modo Somente Leitura</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="317"/>
+        <location filename="../src/editor/dtextedit.cpp" line="415"/>
         <source>Fullscreen</source>
         <translation>Tela Cheia</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="318"/>
+        <location filename="../src/editor/dtextedit.cpp" line="417"/>
         <source>Exit fullscreen</source>
         <translation>Sair da tela cheia</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="319"/>
+        <location filename="../src/editor/dtextedit.cpp" line="419"/>
         <source>Display in file manager</source>
         <translation>Exibir no Gerenciador de Arquivos</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="320"/>
-        <location filename="../src/editor/dtextedit.cpp" line="374"/>
+        <location filename="../src/editor/dtextedit.cpp" line="421"/>
+        <location filename="../src/editor/dtextedit.cpp" line="493"/>
         <source>Add Comment</source>
         <translation>Adicionar Comentário</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="321"/>
+        <location filename="../src/editor/dtextedit.cpp" line="423"/>
         <source>Text to Speech</source>
         <translation>Texto em Voz</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="322"/>
-        <source>Stop reading</source>
-        <translation>Parar a leitura</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="323"/>
+        <location filename="../src/editor/dtextedit.cpp" line="425"/>
         <source>Speech to Text</source>
         <translation>Voz em Texto</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="324"/>
+        <location filename="../src/editor/dtextedit.cpp" line="427"/>
         <source>Translate</source>
         <translation>Traduzir</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="325"/>
+        <location filename="../src/editor/dtextedit.cpp" line="429"/>
         <source>Column Mode</source>
         <translation>Modo de Coluna</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="326"/>
+        <location filename="../src/editor/dtextedit.cpp" line="431"/>
         <source>Add bookmark</source>
         <translation>Adicionar marcador</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="327"/>
+        <location filename="../src/editor/dtextedit.cpp" line="433"/>
         <source>Remove Bookmark</source>
         <translation>Remover Marcador</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="328"/>
+        <location filename="../src/editor/dtextedit.cpp" line="435"/>
         <source>Previous bookmark</source>
         <translation>Marcador anterior</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="329"/>
+        <location filename="../src/editor/dtextedit.cpp" line="437"/>
         <source>Next bookmark</source>
         <translation>Próximo marcador</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="330"/>
+        <location filename="../src/editor/dtextedit.cpp" line="439"/>
         <source>Remove All Bookmarks</source>
         <translation>Remover Todos os Marcadores</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="331"/>
+        <location filename="../src/editor/dtextedit.cpp" line="441"/>
         <source>Fold All</source>
         <translation>Dobrar Tudo</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="332"/>
+        <location filename="../src/editor/dtextedit.cpp" line="443"/>
         <source>Fold Current Level</source>
         <translation>Dobrar o Nível Atual</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="333"/>
+        <location filename="../src/editor/dtextedit.cpp" line="445"/>
         <source>Unfold All</source>
         <translation>Desdobrar Tudo</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="334"/>
+        <location filename="../src/editor/dtextedit.cpp" line="447"/>
         <source>Unfold Current Level</source>
         <translation>Desdobrar o Nível Atual</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="339"/>
+        <location filename="../src/editor/dtextedit.cpp" line="453"/>
         <source>Color Mark</source>
         <translation>Marca Colorida</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="343"/>
+        <location filename="../src/editor/dtextedit.cpp" line="458"/>
         <source>Clear All Marks</source>
         <translation>Limpar Todas as Marcações</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="344"/>
+        <location filename="../src/editor/dtextedit.cpp" line="460"/>
         <source>Clear Last Mark</source>
         <translation>Limpar a Última Marcação</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="353"/>
+        <location filename="../src/editor/dtextedit.cpp" line="470"/>
         <source>Mark</source>
         <translation>Marcar</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="366"/>
+        <location filename="../src/editor/dtextedit.cpp" line="484"/>
         <source>Mark All</source>
         <translation>Marcar Tudo</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="375"/>
+        <location filename="../src/editor/dtextedit.cpp" line="494"/>
         <source>Remove Comment</source>
         <translation>Remover Comentário</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3208"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3211"/>
+        <location filename="../src/editor/dtextedit.cpp" line="543"/>
+        <source>View Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="3531"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3534"/>
         <source>Copy failed: not enough memory</source>
         <translation>Falha ao copiar: não há memória suficiente.</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3333"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3335"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3656"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3658"/>
         <source>Press ALT and click lines to edit in column mode</source>
         <translation>Pressione ALT e clique nas linhas para editar no modo de coluna</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="418"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9574"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9576"/>
+        <source>No audio output device was detected. Please ensure your speakers or headphones are properly connected and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="9583"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9585"/>
+        <source>No audio input device was detected. Please ensure your speakers or headphones are properly connected and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="534"/>
         <source>Change Case</source>
         <translation>Alterar entre Maiúscula e Minúscula</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="419"/>
+        <location filename="../src/editor/dtextedit.cpp" line="409"/>
+        <source>Edit Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="411"/>
+        <source>Read View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="413"/>
+        <source>Live Preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="535"/>
         <source>Upper Case</source>
         <translation>Maiúscula</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="420"/>
+        <location filename="../src/editor/dtextedit.cpp" line="536"/>
         <source>Lower Case</source>
         <translation>Minúscula</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="421"/>
+        <location filename="../src/editor/dtextedit.cpp" line="537"/>
         <source>Capitalize</source>
         <translation>Autocapitalizar</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="78"/>
+        <location filename="../src/widgets/bottombar.cpp" line="110"/>
         <source>None</source>
         <translation>Nenhum</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1363"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1490"/>
         <source>Selected line(s) copied</source>
         <translation>Linha(s) selecionada(s) copiada(s)</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1370"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1497"/>
         <source>Current line copied</source>
         <translation>Linha atual copiada</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1400"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1527"/>
         <source>Selected line(s) clipped</source>
         <translation>Linha(s) selecionada(s) recortada(s)</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1412"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1539"/>
         <source>Current line clipped</source>
         <translation>Linha atual recortada</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3227"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3230"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3550"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3553"/>
         <source>Paste failed: not enough memory</source>
         <translation>Falha ao colar: memória insuficiente</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="4548"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4873"/>
         <source>Read-Only mode is off</source>
         <translation>O modo Somente Leitura está desativado</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="4560"/>
-        <location filename="../src/editor/dtextedit.cpp" line="4584"/>
-        <location filename="../src/editor/dtextedit.cpp" line="7896"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8007"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8015"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8026"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4885"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4909"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8236"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8347"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8355"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8366"/>
         <source>Read-Only mode is on</source>
         <translation>O modo Somente Leitura está ativado</translation>
     </message>
@@ -1231,138 +1299,175 @@
 <context>
     <name>WarningNotices</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="24"/>
+        <location filename="../src/controls/warningnotices.cpp" line="25"/>
         <source>Reload</source>
         <translation>Recarregar</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/warningnotices.cpp" line="29"/>
+        <source>Edit Anyway</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>Window</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="25"/>
-        <location filename="../src/widgets/window.cpp" line="531"/>
+        <location filename="../src/controls/warningnotices.cpp" line="27"/>
+        <location filename="../src/widgets/window.cpp" line="548"/>
         <source>Save as</source>
         <translation>Salvar como</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="527"/>
+        <location filename="../src/widgets/window.cpp" line="540"/>
         <source>New window</source>
         <translation>Nova janela</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="528"/>
+        <location filename="../src/widgets/window.cpp" line="542"/>
         <source>New tab</source>
         <translation>Nova aba</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="529"/>
+        <location filename="../src/widgets/window.cpp" line="544"/>
         <source>Open file</source>
         <translation>Abrir arquivo</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="530"/>
-        <location filename="../src/widgets/window.cpp" line="3545"/>
+        <location filename="../src/widgets/window.cpp" line="546"/>
+        <location filename="../src/widgets/window.cpp" line="3950"/>
         <source>Save</source>
         <translation>Salvar</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="532"/>
+        <location filename="../src/widgets/window.cpp" line="550"/>
         <source>Print</source>
         <translation>Imprimir</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="533"/>
+        <location filename="../src/widgets/window.cpp" line="552"/>
         <source>Switch theme</source>
         <translation>Alternar tema</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="534"/>
-        <location filename="../src/widgets/window.cpp" line="2448"/>
+        <location filename="../src/widgets/window.cpp" line="554"/>
+        <location filename="../src/widgets/window.cpp" line="2641"/>
         <source>Settings</source>
         <translation>Configurações</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="666"/>
-        <location filename="../src/widgets/window.cpp" line="3845"/>
+        <location filename="../src/widgets/window.cpp" line="696"/>
+        <location filename="../src/widgets/window.cpp" line="4250"/>
         <source>Read-Only</source>
         <translation>Somente-Leitura</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="687"/>
+        <location filename="../src/widgets/window.cpp" line="719"/>
         <source>You do not have permission to open %1</source>
         <translation>Você não tem permissão para abrir %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="738"/>
-        <location filename="../src/widgets/window.cpp" line="2963"/>
+        <location filename="../src/widgets/window.cpp" line="773"/>
+        <location filename="../src/widgets/window.cpp" line="3266"/>
         <source>Invalid file: %1</source>
         <translation>Arquivo Inválido: %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="903"/>
-        <location filename="../src/widgets/window.cpp" line="956"/>
+        <location filename="../src/widgets/window.cpp" line="957"/>
+        <location filename="../src/widgets/window.cpp" line="1050"/>
+        <location filename="../src/widgets/window.cpp" line="3217"/>
         <source>Do you want to save this file?</source>
         <translation>Salvar este arquivo?</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1290"/>
+        <location filename="../src/widgets/window.cpp" line="1381"/>
+        <source>Invalid characters detected while saving &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1382"/>
+        <source>If you force save this file, it may cause file corruption. Still want to save?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1386"/>
+        <source>Don&apos;t Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1387"/>
+        <source>Save As</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1388"/>
+        <source>Save Anyway</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1456"/>
         <source>You do not have permission to save %1</source>
         <translation>Você não tem permissão para salvar %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1312"/>
+        <location filename="../src/widgets/window.cpp" line="1428"/>
+        <location filename="../src/widgets/window.cpp" line="1478"/>
         <source>Saved successfully</source>
         <translation>Salvo</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1354"/>
-        <location filename="../src/widgets/window.cpp" line="1481"/>
-        <location filename="../src/widgets/window.cpp" line="1529"/>
+        <location filename="../src/widgets/window.cpp" line="1520"/>
+        <location filename="../src/widgets/window.cpp" line="1665"/>
+        <location filename="../src/widgets/window.cpp" line="1713"/>
         <source>Save File</source>
         <translation>Salvar Arquivo</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1483"/>
+        <location filename="../src/widgets/window.cpp" line="1569"/>
+        <source>Cannot save as the original file in preview mode. Please choose a different path.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1667"/>
         <source>Encoding</source>
         <translation>Codificação</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1773"/>
+        <location filename="../src/widgets/window.cpp" line="1957"/>
         <source>Read-Only mode is on</source>
         <translation>O modo Somente Leitura está ativado</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2322"/>
+        <location filename="../src/widgets/window.cpp" line="2511"/>
         <source>Current location remembered</source>
         <translation>Lembrar o local atual</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2398"/>
+        <location filename="../src/widgets/window.cpp" line="2591"/>
         <source>Ctrl+&apos;=&apos;</source>
         <translation>Ctrl + =</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2401"/>
+        <location filename="../src/widgets/window.cpp" line="2594"/>
         <source>Ctrl+&apos;-&apos;</source>
         <translation>Ctrl + -</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2430"/>
+        <location filename="../src/widgets/window.cpp" line="2623"/>
         <source>Editor</source>
         <translation>Editor de Textos</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3061"/>
+        <location filename="../src/widgets/window.cpp" line="3436"/>
         <source>Untitled %1</source>
         <translation>Sem título %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3543"/>
+        <location filename="../src/widgets/window.cpp" line="3948"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3544"/>
+        <location filename="../src/widgets/window.cpp" line="3949"/>
         <source>Discard</source>
         <translation>Descartar</translation>
     </message>

--- a/translations/deepin-editor_ro.ts
+++ b/translations/deepin-editor_ro.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ro">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ro">
 <context>
     <name>BottomBar</name>
     <message>
@@ -14,91 +16,99 @@
     <message>
         <location filename="../src/widgets/bottombar.cpp" line="32"/>
         <source>Characters %1</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="44"/>
+        <location filename="../src/widgets/bottombar.cpp" line="47"/>
         <source>Loading:</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="73"/>
+        <location filename="../src/widgets/bottombar.cpp" line="91"/>
+        <location filename="../src/widgets/bottombar.cpp" line="499"/>
+        <source>Edit Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="74"/>
+        <location filename="../src/widgets/bottombar.cpp" line="489"/>
+        <source>Read View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="75"/>
+        <location filename="../src/widgets/bottombar.cpp" line="493"/>
+        <source>Live Preview</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DDropdownMenu</name>
     <message>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="362"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="420"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="425"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="363"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="421"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="426"/>
         <source>None</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>EditWrapper</name>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="292"/>
-        <location filename="../src/editor/editwrapper.cpp" line="365"/>
-        <location filename="../src/editor/editwrapper.cpp" line="521"/>
-        <location filename="../src/editor/editwrapper.cpp" line="751"/>
+        <location filename="../src/editor/editwrapper.cpp" line="355"/>
+        <location filename="../src/editor/editwrapper.cpp" line="429"/>
+        <location filename="../src/editor/editwrapper.cpp" line="595"/>
+        <location filename="../src/editor/editwrapper.cpp" line="887"/>
         <source>Save</source>
         <translation>Salvați</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="516"/>
+        <location filename="../src/editor/editwrapper.cpp" line="590"/>
         <source>Do you want to save this file?</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="363"/>
-        <location filename="../src/editor/editwrapper.cpp" line="519"/>
+        <location filename="../src/editor/editwrapper.cpp" line="427"/>
+        <location filename="../src/editor/editwrapper.cpp" line="593"/>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="360"/>
+        <location filename="../src/editor/editwrapper.cpp" line="424"/>
         <source>Encoding changed. Do you want to save the file now?</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="520"/>
+        <location filename="../src/editor/editwrapper.cpp" line="594"/>
         <source>Discard</source>
         <translation>Renunțați</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="274"/>
-        <location filename="../src/editor/editwrapper.cpp" line="620"/>
+        <location filename="../src/editor/editwrapper.cpp" line="1121"/>
+        <source>The file contains invalid characters (NUL). Preview mode is read-only.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="337"/>
+        <location filename="../src/editor/editwrapper.cpp" line="705"/>
         <source>You do not have permission to save %1</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="836"/>
+        <location filename="../src/editor/editwrapper.cpp" line="987"/>
         <source>File removed on the disk. Save it now?</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="842"/>
+        <location filename="../src/editor/editwrapper.cpp" line="993"/>
         <source>File has changed on disk. Reload?</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="884"/>
-        <location filename="../src/widgets/bottombar.cpp" line="74"/>
-        <source>INSERT</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="888"/>
-        <source>OVERWRITE</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="892"/>
-        <source>R/O</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="1618"/>
+        <location filename="../src/editor/editwrapper.cpp" line="1806"/>
         <source>The file cannot be read, which may be too large or has been damaged!</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -106,20 +116,20 @@
     <message>
         <location filename="../src/controls/findbar.cpp" line="34"/>
         <source>Find</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="36"/>
+        <location filename="../src/controls/findbar.cpp" line="38"/>
         <source>Previous</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="37"/>
+        <location filename="../src/controls/findbar.cpp" line="40"/>
         <source>Next</source>
         <translation>Următorul</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="38"/>
+        <location filename="../src/controls/findbar.cpp" line="42"/>
         <source>Replace</source>
         <translation>Înlocuiți</translation>
     </message>
@@ -127,9 +137,17 @@
 <context>
     <name>JumpLineBar</name>
     <message>
-        <location filename="../src/controls/jumplinebar.cpp" line="45"/>
+        <location filename="../src/controls/jumplinebar.cpp" line="46"/>
         <source>Go to Line: </source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>LineBar</name>
+    <message>
+        <location filename="../src/controls/linebar.cpp" line="144"/>
+        <source>第%1/%2项</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -137,30 +155,58 @@
     <message>
         <location filename="../src/editorapplication.cpp" line="12"/>
         <source>Text Editor is a powerful tool for viewing and editing text files.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/editorapplication.cpp" line="34"/>
         <source>Text Editor</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MarkdownBridge</name>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="37"/>
+        <source>Collapse code block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="38"/>
+        <source>Expand code block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="39"/>
+        <source>Copy code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="40"/>
+        <source>Expand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="42"/>
+        <source>%1 line(s) of code collapsed</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>PathSettingWgt</name>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="84"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="90"/>
         <source>Remember the last used path</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="85"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="91"/>
         <source>Same path as the current file</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="86"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="92"/>
         <source>Customize the default path</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -168,28 +214,33 @@
     <message>
         <location filename="../src/editorapplication.cpp" line="28"/>
         <source>Text Editor</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="294"/>
-        <location filename="../src/editor/editwrapper.cpp" line="761"/>
-        <location filename="../src/editor/editwrapper.cpp" line="776"/>
-        <location filename="../src/widgets/window.cpp" line="1362"/>
-        <location filename="../src/widgets/window.cpp" line="1390"/>
-        <location filename="../src/widgets/window.cpp" line="1531"/>
-        <location filename="../src/widgets/window.cpp" line="1548"/>
+        <location filename="../src/editor/editwrapper.cpp" line="357"/>
+        <location filename="../src/editor/editwrapper.cpp" line="897"/>
+        <location filename="../src/editor/editwrapper.cpp" line="912"/>
+        <location filename="../src/widgets/window.cpp" line="1528"/>
+        <location filename="../src/widgets/window.cpp" line="1556"/>
+        <location filename="../src/widgets/window.cpp" line="1715"/>
+        <location filename="../src/widgets/window.cpp" line="1732"/>
         <source>Encoding</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="2001"/>
+        <source>视图模式</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="11"/>
         <source>Basic</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="12"/>
         <source>Font Style</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="13"/>
@@ -199,23 +250,23 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="14"/>
         <source>Font Size</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="15"/>
         <source>Shortcuts</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="16"/>
         <location filename="../src/controls/settingsdialog.cpp" line="17"/>
         <source>Keymap</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="18"/>
         <location filename="../src/controls/settingsdialog.cpp" line="96"/>
-        <location filename="../src/widgets/window.cpp" line="2388"/>
+        <location filename="../src/widgets/window.cpp" line="2581"/>
         <source>Window</source>
         <translation>Fereastră</translation>
     </message>
@@ -242,12 +293,12 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="23"/>
         <source>Next tab</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="24"/>
         <source>Previous tab</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="25"/>
@@ -257,12 +308,12 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="26"/>
         <source>Close other tabs</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="27"/>
         <source>Restore tab</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="28"/>
@@ -272,17 +323,17 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="29"/>
         <source>Increment font size</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="30"/>
         <source>Decrement font size</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="31"/>
         <source>Reset font size</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="32"/>
@@ -292,22 +343,22 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="33"/>
         <source>Toggle fullscreen</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="34"/>
         <source>Find</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="35"/>
         <source>Find Next</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="36"/>
         <source>Find Previous</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="37"/>
@@ -317,17 +368,17 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="38"/>
         <source>Go to line</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="39"/>
         <source>Save cursor position</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="40"/>
         <source>Reset cursor position</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="41"/>
@@ -337,7 +388,7 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="42"/>
         <source>Display shortcuts</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="43"/>
@@ -352,42 +403,42 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="45"/>
         <source>Increase indent</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="46"/>
         <source>Decrease indent</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="47"/>
         <source>Forward character</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="48"/>
         <source>Backward character</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="49"/>
         <source>Forward word</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="50"/>
         <source>Backward word</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="51"/>
         <source>Next line</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="52"/>
         <source>Previous line</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="53"/>
@@ -397,122 +448,122 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="54"/>
         <source>New line above</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="55"/>
         <source>New line below</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="56"/>
         <source>Duplicate line</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="57"/>
         <source>Delete to end of line</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="58"/>
         <source>Delete current line</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="59"/>
         <source>Swap line up</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="60"/>
         <source>Swap line down</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="61"/>
         <source>Scroll up one line</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="62"/>
         <source>Scroll down one line</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="63"/>
         <source>Page up</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="64"/>
         <source>Page down</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="65"/>
         <source>Move to end of line</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="66"/>
         <source>Move to start of line</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="67"/>
         <source>Move to end of text</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="68"/>
         <source>Move to start of text</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="69"/>
         <source>Move to line indentation</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="70"/>
         <source>Upper case</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="71"/>
         <source>Lower case</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="72"/>
         <source>Capitalize</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="73"/>
         <source>Delete backward word</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="74"/>
         <source>Delete forward word</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="75"/>
         <source>Forward over a pair</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="76"/>
         <source>Backward over a pair</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="77"/>
         <source>Select all</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="78"/>
@@ -522,27 +573,27 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="79"/>
         <source>Cut</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="80"/>
         <source>Paste</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="81"/>
         <source>Transpose character</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="82"/>
         <source>Mark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="83"/>
         <source>Unmark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="84"/>
@@ -552,52 +603,52 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="85"/>
         <source>Cut line</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="86"/>
         <source>Merge lines</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="87"/>
         <source>Read-Only mode</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="88"/>
         <source>Add comment</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="89"/>
         <source>Remove comment</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="90"/>
         <source>Undo</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="91"/>
         <source>Redo</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="92"/>
         <source>Add/Remove bookmark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="93"/>
         <source>Move to previous bookmark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="94"/>
         <source>Move to next bookmark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="95"/>
@@ -607,218 +658,218 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="97"/>
         <source>Window size</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="98"/>
         <source>Tab width</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="99"/>
         <source>Paste by pressing a middle mouse button</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="101"/>
         <source>Startup</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="102"/>
         <source>Reopen last closed tabs</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="104"/>
         <source>Open/Save Settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="106"/>
         <source>Word wrap</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="107"/>
         <source>Code folding flag</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="108"/>
         <source>Show line numbers</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="109"/>
         <source>Show bookmarks icon</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="110"/>
         <source>Show whitespaces and tabs</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="111"/>
         <source>Highlight current line</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="112"/>
         <source>Color mark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="115"/>
         <source>Unicode</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="116"/>
         <source>WesternEuropean</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="117"/>
         <source>CentralEuropean</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="118"/>
         <source>Baltic</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="119"/>
         <source>Cyrillic</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="120"/>
         <source>Arabic</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="125"/>
         <source>Celtic</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="126"/>
         <source>SouthEasternEuropean</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="121"/>
         <source>Greek</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="122"/>
         <source>Hebrew</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="127"/>
         <source>ChineseSimplified</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="128"/>
         <source>ChineseTraditional</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="129"/>
         <source>Japanese</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="130"/>
         <source>Korean</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="124"/>
         <source>Thai</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="123"/>
         <source>Turkish</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="131"/>
         <source>Vietnamese</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/startmanager.cpp" line="971"/>
+        <location filename="../src/startmanager.cpp" line="1035"/>
         <source>File not saved</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1532"/>
-        <location filename="../src/widgets/window.cpp" line="1549"/>
+        <location filename="../src/widgets/window.cpp" line="1716"/>
+        <location filename="../src/widgets/window.cpp" line="1733"/>
         <source>Line Endings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="243"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="379"/>
         <source>Please install &apos;UOS AI&apos; from the App Store before using</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="245"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="381"/>
         <source>No audio input device detected. Please check and try again</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="247"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="383"/>
         <source>No audio output device detected. Please check and try again</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="69"/>
+        <location filename="../src/common/text_file_saver.cpp" line="74"/>
         <source>File path is empty</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="155"/>
+        <location filename="../src/common/text_file_saver.cpp" line="153"/>
         <source>Insufficient memory to load document content</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="177"/>
+        <location filename="../src/common/text_file_saver.cpp" line="178"/>
         <source>Insufficient memory for encoding conversion</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="183"/>
+        <location filename="../src/common/text_file_saver.cpp" line="184"/>
         <source>Encoding conversion failed</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="189"/>
+        <location filename="../src/common/text_file_saver.cpp" line="190"/>
         <source>Converted content is empty</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="207"/>
+        <location filename="../src/common/text_file_saver.cpp" line="208"/>
         <source>Memory allocation failed</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="211"/>
+        <location filename="../src/common/text_file_saver.cpp" line="212"/>
         <source>Error occurred: %1</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="215"/>
+        <location filename="../src/common/text_file_saver.cpp" line="216"/>
         <source>Unknown error occurred</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -826,41 +877,41 @@
     <message>
         <location filename="../src/controls/replacebar.cpp" line="32"/>
         <source>Find</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/controls/replacebar.cpp" line="34"/>
-        <source>Replace With</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/replacebar.cpp" line="36"/>
+        <source>Replace With</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/controls/replacebar.cpp" line="40"/>
         <source>Replace</source>
         <translation>Înlocuiți</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="37"/>
+        <location filename="../src/controls/replacebar.cpp" line="42"/>
         <source>Skip</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="38"/>
+        <location filename="../src/controls/replacebar.cpp" line="44"/>
         <source>Replace Rest</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="39"/>
+        <location filename="../src/controls/replacebar.cpp" line="46"/>
         <source>Replace All</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>S:</name>
     <message>
         <location filename="../third/libiconv-1.16/src/iconv.c" line="103"/>
-        <source/>
+        <source></source>
         <comment>The first line of the short usage message.</comment>
-        <translation type="unfinished"/>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -868,57 +919,57 @@
     <message>
         <location filename="../src/common/settings.cpp" line="141"/>
         <source>Standard</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/common/settings.cpp" line="141"/>
         <source>Customize</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/common/settings.cpp" line="154"/>
         <source>Normal</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/common/settings.cpp" line="154"/>
         <source>Maximum</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/common/settings.cpp" line="154"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="484"/>
+        <location filename="../src/common/settings.cpp" line="491"/>
         <source>This shortcut conflicts with system shortcut %1</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="487"/>
+        <location filename="../src/common/settings.cpp" line="494"/>
         <source>This shortcut conflicts with %1, click on Replace to make this shortcut effective immediately</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="682"/>
-        <location filename="../src/common/settings.cpp" line="695"/>
-        <location filename="../src/common/settings.cpp" line="704"/>
+        <location filename="../src/common/settings.cpp" line="689"/>
+        <location filename="../src/common/settings.cpp" line="702"/>
+        <location filename="../src/common/settings.cpp" line="711"/>
         <source>The shortcut %1 is invalid, please set another one.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="736"/>
+        <location filename="../src/common/settings.cpp" line="743"/>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="737"/>
+        <location filename="../src/common/settings.cpp" line="744"/>
         <source>Replace</source>
         <translation>Înlocuiți</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="740"/>
+        <location filename="../src/common/settings.cpp" line="747"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
@@ -926,443 +977,497 @@
 <context>
     <name>StartManager</name>
     <message>
-        <location filename="../src/startmanager.cpp" line="411"/>
+        <location filename="../src/startmanager.cpp" line="425"/>
         <source>Untitled %1</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>Tabbar</name>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="641"/>
+        <location filename="../src/controls/tabbar.cpp" line="678"/>
         <source>Close tab</source>
         <translation>Închideți fila</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="642"/>
+        <location filename="../src/controls/tabbar.cpp" line="680"/>
         <source>Close other tabs</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="643"/>
+        <location filename="../src/controls/tabbar.cpp" line="682"/>
         <source>More options</source>
         <translation>Mai multe opțiuni</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="644"/>
+        <location filename="../src/controls/tabbar.cpp" line="684"/>
         <source>Close tabs to the left</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="645"/>
+        <location filename="../src/controls/tabbar.cpp" line="686"/>
         <source>Close tabs to the right</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="646"/>
+        <location filename="../src/controls/tabbar.cpp" line="688"/>
         <source>Close unmodified tabs</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>TextEdit</name>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="305"/>
+        <location filename="../src/editor/dtextedit.cpp" line="388"/>
         <source>Undo</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="306"/>
+        <location filename="../src/editor/dtextedit.cpp" line="390"/>
         <source>Redo</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="307"/>
+        <location filename="../src/editor/dtextedit.cpp" line="392"/>
         <source>Cut</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="308"/>
+        <location filename="../src/editor/dtextedit.cpp" line="394"/>
         <source>Copy</source>
         <translation>Copie</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="309"/>
+        <location filename="../src/editor/dtextedit.cpp" line="396"/>
         <source>Paste</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="310"/>
+        <location filename="../src/editor/dtextedit.cpp" line="398"/>
         <source>Delete</source>
         <translation>Șterge</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="311"/>
+        <location filename="../src/editor/dtextedit.cpp" line="400"/>
         <source>Select All</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="312"/>
-        <location filename="../src/widgets/window.cpp" line="535"/>
+        <location filename="../src/editor/dtextedit.cpp" line="402"/>
+        <location filename="../src/widgets/window.cpp" line="556"/>
         <source>Find</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="313"/>
-        <location filename="../src/widgets/window.cpp" line="536"/>
+        <location filename="../src/editor/dtextedit.cpp" line="404"/>
+        <location filename="../src/widgets/window.cpp" line="558"/>
         <source>Replace</source>
         <translation>Înlocuiți</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="314"/>
+        <location filename="../src/editor/dtextedit.cpp" line="406"/>
         <source>Go to Line</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="315"/>
-        <source>Turn on Read-Only mode</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="316"/>
-        <source>Turn off Read-Only mode</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="317"/>
+        <location filename="../src/editor/dtextedit.cpp" line="415"/>
         <source>Fullscreen</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="318"/>
+        <location filename="../src/editor/dtextedit.cpp" line="417"/>
         <source>Exit fullscreen</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="319"/>
+        <location filename="../src/editor/dtextedit.cpp" line="419"/>
         <source>Display in file manager</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="320"/>
-        <location filename="../src/editor/dtextedit.cpp" line="374"/>
+        <location filename="../src/editor/dtextedit.cpp" line="421"/>
+        <location filename="../src/editor/dtextedit.cpp" line="493"/>
         <source>Add Comment</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="321"/>
+        <location filename="../src/editor/dtextedit.cpp" line="423"/>
         <source>Text to Speech</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="322"/>
-        <source>Stop reading</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="323"/>
+        <location filename="../src/editor/dtextedit.cpp" line="425"/>
         <source>Speech to Text</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="324"/>
+        <location filename="../src/editor/dtextedit.cpp" line="427"/>
         <source>Translate</source>
         <translation>Traduceți</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="325"/>
+        <location filename="../src/editor/dtextedit.cpp" line="429"/>
         <source>Column Mode</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="326"/>
+        <location filename="../src/editor/dtextedit.cpp" line="431"/>
         <source>Add bookmark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="327"/>
+        <location filename="../src/editor/dtextedit.cpp" line="433"/>
         <source>Remove Bookmark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="328"/>
+        <location filename="../src/editor/dtextedit.cpp" line="435"/>
         <source>Previous bookmark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="329"/>
+        <location filename="../src/editor/dtextedit.cpp" line="437"/>
         <source>Next bookmark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="330"/>
+        <location filename="../src/editor/dtextedit.cpp" line="439"/>
         <source>Remove All Bookmarks</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="331"/>
+        <location filename="../src/editor/dtextedit.cpp" line="441"/>
         <source>Fold All</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="332"/>
+        <location filename="../src/editor/dtextedit.cpp" line="443"/>
         <source>Fold Current Level</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="333"/>
+        <location filename="../src/editor/dtextedit.cpp" line="445"/>
         <source>Unfold All</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="334"/>
+        <location filename="../src/editor/dtextedit.cpp" line="447"/>
         <source>Unfold Current Level</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="339"/>
+        <location filename="../src/editor/dtextedit.cpp" line="453"/>
         <source>Color Mark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="343"/>
+        <location filename="../src/editor/dtextedit.cpp" line="458"/>
         <source>Clear All Marks</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="344"/>
+        <location filename="../src/editor/dtextedit.cpp" line="460"/>
         <source>Clear Last Mark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="353"/>
+        <location filename="../src/editor/dtextedit.cpp" line="470"/>
         <source>Mark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="366"/>
+        <location filename="../src/editor/dtextedit.cpp" line="484"/>
         <source>Mark All</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="375"/>
+        <location filename="../src/editor/dtextedit.cpp" line="494"/>
         <source>Remove Comment</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3208"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3211"/>
+        <location filename="../src/editor/dtextedit.cpp" line="543"/>
+        <source>View Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="3531"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3534"/>
         <source>Copy failed: not enough memory</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3333"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3335"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3656"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3658"/>
         <source>Press ALT and click lines to edit in column mode</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="418"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9574"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9576"/>
+        <source>No audio output device was detected. Please ensure your speakers or headphones are properly connected and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="9583"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9585"/>
+        <source>No audio input device was detected. Please ensure your speakers or headphones are properly connected and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="534"/>
         <source>Change Case</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="419"/>
+        <location filename="../src/editor/dtextedit.cpp" line="409"/>
+        <source>Edit Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="411"/>
+        <source>Read View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="413"/>
+        <source>Live Preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="535"/>
         <source>Upper Case</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="420"/>
+        <location filename="../src/editor/dtextedit.cpp" line="536"/>
         <source>Lower Case</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="421"/>
+        <location filename="../src/editor/dtextedit.cpp" line="537"/>
         <source>Capitalize</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="78"/>
+        <location filename="../src/widgets/bottombar.cpp" line="110"/>
         <source>None</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1363"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1490"/>
         <source>Selected line(s) copied</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1370"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1497"/>
         <source>Current line copied</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1400"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1527"/>
         <source>Selected line(s) clipped</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1412"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1539"/>
         <source>Current line clipped</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3227"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3230"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3550"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3553"/>
         <source>Paste failed: not enough memory</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="4548"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4873"/>
         <source>Read-Only mode is off</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="4560"/>
-        <location filename="../src/editor/dtextedit.cpp" line="4584"/>
-        <location filename="../src/editor/dtextedit.cpp" line="7896"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8007"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8015"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8026"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4885"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4909"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8236"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8347"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8355"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8366"/>
         <source>Read-Only mode is on</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>WarningNotices</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="24"/>
+        <location filename="../src/controls/warningnotices.cpp" line="25"/>
         <source>Reload</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/controls/warningnotices.cpp" line="29"/>
+        <source>Edit Anyway</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>Window</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="25"/>
-        <location filename="../src/widgets/window.cpp" line="531"/>
+        <location filename="../src/controls/warningnotices.cpp" line="27"/>
+        <location filename="../src/widgets/window.cpp" line="548"/>
         <source>Save as</source>
         <translation>Salvați ca</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="527"/>
+        <location filename="../src/widgets/window.cpp" line="540"/>
         <source>New window</source>
         <translation>Fereastră nouă</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="528"/>
+        <location filename="../src/widgets/window.cpp" line="542"/>
         <source>New tab</source>
         <translation>Filă nouă</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="529"/>
+        <location filename="../src/widgets/window.cpp" line="544"/>
         <source>Open file</source>
         <translation>Deschideți fișierul</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="530"/>
-        <location filename="../src/widgets/window.cpp" line="3545"/>
+        <location filename="../src/widgets/window.cpp" line="546"/>
+        <location filename="../src/widgets/window.cpp" line="3950"/>
         <source>Save</source>
         <translation>Salvați</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="532"/>
+        <location filename="../src/widgets/window.cpp" line="550"/>
         <source>Print</source>
         <translation>Imprimare</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="533"/>
+        <location filename="../src/widgets/window.cpp" line="552"/>
         <source>Switch theme</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="534"/>
-        <location filename="../src/widgets/window.cpp" line="2448"/>
+        <location filename="../src/widgets/window.cpp" line="554"/>
+        <location filename="../src/widgets/window.cpp" line="2641"/>
         <source>Settings</source>
         <translation>Setări</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="666"/>
-        <location filename="../src/widgets/window.cpp" line="3845"/>
+        <location filename="../src/widgets/window.cpp" line="696"/>
+        <location filename="../src/widgets/window.cpp" line="4250"/>
         <source>Read-Only</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="687"/>
+        <location filename="../src/widgets/window.cpp" line="719"/>
         <source>You do not have permission to open %1</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="738"/>
-        <location filename="../src/widgets/window.cpp" line="2963"/>
+        <location filename="../src/widgets/window.cpp" line="773"/>
+        <location filename="../src/widgets/window.cpp" line="3266"/>
         <source>Invalid file: %1</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="903"/>
-        <location filename="../src/widgets/window.cpp" line="956"/>
+        <location filename="../src/widgets/window.cpp" line="957"/>
+        <location filename="../src/widgets/window.cpp" line="1050"/>
+        <location filename="../src/widgets/window.cpp" line="3217"/>
         <source>Do you want to save this file?</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1290"/>
+        <location filename="../src/widgets/window.cpp" line="1381"/>
+        <source>Invalid characters detected while saving &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1382"/>
+        <source>If you force save this file, it may cause file corruption. Still want to save?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1386"/>
+        <source>Don&apos;t Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1387"/>
+        <source>Save As</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1388"/>
+        <source>Save Anyway</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1456"/>
         <source>You do not have permission to save %1</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1312"/>
+        <location filename="../src/widgets/window.cpp" line="1428"/>
+        <location filename="../src/widgets/window.cpp" line="1478"/>
         <source>Saved successfully</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1354"/>
-        <location filename="../src/widgets/window.cpp" line="1481"/>
-        <location filename="../src/widgets/window.cpp" line="1529"/>
+        <location filename="../src/widgets/window.cpp" line="1520"/>
+        <location filename="../src/widgets/window.cpp" line="1665"/>
+        <location filename="../src/widgets/window.cpp" line="1713"/>
         <source>Save File</source>
         <translation>Salvați Fișierul</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1483"/>
+        <location filename="../src/widgets/window.cpp" line="1569"/>
+        <source>Cannot save as the original file in preview mode. Please choose a different path.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1667"/>
         <source>Encoding</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1773"/>
+        <location filename="../src/widgets/window.cpp" line="1957"/>
         <source>Read-Only mode is on</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2322"/>
+        <location filename="../src/widgets/window.cpp" line="2511"/>
         <source>Current location remembered</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2398"/>
+        <location filename="../src/widgets/window.cpp" line="2591"/>
         <source>Ctrl+&apos;=&apos;</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2401"/>
+        <location filename="../src/widgets/window.cpp" line="2594"/>
         <source>Ctrl+&apos;-&apos;</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2430"/>
+        <location filename="../src/widgets/window.cpp" line="2623"/>
         <source>Editor</source>
         <translation>Editor</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3061"/>
+        <location filename="../src/widgets/window.cpp" line="3436"/>
         <source>Untitled %1</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3543"/>
+        <location filename="../src/widgets/window.cpp" line="3948"/>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3544"/>
+        <location filename="../src/widgets/window.cpp" line="3949"/>
         <source>Discard</source>
         <translation>Renunțați</translation>
     </message>

--- a/translations/deepin-editor_ru.ts
+++ b/translations/deepin-editor_ru.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ru">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ru">
 <context>
     <name>BottomBar</name>
     <message>
@@ -17,17 +19,36 @@
         <translation>Символы %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="44"/>
+        <location filename="../src/widgets/bottombar.cpp" line="47"/>
         <source>Loading:</source>
         <translation>Загрузка:</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="73"/>
+        <location filename="../src/widgets/bottombar.cpp" line="91"/>
+        <location filename="../src/widgets/bottombar.cpp" line="499"/>
+        <source>Edit Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="74"/>
+        <location filename="../src/widgets/bottombar.cpp" line="489"/>
+        <source>Read View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="75"/>
+        <location filename="../src/widgets/bottombar.cpp" line="493"/>
+        <source>Live Preview</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DDropdownMenu</name>
     <message>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="362"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="420"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="425"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="363"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="421"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="426"/>
         <source>None</source>
         <translation>Ничего</translation>
     </message>
@@ -35,68 +56,57 @@
 <context>
     <name>EditWrapper</name>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="292"/>
-        <location filename="../src/editor/editwrapper.cpp" line="365"/>
-        <location filename="../src/editor/editwrapper.cpp" line="521"/>
-        <location filename="../src/editor/editwrapper.cpp" line="751"/>
+        <location filename="../src/editor/editwrapper.cpp" line="355"/>
+        <location filename="../src/editor/editwrapper.cpp" line="429"/>
+        <location filename="../src/editor/editwrapper.cpp" line="595"/>
+        <location filename="../src/editor/editwrapper.cpp" line="887"/>
         <source>Save</source>
         <translation>Сохранить</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="516"/>
+        <location filename="../src/editor/editwrapper.cpp" line="590"/>
         <source>Do you want to save this file?</source>
         <translation>Вы хотите сохранить этот документ?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="363"/>
-        <location filename="../src/editor/editwrapper.cpp" line="519"/>
+        <location filename="../src/editor/editwrapper.cpp" line="427"/>
+        <location filename="../src/editor/editwrapper.cpp" line="593"/>
         <source>Cancel</source>
         <translation>Отмена</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="360"/>
+        <location filename="../src/editor/editwrapper.cpp" line="424"/>
         <source>Encoding changed. Do you want to save the file now?</source>
         <translation>Кодирование изменилось. Вы хотите сохранить файл сейчас?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="520"/>
+        <location filename="../src/editor/editwrapper.cpp" line="594"/>
         <source>Discard</source>
         <translation>Забыть</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="274"/>
-        <location filename="../src/editor/editwrapper.cpp" line="620"/>
+        <location filename="../src/editor/editwrapper.cpp" line="1121"/>
+        <source>The file contains invalid characters (NUL). Preview mode is read-only.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="337"/>
+        <location filename="../src/editor/editwrapper.cpp" line="705"/>
         <source>You do not have permission to save %1</source>
         <translation>Вы не имеете разрешения на сохранение %1</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="836"/>
+        <location filename="../src/editor/editwrapper.cpp" line="987"/>
         <source>File removed on the disk. Save it now?</source>
         <translation>Файл удален на диске. Сохранить его сейчас?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="842"/>
+        <location filename="../src/editor/editwrapper.cpp" line="993"/>
         <source>File has changed on disk. Reload?</source>
         <translation>Файл изменился на диске. Обновить?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="884"/>
-        <location filename="../src/widgets/bottombar.cpp" line="74"/>
-        <source>INSERT</source>
-        <translation>ВСТАВИТЬ</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="888"/>
-        <source>OVERWRITE</source>
-        <translation>ПЕРЕЗАПИСАТЬ</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="892"/>
-        <source>R/O</source>
-        <translation>Т/Ч</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="1618"/>
+        <location filename="../src/editor/editwrapper.cpp" line="1806"/>
         <source>The file cannot be read, which may be too large or has been damaged!</source>
         <translation>Файл не может быть прочитан, возможно, он слишком велик или поврежден!</translation>
     </message>
@@ -109,17 +119,17 @@
         <translation>Найти</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="36"/>
+        <location filename="../src/controls/findbar.cpp" line="38"/>
         <source>Previous</source>
         <translation>Предыдущий</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="37"/>
+        <location filename="../src/controls/findbar.cpp" line="40"/>
         <source>Next</source>
         <translation>Следующий</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="38"/>
+        <location filename="../src/controls/findbar.cpp" line="42"/>
         <source>Replace</source>
         <translation>Заменить</translation>
     </message>
@@ -127,9 +137,17 @@
 <context>
     <name>JumpLineBar</name>
     <message>
-        <location filename="../src/controls/jumplinebar.cpp" line="45"/>
+        <location filename="../src/controls/jumplinebar.cpp" line="46"/>
         <source>Go to Line: </source>
         <translation>Перейти к Строке:</translation>
+    </message>
+</context>
+<context>
+    <name>LineBar</name>
+    <message>
+        <location filename="../src/controls/linebar.cpp" line="144"/>
+        <source>第%1/%2项</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -146,19 +164,47 @@
     </message>
 </context>
 <context>
+    <name>MarkdownBridge</name>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="37"/>
+        <source>Collapse code block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="38"/>
+        <source>Expand code block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="39"/>
+        <source>Copy code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="40"/>
+        <source>Expand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="42"/>
+        <source>%1 line(s) of code collapsed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PathSettingWgt</name>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="84"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="90"/>
         <source>Remember the last used path</source>
         <translation>Запомнить последний использованный путь</translation>
     </message>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="85"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="91"/>
         <source>Same path as the current file</source>
         <translation>Тот же путь, что и к текущему файлу</translation>
     </message>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="86"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="92"/>
         <source>Customize the default path</source>
         <translation>Настройка пути по умолчанию</translation>
     </message>
@@ -171,15 +217,20 @@
         <translation>Текстовый редактор</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="294"/>
-        <location filename="../src/editor/editwrapper.cpp" line="761"/>
-        <location filename="../src/editor/editwrapper.cpp" line="776"/>
-        <location filename="../src/widgets/window.cpp" line="1362"/>
-        <location filename="../src/widgets/window.cpp" line="1390"/>
-        <location filename="../src/widgets/window.cpp" line="1531"/>
-        <location filename="../src/widgets/window.cpp" line="1548"/>
+        <location filename="../src/editor/editwrapper.cpp" line="357"/>
+        <location filename="../src/editor/editwrapper.cpp" line="897"/>
+        <location filename="../src/editor/editwrapper.cpp" line="912"/>
+        <location filename="../src/widgets/window.cpp" line="1528"/>
+        <location filename="../src/widgets/window.cpp" line="1556"/>
+        <location filename="../src/widgets/window.cpp" line="1715"/>
+        <location filename="../src/widgets/window.cpp" line="1732"/>
         <source>Encoding</source>
         <translation>Кодировка</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="2001"/>
+        <source>视图模式</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="11"/>
@@ -215,7 +266,7 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="18"/>
         <location filename="../src/controls/settingsdialog.cpp" line="96"/>
-        <location filename="../src/widgets/window.cpp" line="2388"/>
+        <location filename="../src/widgets/window.cpp" line="2581"/>
         <source>Window</source>
         <translation>Окно</translation>
     </message>
@@ -755,68 +806,68 @@
         <translation>Вьетнамский</translation>
     </message>
     <message>
-        <location filename="../src/startmanager.cpp" line="971"/>
+        <location filename="../src/startmanager.cpp" line="1035"/>
         <source>File not saved</source>
         <translation>Файл не сохранен</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1532"/>
-        <location filename="../src/widgets/window.cpp" line="1549"/>
+        <location filename="../src/widgets/window.cpp" line="1716"/>
+        <location filename="../src/widgets/window.cpp" line="1733"/>
         <source>Line Endings</source>
         <translation>Окончание строк</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="243"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="379"/>
         <source>Please install &apos;UOS AI&apos; from the App Store before using</source>
         <translation>Пожалуйста, установите &apos;UOS AI&apos; из магазина приложений перед использованием</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="245"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="381"/>
         <source>No audio input device detected. Please check and try again</source>
         <translation>Не найдено устройство ввода аудио. Пожалуйста, проверьте и попробуйте снова</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="247"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="383"/>
         <source>No audio output device detected. Please check and try again</source>
         <translation>Не найдено устройство вывода аудио. Пожалуйста, проверьте и попробуйте снова</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="69"/>
+        <location filename="../src/common/text_file_saver.cpp" line="74"/>
         <source>File path is empty</source>
         <translation>Путь к файлу пуст</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="155"/>
+        <location filename="../src/common/text_file_saver.cpp" line="153"/>
         <source>Insufficient memory to load document content</source>
         <translation>Недостаточно памяти для загрузки содержимого документа</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="177"/>
+        <location filename="../src/common/text_file_saver.cpp" line="178"/>
         <source>Insufficient memory for encoding conversion</source>
         <translation>Недостаточно памяти для кодирования</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="183"/>
+        <location filename="../src/common/text_file_saver.cpp" line="184"/>
         <source>Encoding conversion failed</source>
         <translation>Кодирование завершилось с ошибкой</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="189"/>
+        <location filename="../src/common/text_file_saver.cpp" line="190"/>
         <source>Converted content is empty</source>
         <translation>Сконвертированное содержимое пусто</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="207"/>
+        <location filename="../src/common/text_file_saver.cpp" line="208"/>
         <source>Memory allocation failed</source>
         <translation>Не удалось выделить память</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="211"/>
+        <location filename="../src/common/text_file_saver.cpp" line="212"/>
         <source>Error occurred: %1</source>
         <translation>&apos;Ошибка: %1&apos;</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="215"/>
+        <location filename="../src/common/text_file_saver.cpp" line="216"/>
         <source>Unknown error occurred</source>
         <translation>Произошла неизвестная ошибка</translation>
     </message>
@@ -829,27 +880,27 @@
         <translation>Найти</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="34"/>
+        <location filename="../src/controls/replacebar.cpp" line="36"/>
         <source>Replace With</source>
         <translation>Заменить На</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="36"/>
+        <location filename="../src/controls/replacebar.cpp" line="40"/>
         <source>Replace</source>
         <translation>Заменить:</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="37"/>
+        <location filename="../src/controls/replacebar.cpp" line="42"/>
         <source>Skip</source>
         <translation>Пропустить</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="38"/>
+        <location filename="../src/controls/replacebar.cpp" line="44"/>
         <source>Replace Rest</source>
         <translation>Заменить Остальное</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="39"/>
+        <location filename="../src/controls/replacebar.cpp" line="46"/>
         <source>Replace All</source>
         <translation>Заменить Всё</translation>
     </message>
@@ -858,9 +909,9 @@
     <name>S:</name>
     <message>
         <location filename="../third/libiconv-1.16/src/iconv.c" line="103"/>
-        <source/>
+        <source></source>
         <comment>The first line of the short usage message.</comment>
-        <translation type="unfinished"/>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -891,34 +942,34 @@
         <translation>Полный экран</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="484"/>
+        <location filename="../src/common/settings.cpp" line="491"/>
         <source>This shortcut conflicts with system shortcut %1</source>
         <translation>Это сочетание конфликтует с системным сочитанием %1</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="487"/>
+        <location filename="../src/common/settings.cpp" line="494"/>
         <source>This shortcut conflicts with %1, click on Replace to make this shortcut effective immediately</source>
         <translation>Это сочетание конфликтует с %1, нажмите Заменить, чтобы это сочетание вступило в силу немедленно</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="682"/>
-        <location filename="../src/common/settings.cpp" line="695"/>
-        <location filename="../src/common/settings.cpp" line="704"/>
+        <location filename="../src/common/settings.cpp" line="689"/>
+        <location filename="../src/common/settings.cpp" line="702"/>
+        <location filename="../src/common/settings.cpp" line="711"/>
         <source>The shortcut %1 is invalid, please set another one.</source>
         <translation>Сочетание %1 недействительно, установите другое.</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="736"/>
+        <location filename="../src/common/settings.cpp" line="743"/>
         <source>Cancel</source>
         <translation>Отмена</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="737"/>
+        <location filename="../src/common/settings.cpp" line="744"/>
         <source>Replace</source>
         <translation>Заменить</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="740"/>
+        <location filename="../src/common/settings.cpp" line="747"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
@@ -926,7 +977,7 @@
 <context>
     <name>StartManager</name>
     <message>
-        <location filename="../src/startmanager.cpp" line="411"/>
+        <location filename="../src/startmanager.cpp" line="425"/>
         <source>Untitled %1</source>
         <translation>Без названия %1</translation>
     </message>
@@ -934,32 +985,32 @@
 <context>
     <name>Tabbar</name>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="641"/>
+        <location filename="../src/controls/tabbar.cpp" line="678"/>
         <source>Close tab</source>
         <translation>Закрыть вкладку</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="642"/>
+        <location filename="../src/controls/tabbar.cpp" line="680"/>
         <source>Close other tabs</source>
         <translation>Закрыть другие вкладки</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="643"/>
+        <location filename="../src/controls/tabbar.cpp" line="682"/>
         <source>More options</source>
         <translation>Больше вариантов</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="644"/>
+        <location filename="../src/controls/tabbar.cpp" line="684"/>
         <source>Close tabs to the left</source>
         <translation>Закрыть вкладки слева</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="645"/>
+        <location filename="../src/controls/tabbar.cpp" line="686"/>
         <source>Close tabs to the right</source>
         <translation>Закрыть вкладки справа</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="646"/>
+        <location filename="../src/controls/tabbar.cpp" line="688"/>
         <source>Close unmodified tabs</source>
         <translation>Закрыть не изменённые вкладки</translation>
     </message>
@@ -967,263 +1018,280 @@
 <context>
     <name>TextEdit</name>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="305"/>
+        <location filename="../src/editor/dtextedit.cpp" line="388"/>
         <source>Undo</source>
         <translation>Отменить</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="306"/>
+        <location filename="../src/editor/dtextedit.cpp" line="390"/>
         <source>Redo</source>
         <translation>Готово</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="307"/>
+        <location filename="../src/editor/dtextedit.cpp" line="392"/>
         <source>Cut</source>
         <translation>Вырезать</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="308"/>
+        <location filename="../src/editor/dtextedit.cpp" line="394"/>
         <source>Copy</source>
         <translation>Копировать</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="309"/>
+        <location filename="../src/editor/dtextedit.cpp" line="396"/>
         <source>Paste</source>
         <translation>Вставить</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="310"/>
+        <location filename="../src/editor/dtextedit.cpp" line="398"/>
         <source>Delete</source>
         <translation>Удалить</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="311"/>
+        <location filename="../src/editor/dtextedit.cpp" line="400"/>
         <source>Select All</source>
         <translation>Выбрать всё</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="312"/>
-        <location filename="../src/widgets/window.cpp" line="535"/>
+        <location filename="../src/editor/dtextedit.cpp" line="402"/>
+        <location filename="../src/widgets/window.cpp" line="556"/>
         <source>Find</source>
         <translation>Найти</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="313"/>
-        <location filename="../src/widgets/window.cpp" line="536"/>
+        <location filename="../src/editor/dtextedit.cpp" line="404"/>
+        <location filename="../src/widgets/window.cpp" line="558"/>
         <source>Replace</source>
         <translation>Заменить</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="314"/>
+        <location filename="../src/editor/dtextedit.cpp" line="406"/>
         <source>Go to Line</source>
         <translation>Перейти к строке</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="315"/>
-        <source>Turn on Read-Only mode</source>
-        <translation>Включить режим Только Чтение</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="316"/>
-        <source>Turn off Read-Only mode</source>
-        <translation>Отключить режим Только Чтение</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="317"/>
+        <location filename="../src/editor/dtextedit.cpp" line="415"/>
         <source>Fullscreen</source>
         <translation>Полноэкранный режим</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="318"/>
+        <location filename="../src/editor/dtextedit.cpp" line="417"/>
         <source>Exit fullscreen</source>
         <translation>Выйти из полноэкранного режима</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="319"/>
+        <location filename="../src/editor/dtextedit.cpp" line="419"/>
         <source>Display in file manager</source>
         <translation>Показать в файловом менеджере</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="320"/>
-        <location filename="../src/editor/dtextedit.cpp" line="374"/>
+        <location filename="../src/editor/dtextedit.cpp" line="421"/>
+        <location filename="../src/editor/dtextedit.cpp" line="493"/>
         <source>Add Comment</source>
         <translation>Добавить комментарий</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="321"/>
+        <location filename="../src/editor/dtextedit.cpp" line="423"/>
         <source>Text to Speech</source>
         <translation>Текст в речь</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="322"/>
-        <source>Stop reading</source>
-        <translation>Прекратить читать</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="323"/>
+        <location filename="../src/editor/dtextedit.cpp" line="425"/>
         <source>Speech to Text</source>
         <translation>Речь в текст</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="324"/>
+        <location filename="../src/editor/dtextedit.cpp" line="427"/>
         <source>Translate</source>
         <translation>Перевести</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="325"/>
+        <location filename="../src/editor/dtextedit.cpp" line="429"/>
         <source>Column Mode</source>
         <translation>Режим колонки</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="326"/>
+        <location filename="../src/editor/dtextedit.cpp" line="431"/>
         <source>Add bookmark</source>
         <translation>Добавить закладку</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="327"/>
+        <location filename="../src/editor/dtextedit.cpp" line="433"/>
         <source>Remove Bookmark</source>
         <translation>Удалить закладку</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="328"/>
+        <location filename="../src/editor/dtextedit.cpp" line="435"/>
         <source>Previous bookmark</source>
         <translation>Предыдущая закладка</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="329"/>
+        <location filename="../src/editor/dtextedit.cpp" line="437"/>
         <source>Next bookmark</source>
         <translation>Следующая закладка</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="330"/>
+        <location filename="../src/editor/dtextedit.cpp" line="439"/>
         <source>Remove All Bookmarks</source>
         <translation>Удалить все закладки</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="331"/>
+        <location filename="../src/editor/dtextedit.cpp" line="441"/>
         <source>Fold All</source>
         <translation>Свернуть всё</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="332"/>
+        <location filename="../src/editor/dtextedit.cpp" line="443"/>
         <source>Fold Current Level</source>
         <translation>Свернуть текущий уровень</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="333"/>
+        <location filename="../src/editor/dtextedit.cpp" line="445"/>
         <source>Unfold All</source>
         <translation>Развернуть всё</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="334"/>
+        <location filename="../src/editor/dtextedit.cpp" line="447"/>
         <source>Unfold Current Level</source>
         <translation>Развернуть текущий уровень</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="339"/>
+        <location filename="../src/editor/dtextedit.cpp" line="453"/>
         <source>Color Mark</source>
         <translation>Цветная метка</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="343"/>
+        <location filename="../src/editor/dtextedit.cpp" line="458"/>
         <source>Clear All Marks</source>
         <translation>Очистить все метки</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="344"/>
+        <location filename="../src/editor/dtextedit.cpp" line="460"/>
         <source>Clear Last Mark</source>
         <translation>Очистить последнюю метку</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="353"/>
+        <location filename="../src/editor/dtextedit.cpp" line="470"/>
         <source>Mark</source>
         <translation>Пометить</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="366"/>
+        <location filename="../src/editor/dtextedit.cpp" line="484"/>
         <source>Mark All</source>
         <translation>Пометить всё</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="375"/>
+        <location filename="../src/editor/dtextedit.cpp" line="494"/>
         <source>Remove Comment</source>
         <translation>Удалить комментарий</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3208"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3211"/>
+        <location filename="../src/editor/dtextedit.cpp" line="543"/>
+        <source>View Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="3531"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3534"/>
         <source>Copy failed: not enough memory</source>
         <translation>Копирование не удалось: недостаточно памяти</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3333"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3335"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3656"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3658"/>
         <source>Press ALT and click lines to edit in column mode</source>
         <translation>Нажмите ALT и щелкните строки для редактирования в режиме колонки</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="418"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9574"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9576"/>
+        <source>No audio output device was detected. Please ensure your speakers or headphones are properly connected and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="9583"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9585"/>
+        <source>No audio input device was detected. Please ensure your speakers or headphones are properly connected and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="534"/>
         <source>Change Case</source>
         <translation>Изменить регистр</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="419"/>
+        <location filename="../src/editor/dtextedit.cpp" line="409"/>
+        <source>Edit Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="411"/>
+        <source>Read View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="413"/>
+        <source>Live Preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="535"/>
         <source>Upper Case</source>
         <translation>Верхний регистр</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="420"/>
+        <location filename="../src/editor/dtextedit.cpp" line="536"/>
         <source>Lower Case</source>
         <translation>Нижний регистр</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="421"/>
+        <location filename="../src/editor/dtextedit.cpp" line="537"/>
         <source>Capitalize</source>
         <translation>Заглавные буквы</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="78"/>
+        <location filename="../src/widgets/bottombar.cpp" line="110"/>
         <source>None</source>
         <translation>Ничего</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1363"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1490"/>
         <source>Selected line(s) copied</source>
         <translation>Выбранные строки скопированы</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1370"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1497"/>
         <source>Current line copied</source>
         <translation>Текущая строка скопирована</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1400"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1527"/>
         <source>Selected line(s) clipped</source>
         <translation>Выбранные строки обрезаны</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1412"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1539"/>
         <source>Current line clipped</source>
         <translation>Текущая строка отрезана</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3227"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3230"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3550"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3553"/>
         <source>Paste failed: not enough memory</source>
         <translation>Вставка не удалось: недостаточно памяти</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="4548"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4873"/>
         <source>Read-Only mode is off</source>
         <translation>Режим Только Чтение отключён</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="4560"/>
-        <location filename="../src/editor/dtextedit.cpp" line="4584"/>
-        <location filename="../src/editor/dtextedit.cpp" line="7896"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8007"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8015"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8026"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4885"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4909"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8236"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8347"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8355"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8366"/>
         <source>Read-Only mode is on</source>
         <translation>Режим Только Чтение включён</translation>
     </message>
@@ -1231,138 +1299,175 @@
 <context>
     <name>WarningNotices</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="24"/>
+        <location filename="../src/controls/warningnotices.cpp" line="25"/>
         <source>Reload</source>
         <translation>Обновить</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/warningnotices.cpp" line="29"/>
+        <source>Edit Anyway</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>Window</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="25"/>
-        <location filename="../src/widgets/window.cpp" line="531"/>
+        <location filename="../src/controls/warningnotices.cpp" line="27"/>
+        <location filename="../src/widgets/window.cpp" line="548"/>
         <source>Save as</source>
         <translation>Сохранить как</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="527"/>
+        <location filename="../src/widgets/window.cpp" line="540"/>
         <source>New window</source>
         <translation>Новое окно</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="528"/>
+        <location filename="../src/widgets/window.cpp" line="542"/>
         <source>New tab</source>
         <translation>Новая вкладка</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="529"/>
+        <location filename="../src/widgets/window.cpp" line="544"/>
         <source>Open file</source>
         <translation>Открыть файл</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="530"/>
-        <location filename="../src/widgets/window.cpp" line="3545"/>
+        <location filename="../src/widgets/window.cpp" line="546"/>
+        <location filename="../src/widgets/window.cpp" line="3950"/>
         <source>Save</source>
         <translation>Сохранить</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="532"/>
+        <location filename="../src/widgets/window.cpp" line="550"/>
         <source>Print</source>
         <translation>Печать</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="533"/>
+        <location filename="../src/widgets/window.cpp" line="552"/>
         <source>Switch theme</source>
         <translation>Переключить тему</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="534"/>
-        <location filename="../src/widgets/window.cpp" line="2448"/>
+        <location filename="../src/widgets/window.cpp" line="554"/>
+        <location filename="../src/widgets/window.cpp" line="2641"/>
         <source>Settings</source>
         <translation>Настройки</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="666"/>
-        <location filename="../src/widgets/window.cpp" line="3845"/>
+        <location filename="../src/widgets/window.cpp" line="696"/>
+        <location filename="../src/widgets/window.cpp" line="4250"/>
         <source>Read-Only</source>
         <translation>Только Чтение</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="687"/>
+        <location filename="../src/widgets/window.cpp" line="719"/>
         <source>You do not have permission to open %1</source>
         <translation>Вы не имеете разрешения на открытие %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="738"/>
-        <location filename="../src/widgets/window.cpp" line="2963"/>
+        <location filename="../src/widgets/window.cpp" line="773"/>
+        <location filename="../src/widgets/window.cpp" line="3266"/>
         <source>Invalid file: %1</source>
         <translation>Недопустимый файл: %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="903"/>
-        <location filename="../src/widgets/window.cpp" line="956"/>
+        <location filename="../src/widgets/window.cpp" line="957"/>
+        <location filename="../src/widgets/window.cpp" line="1050"/>
+        <location filename="../src/widgets/window.cpp" line="3217"/>
         <source>Do you want to save this file?</source>
         <translation>Вы хотите сохранить этот документ?</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1290"/>
+        <location filename="../src/widgets/window.cpp" line="1381"/>
+        <source>Invalid characters detected while saving &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1382"/>
+        <source>If you force save this file, it may cause file corruption. Still want to save?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1386"/>
+        <source>Don&apos;t Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1387"/>
+        <source>Save As</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1388"/>
+        <source>Save Anyway</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1456"/>
         <source>You do not have permission to save %1</source>
         <translation>Вы не имеете разрешения на сохранение %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1312"/>
+        <location filename="../src/widgets/window.cpp" line="1428"/>
+        <location filename="../src/widgets/window.cpp" line="1478"/>
         <source>Saved successfully</source>
         <translation>Успешно сохранено</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1354"/>
-        <location filename="../src/widgets/window.cpp" line="1481"/>
-        <location filename="../src/widgets/window.cpp" line="1529"/>
+        <location filename="../src/widgets/window.cpp" line="1520"/>
+        <location filename="../src/widgets/window.cpp" line="1665"/>
+        <location filename="../src/widgets/window.cpp" line="1713"/>
         <source>Save File</source>
         <translation>Сохранить Файл</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1483"/>
+        <location filename="../src/widgets/window.cpp" line="1569"/>
+        <source>Cannot save as the original file in preview mode. Please choose a different path.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1667"/>
         <source>Encoding</source>
         <translation>Кодировка</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1773"/>
+        <location filename="../src/widgets/window.cpp" line="1957"/>
         <source>Read-Only mode is on</source>
         <translation>Режим Только Чтение включён</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2322"/>
+        <location filename="../src/widgets/window.cpp" line="2511"/>
         <source>Current location remembered</source>
         <translation>Текущее местоположение запомнилось</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2398"/>
+        <location filename="../src/widgets/window.cpp" line="2591"/>
         <source>Ctrl+&apos;=&apos;</source>
         <translation>Ctrl+&apos;=&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2401"/>
+        <location filename="../src/widgets/window.cpp" line="2594"/>
         <source>Ctrl+&apos;-&apos;</source>
         <translation>Ctrl+&apos;-&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2430"/>
+        <location filename="../src/widgets/window.cpp" line="2623"/>
         <source>Editor</source>
         <translation>Редактор</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3061"/>
+        <location filename="../src/widgets/window.cpp" line="3436"/>
         <source>Untitled %1</source>
         <translation>Без названия %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3543"/>
+        <location filename="../src/widgets/window.cpp" line="3948"/>
         <source>Cancel</source>
         <translation>Отмена</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3544"/>
+        <location filename="../src/widgets/window.cpp" line="3949"/>
         <source>Discard</source>
         <translation>Отмена</translation>
     </message>

--- a/translations/deepin-editor_sk.ts
+++ b/translations/deepin-editor_sk.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="sk">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="sk">
 <context>
     <name>BottomBar</name>
     <message>
@@ -17,17 +19,36 @@
         <translation>Znakov %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="44"/>
+        <location filename="../src/widgets/bottombar.cpp" line="47"/>
         <source>Loading:</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="73"/>
+        <location filename="../src/widgets/bottombar.cpp" line="91"/>
+        <location filename="../src/widgets/bottombar.cpp" line="499"/>
+        <source>Edit Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="74"/>
+        <location filename="../src/widgets/bottombar.cpp" line="489"/>
+        <source>Read View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="75"/>
+        <location filename="../src/widgets/bottombar.cpp" line="493"/>
+        <source>Live Preview</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DDropdownMenu</name>
     <message>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="362"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="420"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="425"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="363"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="421"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="426"/>
         <source>None</source>
         <translation>Nič</translation>
     </message>
@@ -35,70 +56,59 @@
 <context>
     <name>EditWrapper</name>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="292"/>
-        <location filename="../src/editor/editwrapper.cpp" line="365"/>
-        <location filename="../src/editor/editwrapper.cpp" line="521"/>
-        <location filename="../src/editor/editwrapper.cpp" line="751"/>
+        <location filename="../src/editor/editwrapper.cpp" line="355"/>
+        <location filename="../src/editor/editwrapper.cpp" line="429"/>
+        <location filename="../src/editor/editwrapper.cpp" line="595"/>
+        <location filename="../src/editor/editwrapper.cpp" line="887"/>
         <source>Save</source>
         <translation>Uložiť</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="516"/>
+        <location filename="../src/editor/editwrapper.cpp" line="590"/>
         <source>Do you want to save this file?</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="363"/>
-        <location filename="../src/editor/editwrapper.cpp" line="519"/>
+        <location filename="../src/editor/editwrapper.cpp" line="427"/>
+        <location filename="../src/editor/editwrapper.cpp" line="593"/>
         <source>Cancel</source>
         <translation>Zrušiť</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="360"/>
+        <location filename="../src/editor/editwrapper.cpp" line="424"/>
         <source>Encoding changed. Do you want to save the file now?</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="520"/>
+        <location filename="../src/editor/editwrapper.cpp" line="594"/>
         <source>Discard</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="274"/>
-        <location filename="../src/editor/editwrapper.cpp" line="620"/>
+        <location filename="../src/editor/editwrapper.cpp" line="1121"/>
+        <source>The file contains invalid characters (NUL). Preview mode is read-only.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="337"/>
+        <location filename="../src/editor/editwrapper.cpp" line="705"/>
         <source>You do not have permission to save %1</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="836"/>
+        <location filename="../src/editor/editwrapper.cpp" line="987"/>
         <source>File removed on the disk. Save it now?</source>
         <translation>Súbor bol odstránený na disku. Uložiť ho znova?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="842"/>
+        <location filename="../src/editor/editwrapper.cpp" line="993"/>
         <source>File has changed on disk. Reload?</source>
         <translation>Súbor bol zmenený na disku. Obnoviť?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="884"/>
-        <location filename="../src/widgets/bottombar.cpp" line="74"/>
-        <source>INSERT</source>
-        <translation>VLOŽIŤ</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="888"/>
-        <source>OVERWRITE</source>
-        <translation>PREPÍSAŤ</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="892"/>
-        <source>R/O</source>
-        <translation>R/O</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="1618"/>
+        <location filename="../src/editor/editwrapper.cpp" line="1806"/>
         <source>The file cannot be read, which may be too large or has been damaged!</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -109,17 +119,17 @@
         <translation>Hľadať</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="36"/>
+        <location filename="../src/controls/findbar.cpp" line="38"/>
         <source>Previous</source>
         <translation>Predošlý</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="37"/>
+        <location filename="../src/controls/findbar.cpp" line="40"/>
         <source>Next</source>
         <translation>Ďaľší</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="38"/>
+        <location filename="../src/controls/findbar.cpp" line="42"/>
         <source>Replace</source>
         <translation>Nahradiť</translation>
     </message>
@@ -127,9 +137,17 @@
 <context>
     <name>JumpLineBar</name>
     <message>
-        <location filename="../src/controls/jumplinebar.cpp" line="45"/>
+        <location filename="../src/controls/jumplinebar.cpp" line="46"/>
         <source>Go to Line: </source>
         <translation>Choď na riadok:</translation>
+    </message>
+</context>
+<context>
+    <name>LineBar</name>
+    <message>
+        <location filename="../src/controls/linebar.cpp" line="144"/>
+        <source>第%1/%2项</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -137,30 +155,58 @@
     <message>
         <location filename="../src/editorapplication.cpp" line="12"/>
         <source>Text Editor is a powerful tool for viewing and editing text files.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/editorapplication.cpp" line="34"/>
         <source>Text Editor</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MarkdownBridge</name>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="37"/>
+        <source>Collapse code block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="38"/>
+        <source>Expand code block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="39"/>
+        <source>Copy code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="40"/>
+        <source>Expand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="42"/>
+        <source>%1 line(s) of code collapsed</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>PathSettingWgt</name>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="84"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="90"/>
         <source>Remember the last used path</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="85"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="91"/>
         <source>Same path as the current file</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="86"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="92"/>
         <source>Customize the default path</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -168,18 +214,23 @@
     <message>
         <location filename="../src/editorapplication.cpp" line="28"/>
         <source>Text Editor</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="294"/>
-        <location filename="../src/editor/editwrapper.cpp" line="761"/>
-        <location filename="../src/editor/editwrapper.cpp" line="776"/>
-        <location filename="../src/widgets/window.cpp" line="1362"/>
-        <location filename="../src/widgets/window.cpp" line="1390"/>
-        <location filename="../src/widgets/window.cpp" line="1531"/>
-        <location filename="../src/widgets/window.cpp" line="1548"/>
+        <location filename="../src/editor/editwrapper.cpp" line="357"/>
+        <location filename="../src/editor/editwrapper.cpp" line="897"/>
+        <location filename="../src/editor/editwrapper.cpp" line="912"/>
+        <location filename="../src/widgets/window.cpp" line="1528"/>
+        <location filename="../src/widgets/window.cpp" line="1556"/>
+        <location filename="../src/widgets/window.cpp" line="1715"/>
+        <location filename="../src/widgets/window.cpp" line="1732"/>
         <source>Encoding</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="2001"/>
+        <source>视图模式</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="11"/>
@@ -215,7 +266,7 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="18"/>
         <location filename="../src/controls/settingsdialog.cpp" line="96"/>
-        <location filename="../src/widgets/window.cpp" line="2388"/>
+        <location filename="../src/widgets/window.cpp" line="2581"/>
         <source>Window</source>
         <translation>Okno</translation>
     </message>
@@ -242,52 +293,52 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="23"/>
         <source>Next tab</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="24"/>
         <source>Previous tab</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="25"/>
         <source>Close tab</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="26"/>
         <source>Close other tabs</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="27"/>
         <source>Restore tab</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="28"/>
         <source>Open file</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="29"/>
         <source>Increment font size</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="30"/>
         <source>Decrement font size</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="31"/>
         <source>Reset font size</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="32"/>
         <source>Help</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="33"/>
@@ -302,12 +353,12 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="35"/>
         <source>Find Next</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="36"/>
         <source>Find Previous</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="37"/>
@@ -317,17 +368,17 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="38"/>
         <source>Go to line</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="39"/>
         <source>Save cursor position</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="40"/>
         <source>Reset cursor position</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="41"/>
@@ -337,7 +388,7 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="42"/>
         <source>Display shortcuts</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="43"/>
@@ -352,137 +403,137 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="45"/>
         <source>Increase indent</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="46"/>
         <source>Decrease indent</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="47"/>
         <source>Forward character</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="48"/>
         <source>Backward character</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="49"/>
         <source>Forward word</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="50"/>
         <source>Backward word</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="51"/>
         <source>Next line</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="52"/>
         <source>Previous line</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="53"/>
         <source>New line</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="54"/>
         <source>New line above</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="55"/>
         <source>New line below</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="56"/>
         <source>Duplicate line</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="57"/>
         <source>Delete to end of line</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="58"/>
         <source>Delete current line</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="59"/>
         <source>Swap line up</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="60"/>
         <source>Swap line down</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="61"/>
         <source>Scroll up one line</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="62"/>
         <source>Scroll down one line</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="63"/>
         <source>Page up</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="64"/>
         <source>Page down</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="65"/>
         <source>Move to end of line</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="66"/>
         <source>Move to start of line</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="67"/>
         <source>Move to end of text</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="68"/>
         <source>Move to start of text</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="69"/>
         <source>Move to line indentation</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="70"/>
         <source>Upper case</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="71"/>
         <source>Lower case</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="72"/>
@@ -492,22 +543,22 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="73"/>
         <source>Delete backward word</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="74"/>
         <source>Delete forward word</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="75"/>
         <source>Forward over a pair</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="76"/>
         <source>Backward over a pair</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="77"/>
@@ -532,47 +583,47 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="81"/>
         <source>Transpose character</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="82"/>
         <source>Mark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="83"/>
         <source>Unmark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="84"/>
         <source>Copy line</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="85"/>
         <source>Cut line</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="86"/>
         <source>Merge lines</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="87"/>
         <source>Read-Only mode</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="88"/>
         <source>Add comment</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="89"/>
         <source>Remove comment</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="90"/>
@@ -587,17 +638,17 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="92"/>
         <source>Add/Remove bookmark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="93"/>
         <source>Move to previous bookmark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="94"/>
         <source>Move to next bookmark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="95"/>
@@ -607,218 +658,218 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="97"/>
         <source>Window size</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="98"/>
         <source>Tab width</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="99"/>
         <source>Paste by pressing a middle mouse button</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="101"/>
         <source>Startup</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="102"/>
         <source>Reopen last closed tabs</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="104"/>
         <source>Open/Save Settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="106"/>
         <source>Word wrap</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="107"/>
         <source>Code folding flag</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="108"/>
         <source>Show line numbers</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="109"/>
         <source>Show bookmarks icon</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="110"/>
         <source>Show whitespaces and tabs</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="111"/>
         <source>Highlight current line</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="112"/>
         <source>Color mark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="115"/>
         <source>Unicode</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="116"/>
         <source>WesternEuropean</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="117"/>
         <source>CentralEuropean</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="118"/>
         <source>Baltic</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="119"/>
         <source>Cyrillic</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="120"/>
         <source>Arabic</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="125"/>
         <source>Celtic</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="126"/>
         <source>SouthEasternEuropean</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="121"/>
         <source>Greek</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="122"/>
         <source>Hebrew</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="127"/>
         <source>ChineseSimplified</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="128"/>
         <source>ChineseTraditional</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="129"/>
         <source>Japanese</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="130"/>
         <source>Korean</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="124"/>
         <source>Thai</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="123"/>
         <source>Turkish</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="131"/>
         <source>Vietnamese</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/startmanager.cpp" line="971"/>
+        <location filename="../src/startmanager.cpp" line="1035"/>
         <source>File not saved</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1532"/>
-        <location filename="../src/widgets/window.cpp" line="1549"/>
+        <location filename="../src/widgets/window.cpp" line="1716"/>
+        <location filename="../src/widgets/window.cpp" line="1733"/>
         <source>Line Endings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="243"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="379"/>
         <source>Please install &apos;UOS AI&apos; from the App Store before using</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="245"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="381"/>
         <source>No audio input device detected. Please check and try again</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="247"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="383"/>
         <source>No audio output device detected. Please check and try again</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="69"/>
+        <location filename="../src/common/text_file_saver.cpp" line="74"/>
         <source>File path is empty</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="155"/>
+        <location filename="../src/common/text_file_saver.cpp" line="153"/>
         <source>Insufficient memory to load document content</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="177"/>
+        <location filename="../src/common/text_file_saver.cpp" line="178"/>
         <source>Insufficient memory for encoding conversion</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="183"/>
+        <location filename="../src/common/text_file_saver.cpp" line="184"/>
         <source>Encoding conversion failed</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="189"/>
+        <location filename="../src/common/text_file_saver.cpp" line="190"/>
         <source>Converted content is empty</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="207"/>
+        <location filename="../src/common/text_file_saver.cpp" line="208"/>
         <source>Memory allocation failed</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="211"/>
+        <location filename="../src/common/text_file_saver.cpp" line="212"/>
         <source>Error occurred: %1</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="215"/>
+        <location filename="../src/common/text_file_saver.cpp" line="216"/>
         <source>Unknown error occurred</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -829,38 +880,38 @@
         <translation>Hľadať</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="34"/>
+        <location filename="../src/controls/replacebar.cpp" line="36"/>
         <source>Replace With</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="36"/>
+        <location filename="../src/controls/replacebar.cpp" line="40"/>
         <source>Replace</source>
         <translation>Nahradiť</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="37"/>
+        <location filename="../src/controls/replacebar.cpp" line="42"/>
         <source>Skip</source>
         <translation>Preskočiť</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="38"/>
+        <location filename="../src/controls/replacebar.cpp" line="44"/>
         <source>Replace Rest</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="39"/>
+        <location filename="../src/controls/replacebar.cpp" line="46"/>
         <source>Replace All</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>S:</name>
     <message>
         <location filename="../third/libiconv-1.16/src/iconv.c" line="103"/>
-        <source/>
+        <source></source>
         <comment>The first line of the short usage message.</comment>
-        <translation type="unfinished"/>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -868,22 +919,22 @@
     <message>
         <location filename="../src/common/settings.cpp" line="141"/>
         <source>Standard</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/common/settings.cpp" line="141"/>
         <source>Customize</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/common/settings.cpp" line="154"/>
         <source>Normal</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/common/settings.cpp" line="154"/>
         <source>Maximum</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/common/settings.cpp" line="154"/>
@@ -891,339 +942,356 @@
         <translation>Na celú obrazovku</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="484"/>
+        <location filename="../src/common/settings.cpp" line="491"/>
         <source>This shortcut conflicts with system shortcut %1</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="487"/>
+        <location filename="../src/common/settings.cpp" line="494"/>
         <source>This shortcut conflicts with %1, click on Replace to make this shortcut effective immediately</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="682"/>
-        <location filename="../src/common/settings.cpp" line="695"/>
-        <location filename="../src/common/settings.cpp" line="704"/>
+        <location filename="../src/common/settings.cpp" line="689"/>
+        <location filename="../src/common/settings.cpp" line="702"/>
+        <location filename="../src/common/settings.cpp" line="711"/>
         <source>The shortcut %1 is invalid, please set another one.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="736"/>
+        <location filename="../src/common/settings.cpp" line="743"/>
         <source>Cancel</source>
         <translation>Zrušiť</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="737"/>
+        <location filename="../src/common/settings.cpp" line="744"/>
         <source>Replace</source>
         <translation>Nahradiť</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="740"/>
+        <location filename="../src/common/settings.cpp" line="747"/>
         <source>OK</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>StartManager</name>
     <message>
-        <location filename="../src/startmanager.cpp" line="411"/>
+        <location filename="../src/startmanager.cpp" line="425"/>
         <source>Untitled %1</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>Tabbar</name>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="641"/>
+        <location filename="../src/controls/tabbar.cpp" line="678"/>
         <source>Close tab</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="642"/>
+        <location filename="../src/controls/tabbar.cpp" line="680"/>
         <source>Close other tabs</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="643"/>
+        <location filename="../src/controls/tabbar.cpp" line="682"/>
         <source>More options</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="644"/>
+        <location filename="../src/controls/tabbar.cpp" line="684"/>
         <source>Close tabs to the left</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="645"/>
+        <location filename="../src/controls/tabbar.cpp" line="686"/>
         <source>Close tabs to the right</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="646"/>
+        <location filename="../src/controls/tabbar.cpp" line="688"/>
         <source>Close unmodified tabs</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>TextEdit</name>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="305"/>
+        <location filename="../src/editor/dtextedit.cpp" line="388"/>
         <source>Undo</source>
         <translation>O krok späť</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="306"/>
+        <location filename="../src/editor/dtextedit.cpp" line="390"/>
         <source>Redo</source>
         <translation>O krok vpred</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="307"/>
+        <location filename="../src/editor/dtextedit.cpp" line="392"/>
         <source>Cut</source>
         <translation>Vystrihnúť</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="308"/>
+        <location filename="../src/editor/dtextedit.cpp" line="394"/>
         <source>Copy</source>
         <translation>Kopírovať</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="309"/>
+        <location filename="../src/editor/dtextedit.cpp" line="396"/>
         <source>Paste</source>
         <translation>Vložiť</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="310"/>
+        <location filename="../src/editor/dtextedit.cpp" line="398"/>
         <source>Delete</source>
         <translation>Zmazať</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="311"/>
+        <location filename="../src/editor/dtextedit.cpp" line="400"/>
         <source>Select All</source>
         <translation>Vybrať všetko</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="312"/>
-        <location filename="../src/widgets/window.cpp" line="535"/>
+        <location filename="../src/editor/dtextedit.cpp" line="402"/>
+        <location filename="../src/widgets/window.cpp" line="556"/>
         <source>Find</source>
         <translation>Hľadať</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="313"/>
-        <location filename="../src/widgets/window.cpp" line="536"/>
+        <location filename="../src/editor/dtextedit.cpp" line="404"/>
+        <location filename="../src/widgets/window.cpp" line="558"/>
         <source>Replace</source>
         <translation>Nahradiť</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="314"/>
+        <location filename="../src/editor/dtextedit.cpp" line="406"/>
         <source>Go to Line</source>
         <translation>Ísť na riadok</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="315"/>
-        <source>Turn on Read-Only mode</source>
-        <translation>Zapnúť chránený mód</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="316"/>
-        <source>Turn off Read-Only mode</source>
-        <translation>Vypnúť chránený mód</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="317"/>
+        <location filename="../src/editor/dtextedit.cpp" line="415"/>
         <source>Fullscreen</source>
         <translation>Na celú obrazovku</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="318"/>
+        <location filename="../src/editor/dtextedit.cpp" line="417"/>
         <source>Exit fullscreen</source>
         <translation>Vypnúť mód na celú obrazovku</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="319"/>
+        <location filename="../src/editor/dtextedit.cpp" line="419"/>
         <source>Display in file manager</source>
         <translation>Zobraziť v zložke</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="320"/>
-        <location filename="../src/editor/dtextedit.cpp" line="374"/>
+        <location filename="../src/editor/dtextedit.cpp" line="421"/>
+        <location filename="../src/editor/dtextedit.cpp" line="493"/>
         <source>Add Comment</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="321"/>
+        <location filename="../src/editor/dtextedit.cpp" line="423"/>
         <source>Text to Speech</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="322"/>
-        <source>Stop reading</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="323"/>
+        <location filename="../src/editor/dtextedit.cpp" line="425"/>
         <source>Speech to Text</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="324"/>
+        <location filename="../src/editor/dtextedit.cpp" line="427"/>
         <source>Translate</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="325"/>
+        <location filename="../src/editor/dtextedit.cpp" line="429"/>
         <source>Column Mode</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="326"/>
+        <location filename="../src/editor/dtextedit.cpp" line="431"/>
         <source>Add bookmark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="327"/>
+        <location filename="../src/editor/dtextedit.cpp" line="433"/>
         <source>Remove Bookmark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="328"/>
+        <location filename="../src/editor/dtextedit.cpp" line="435"/>
         <source>Previous bookmark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="329"/>
+        <location filename="../src/editor/dtextedit.cpp" line="437"/>
         <source>Next bookmark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="330"/>
+        <location filename="../src/editor/dtextedit.cpp" line="439"/>
         <source>Remove All Bookmarks</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="331"/>
+        <location filename="../src/editor/dtextedit.cpp" line="441"/>
         <source>Fold All</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="332"/>
+        <location filename="../src/editor/dtextedit.cpp" line="443"/>
         <source>Fold Current Level</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="333"/>
+        <location filename="../src/editor/dtextedit.cpp" line="445"/>
         <source>Unfold All</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="334"/>
+        <location filename="../src/editor/dtextedit.cpp" line="447"/>
         <source>Unfold Current Level</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="339"/>
+        <location filename="../src/editor/dtextedit.cpp" line="453"/>
         <source>Color Mark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="343"/>
+        <location filename="../src/editor/dtextedit.cpp" line="458"/>
         <source>Clear All Marks</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="344"/>
+        <location filename="../src/editor/dtextedit.cpp" line="460"/>
         <source>Clear Last Mark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="353"/>
+        <location filename="../src/editor/dtextedit.cpp" line="470"/>
         <source>Mark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="366"/>
+        <location filename="../src/editor/dtextedit.cpp" line="484"/>
         <source>Mark All</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="375"/>
+        <location filename="../src/editor/dtextedit.cpp" line="494"/>
         <source>Remove Comment</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3208"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3211"/>
+        <location filename="../src/editor/dtextedit.cpp" line="543"/>
+        <source>View Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="3531"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3534"/>
         <source>Copy failed: not enough memory</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3333"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3335"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3656"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3658"/>
         <source>Press ALT and click lines to edit in column mode</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="418"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9574"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9576"/>
+        <source>No audio output device was detected. Please ensure your speakers or headphones are properly connected and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="9583"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9585"/>
+        <source>No audio input device was detected. Please ensure your speakers or headphones are properly connected and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="534"/>
         <source>Change Case</source>
         <translation>Zmeniť veľkosť</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="419"/>
+        <location filename="../src/editor/dtextedit.cpp" line="409"/>
+        <source>Edit Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="411"/>
+        <source>Read View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="413"/>
+        <source>Live Preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="535"/>
         <source>Upper Case</source>
         <translation>Veľké písmo</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="420"/>
+        <location filename="../src/editor/dtextedit.cpp" line="536"/>
         <source>Lower Case</source>
         <translation>Malé písmo</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="421"/>
+        <location filename="../src/editor/dtextedit.cpp" line="537"/>
         <source>Capitalize</source>
         <translation>Kapitálky</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="78"/>
+        <location filename="../src/widgets/bottombar.cpp" line="110"/>
         <source>None</source>
         <translation>Nič</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1363"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1490"/>
         <source>Selected line(s) copied</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1370"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1497"/>
         <source>Current line copied</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1400"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1527"/>
         <source>Selected line(s) clipped</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1412"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1539"/>
         <source>Current line clipped</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3227"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3230"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3550"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3553"/>
         <source>Paste failed: not enough memory</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="4548"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4873"/>
         <source>Read-Only mode is off</source>
         <translation>Mód iba-čítanie je vypnutý</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="4560"/>
-        <location filename="../src/editor/dtextedit.cpp" line="4584"/>
-        <location filename="../src/editor/dtextedit.cpp" line="7896"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8007"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8015"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8026"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4885"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4909"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8236"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8347"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8355"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8366"/>
         <source>Read-Only mode is on</source>
         <translation>Mód iba-čítanie je zapnutý</translation>
     </message>
@@ -1231,140 +1299,177 @@
 <context>
     <name>WarningNotices</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="24"/>
+        <location filename="../src/controls/warningnotices.cpp" line="25"/>
         <source>Reload</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/controls/warningnotices.cpp" line="29"/>
+        <source>Edit Anyway</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>Window</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="25"/>
-        <location filename="../src/widgets/window.cpp" line="531"/>
+        <location filename="../src/controls/warningnotices.cpp" line="27"/>
+        <location filename="../src/widgets/window.cpp" line="548"/>
         <source>Save as</source>
         <translation>Uložiť ako</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="527"/>
+        <location filename="../src/widgets/window.cpp" line="540"/>
         <source>New window</source>
         <translation>Nové okno</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="528"/>
+        <location filename="../src/widgets/window.cpp" line="542"/>
         <source>New tab</source>
         <translation>Nový tab</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="529"/>
+        <location filename="../src/widgets/window.cpp" line="544"/>
         <source>Open file</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="530"/>
-        <location filename="../src/widgets/window.cpp" line="3545"/>
+        <location filename="../src/widgets/window.cpp" line="546"/>
+        <location filename="../src/widgets/window.cpp" line="3950"/>
         <source>Save</source>
         <translation>Uložiť</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="532"/>
+        <location filename="../src/widgets/window.cpp" line="550"/>
         <source>Print</source>
         <translation>Tlač</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="533"/>
+        <location filename="../src/widgets/window.cpp" line="552"/>
         <source>Switch theme</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="534"/>
-        <location filename="../src/widgets/window.cpp" line="2448"/>
+        <location filename="../src/widgets/window.cpp" line="554"/>
+        <location filename="../src/widgets/window.cpp" line="2641"/>
         <source>Settings</source>
         <translation>Nastavenia</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="666"/>
-        <location filename="../src/widgets/window.cpp" line="3845"/>
+        <location filename="../src/widgets/window.cpp" line="696"/>
+        <location filename="../src/widgets/window.cpp" line="4250"/>
         <source>Read-Only</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="687"/>
+        <location filename="../src/widgets/window.cpp" line="719"/>
         <source>You do not have permission to open %1</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="738"/>
-        <location filename="../src/widgets/window.cpp" line="2963"/>
+        <location filename="../src/widgets/window.cpp" line="773"/>
+        <location filename="../src/widgets/window.cpp" line="3266"/>
         <source>Invalid file: %1</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="903"/>
-        <location filename="../src/widgets/window.cpp" line="956"/>
+        <location filename="../src/widgets/window.cpp" line="957"/>
+        <location filename="../src/widgets/window.cpp" line="1050"/>
+        <location filename="../src/widgets/window.cpp" line="3217"/>
         <source>Do you want to save this file?</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1290"/>
+        <location filename="../src/widgets/window.cpp" line="1381"/>
+        <source>Invalid characters detected while saving &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1382"/>
+        <source>If you force save this file, it may cause file corruption. Still want to save?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1386"/>
+        <source>Don&apos;t Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1387"/>
+        <source>Save As</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1388"/>
+        <source>Save Anyway</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1456"/>
         <source>You do not have permission to save %1</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1312"/>
+        <location filename="../src/widgets/window.cpp" line="1428"/>
+        <location filename="../src/widgets/window.cpp" line="1478"/>
         <source>Saved successfully</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1354"/>
-        <location filename="../src/widgets/window.cpp" line="1481"/>
-        <location filename="../src/widgets/window.cpp" line="1529"/>
+        <location filename="../src/widgets/window.cpp" line="1520"/>
+        <location filename="../src/widgets/window.cpp" line="1665"/>
+        <location filename="../src/widgets/window.cpp" line="1713"/>
         <source>Save File</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1483"/>
+        <location filename="../src/widgets/window.cpp" line="1569"/>
+        <source>Cannot save as the original file in preview mode. Please choose a different path.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1667"/>
         <source>Encoding</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1773"/>
+        <location filename="../src/widgets/window.cpp" line="1957"/>
         <source>Read-Only mode is on</source>
         <translation>Mód iba-čítanie je zapnutý</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2322"/>
+        <location filename="../src/widgets/window.cpp" line="2511"/>
         <source>Current location remembered</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2398"/>
+        <location filename="../src/widgets/window.cpp" line="2591"/>
         <source>Ctrl+&apos;=&apos;</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2401"/>
+        <location filename="../src/widgets/window.cpp" line="2594"/>
         <source>Ctrl+&apos;-&apos;</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2430"/>
+        <location filename="../src/widgets/window.cpp" line="2623"/>
         <source>Editor</source>
         <translation>Editor</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3061"/>
+        <location filename="../src/widgets/window.cpp" line="3436"/>
         <source>Untitled %1</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3543"/>
+        <location filename="../src/widgets/window.cpp" line="3948"/>
         <source>Cancel</source>
         <translation>Zrušiť</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3544"/>
+        <location filename="../src/widgets/window.cpp" line="3949"/>
         <source>Discard</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/deepin-editor_sl.ts
+++ b/translations/deepin-editor_sl.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="sl">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="sl">
 <context>
     <name>BottomBar</name>
     <message>
@@ -17,17 +19,36 @@
         <translation>Znakov %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="44"/>
+        <location filename="../src/widgets/bottombar.cpp" line="47"/>
         <source>Loading:</source>
         <translation>Naloženje:</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="73"/>
+        <location filename="../src/widgets/bottombar.cpp" line="91"/>
+        <location filename="../src/widgets/bottombar.cpp" line="499"/>
+        <source>Edit Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="74"/>
+        <location filename="../src/widgets/bottombar.cpp" line="489"/>
+        <source>Read View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="75"/>
+        <location filename="../src/widgets/bottombar.cpp" line="493"/>
+        <source>Live Preview</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DDropdownMenu</name>
     <message>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="362"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="420"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="425"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="363"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="421"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="426"/>
         <source>None</source>
         <translation>brez</translation>
     </message>
@@ -35,68 +56,57 @@
 <context>
     <name>EditWrapper</name>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="292"/>
-        <location filename="../src/editor/editwrapper.cpp" line="365"/>
-        <location filename="../src/editor/editwrapper.cpp" line="521"/>
-        <location filename="../src/editor/editwrapper.cpp" line="751"/>
+        <location filename="../src/editor/editwrapper.cpp" line="355"/>
+        <location filename="../src/editor/editwrapper.cpp" line="429"/>
+        <location filename="../src/editor/editwrapper.cpp" line="595"/>
+        <location filename="../src/editor/editwrapper.cpp" line="887"/>
         <source>Save</source>
         <translation>Shrani</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="516"/>
+        <location filename="../src/editor/editwrapper.cpp" line="590"/>
         <source>Do you want to save this file?</source>
         <translation>Bi radi shranili to datoteko?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="363"/>
-        <location filename="../src/editor/editwrapper.cpp" line="519"/>
+        <location filename="../src/editor/editwrapper.cpp" line="427"/>
+        <location filename="../src/editor/editwrapper.cpp" line="593"/>
         <source>Cancel</source>
         <translation>Prekini</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="360"/>
+        <location filename="../src/editor/editwrapper.cpp" line="424"/>
         <source>Encoding changed. Do you want to save the file now?</source>
         <translation>Kodiranje je bilo spremenjeno. Želite sedaj shraniti to datoteko?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="520"/>
+        <location filename="../src/editor/editwrapper.cpp" line="594"/>
         <source>Discard</source>
         <translation>Opusti</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="274"/>
-        <location filename="../src/editor/editwrapper.cpp" line="620"/>
+        <location filename="../src/editor/editwrapper.cpp" line="1121"/>
+        <source>The file contains invalid characters (NUL). Preview mode is read-only.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="337"/>
+        <location filename="../src/editor/editwrapper.cpp" line="705"/>
         <source>You do not have permission to save %1</source>
         <translation>Nimate pravic za shranjevanje %1</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="836"/>
+        <location filename="../src/editor/editwrapper.cpp" line="987"/>
         <source>File removed on the disk. Save it now?</source>
         <translation>Datoteka je bila odstranjena z diska. Shranim sedaj?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="842"/>
+        <location filename="../src/editor/editwrapper.cpp" line="993"/>
         <source>File has changed on disk. Reload?</source>
         <translation>Datoteka je bila spremenjena na disku. Ponovno naložim?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="884"/>
-        <location filename="../src/widgets/bottombar.cpp" line="74"/>
-        <source>INSERT</source>
-        <translation>VSTAVI</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="888"/>
-        <source>OVERWRITE</source>
-        <translation>PREPIŠI</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="892"/>
-        <source>R/O</source>
-        <translation>S/B</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="1618"/>
+        <location filename="../src/editor/editwrapper.cpp" line="1806"/>
         <source>The file cannot be read, which may be too large or has been damaged!</source>
         <translation>Datoteka se ne može prečitati, možda je prevelika ili je poškodjena!</translation>
     </message>
@@ -109,17 +119,17 @@
         <translation>Najdi</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="36"/>
+        <location filename="../src/controls/findbar.cpp" line="38"/>
         <source>Previous</source>
         <translation>Nazaj</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="37"/>
+        <location filename="../src/controls/findbar.cpp" line="40"/>
         <source>Next</source>
         <translation>Naprej</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="38"/>
+        <location filename="../src/controls/findbar.cpp" line="42"/>
         <source>Replace</source>
         <translation>Zamenjaj</translation>
     </message>
@@ -127,9 +137,17 @@
 <context>
     <name>JumpLineBar</name>
     <message>
-        <location filename="../src/controls/jumplinebar.cpp" line="45"/>
+        <location filename="../src/controls/jumplinebar.cpp" line="46"/>
         <source>Go to Line: </source>
         <translation>Skok na vrstico:</translation>
+    </message>
+</context>
+<context>
+    <name>LineBar</name>
+    <message>
+        <location filename="../src/controls/linebar.cpp" line="144"/>
+        <source>第%1/%2项</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -146,19 +164,47 @@
     </message>
 </context>
 <context>
+    <name>MarkdownBridge</name>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="37"/>
+        <source>Collapse code block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="38"/>
+        <source>Expand code block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="39"/>
+        <source>Copy code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="40"/>
+        <source>Expand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="42"/>
+        <source>%1 line(s) of code collapsed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PathSettingWgt</name>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="84"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="90"/>
         <source>Remember the last used path</source>
         <translation>Zapomni zadnji upotavljeni put</translation>
     </message>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="85"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="91"/>
         <source>Same path as the current file</source>
         <translation>Isti put kao trenutna datoteka</translation>
     </message>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="86"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="92"/>
         <source>Customize the default path</source>
         <translation>Prilagodi zadani put</translation>
     </message>
@@ -171,15 +217,20 @@
         <translation>Urejevalnik besedil</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="294"/>
-        <location filename="../src/editor/editwrapper.cpp" line="761"/>
-        <location filename="../src/editor/editwrapper.cpp" line="776"/>
-        <location filename="../src/widgets/window.cpp" line="1362"/>
-        <location filename="../src/widgets/window.cpp" line="1390"/>
-        <location filename="../src/widgets/window.cpp" line="1531"/>
-        <location filename="../src/widgets/window.cpp" line="1548"/>
+        <location filename="../src/editor/editwrapper.cpp" line="357"/>
+        <location filename="../src/editor/editwrapper.cpp" line="897"/>
+        <location filename="../src/editor/editwrapper.cpp" line="912"/>
+        <location filename="../src/widgets/window.cpp" line="1528"/>
+        <location filename="../src/widgets/window.cpp" line="1556"/>
+        <location filename="../src/widgets/window.cpp" line="1715"/>
+        <location filename="../src/widgets/window.cpp" line="1732"/>
         <source>Encoding</source>
         <translation>Kodiranje</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="2001"/>
+        <source>视图模式</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="11"/>
@@ -215,7 +266,7 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="18"/>
         <location filename="../src/controls/settingsdialog.cpp" line="96"/>
-        <location filename="../src/widgets/window.cpp" line="2388"/>
+        <location filename="../src/widgets/window.cpp" line="2581"/>
         <source>Window</source>
         <translation>Okno</translation>
     </message>
@@ -755,68 +806,68 @@
         <translation>Vietnamsko</translation>
     </message>
     <message>
-        <location filename="../src/startmanager.cpp" line="971"/>
+        <location filename="../src/startmanager.cpp" line="1035"/>
         <source>File not saved</source>
         <translation>Datoteka ni bila shranjena</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1532"/>
-        <location filename="../src/widgets/window.cpp" line="1549"/>
+        <location filename="../src/widgets/window.cpp" line="1716"/>
+        <location filename="../src/widgets/window.cpp" line="1733"/>
         <source>Line Endings</source>
         <translation>Zaključki vrstic</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="243"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="379"/>
         <source>Please install &apos;UOS AI&apos; from the App Store before using</source>
         <translation>Molimo vas instalirajte &apos;UOS AI&apos; iz App Store pre upotrebe</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="245"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="381"/>
         <source>No audio input device detected. Please check and try again</source>
         <translation>Nije pronađen audio ulazni uređaj. Molimo vas proverite i pokušajte ponovo</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="247"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="383"/>
         <source>No audio output device detected. Please check and try again</source>
         <translation>Nije pronađen audio izlazni uređaj. Molimo vas proverite i pokušajte ponovo</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="69"/>
+        <location filename="../src/common/text_file_saver.cpp" line="74"/>
         <source>File path is empty</source>
         <translation>Put do datoteke je prazan</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="155"/>
+        <location filename="../src/common/text_file_saver.cpp" line="153"/>
         <source>Insufficient memory to load document content</source>
         <translation>Nedovoljno memorije za učitavanje sadržaja dokumenta</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="177"/>
+        <location filename="../src/common/text_file_saver.cpp" line="178"/>
         <source>Insufficient memory for encoding conversion</source>
         <translation>Nedovoljno memorije za konverziju kodiranja</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="183"/>
+        <location filename="../src/common/text_file_saver.cpp" line="184"/>
         <source>Encoding conversion failed</source>
         <translation>Konverzija kodiranja je neuspješna</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="189"/>
+        <location filename="../src/common/text_file_saver.cpp" line="190"/>
         <source>Converted content is empty</source>
         <translation>Konvertovani sadržaj je prazan</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="207"/>
+        <location filename="../src/common/text_file_saver.cpp" line="208"/>
         <source>Memory allocation failed</source>
         <translation>Dodela memorije je neuspješna</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="211"/>
+        <location filename="../src/common/text_file_saver.cpp" line="212"/>
         <source>Error occurred: %1</source>
         <translation>&apos;Greška je došla: %1&apos;</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="215"/>
+        <location filename="../src/common/text_file_saver.cpp" line="216"/>
         <source>Unknown error occurred</source>
         <translation>Nepoznata greška je došla</translation>
     </message>
@@ -829,27 +880,27 @@
         <translation>Najdi</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="34"/>
+        <location filename="../src/controls/replacebar.cpp" line="36"/>
         <source>Replace With</source>
         <translation>Zamenjaj z</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="36"/>
+        <location filename="../src/controls/replacebar.cpp" line="40"/>
         <source>Replace</source>
         <translation>Zamenjaj</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="37"/>
+        <location filename="../src/controls/replacebar.cpp" line="42"/>
         <source>Skip</source>
         <translation>Preskoči</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="38"/>
+        <location filename="../src/controls/replacebar.cpp" line="44"/>
         <source>Replace Rest</source>
         <translation>Zamenjaj ostalo</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="39"/>
+        <location filename="../src/controls/replacebar.cpp" line="46"/>
         <source>Replace All</source>
         <translation>Zamenjaj vse</translation>
     </message>
@@ -858,9 +909,9 @@
     <name>S:</name>
     <message>
         <location filename="../third/libiconv-1.16/src/iconv.c" line="103"/>
-        <source/>
+        <source></source>
         <comment>The first line of the short usage message.</comment>
-        <translation type="unfinished"/>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -891,34 +942,34 @@
         <translation>Celozaslonsko</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="484"/>
+        <location filename="../src/common/settings.cpp" line="491"/>
         <source>This shortcut conflicts with system shortcut %1</source>
         <translation>Ta bljižnica je enaka sistemski bližnjici %1</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="487"/>
+        <location filename="../src/common/settings.cpp" line="494"/>
         <source>This shortcut conflicts with %1, click on Replace to make this shortcut effective immediately</source>
         <translation>Ta bližnjica je enaka kot %1. Kliknite na Zamenjaj, da jo nemudoma vklopite</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="682"/>
-        <location filename="../src/common/settings.cpp" line="695"/>
-        <location filename="../src/common/settings.cpp" line="704"/>
+        <location filename="../src/common/settings.cpp" line="689"/>
+        <location filename="../src/common/settings.cpp" line="702"/>
+        <location filename="../src/common/settings.cpp" line="711"/>
         <source>The shortcut %1 is invalid, please set another one.</source>
         <translation>Bližnjica %1 ni veljavna. Določite drugo.</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="736"/>
+        <location filename="../src/common/settings.cpp" line="743"/>
         <source>Cancel</source>
         <translation>Prekini</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="737"/>
+        <location filename="../src/common/settings.cpp" line="744"/>
         <source>Replace</source>
         <translation>Zamenjaj</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="740"/>
+        <location filename="../src/common/settings.cpp" line="747"/>
         <source>OK</source>
         <translation>V redu</translation>
     </message>
@@ -926,7 +977,7 @@
 <context>
     <name>StartManager</name>
     <message>
-        <location filename="../src/startmanager.cpp" line="411"/>
+        <location filename="../src/startmanager.cpp" line="425"/>
         <source>Untitled %1</source>
         <translation>Neimenovano %1</translation>
     </message>
@@ -934,32 +985,32 @@
 <context>
     <name>Tabbar</name>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="641"/>
+        <location filename="../src/controls/tabbar.cpp" line="678"/>
         <source>Close tab</source>
         <translation>Zapri zavihek</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="642"/>
+        <location filename="../src/controls/tabbar.cpp" line="680"/>
         <source>Close other tabs</source>
         <translation>Zapri ostale zavihke</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="643"/>
+        <location filename="../src/controls/tabbar.cpp" line="682"/>
         <source>More options</source>
         <translation>Več možnosti</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="644"/>
+        <location filename="../src/controls/tabbar.cpp" line="684"/>
         <source>Close tabs to the left</source>
         <translation>Zapri zavihke na levi</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="645"/>
+        <location filename="../src/controls/tabbar.cpp" line="686"/>
         <source>Close tabs to the right</source>
         <translation>Zapri zavihke na desni</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="646"/>
+        <location filename="../src/controls/tabbar.cpp" line="688"/>
         <source>Close unmodified tabs</source>
         <translation>Zapri nespremenjene zavihke</translation>
     </message>
@@ -967,263 +1018,280 @@
 <context>
     <name>TextEdit</name>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="305"/>
+        <location filename="../src/editor/dtextedit.cpp" line="388"/>
         <source>Undo</source>
         <translation>razveljavi</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="306"/>
+        <location filename="../src/editor/dtextedit.cpp" line="390"/>
         <source>Redo</source>
         <translation>Uveljavi</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="307"/>
+        <location filename="../src/editor/dtextedit.cpp" line="392"/>
         <source>Cut</source>
         <translation>Izreži</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="308"/>
+        <location filename="../src/editor/dtextedit.cpp" line="394"/>
         <source>Copy</source>
         <translation>Kopiraj</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="309"/>
+        <location filename="../src/editor/dtextedit.cpp" line="396"/>
         <source>Paste</source>
         <translation>Prilepi</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="310"/>
+        <location filename="../src/editor/dtextedit.cpp" line="398"/>
         <source>Delete</source>
         <translation>Izbriši</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="311"/>
+        <location filename="../src/editor/dtextedit.cpp" line="400"/>
         <source>Select All</source>
         <translation>Označi vse</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="312"/>
-        <location filename="../src/widgets/window.cpp" line="535"/>
+        <location filename="../src/editor/dtextedit.cpp" line="402"/>
+        <location filename="../src/widgets/window.cpp" line="556"/>
         <source>Find</source>
         <translation>Najdi</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="313"/>
-        <location filename="../src/widgets/window.cpp" line="536"/>
+        <location filename="../src/editor/dtextedit.cpp" line="404"/>
+        <location filename="../src/widgets/window.cpp" line="558"/>
         <source>Replace</source>
         <translation>Zamenjaj</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="314"/>
+        <location filename="../src/editor/dtextedit.cpp" line="406"/>
         <source>Go to Line</source>
         <translation>Skok na vrstico</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="315"/>
-        <source>Turn on Read-Only mode</source>
-        <translation>Vklopi samo branje</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="316"/>
-        <source>Turn off Read-Only mode</source>
-        <translation>Izklopi samo branje</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="317"/>
+        <location filename="../src/editor/dtextedit.cpp" line="415"/>
         <source>Fullscreen</source>
         <translation>Celozaslonsko</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="318"/>
+        <location filename="../src/editor/dtextedit.cpp" line="417"/>
         <source>Exit fullscreen</source>
         <translation>Zapri celozaslonski način</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="319"/>
+        <location filename="../src/editor/dtextedit.cpp" line="419"/>
         <source>Display in file manager</source>
         <translation>Prikaži v upravljalniku datotek</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="320"/>
-        <location filename="../src/editor/dtextedit.cpp" line="374"/>
+        <location filename="../src/editor/dtextedit.cpp" line="421"/>
+        <location filename="../src/editor/dtextedit.cpp" line="493"/>
         <source>Add Comment</source>
         <translation>Dodaj komentar</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="321"/>
+        <location filename="../src/editor/dtextedit.cpp" line="423"/>
         <source>Text to Speech</source>
         <translation>Besedilo v govor</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="322"/>
-        <source>Stop reading</source>
-        <translation>Zaustavi branje</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="323"/>
+        <location filename="../src/editor/dtextedit.cpp" line="425"/>
         <source>Speech to Text</source>
         <translation>Govor v besedilo</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="324"/>
+        <location filename="../src/editor/dtextedit.cpp" line="427"/>
         <source>Translate</source>
         <translation>Prevedi</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="325"/>
+        <location filename="../src/editor/dtextedit.cpp" line="429"/>
         <source>Column Mode</source>
         <translation>Stolpčni način</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="326"/>
+        <location filename="../src/editor/dtextedit.cpp" line="431"/>
         <source>Add bookmark</source>
         <translation>Dodaj zaznamek</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="327"/>
+        <location filename="../src/editor/dtextedit.cpp" line="433"/>
         <source>Remove Bookmark</source>
         <translation>Odstrani zaznamek</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="328"/>
+        <location filename="../src/editor/dtextedit.cpp" line="435"/>
         <source>Previous bookmark</source>
         <translation>Prejšnji zaznamek</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="329"/>
+        <location filename="../src/editor/dtextedit.cpp" line="437"/>
         <source>Next bookmark</source>
         <translation>Naslednji zaznamek</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="330"/>
+        <location filename="../src/editor/dtextedit.cpp" line="439"/>
         <source>Remove All Bookmarks</source>
         <translation>Odstrani vse zaznamke</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="331"/>
+        <location filename="../src/editor/dtextedit.cpp" line="441"/>
         <source>Fold All</source>
         <translation>Zloži vse</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="332"/>
+        <location filename="../src/editor/dtextedit.cpp" line="443"/>
         <source>Fold Current Level</source>
         <translation>Zloži trenutni nivo</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="333"/>
+        <location filename="../src/editor/dtextedit.cpp" line="445"/>
         <source>Unfold All</source>
         <translation>Razpri vse</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="334"/>
+        <location filename="../src/editor/dtextedit.cpp" line="447"/>
         <source>Unfold Current Level</source>
         <translation>Razpri trenutni nivo</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="339"/>
+        <location filename="../src/editor/dtextedit.cpp" line="453"/>
         <source>Color Mark</source>
         <translation>Barvna oznaka</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="343"/>
+        <location filename="../src/editor/dtextedit.cpp" line="458"/>
         <source>Clear All Marks</source>
         <translation>Odstrani vse oznake</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="344"/>
+        <location filename="../src/editor/dtextedit.cpp" line="460"/>
         <source>Clear Last Mark</source>
         <translation>Odstrani zadnjo oznako</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="353"/>
+        <location filename="../src/editor/dtextedit.cpp" line="470"/>
         <source>Mark</source>
         <translation>Označi</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="366"/>
+        <location filename="../src/editor/dtextedit.cpp" line="484"/>
         <source>Mark All</source>
         <translation>Označi vse</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="375"/>
+        <location filename="../src/editor/dtextedit.cpp" line="494"/>
         <source>Remove Comment</source>
         <translation>Odstrani komentar</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3208"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3211"/>
+        <location filename="../src/editor/dtextedit.cpp" line="543"/>
+        <source>View Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="3531"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3534"/>
         <source>Copy failed: not enough memory</source>
         <translation>Kopiranje ni uspelo: ni dovolj pomnilnika</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3333"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3335"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3656"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3658"/>
         <source>Press ALT and click lines to edit in column mode</source>
         <translation>Pritisnite ALT in kliknite na vrstice za urejanje v stolpcu</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="418"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9574"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9576"/>
+        <source>No audio output device was detected. Please ensure your speakers or headphones are properly connected and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="9583"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9585"/>
+        <source>No audio input device was detected. Please ensure your speakers or headphones are properly connected and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="534"/>
         <source>Change Case</source>
         <translation>Spremeni velikost črk</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="419"/>
+        <location filename="../src/editor/dtextedit.cpp" line="409"/>
+        <source>Edit Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="411"/>
+        <source>Read View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="413"/>
+        <source>Live Preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="535"/>
         <source>Upper Case</source>
         <translation>Velike črke</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="420"/>
+        <location filename="../src/editor/dtextedit.cpp" line="536"/>
         <source>Lower Case</source>
         <translation>Male črke</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="421"/>
+        <location filename="../src/editor/dtextedit.cpp" line="537"/>
         <source>Capitalize</source>
         <translation>Velika začetnica</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="78"/>
+        <location filename="../src/widgets/bottombar.cpp" line="110"/>
         <source>None</source>
         <translation>brez</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1363"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1490"/>
         <source>Selected line(s) copied</source>
         <translation>Izbrane vrstice so bile kopirane</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1370"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1497"/>
         <source>Current line copied</source>
         <translation>Trenutna vrstica je bila skopirana</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1400"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1527"/>
         <source>Selected line(s) clipped</source>
         <translation>Izbrane vrstice so bile porezane</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1412"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1539"/>
         <source>Current line clipped</source>
         <translation>Trenutna vrstica je bila porezana</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3227"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3230"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3550"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3553"/>
         <source>Paste failed: not enough memory</source>
         <translation>Kopiranje ni uspelo: ni dovolj pomnilnika</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="4548"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4873"/>
         <source>Read-Only mode is off</source>
         <translation>Samo branje je izklopljeno</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="4560"/>
-        <location filename="../src/editor/dtextedit.cpp" line="4584"/>
-        <location filename="../src/editor/dtextedit.cpp" line="7896"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8007"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8015"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8026"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4885"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4909"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8236"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8347"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8355"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8366"/>
         <source>Read-Only mode is on</source>
         <translation>Vklopljeno je samo branje</translation>
     </message>
@@ -1231,138 +1299,175 @@
 <context>
     <name>WarningNotices</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="24"/>
+        <location filename="../src/controls/warningnotices.cpp" line="25"/>
         <source>Reload</source>
         <translation>Ponovno naloži</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/warningnotices.cpp" line="29"/>
+        <source>Edit Anyway</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>Window</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="25"/>
-        <location filename="../src/widgets/window.cpp" line="531"/>
+        <location filename="../src/controls/warningnotices.cpp" line="27"/>
+        <location filename="../src/widgets/window.cpp" line="548"/>
         <source>Save as</source>
         <translation>Shrani kot</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="527"/>
+        <location filename="../src/widgets/window.cpp" line="540"/>
         <source>New window</source>
         <translation>Novo okno</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="528"/>
+        <location filename="../src/widgets/window.cpp" line="542"/>
         <source>New tab</source>
         <translation>Nov zavihek</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="529"/>
+        <location filename="../src/widgets/window.cpp" line="544"/>
         <source>Open file</source>
         <translation>Odpir datoteko</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="530"/>
-        <location filename="../src/widgets/window.cpp" line="3545"/>
+        <location filename="../src/widgets/window.cpp" line="546"/>
+        <location filename="../src/widgets/window.cpp" line="3950"/>
         <source>Save</source>
         <translation>Shrani</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="532"/>
+        <location filename="../src/widgets/window.cpp" line="550"/>
         <source>Print</source>
         <translation>Tiskanje</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="533"/>
+        <location filename="../src/widgets/window.cpp" line="552"/>
         <source>Switch theme</source>
         <translation>Zamenjaj temo</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="534"/>
-        <location filename="../src/widgets/window.cpp" line="2448"/>
+        <location filename="../src/widgets/window.cpp" line="554"/>
+        <location filename="../src/widgets/window.cpp" line="2641"/>
         <source>Settings</source>
         <translation>nastavitve</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="666"/>
-        <location filename="../src/widgets/window.cpp" line="3845"/>
+        <location filename="../src/widgets/window.cpp" line="696"/>
+        <location filename="../src/widgets/window.cpp" line="4250"/>
         <source>Read-Only</source>
         <translation>Samo branje</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="687"/>
+        <location filename="../src/widgets/window.cpp" line="719"/>
         <source>You do not have permission to open %1</source>
         <translation>Nimate pravic za odpiranje %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="738"/>
-        <location filename="../src/widgets/window.cpp" line="2963"/>
+        <location filename="../src/widgets/window.cpp" line="773"/>
+        <location filename="../src/widgets/window.cpp" line="3266"/>
         <source>Invalid file: %1</source>
         <translation>Napačna datoteka: %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="903"/>
-        <location filename="../src/widgets/window.cpp" line="956"/>
+        <location filename="../src/widgets/window.cpp" line="957"/>
+        <location filename="../src/widgets/window.cpp" line="1050"/>
+        <location filename="../src/widgets/window.cpp" line="3217"/>
         <source>Do you want to save this file?</source>
         <translation>Bi radi shranili to datoteko?</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1290"/>
+        <location filename="../src/widgets/window.cpp" line="1381"/>
+        <source>Invalid characters detected while saving &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1382"/>
+        <source>If you force save this file, it may cause file corruption. Still want to save?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1386"/>
+        <source>Don&apos;t Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1387"/>
+        <source>Save As</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1388"/>
+        <source>Save Anyway</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1456"/>
         <source>You do not have permission to save %1</source>
         <translation>Nimate pravic za shranjevanje %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1312"/>
+        <location filename="../src/widgets/window.cpp" line="1428"/>
+        <location filename="../src/widgets/window.cpp" line="1478"/>
         <source>Saved successfully</source>
         <translation>Uspešno shranjeno</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1354"/>
-        <location filename="../src/widgets/window.cpp" line="1481"/>
-        <location filename="../src/widgets/window.cpp" line="1529"/>
+        <location filename="../src/widgets/window.cpp" line="1520"/>
+        <location filename="../src/widgets/window.cpp" line="1665"/>
+        <location filename="../src/widgets/window.cpp" line="1713"/>
         <source>Save File</source>
         <translation>Shrani datoteko</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1483"/>
+        <location filename="../src/widgets/window.cpp" line="1569"/>
+        <source>Cannot save as the original file in preview mode. Please choose a different path.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1667"/>
         <source>Encoding</source>
         <translation>Kodiranje</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1773"/>
+        <location filename="../src/widgets/window.cpp" line="1957"/>
         <source>Read-Only mode is on</source>
         <translation>Vklopljeno je samo branje</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2322"/>
+        <location filename="../src/widgets/window.cpp" line="2511"/>
         <source>Current location remembered</source>
         <translation>Trenutni položaj je shranjen</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2398"/>
+        <location filename="../src/widgets/window.cpp" line="2591"/>
         <source>Ctrl+&apos;=&apos;</source>
         <translation>Ctrl+&apos;=&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2401"/>
+        <location filename="../src/widgets/window.cpp" line="2594"/>
         <source>Ctrl+&apos;-&apos;</source>
         <translation>Ctrl+&apos;-&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2430"/>
+        <location filename="../src/widgets/window.cpp" line="2623"/>
         <source>Editor</source>
         <translation>Urejevalnik</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3061"/>
+        <location filename="../src/widgets/window.cpp" line="3436"/>
         <source>Untitled %1</source>
         <translation>Neimenovano %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3543"/>
+        <location filename="../src/widgets/window.cpp" line="3948"/>
         <source>Cancel</source>
         <translation>Prekini</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3544"/>
+        <location filename="../src/widgets/window.cpp" line="3949"/>
         <source>Discard</source>
         <translation>Opusti</translation>
     </message>

--- a/translations/deepin-editor_sq.ts
+++ b/translations/deepin-editor_sq.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="sq">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="sq">
 <context>
     <name>BottomBar</name>
     <message>
@@ -17,17 +19,36 @@
         <translation>Shenja %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="44"/>
+        <location filename="../src/widgets/bottombar.cpp" line="47"/>
         <source>Loading:</source>
         <translation>Po ngarkohet:</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="73"/>
+        <location filename="../src/widgets/bottombar.cpp" line="91"/>
+        <location filename="../src/widgets/bottombar.cpp" line="499"/>
+        <source>Edit Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="74"/>
+        <location filename="../src/widgets/bottombar.cpp" line="489"/>
+        <source>Read View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="75"/>
+        <location filename="../src/widgets/bottombar.cpp" line="493"/>
+        <source>Live Preview</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DDropdownMenu</name>
     <message>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="362"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="420"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="425"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="363"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="421"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="426"/>
         <source>None</source>
         <translation>Asnjë</translation>
     </message>
@@ -35,68 +56,57 @@
 <context>
     <name>EditWrapper</name>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="292"/>
-        <location filename="../src/editor/editwrapper.cpp" line="365"/>
-        <location filename="../src/editor/editwrapper.cpp" line="521"/>
-        <location filename="../src/editor/editwrapper.cpp" line="751"/>
+        <location filename="../src/editor/editwrapper.cpp" line="355"/>
+        <location filename="../src/editor/editwrapper.cpp" line="429"/>
+        <location filename="../src/editor/editwrapper.cpp" line="595"/>
+        <location filename="../src/editor/editwrapper.cpp" line="887"/>
         <source>Save</source>
         <translation>Ruaje</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="516"/>
+        <location filename="../src/editor/editwrapper.cpp" line="590"/>
         <source>Do you want to save this file?</source>
         <translation>Doni të ruhet kjo kartelë?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="363"/>
-        <location filename="../src/editor/editwrapper.cpp" line="519"/>
+        <location filename="../src/editor/editwrapper.cpp" line="427"/>
+        <location filename="../src/editor/editwrapper.cpp" line="593"/>
         <source>Cancel</source>
         <translation>Anuloje</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="360"/>
+        <location filename="../src/editor/editwrapper.cpp" line="424"/>
         <source>Encoding changed. Do you want to save the file now?</source>
         <translation>Kodimi ndryshoi. Doni të ruhet kartela tani?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="520"/>
+        <location filename="../src/editor/editwrapper.cpp" line="594"/>
         <source>Discard</source>
         <translation>Hidhe Tej</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="274"/>
-        <location filename="../src/editor/editwrapper.cpp" line="620"/>
+        <location filename="../src/editor/editwrapper.cpp" line="1121"/>
+        <source>The file contains invalid characters (NUL). Preview mode is read-only.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="337"/>
+        <location filename="../src/editor/editwrapper.cpp" line="705"/>
         <source>You do not have permission to save %1</source>
         <translation>S’keni leje të ruani %1</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="836"/>
+        <location filename="../src/editor/editwrapper.cpp" line="987"/>
         <source>File removed on the disk. Save it now?</source>
         <translation>Kartela u hoq nga disku. Të ruhet tani?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="842"/>
+        <location filename="../src/editor/editwrapper.cpp" line="993"/>
         <source>File has changed on disk. Reload?</source>
         <translation>Kartela ka ndryshuar në disk. Të ringarkohet?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="884"/>
-        <location filename="../src/widgets/bottombar.cpp" line="74"/>
-        <source>INSERT</source>
-        <translation>FUTE</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="888"/>
-        <source>OVERWRITE</source>
-        <translation>MBISHKRUAJE</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="892"/>
-        <source>R/O</source>
-        <translation>V/L</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="1618"/>
+        <location filename="../src/editor/editwrapper.cpp" line="1806"/>
         <source>The file cannot be read, which may be too large or has been damaged!</source>
         <translation>Kartela s’mund të lexohet, ngaqë mund të jetë shumë e madhe, ose është dëmtuar!</translation>
     </message>
@@ -109,17 +119,17 @@
         <translation>Gjej</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="36"/>
+        <location filename="../src/controls/findbar.cpp" line="38"/>
         <source>Previous</source>
         <translation>E mëparshmja</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="37"/>
+        <location filename="../src/controls/findbar.cpp" line="40"/>
         <source>Next</source>
         <translation>Pasuesja</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="38"/>
+        <location filename="../src/controls/findbar.cpp" line="42"/>
         <source>Replace</source>
         <translation>Zëvendësoje</translation>
     </message>
@@ -127,9 +137,17 @@
 <context>
     <name>JumpLineBar</name>
     <message>
-        <location filename="../src/controls/jumplinebar.cpp" line="45"/>
+        <location filename="../src/controls/jumplinebar.cpp" line="46"/>
         <source>Go to Line: </source>
         <translation>Shko te Rreshti: </translation>
+    </message>
+</context>
+<context>
+    <name>LineBar</name>
+    <message>
+        <location filename="../src/controls/linebar.cpp" line="144"/>
+        <source>第%1/%2项</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -146,19 +164,47 @@
     </message>
 </context>
 <context>
+    <name>MarkdownBridge</name>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="37"/>
+        <source>Collapse code block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="38"/>
+        <source>Expand code block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="39"/>
+        <source>Copy code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="40"/>
+        <source>Expand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="42"/>
+        <source>%1 line(s) of code collapsed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PathSettingWgt</name>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="84"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="90"/>
         <source>Remember the last used path</source>
         <translation>Mbaj mend shtegun e përdorur së fundi</translation>
     </message>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="85"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="91"/>
         <source>Same path as the current file</source>
         <translation>I njëjti shteg me kartelën e tanishme</translation>
     </message>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="86"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="92"/>
         <source>Customize the default path</source>
         <translation>Përshtatni shtegun parazgjedhje</translation>
     </message>
@@ -171,15 +217,20 @@
         <translation>Përpunues Tekstesh</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="294"/>
-        <location filename="../src/editor/editwrapper.cpp" line="761"/>
-        <location filename="../src/editor/editwrapper.cpp" line="776"/>
-        <location filename="../src/widgets/window.cpp" line="1362"/>
-        <location filename="../src/widgets/window.cpp" line="1390"/>
-        <location filename="../src/widgets/window.cpp" line="1531"/>
-        <location filename="../src/widgets/window.cpp" line="1548"/>
+        <location filename="../src/editor/editwrapper.cpp" line="357"/>
+        <location filename="../src/editor/editwrapper.cpp" line="897"/>
+        <location filename="../src/editor/editwrapper.cpp" line="912"/>
+        <location filename="../src/widgets/window.cpp" line="1528"/>
+        <location filename="../src/widgets/window.cpp" line="1556"/>
+        <location filename="../src/widgets/window.cpp" line="1715"/>
+        <location filename="../src/widgets/window.cpp" line="1732"/>
         <source>Encoding</source>
         <translation>Kodim</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="2001"/>
+        <source>视图模式</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="11"/>
@@ -215,7 +266,7 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="18"/>
         <location filename="../src/controls/settingsdialog.cpp" line="96"/>
-        <location filename="../src/widgets/window.cpp" line="2388"/>
+        <location filename="../src/widgets/window.cpp" line="2581"/>
         <source>Window</source>
         <translation>Dritare</translation>
     </message>
@@ -362,12 +413,12 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="47"/>
         <source>Forward character</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="48"/>
         <source>Backward character</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="49"/>
@@ -755,68 +806,68 @@
         <translation>Vietnameze</translation>
     </message>
     <message>
-        <location filename="../src/startmanager.cpp" line="971"/>
+        <location filename="../src/startmanager.cpp" line="1035"/>
         <source>File not saved</source>
         <translation>Kartela s’u ruajt</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1532"/>
-        <location filename="../src/widgets/window.cpp" line="1549"/>
+        <location filename="../src/widgets/window.cpp" line="1716"/>
+        <location filename="../src/widgets/window.cpp" line="1733"/>
         <source>Line Endings</source>
         <translation>Funde Rreshtash</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="243"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="379"/>
         <source>Please install &apos;UOS AI&apos; from the App Store before using</source>
         <translation>Ju lutemi, instaloni &apos;UOS AI&apos; nga Shitorja e Aplikacioneve, përpara se ta përdorni</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="245"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="381"/>
         <source>No audio input device detected. Please check and try again</source>
         <translation>S’u pikas pajisje audio hyrje. Ju lutemi, kontrolloni dhe riprovoni</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="247"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="383"/>
         <source>No audio output device detected. Please check and try again</source>
         <translation>S’u pikas pajisje audio dalje. Ju lutemi, kontrolloni dhe riprovoni</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="69"/>
+        <location filename="../src/common/text_file_saver.cpp" line="74"/>
         <source>File path is empty</source>
         <translation>Shtegu i kartelës është i zbrazët</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="155"/>
+        <location filename="../src/common/text_file_saver.cpp" line="153"/>
         <source>Insufficient memory to load document content</source>
         <translation>Kujtesë e pamjaftueshme për ngarkim lënde dokumenti</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="177"/>
+        <location filename="../src/common/text_file_saver.cpp" line="178"/>
         <source>Insufficient memory for encoding conversion</source>
         <translation>Kujtesë e pamjaftueshme për shndërrim kodimi</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="183"/>
+        <location filename="../src/common/text_file_saver.cpp" line="184"/>
         <source>Encoding conversion failed</source>
         <translation>Shndërrimi i kodimit dështoi</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="189"/>
+        <location filename="../src/common/text_file_saver.cpp" line="190"/>
         <source>Converted content is empty</source>
         <translation>Lënda e shndërruar është e zbrazët</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="207"/>
+        <location filename="../src/common/text_file_saver.cpp" line="208"/>
         <source>Memory allocation failed</source>
         <translation>Dështoi dhënie kujtese</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="211"/>
+        <location filename="../src/common/text_file_saver.cpp" line="212"/>
         <source>Error occurred: %1</source>
         <translation>Ndodhi një gabim: %1</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="215"/>
+        <location filename="../src/common/text_file_saver.cpp" line="216"/>
         <source>Unknown error occurred</source>
         <translation>Ndodhi një gabim i panjohur</translation>
     </message>
@@ -829,27 +880,27 @@
         <translation>Gjej</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="34"/>
+        <location filename="../src/controls/replacebar.cpp" line="36"/>
         <source>Replace With</source>
         <translation>Zëvendësoje Me</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="36"/>
+        <location filename="../src/controls/replacebar.cpp" line="40"/>
         <source>Replace</source>
         <translation>Zëvendësoje</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="37"/>
+        <location filename="../src/controls/replacebar.cpp" line="42"/>
         <source>Skip</source>
         <translation>Anashkaloje</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="38"/>
+        <location filename="../src/controls/replacebar.cpp" line="44"/>
         <source>Replace Rest</source>
         <translation>Zëvendëso Pjesën e Mbetur</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="39"/>
+        <location filename="../src/controls/replacebar.cpp" line="46"/>
         <source>Replace All</source>
         <translation>Zëvendësoji Krejt</translation>
     </message>
@@ -858,9 +909,9 @@
     <name>S:</name>
     <message>
         <location filename="../third/libiconv-1.16/src/iconv.c" line="103"/>
-        <source/>
+        <source></source>
         <comment>The first line of the short usage message.</comment>
-        <translation type="unfinished"/>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -891,34 +942,34 @@
         <translation>Sa krejt ekrani</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="484"/>
+        <location filename="../src/common/settings.cpp" line="491"/>
         <source>This shortcut conflicts with system shortcut %1</source>
         <translation>Kjo shkurtore përplaset me shkurtoren e sistemit %1</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="487"/>
+        <location filename="../src/common/settings.cpp" line="494"/>
         <source>This shortcut conflicts with %1, click on Replace to make this shortcut effective immediately</source>
         <translation>Kjo shkurtore përplaset me %1, klikoni mbi “Zëvendësoje” për ta bërë këtë shkurtore të hyjë në fuqi menjëherë</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="682"/>
-        <location filename="../src/common/settings.cpp" line="695"/>
-        <location filename="../src/common/settings.cpp" line="704"/>
+        <location filename="../src/common/settings.cpp" line="689"/>
+        <location filename="../src/common/settings.cpp" line="702"/>
+        <location filename="../src/common/settings.cpp" line="711"/>
         <source>The shortcut %1 is invalid, please set another one.</source>
         <translation>Shkurtorja %1 është e pavlefshme, ju lutemi, caktoni një tjetër.</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="736"/>
+        <location filename="../src/common/settings.cpp" line="743"/>
         <source>Cancel</source>
         <translation>Anuloje</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="737"/>
+        <location filename="../src/common/settings.cpp" line="744"/>
         <source>Replace</source>
         <translation>Zëvendësoje</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="740"/>
+        <location filename="../src/common/settings.cpp" line="747"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
@@ -926,7 +977,7 @@
 <context>
     <name>StartManager</name>
     <message>
-        <location filename="../src/startmanager.cpp" line="411"/>
+        <location filename="../src/startmanager.cpp" line="425"/>
         <source>Untitled %1</source>
         <translation>%1 pa titull</translation>
     </message>
@@ -934,32 +985,32 @@
 <context>
     <name>Tabbar</name>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="641"/>
+        <location filename="../src/controls/tabbar.cpp" line="678"/>
         <source>Close tab</source>
         <translation>Mbylle skedën</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="642"/>
+        <location filename="../src/controls/tabbar.cpp" line="680"/>
         <source>Close other tabs</source>
         <translation>Mbylli skedat e tjera</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="643"/>
+        <location filename="../src/controls/tabbar.cpp" line="682"/>
         <source>More options</source>
         <translation>Më tepër mundësi</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="644"/>
+        <location filename="../src/controls/tabbar.cpp" line="684"/>
         <source>Close tabs to the left</source>
         <translation>Mbylli skedat në të majtë</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="645"/>
+        <location filename="../src/controls/tabbar.cpp" line="686"/>
         <source>Close tabs to the right</source>
         <translation>Mbylli skedat në të djathtë</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="646"/>
+        <location filename="../src/controls/tabbar.cpp" line="688"/>
         <source>Close unmodified tabs</source>
         <translation>Mbylli skedat e paprekura</translation>
     </message>
@@ -967,263 +1018,280 @@
 <context>
     <name>TextEdit</name>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="305"/>
+        <location filename="../src/editor/dtextedit.cpp" line="388"/>
         <source>Undo</source>
         <translation>Zhbëje</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="306"/>
+        <location filename="../src/editor/dtextedit.cpp" line="390"/>
         <source>Redo</source>
         <translation>Ribëje</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="307"/>
+        <location filename="../src/editor/dtextedit.cpp" line="392"/>
         <source>Cut</source>
         <translation>Prije</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="308"/>
+        <location filename="../src/editor/dtextedit.cpp" line="394"/>
         <source>Copy</source>
         <translation>Kopjoje</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="309"/>
+        <location filename="../src/editor/dtextedit.cpp" line="396"/>
         <source>Paste</source>
         <translation>Ngjite</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="310"/>
+        <location filename="../src/editor/dtextedit.cpp" line="398"/>
         <source>Delete</source>
         <translation>Fshije</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="311"/>
+        <location filename="../src/editor/dtextedit.cpp" line="400"/>
         <source>Select All</source>
         <translation>Përzgjidhi Krejt</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="312"/>
-        <location filename="../src/widgets/window.cpp" line="535"/>
+        <location filename="../src/editor/dtextedit.cpp" line="402"/>
+        <location filename="../src/widgets/window.cpp" line="556"/>
         <source>Find</source>
         <translation>Gjej</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="313"/>
-        <location filename="../src/widgets/window.cpp" line="536"/>
+        <location filename="../src/editor/dtextedit.cpp" line="404"/>
+        <location filename="../src/widgets/window.cpp" line="558"/>
         <source>Replace</source>
         <translation>Zëvendësoje</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="314"/>
+        <location filename="../src/editor/dtextedit.cpp" line="406"/>
         <source>Go to Line</source>
         <translation>Shko te Rreshti</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="315"/>
-        <source>Turn on Read-Only mode</source>
-        <translation>Aktivizo mënyrën “Vetëm Për Lexim”</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="316"/>
-        <source>Turn off Read-Only mode</source>
-        <translation>Çaktivizo mënyrën “Vetëm Për Lexim”</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="317"/>
+        <location filename="../src/editor/dtextedit.cpp" line="415"/>
         <source>Fullscreen</source>
         <translation>Sa krejt ekrani</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="318"/>
+        <location filename="../src/editor/dtextedit.cpp" line="417"/>
         <source>Exit fullscreen</source>
         <translation>Dil nga mënyra sa krejt ekrani</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="319"/>
+        <location filename="../src/editor/dtextedit.cpp" line="419"/>
         <source>Display in file manager</source>
         <translation>Shfaqe në përgjegjës kartelash</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="320"/>
-        <location filename="../src/editor/dtextedit.cpp" line="374"/>
+        <location filename="../src/editor/dtextedit.cpp" line="421"/>
+        <location filename="../src/editor/dtextedit.cpp" line="493"/>
         <source>Add Comment</source>
         <translation>Shtoni Koment</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="321"/>
+        <location filename="../src/editor/dtextedit.cpp" line="423"/>
         <source>Text to Speech</source>
         <translation>Nga Tekst Në të Folur</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="322"/>
-        <source>Stop reading</source>
-        <translation>Ndale leximin</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="323"/>
+        <location filename="../src/editor/dtextedit.cpp" line="425"/>
         <source>Speech to Text</source>
         <translation>Nga e Folur Në Tekst</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="324"/>
+        <location filename="../src/editor/dtextedit.cpp" line="427"/>
         <source>Translate</source>
         <translation>Përkthejeni</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="325"/>
+        <location filename="../src/editor/dtextedit.cpp" line="429"/>
         <source>Column Mode</source>
         <translation>Mënyrë Shtylla</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="326"/>
+        <location filename="../src/editor/dtextedit.cpp" line="431"/>
         <source>Add bookmark</source>
         <translation>Shtoni faqerojtës</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="327"/>
+        <location filename="../src/editor/dtextedit.cpp" line="433"/>
         <source>Remove Bookmark</source>
         <translation>Hiqe Faqerojtësin</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="328"/>
+        <location filename="../src/editor/dtextedit.cpp" line="435"/>
         <source>Previous bookmark</source>
         <translation>Faqerojtësi i mëparshëm</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="329"/>
+        <location filename="../src/editor/dtextedit.cpp" line="437"/>
         <source>Next bookmark</source>
         <translation>Faqerojtësi pasues</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="330"/>
+        <location filename="../src/editor/dtextedit.cpp" line="439"/>
         <source>Remove All Bookmarks</source>
         <translation>Hiqi Krejt Faqerojtësit</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="331"/>
+        <location filename="../src/editor/dtextedit.cpp" line="441"/>
         <source>Fold All</source>
         <translation>Palosi Krejt</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="332"/>
+        <location filename="../src/editor/dtextedit.cpp" line="443"/>
         <source>Fold Current Level</source>
         <translation>Palos Nivelin e Tanishëm</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="333"/>
+        <location filename="../src/editor/dtextedit.cpp" line="445"/>
         <source>Unfold All</source>
         <translation>Shpalosi Krejt</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="334"/>
+        <location filename="../src/editor/dtextedit.cpp" line="447"/>
         <source>Unfold Current Level</source>
         <translation>Shpalos Nivelin e Tanishëm</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="339"/>
+        <location filename="../src/editor/dtextedit.cpp" line="453"/>
         <source>Color Mark</source>
         <translation>Shenjë Ngjyre</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="343"/>
+        <location filename="../src/editor/dtextedit.cpp" line="458"/>
         <source>Clear All Marks</source>
         <translation>Hiqi Krejt Shenjat</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="344"/>
+        <location filename="../src/editor/dtextedit.cpp" line="460"/>
         <source>Clear Last Mark</source>
         <translation>Spastro Shenjën e Fundit</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="353"/>
+        <location filename="../src/editor/dtextedit.cpp" line="470"/>
         <source>Mark</source>
         <translation>Vëri shenjë</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="366"/>
+        <location filename="../src/editor/dtextedit.cpp" line="484"/>
         <source>Mark All</source>
         <translation>Vëru Shenjë të Tërëve</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="375"/>
+        <location filename="../src/editor/dtextedit.cpp" line="494"/>
         <source>Remove Comment</source>
         <translation>Hiqe Komentin</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3208"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3211"/>
+        <location filename="../src/editor/dtextedit.cpp" line="543"/>
+        <source>View Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="3531"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3534"/>
         <source>Copy failed: not enough memory</source>
         <translation>Kopjimi dështoi: s’ka kujtesë të mjaftueshme</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3333"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3335"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3656"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3658"/>
         <source>Press ALT and click lines to edit in column mode</source>
         <translation>Shtypni tastin ALT dhe klikoni mbi rreshtat që të përpunohen nën mënyrën shtyllë</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="418"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9574"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9576"/>
+        <source>No audio output device was detected. Please ensure your speakers or headphones are properly connected and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="9583"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9585"/>
+        <source>No audio input device was detected. Please ensure your speakers or headphones are properly connected and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="534"/>
         <source>Change Case</source>
         <translation>Ndryshoni Shkronjë të Madhe/të Vogël</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="419"/>
+        <location filename="../src/editor/dtextedit.cpp" line="409"/>
+        <source>Edit Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="411"/>
+        <source>Read View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="413"/>
+        <source>Live Preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="535"/>
         <source>Upper Case</source>
         <translation>Kaloje në Shkronja të Mëdha</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="420"/>
+        <location filename="../src/editor/dtextedit.cpp" line="536"/>
         <source>Lower Case</source>
         <translation>Shkronja të Vogla</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="421"/>
+        <location filename="../src/editor/dtextedit.cpp" line="537"/>
         <source>Capitalize</source>
         <translation>Kaloje Në Shkronjë të Madhe</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="78"/>
+        <location filename="../src/widgets/bottombar.cpp" line="110"/>
         <source>None</source>
         <translation>Asnjë</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1363"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1490"/>
         <source>Selected line(s) copied</source>
         <translation>U kopjua rreshti(at) i përzgjedhur</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1370"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1497"/>
         <source>Current line copied</source>
         <translation>U kopjua rreshti i tanishëm</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1400"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1527"/>
         <source>Selected line(s) clipped</source>
         <translation>Rreshti(at) i përzgjedhur u qeth</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1412"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1539"/>
         <source>Current line clipped</source>
         <translation>Rreshti i tanishëm u qeth</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3227"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3230"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3550"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3553"/>
         <source>Paste failed: not enough memory</source>
         <translation>Ngjitja dështoi: kujtesë e pamjaftueshme</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="4548"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4873"/>
         <source>Read-Only mode is off</source>
         <translation>Mënyra “Vetëm Për Lexim” është e çaktivizuar</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="4560"/>
-        <location filename="../src/editor/dtextedit.cpp" line="4584"/>
-        <location filename="../src/editor/dtextedit.cpp" line="7896"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8007"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8015"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8026"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4885"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4909"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8236"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8347"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8355"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8366"/>
         <source>Read-Only mode is on</source>
         <translation>Mënyra “Vetëm Për Lexim” është e aktivizuar</translation>
     </message>
@@ -1231,138 +1299,175 @@
 <context>
     <name>WarningNotices</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="24"/>
+        <location filename="../src/controls/warningnotices.cpp" line="25"/>
         <source>Reload</source>
         <translation>Ringarkoje</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/warningnotices.cpp" line="29"/>
+        <source>Edit Anyway</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>Window</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="25"/>
-        <location filename="../src/widgets/window.cpp" line="531"/>
+        <location filename="../src/controls/warningnotices.cpp" line="27"/>
+        <location filename="../src/widgets/window.cpp" line="548"/>
         <source>Save as</source>
         <translation>Ruaje si</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="527"/>
+        <location filename="../src/widgets/window.cpp" line="540"/>
         <source>New window</source>
         <translation>Dritare e re</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="528"/>
+        <location filename="../src/widgets/window.cpp" line="542"/>
         <source>New tab</source>
         <translation>Skedë e re</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="529"/>
+        <location filename="../src/widgets/window.cpp" line="544"/>
         <source>Open file</source>
         <translation>Hap kartelë</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="530"/>
-        <location filename="../src/widgets/window.cpp" line="3545"/>
+        <location filename="../src/widgets/window.cpp" line="546"/>
+        <location filename="../src/widgets/window.cpp" line="3950"/>
         <source>Save</source>
         <translation>Ruaje</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="532"/>
+        <location filename="../src/widgets/window.cpp" line="550"/>
         <source>Print</source>
         <translation>Shtype</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="533"/>
+        <location filename="../src/widgets/window.cpp" line="552"/>
         <source>Switch theme</source>
         <translation>Ndërroni temë</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="534"/>
-        <location filename="../src/widgets/window.cpp" line="2448"/>
+        <location filename="../src/widgets/window.cpp" line="554"/>
+        <location filename="../src/widgets/window.cpp" line="2641"/>
         <source>Settings</source>
         <translation>Rregullime</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="666"/>
-        <location filename="../src/widgets/window.cpp" line="3845"/>
+        <location filename="../src/widgets/window.cpp" line="696"/>
+        <location filename="../src/widgets/window.cpp" line="4250"/>
         <source>Read-Only</source>
         <translation>Vetëm-Lexim</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="687"/>
+        <location filename="../src/widgets/window.cpp" line="719"/>
         <source>You do not have permission to open %1</source>
         <translation>S’keni leje të hapni %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="738"/>
-        <location filename="../src/widgets/window.cpp" line="2963"/>
+        <location filename="../src/widgets/window.cpp" line="773"/>
+        <location filename="../src/widgets/window.cpp" line="3266"/>
         <source>Invalid file: %1</source>
         <translation>Kartelë e pavlefshme: %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="903"/>
-        <location filename="../src/widgets/window.cpp" line="956"/>
+        <location filename="../src/widgets/window.cpp" line="957"/>
+        <location filename="../src/widgets/window.cpp" line="1050"/>
+        <location filename="../src/widgets/window.cpp" line="3217"/>
         <source>Do you want to save this file?</source>
         <translation>Doni të ruhet kjo kartelë?</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1290"/>
+        <location filename="../src/widgets/window.cpp" line="1381"/>
+        <source>Invalid characters detected while saving &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1382"/>
+        <source>If you force save this file, it may cause file corruption. Still want to save?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1386"/>
+        <source>Don&apos;t Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1387"/>
+        <source>Save As</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1388"/>
+        <source>Save Anyway</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1456"/>
         <source>You do not have permission to save %1</source>
         <translation>S’keni leje të ruani %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1312"/>
+        <location filename="../src/widgets/window.cpp" line="1428"/>
+        <location filename="../src/widgets/window.cpp" line="1478"/>
         <source>Saved successfully</source>
         <translation>U ruajt me sukses</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1354"/>
-        <location filename="../src/widgets/window.cpp" line="1481"/>
-        <location filename="../src/widgets/window.cpp" line="1529"/>
+        <location filename="../src/widgets/window.cpp" line="1520"/>
+        <location filename="../src/widgets/window.cpp" line="1665"/>
+        <location filename="../src/widgets/window.cpp" line="1713"/>
         <source>Save File</source>
         <translation>Ruaje Kartelën</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1483"/>
+        <location filename="../src/widgets/window.cpp" line="1569"/>
+        <source>Cannot save as the original file in preview mode. Please choose a different path.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1667"/>
         <source>Encoding</source>
         <translation>Kodim</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1773"/>
+        <location filename="../src/widgets/window.cpp" line="1957"/>
         <source>Read-Only mode is on</source>
         <translation>Mënyra “Vetëm Për Lexim” është e aktivizuar</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2322"/>
+        <location filename="../src/widgets/window.cpp" line="2511"/>
         <source>Current location remembered</source>
         <translation>Vendi i tanishëm u mbajt mend</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2398"/>
+        <location filename="../src/widgets/window.cpp" line="2591"/>
         <source>Ctrl+&apos;=&apos;</source>
         <translation>Ctrl+&apos;=&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2401"/>
+        <location filename="../src/widgets/window.cpp" line="2594"/>
         <source>Ctrl+&apos;-&apos;</source>
         <translation>Ctrl+&apos;-&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2430"/>
+        <location filename="../src/widgets/window.cpp" line="2623"/>
         <source>Editor</source>
         <translation>Përpunues</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3061"/>
+        <location filename="../src/widgets/window.cpp" line="3436"/>
         <source>Untitled %1</source>
         <translation>%1 pa titull</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3543"/>
+        <location filename="../src/widgets/window.cpp" line="3948"/>
         <source>Cancel</source>
         <translation>Anuloje</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3544"/>
+        <location filename="../src/widgets/window.cpp" line="3949"/>
         <source>Discard</source>
         <translation>Hidhe Tej</translation>
     </message>

--- a/translations/deepin-editor_sr.ts
+++ b/translations/deepin-editor_sr.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="sr">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="sr">
 <context>
     <name>BottomBar</name>
     <message>
@@ -17,17 +19,36 @@
         <translation>Карактера %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="44"/>
+        <location filename="../src/widgets/bottombar.cpp" line="47"/>
         <source>Loading:</source>
         <translation>Учитывам:</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="73"/>
+        <location filename="../src/widgets/bottombar.cpp" line="91"/>
+        <location filename="../src/widgets/bottombar.cpp" line="499"/>
+        <source>Edit Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="74"/>
+        <location filename="../src/widgets/bottombar.cpp" line="489"/>
+        <source>Read View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="75"/>
+        <location filename="../src/widgets/bottombar.cpp" line="493"/>
+        <source>Live Preview</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DDropdownMenu</name>
     <message>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="362"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="420"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="425"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="363"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="421"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="426"/>
         <source>None</source>
         <translation>Ништа</translation>
     </message>
@@ -35,68 +56,57 @@
 <context>
     <name>EditWrapper</name>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="292"/>
-        <location filename="../src/editor/editwrapper.cpp" line="365"/>
-        <location filename="../src/editor/editwrapper.cpp" line="521"/>
-        <location filename="../src/editor/editwrapper.cpp" line="751"/>
+        <location filename="../src/editor/editwrapper.cpp" line="355"/>
+        <location filename="../src/editor/editwrapper.cpp" line="429"/>
+        <location filename="../src/editor/editwrapper.cpp" line="595"/>
+        <location filename="../src/editor/editwrapper.cpp" line="887"/>
         <source>Save</source>
         <translation>Сачувај</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="516"/>
+        <location filename="../src/editor/editwrapper.cpp" line="590"/>
         <source>Do you want to save this file?</source>
         <translation>Желите ли да сачувате ову датотеку?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="363"/>
-        <location filename="../src/editor/editwrapper.cpp" line="519"/>
+        <location filename="../src/editor/editwrapper.cpp" line="427"/>
+        <location filename="../src/editor/editwrapper.cpp" line="593"/>
         <source>Cancel</source>
         <translation>Откажи</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="360"/>
+        <location filename="../src/editor/editwrapper.cpp" line="424"/>
         <source>Encoding changed. Do you want to save the file now?</source>
         <translation>Промењено кодирање. Желите ли да сачувате датотеку сад?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="520"/>
+        <location filename="../src/editor/editwrapper.cpp" line="594"/>
         <source>Discard</source>
         <translation>Одбаци</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="274"/>
-        <location filename="../src/editor/editwrapper.cpp" line="620"/>
+        <location filename="../src/editor/editwrapper.cpp" line="1121"/>
+        <source>The file contains invalid characters (NUL). Preview mode is read-only.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="337"/>
+        <location filename="../src/editor/editwrapper.cpp" line="705"/>
         <source>You do not have permission to save %1</source>
         <translation>Немате дозволу да сачувате %1</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="836"/>
+        <location filename="../src/editor/editwrapper.cpp" line="987"/>
         <source>File removed on the disk. Save it now?</source>
         <translation>Датотека је уклоњена са диска. Сачувајте је сад?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="842"/>
+        <location filename="../src/editor/editwrapper.cpp" line="993"/>
         <source>File has changed on disk. Reload?</source>
         <translation>Датотека је промењена на диску. Поново учитати?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="884"/>
-        <location filename="../src/widgets/bottombar.cpp" line="74"/>
-        <source>INSERT</source>
-        <translation>УМЕТНИ</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="888"/>
-        <source>OVERWRITE</source>
-        <translation>ПРЕПИШИ</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="892"/>
-        <source>R/O</source>
-        <translation>С/Ч</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="1618"/>
+        <location filename="../src/editor/editwrapper.cpp" line="1806"/>
         <source>The file cannot be read, which may be too large or has been damaged!</source>
         <translation>Датотека не може да се прочита, можда је превелика или је повређена!</translation>
     </message>
@@ -109,17 +119,17 @@
         <translation>Тражи</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="36"/>
+        <location filename="../src/controls/findbar.cpp" line="38"/>
         <source>Previous</source>
         <translation>Претходно</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="37"/>
+        <location filename="../src/controls/findbar.cpp" line="40"/>
         <source>Next</source>
         <translation>Следеће</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="38"/>
+        <location filename="../src/controls/findbar.cpp" line="42"/>
         <source>Replace</source>
         <translation>Замени</translation>
     </message>
@@ -127,9 +137,17 @@
 <context>
     <name>JumpLineBar</name>
     <message>
-        <location filename="../src/controls/jumplinebar.cpp" line="45"/>
+        <location filename="../src/controls/jumplinebar.cpp" line="46"/>
         <source>Go to Line: </source>
         <translation>Иди на ред:</translation>
+    </message>
+</context>
+<context>
+    <name>LineBar</name>
+    <message>
+        <location filename="../src/controls/linebar.cpp" line="144"/>
+        <source>第%1/%2项</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -146,19 +164,47 @@
     </message>
 </context>
 <context>
+    <name>MarkdownBridge</name>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="37"/>
+        <source>Collapse code block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="38"/>
+        <source>Expand code block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="39"/>
+        <source>Copy code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="40"/>
+        <source>Expand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="42"/>
+        <source>%1 line(s) of code collapsed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PathSettingWgt</name>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="84"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="90"/>
         <source>Remember the last used path</source>
         <translation>Запамети последњу коришћену папку</translation>
     </message>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="85"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="91"/>
         <source>Same path as the current file</source>
         <translation>Иста папка као и тренутна датотека</translation>
     </message>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="86"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="92"/>
         <source>Customize the default path</source>
         <translation>Промени подразуметан пут</translation>
     </message>
@@ -171,15 +217,20 @@
         <translation>Уређивач текста</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="294"/>
-        <location filename="../src/editor/editwrapper.cpp" line="761"/>
-        <location filename="../src/editor/editwrapper.cpp" line="776"/>
-        <location filename="../src/widgets/window.cpp" line="1362"/>
-        <location filename="../src/widgets/window.cpp" line="1390"/>
-        <location filename="../src/widgets/window.cpp" line="1531"/>
-        <location filename="../src/widgets/window.cpp" line="1548"/>
+        <location filename="../src/editor/editwrapper.cpp" line="357"/>
+        <location filename="../src/editor/editwrapper.cpp" line="897"/>
+        <location filename="../src/editor/editwrapper.cpp" line="912"/>
+        <location filename="../src/widgets/window.cpp" line="1528"/>
+        <location filename="../src/widgets/window.cpp" line="1556"/>
+        <location filename="../src/widgets/window.cpp" line="1715"/>
+        <location filename="../src/widgets/window.cpp" line="1732"/>
         <source>Encoding</source>
         <translation>Кодирање</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="2001"/>
+        <source>视图模式</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="11"/>
@@ -215,7 +266,7 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="18"/>
         <location filename="../src/controls/settingsdialog.cpp" line="96"/>
-        <location filename="../src/widgets/window.cpp" line="2388"/>
+        <location filename="../src/widgets/window.cpp" line="2581"/>
         <source>Window</source>
         <translation>Прозор</translation>
     </message>
@@ -755,68 +806,68 @@
         <translation>Вијетнамски</translation>
     </message>
     <message>
-        <location filename="../src/startmanager.cpp" line="971"/>
+        <location filename="../src/startmanager.cpp" line="1035"/>
         <source>File not saved</source>
         <translation>Датотека није сачувана</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1532"/>
-        <location filename="../src/widgets/window.cpp" line="1549"/>
+        <location filename="../src/widgets/window.cpp" line="1716"/>
+        <location filename="../src/widgets/window.cpp" line="1733"/>
         <source>Line Endings</source>
         <translation>Крајеви редова</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="243"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="379"/>
         <source>Please install &apos;UOS AI&apos; from the App Store before using</source>
         <translation>Молимо вас инсталирајте &apos;UOS AI&apos; из Ап Сторе пре него што почнете да користите</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="245"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="381"/>
         <source>No audio input device detected. Please check and try again</source>
         <translation>Аудио уређај за унос није детектован. Молимо вас проверите и покушајте поново</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="247"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="383"/>
         <source>No audio output device detected. Please check and try again</source>
         <translation>Аудио уређај за излаз није детектован. Молимо вас проверите и покушајте поново</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="69"/>
+        <location filename="../src/common/text_file_saver.cpp" line="74"/>
         <source>File path is empty</source>
         <translation>Пут до датотеке је празан</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="155"/>
+        <location filename="../src/common/text_file_saver.cpp" line="153"/>
         <source>Insufficient memory to load document content</source>
         <translation>Недовољно меморије да би се учитало садржај документа</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="177"/>
+        <location filename="../src/common/text_file_saver.cpp" line="178"/>
         <source>Insufficient memory for encoding conversion</source>
         <translation>Недовољно меморије за конверзију кодирања</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="183"/>
+        <location filename="../src/common/text_file_saver.cpp" line="184"/>
         <source>Encoding conversion failed</source>
         <translation>Конверзија кодирања је неуспела</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="189"/>
+        <location filename="../src/common/text_file_saver.cpp" line="190"/>
         <source>Converted content is empty</source>
         <translation>Садржај конвертован је празан</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="207"/>
+        <location filename="../src/common/text_file_saver.cpp" line="208"/>
         <source>Memory allocation failed</source>
         <translation>Доделјивање меморије је неуспело</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="211"/>
+        <location filename="../src/common/text_file_saver.cpp" line="212"/>
         <source>Error occurred: %1</source>
         <translation>Десио се грешка: %1</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="215"/>
+        <location filename="../src/common/text_file_saver.cpp" line="216"/>
         <source>Unknown error occurred</source>
         <translation>Десила се непозната грешка</translation>
     </message>
@@ -829,27 +880,27 @@
         <translation>Тражи</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="34"/>
+        <location filename="../src/controls/replacebar.cpp" line="36"/>
         <source>Replace With</source>
         <translation>Замени са</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="36"/>
+        <location filename="../src/controls/replacebar.cpp" line="40"/>
         <source>Replace</source>
         <translation>Замени</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="37"/>
+        <location filename="../src/controls/replacebar.cpp" line="42"/>
         <source>Skip</source>
         <translation>Прескочи</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="38"/>
+        <location filename="../src/controls/replacebar.cpp" line="44"/>
         <source>Replace Rest</source>
         <translation>Замени остатак</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="39"/>
+        <location filename="../src/controls/replacebar.cpp" line="46"/>
         <source>Replace All</source>
         <translation>Замени све</translation>
     </message>
@@ -858,9 +909,9 @@
     <name>S:</name>
     <message>
         <location filename="../third/libiconv-1.16/src/iconv.c" line="103"/>
-        <source/>
+        <source></source>
         <comment>The first line of the short usage message.</comment>
-        <translation type="unfinished"/>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -891,34 +942,34 @@
         <translation>Цео екран</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="484"/>
+        <location filename="../src/common/settings.cpp" line="491"/>
         <source>This shortcut conflicts with system shortcut %1</source>
         <translation>Ова пречица је у сукобу са системском пречицом %1</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="487"/>
+        <location filename="../src/common/settings.cpp" line="494"/>
         <source>This shortcut conflicts with %1, click on Replace to make this shortcut effective immediately</source>
         <translation>Ова пречица је у сукобу са %1, кликните на Замени да пречица одмах ступи на снагу</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="682"/>
-        <location filename="../src/common/settings.cpp" line="695"/>
-        <location filename="../src/common/settings.cpp" line="704"/>
+        <location filename="../src/common/settings.cpp" line="689"/>
+        <location filename="../src/common/settings.cpp" line="702"/>
+        <location filename="../src/common/settings.cpp" line="711"/>
         <source>The shortcut %1 is invalid, please set another one.</source>
         <translation>Пречица %1 је неважећа, поставите другу.</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="736"/>
+        <location filename="../src/common/settings.cpp" line="743"/>
         <source>Cancel</source>
         <translation>Откажи</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="737"/>
+        <location filename="../src/common/settings.cpp" line="744"/>
         <source>Replace</source>
         <translation>Замени</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="740"/>
+        <location filename="../src/common/settings.cpp" line="747"/>
         <source>OK</source>
         <translation>У реду</translation>
     </message>
@@ -926,7 +977,7 @@
 <context>
     <name>StartManager</name>
     <message>
-        <location filename="../src/startmanager.cpp" line="411"/>
+        <location filename="../src/startmanager.cpp" line="425"/>
         <source>Untitled %1</source>
         <translation>Ненасловњено %1</translation>
     </message>
@@ -934,32 +985,32 @@
 <context>
     <name>Tabbar</name>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="641"/>
+        <location filename="../src/controls/tabbar.cpp" line="678"/>
         <source>Close tab</source>
         <translation>Затвори картицу</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="642"/>
+        <location filename="../src/controls/tabbar.cpp" line="680"/>
         <source>Close other tabs</source>
         <translation>Затвори остале картице</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="643"/>
+        <location filename="../src/controls/tabbar.cpp" line="682"/>
         <source>More options</source>
         <translation>Више опција</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="644"/>
+        <location filename="../src/controls/tabbar.cpp" line="684"/>
         <source>Close tabs to the left</source>
         <translation>Затвори леве картице</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="645"/>
+        <location filename="../src/controls/tabbar.cpp" line="686"/>
         <source>Close tabs to the right</source>
         <translation>Затвори десне картице</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="646"/>
+        <location filename="../src/controls/tabbar.cpp" line="688"/>
         <source>Close unmodified tabs</source>
         <translation>Затвори непромењене картице</translation>
     </message>
@@ -967,263 +1018,280 @@
 <context>
     <name>TextEdit</name>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="305"/>
+        <location filename="../src/editor/dtextedit.cpp" line="388"/>
         <source>Undo</source>
         <translation>Опозови</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="306"/>
+        <location filename="../src/editor/dtextedit.cpp" line="390"/>
         <source>Redo</source>
         <translation>Обнови</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="307"/>
+        <location filename="../src/editor/dtextedit.cpp" line="392"/>
         <source>Cut</source>
         <translation>Исеци</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="308"/>
+        <location filename="../src/editor/dtextedit.cpp" line="394"/>
         <source>Copy</source>
         <translation>Копирај</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="309"/>
+        <location filename="../src/editor/dtextedit.cpp" line="396"/>
         <source>Paste</source>
         <translation>Убаци</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="310"/>
+        <location filename="../src/editor/dtextedit.cpp" line="398"/>
         <source>Delete</source>
         <translation>Обриши</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="311"/>
+        <location filename="../src/editor/dtextedit.cpp" line="400"/>
         <source>Select All</source>
         <translation>Изабери све</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="312"/>
-        <location filename="../src/widgets/window.cpp" line="535"/>
+        <location filename="../src/editor/dtextedit.cpp" line="402"/>
+        <location filename="../src/widgets/window.cpp" line="556"/>
         <source>Find</source>
         <translation>Тражи</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="313"/>
-        <location filename="../src/widgets/window.cpp" line="536"/>
+        <location filename="../src/editor/dtextedit.cpp" line="404"/>
+        <location filename="../src/widgets/window.cpp" line="558"/>
         <source>Replace</source>
         <translation>Замени</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="314"/>
+        <location filename="../src/editor/dtextedit.cpp" line="406"/>
         <source>Go to Line</source>
         <translation>Иди на ред</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="315"/>
-        <source>Turn on Read-Only mode</source>
-        <translation>Укључи режим Само-Читање</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="316"/>
-        <source>Turn off Read-Only mode</source>
-        <translation>Искључи режим Само-Читање</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="317"/>
+        <location filename="../src/editor/dtextedit.cpp" line="415"/>
         <source>Fullscreen</source>
         <translation>Цео екран</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="318"/>
+        <location filename="../src/editor/dtextedit.cpp" line="417"/>
         <source>Exit fullscreen</source>
         <translation>Напусти цео екран</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="319"/>
+        <location filename="../src/editor/dtextedit.cpp" line="419"/>
         <source>Display in file manager</source>
         <translation>Прикажи у управнику података</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="320"/>
-        <location filename="../src/editor/dtextedit.cpp" line="374"/>
+        <location filename="../src/editor/dtextedit.cpp" line="421"/>
+        <location filename="../src/editor/dtextedit.cpp" line="493"/>
         <source>Add Comment</source>
         <translation>Додај коментар</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="321"/>
+        <location filename="../src/editor/dtextedit.cpp" line="423"/>
         <source>Text to Speech</source>
         <translation>Текст у говор</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="322"/>
-        <source>Stop reading</source>
-        <translation>Заустави читање</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="323"/>
+        <location filename="../src/editor/dtextedit.cpp" line="425"/>
         <source>Speech to Text</source>
         <translation>Говор у текст</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="324"/>
+        <location filename="../src/editor/dtextedit.cpp" line="427"/>
         <source>Translate</source>
         <translation>Преведи</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="325"/>
+        <location filename="../src/editor/dtextedit.cpp" line="429"/>
         <source>Column Mode</source>
         <translation>Режим колона</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="326"/>
+        <location filename="../src/editor/dtextedit.cpp" line="431"/>
         <source>Add bookmark</source>
         <translation>Додај забелешку</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="327"/>
+        <location filename="../src/editor/dtextedit.cpp" line="433"/>
         <source>Remove Bookmark</source>
         <translation>Уклони забелешку</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="328"/>
+        <location filename="../src/editor/dtextedit.cpp" line="435"/>
         <source>Previous bookmark</source>
         <translation>Претходна забелешка</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="329"/>
+        <location filename="../src/editor/dtextedit.cpp" line="437"/>
         <source>Next bookmark</source>
         <translation>Следећа забелешка</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="330"/>
+        <location filename="../src/editor/dtextedit.cpp" line="439"/>
         <source>Remove All Bookmarks</source>
         <translation>Уклони све забелешке</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="331"/>
+        <location filename="../src/editor/dtextedit.cpp" line="441"/>
         <source>Fold All</source>
         <translation>Скупи све</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="332"/>
+        <location filename="../src/editor/dtextedit.cpp" line="443"/>
         <source>Fold Current Level</source>
         <translation>Скупи тренутни ниво</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="333"/>
+        <location filename="../src/editor/dtextedit.cpp" line="445"/>
         <source>Unfold All</source>
         <translation>Рашири све</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="334"/>
+        <location filename="../src/editor/dtextedit.cpp" line="447"/>
         <source>Unfold Current Level</source>
         <translation>Рашири тренутни ниво</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="339"/>
+        <location filename="../src/editor/dtextedit.cpp" line="453"/>
         <source>Color Mark</source>
         <translation>Истицање у боји</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="343"/>
+        <location filename="../src/editor/dtextedit.cpp" line="458"/>
         <source>Clear All Marks</source>
         <translation>Уклони сва истицања</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="344"/>
+        <location filename="../src/editor/dtextedit.cpp" line="460"/>
         <source>Clear Last Mark</source>
         <translation>Уклони последње истицање</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="353"/>
+        <location filename="../src/editor/dtextedit.cpp" line="470"/>
         <source>Mark</source>
         <translation>Обележи</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="366"/>
+        <location filename="../src/editor/dtextedit.cpp" line="484"/>
         <source>Mark All</source>
         <translation>Обележи све</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="375"/>
+        <location filename="../src/editor/dtextedit.cpp" line="494"/>
         <source>Remove Comment</source>
         <translation>Уклони коментар</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3208"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3211"/>
+        <location filename="../src/editor/dtextedit.cpp" line="543"/>
+        <source>View Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="3531"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3534"/>
         <source>Copy failed: not enough memory</source>
         <translation>Копирање неуспело: недовољно меморије</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3333"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3335"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3656"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3658"/>
         <source>Press ALT and click lines to edit in column mode</source>
         <translation>Притисните ALT и кликните на редове да уредите у режиму колона</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="418"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9574"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9576"/>
+        <source>No audio output device was detected. Please ensure your speakers or headphones are properly connected and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="9583"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9585"/>
+        <source>No audio input device was detected. Please ensure your speakers or headphones are properly connected and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="534"/>
         <source>Change Case</source>
         <translation>Промени величину слова</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="419"/>
+        <location filename="../src/editor/dtextedit.cpp" line="409"/>
+        <source>Edit Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="411"/>
+        <source>Read View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="413"/>
+        <source>Live Preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="535"/>
         <source>Upper Case</source>
         <translation>Велика слова</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="420"/>
+        <location filename="../src/editor/dtextedit.cpp" line="536"/>
         <source>Lower Case</source>
         <translation>Мала слова</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="421"/>
+        <location filename="../src/editor/dtextedit.cpp" line="537"/>
         <source>Capitalize</source>
         <translation>Почетна велика</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="78"/>
+        <location filename="../src/widgets/bottombar.cpp" line="110"/>
         <source>None</source>
         <translation>Ништа</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1363"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1490"/>
         <source>Selected line(s) copied</source>
         <translation>Изабрани редови копирани</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1370"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1497"/>
         <source>Current line copied</source>
         <translation>Тренутни ред копиран</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1400"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1527"/>
         <source>Selected line(s) clipped</source>
         <translation>Изабрани редови копирани</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1412"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1539"/>
         <source>Current line clipped</source>
         <translation>Тренутни ред копиран</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3227"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3230"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3550"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3553"/>
         <source>Paste failed: not enough memory</source>
         <translation>Лепљење неуспело: недовољно меморије</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="4548"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4873"/>
         <source>Read-Only mode is off</source>
         <translation>Режим Само-Читање је искључен</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="4560"/>
-        <location filename="../src/editor/dtextedit.cpp" line="4584"/>
-        <location filename="../src/editor/dtextedit.cpp" line="7896"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8007"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8015"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8026"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4885"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4909"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8236"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8347"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8355"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8366"/>
         <source>Read-Only mode is on</source>
         <translation>Режим Само-Читање је укључен</translation>
     </message>
@@ -1231,138 +1299,175 @@
 <context>
     <name>WarningNotices</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="24"/>
+        <location filename="../src/controls/warningnotices.cpp" line="25"/>
         <source>Reload</source>
         <translation>Поново учитај</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/warningnotices.cpp" line="29"/>
+        <source>Edit Anyway</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>Window</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="25"/>
-        <location filename="../src/widgets/window.cpp" line="531"/>
+        <location filename="../src/controls/warningnotices.cpp" line="27"/>
+        <location filename="../src/widgets/window.cpp" line="548"/>
         <source>Save as</source>
         <translation>Сачувај као</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="527"/>
+        <location filename="../src/widgets/window.cpp" line="540"/>
         <source>New window</source>
         <translation>Нови прозор</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="528"/>
+        <location filename="../src/widgets/window.cpp" line="542"/>
         <source>New tab</source>
         <translation>Нова картица</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="529"/>
+        <location filename="../src/widgets/window.cpp" line="544"/>
         <source>Open file</source>
         <translation>Отвори датотеку</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="530"/>
-        <location filename="../src/widgets/window.cpp" line="3545"/>
+        <location filename="../src/widgets/window.cpp" line="546"/>
+        <location filename="../src/widgets/window.cpp" line="3950"/>
         <source>Save</source>
         <translation>Сачувај</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="532"/>
+        <location filename="../src/widgets/window.cpp" line="550"/>
         <source>Print</source>
         <translation>Штампај</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="533"/>
+        <location filename="../src/widgets/window.cpp" line="552"/>
         <source>Switch theme</source>
         <translation>Промени тему</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="534"/>
-        <location filename="../src/widgets/window.cpp" line="2448"/>
+        <location filename="../src/widgets/window.cpp" line="554"/>
+        <location filename="../src/widgets/window.cpp" line="2641"/>
         <source>Settings</source>
         <translation>Подешавања</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="666"/>
-        <location filename="../src/widgets/window.cpp" line="3845"/>
+        <location filename="../src/widgets/window.cpp" line="696"/>
+        <location filename="../src/widgets/window.cpp" line="4250"/>
         <source>Read-Only</source>
         <translation>Само-Чтање</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="687"/>
+        <location filename="../src/widgets/window.cpp" line="719"/>
         <source>You do not have permission to open %1</source>
         <translation>Немате дозволу да отворите %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="738"/>
-        <location filename="../src/widgets/window.cpp" line="2963"/>
+        <location filename="../src/widgets/window.cpp" line="773"/>
+        <location filename="../src/widgets/window.cpp" line="3266"/>
         <source>Invalid file: %1</source>
         <translation>Неважећа датотека: %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="903"/>
-        <location filename="../src/widgets/window.cpp" line="956"/>
+        <location filename="../src/widgets/window.cpp" line="957"/>
+        <location filename="../src/widgets/window.cpp" line="1050"/>
+        <location filename="../src/widgets/window.cpp" line="3217"/>
         <source>Do you want to save this file?</source>
         <translation>Да ли желите да сачувате ову датотеку?</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1290"/>
+        <location filename="../src/widgets/window.cpp" line="1381"/>
+        <source>Invalid characters detected while saving &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1382"/>
+        <source>If you force save this file, it may cause file corruption. Still want to save?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1386"/>
+        <source>Don&apos;t Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1387"/>
+        <source>Save As</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1388"/>
+        <source>Save Anyway</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1456"/>
         <source>You do not have permission to save %1</source>
         <translation>Немате дозволу да сачувате %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1312"/>
+        <location filename="../src/widgets/window.cpp" line="1428"/>
+        <location filename="../src/widgets/window.cpp" line="1478"/>
         <source>Saved successfully</source>
         <translation>Успешно сачувано</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1354"/>
-        <location filename="../src/widgets/window.cpp" line="1481"/>
-        <location filename="../src/widgets/window.cpp" line="1529"/>
+        <location filename="../src/widgets/window.cpp" line="1520"/>
+        <location filename="../src/widgets/window.cpp" line="1665"/>
+        <location filename="../src/widgets/window.cpp" line="1713"/>
         <source>Save File</source>
         <translation>Сачувај датотеку</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1483"/>
+        <location filename="../src/widgets/window.cpp" line="1569"/>
+        <source>Cannot save as the original file in preview mode. Please choose a different path.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1667"/>
         <source>Encoding</source>
         <translation>Кодирање</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1773"/>
+        <location filename="../src/widgets/window.cpp" line="1957"/>
         <source>Read-Only mode is on</source>
         <translation>Режим Само-Читање је укључен</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2322"/>
+        <location filename="../src/widgets/window.cpp" line="2511"/>
         <source>Current location remembered</source>
         <translation>Тренутна локација запамћена</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2398"/>
+        <location filename="../src/widgets/window.cpp" line="2591"/>
         <source>Ctrl+&apos;=&apos;</source>
         <translation>Ctrl+&apos;=&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2401"/>
+        <location filename="../src/widgets/window.cpp" line="2594"/>
         <source>Ctrl+&apos;-&apos;</source>
         <translation>Ctrl+&apos;-&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2430"/>
+        <location filename="../src/widgets/window.cpp" line="2623"/>
         <source>Editor</source>
         <translation>Уређивач</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3061"/>
+        <location filename="../src/widgets/window.cpp" line="3436"/>
         <source>Untitled %1</source>
         <translation> Ненасловњено %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3543"/>
+        <location filename="../src/widgets/window.cpp" line="3948"/>
         <source>Cancel</source>
         <translation>Откажи</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3544"/>
+        <location filename="../src/widgets/window.cpp" line="3949"/>
         <source>Discard</source>
         <translation>Одбаци</translation>
     </message>

--- a/translations/deepin-editor_sv.ts
+++ b/translations/deepin-editor_sv.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="sv">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="sv">
 <context>
     <name>BottomBar</name>
     <message>
@@ -17,17 +19,36 @@
         <translation>Tecken %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="44"/>
+        <location filename="../src/widgets/bottombar.cpp" line="47"/>
         <source>Loading:</source>
         <translation>Läser in:</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="73"/>
+        <location filename="../src/widgets/bottombar.cpp" line="91"/>
+        <location filename="../src/widgets/bottombar.cpp" line="499"/>
+        <source>Edit Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="74"/>
+        <location filename="../src/widgets/bottombar.cpp" line="489"/>
+        <source>Read View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="75"/>
+        <location filename="../src/widgets/bottombar.cpp" line="493"/>
+        <source>Live Preview</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DDropdownMenu</name>
     <message>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="362"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="420"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="425"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="363"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="421"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="426"/>
         <source>None</source>
         <translation>Inga</translation>
     </message>
@@ -35,68 +56,57 @@
 <context>
     <name>EditWrapper</name>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="292"/>
-        <location filename="../src/editor/editwrapper.cpp" line="365"/>
-        <location filename="../src/editor/editwrapper.cpp" line="521"/>
-        <location filename="../src/editor/editwrapper.cpp" line="751"/>
+        <location filename="../src/editor/editwrapper.cpp" line="355"/>
+        <location filename="../src/editor/editwrapper.cpp" line="429"/>
+        <location filename="../src/editor/editwrapper.cpp" line="595"/>
+        <location filename="../src/editor/editwrapper.cpp" line="887"/>
         <source>Save</source>
         <translation>Spara</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="516"/>
+        <location filename="../src/editor/editwrapper.cpp" line="590"/>
         <source>Do you want to save this file?</source>
         <translation>Vill du spara denna filen?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="363"/>
-        <location filename="../src/editor/editwrapper.cpp" line="519"/>
+        <location filename="../src/editor/editwrapper.cpp" line="427"/>
+        <location filename="../src/editor/editwrapper.cpp" line="593"/>
         <source>Cancel</source>
         <translation>Avbryt</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="360"/>
+        <location filename="../src/editor/editwrapper.cpp" line="424"/>
         <source>Encoding changed. Do you want to save the file now?</source>
         <translation>Kodningen har ändrats. Vill du spara filen nu?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="520"/>
+        <location filename="../src/editor/editwrapper.cpp" line="594"/>
         <source>Discard</source>
         <translation>Förkasta</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="274"/>
-        <location filename="../src/editor/editwrapper.cpp" line="620"/>
+        <location filename="../src/editor/editwrapper.cpp" line="1121"/>
+        <source>The file contains invalid characters (NUL). Preview mode is read-only.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="337"/>
+        <location filename="../src/editor/editwrapper.cpp" line="705"/>
         <source>You do not have permission to save %1</source>
         <translation>Du har ej behörighet för att spara %1</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="836"/>
+        <location filename="../src/editor/editwrapper.cpp" line="987"/>
         <source>File removed on the disk. Save it now?</source>
         <translation>Filen har raderats från disken. Spara nu?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="842"/>
+        <location filename="../src/editor/editwrapper.cpp" line="993"/>
         <source>File has changed on disk. Reload?</source>
         <translation>Filen har ändrats på disken. Ladda om?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="884"/>
-        <location filename="../src/widgets/bottombar.cpp" line="74"/>
-        <source>INSERT</source>
-        <translation>INFOGA</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="888"/>
-        <source>OVERWRITE</source>
-        <translation>SKRIVÖVER</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="892"/>
-        <source>R/O</source>
-        <translation>R/O</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="1618"/>
+        <location filename="../src/editor/editwrapper.cpp" line="1806"/>
         <source>The file cannot be read, which may be too large or has been damaged!</source>
         <translation>Filen kan inte läsas, den kan vara för stor eller ha skadats!</translation>
     </message>
@@ -109,17 +119,17 @@
         <translation>Hitta</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="36"/>
+        <location filename="../src/controls/findbar.cpp" line="38"/>
         <source>Previous</source>
         <translation>Föregående</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="37"/>
+        <location filename="../src/controls/findbar.cpp" line="40"/>
         <source>Next</source>
         <translation>Nästa</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="38"/>
+        <location filename="../src/controls/findbar.cpp" line="42"/>
         <source>Replace</source>
         <translation>Ersätt</translation>
     </message>
@@ -127,9 +137,17 @@
 <context>
     <name>JumpLineBar</name>
     <message>
-        <location filename="../src/controls/jumplinebar.cpp" line="45"/>
+        <location filename="../src/controls/jumplinebar.cpp" line="46"/>
         <source>Go to Line: </source>
         <translation>Gå till rad:</translation>
+    </message>
+</context>
+<context>
+    <name>LineBar</name>
+    <message>
+        <location filename="../src/controls/linebar.cpp" line="144"/>
+        <source>第%1/%2项</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -146,19 +164,47 @@
     </message>
 </context>
 <context>
+    <name>MarkdownBridge</name>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="37"/>
+        <source>Collapse code block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="38"/>
+        <source>Expand code block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="39"/>
+        <source>Copy code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="40"/>
+        <source>Expand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="42"/>
+        <source>%1 line(s) of code collapsed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PathSettingWgt</name>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="84"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="90"/>
         <source>Remember the last used path</source>
         <translation>Kom ihåg den senast använda sökvägen</translation>
     </message>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="85"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="91"/>
         <source>Same path as the current file</source>
         <translation>Samma sökväg som den aktuella filen</translation>
     </message>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="86"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="92"/>
         <source>Customize the default path</source>
         <translation>Anpassa standardsökvägen</translation>
     </message>
@@ -171,15 +217,20 @@
         <translation>Textredigerare</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="294"/>
-        <location filename="../src/editor/editwrapper.cpp" line="761"/>
-        <location filename="../src/editor/editwrapper.cpp" line="776"/>
-        <location filename="../src/widgets/window.cpp" line="1362"/>
-        <location filename="../src/widgets/window.cpp" line="1390"/>
-        <location filename="../src/widgets/window.cpp" line="1531"/>
-        <location filename="../src/widgets/window.cpp" line="1548"/>
+        <location filename="../src/editor/editwrapper.cpp" line="357"/>
+        <location filename="../src/editor/editwrapper.cpp" line="897"/>
+        <location filename="../src/editor/editwrapper.cpp" line="912"/>
+        <location filename="../src/widgets/window.cpp" line="1528"/>
+        <location filename="../src/widgets/window.cpp" line="1556"/>
+        <location filename="../src/widgets/window.cpp" line="1715"/>
+        <location filename="../src/widgets/window.cpp" line="1732"/>
         <source>Encoding</source>
         <translation>Kodning</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="2001"/>
+        <source>视图模式</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="11"/>
@@ -215,7 +266,7 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="18"/>
         <location filename="../src/controls/settingsdialog.cpp" line="96"/>
-        <location filename="../src/widgets/window.cpp" line="2388"/>
+        <location filename="../src/widgets/window.cpp" line="2581"/>
         <source>Window</source>
         <translation>Fönster</translation>
     </message>
@@ -422,22 +473,22 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="59"/>
         <source>Swap line up</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="60"/>
         <source>Swap line down</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="61"/>
         <source>Scroll up one line</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="62"/>
         <source>Scroll down one line</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="63"/>
@@ -492,22 +543,22 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="73"/>
         <source>Delete backward word</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="74"/>
         <source>Delete forward word</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="75"/>
         <source>Forward over a pair</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="76"/>
         <source>Backward over a pair</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="77"/>
@@ -532,7 +583,7 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="81"/>
         <source>Transpose character</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="82"/>
@@ -637,12 +688,12 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="106"/>
         <source>Word wrap</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="107"/>
         <source>Code folding flag</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="108"/>
@@ -657,17 +708,17 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="110"/>
         <source>Show whitespaces and tabs</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="111"/>
         <source>Highlight current line</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="112"/>
         <source>Color mark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="115"/>
@@ -755,68 +806,68 @@
         <translation>Vietnamesisk</translation>
     </message>
     <message>
-        <location filename="../src/startmanager.cpp" line="971"/>
+        <location filename="../src/startmanager.cpp" line="1035"/>
         <source>File not saved</source>
         <translation>Filen inte sparad</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1532"/>
-        <location filename="../src/widgets/window.cpp" line="1549"/>
+        <location filename="../src/widgets/window.cpp" line="1716"/>
+        <location filename="../src/widgets/window.cpp" line="1733"/>
         <source>Line Endings</source>
         <translation>Radslut</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="243"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="379"/>
         <source>Please install &apos;UOS AI&apos; from the App Store before using</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="245"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="381"/>
         <source>No audio input device detected. Please check and try again</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="247"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="383"/>
         <source>No audio output device detected. Please check and try again</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="69"/>
+        <location filename="../src/common/text_file_saver.cpp" line="74"/>
         <source>File path is empty</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="155"/>
+        <location filename="../src/common/text_file_saver.cpp" line="153"/>
         <source>Insufficient memory to load document content</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="177"/>
+        <location filename="../src/common/text_file_saver.cpp" line="178"/>
         <source>Insufficient memory for encoding conversion</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="183"/>
+        <location filename="../src/common/text_file_saver.cpp" line="184"/>
         <source>Encoding conversion failed</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="189"/>
+        <location filename="../src/common/text_file_saver.cpp" line="190"/>
         <source>Converted content is empty</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="207"/>
+        <location filename="../src/common/text_file_saver.cpp" line="208"/>
         <source>Memory allocation failed</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="211"/>
+        <location filename="../src/common/text_file_saver.cpp" line="212"/>
         <source>Error occurred: %1</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="215"/>
+        <location filename="../src/common/text_file_saver.cpp" line="216"/>
         <source>Unknown error occurred</source>
         <translation>Okänt fel inträffade</translation>
     </message>
@@ -829,27 +880,27 @@
         <translation>Hitta</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="34"/>
+        <location filename="../src/controls/replacebar.cpp" line="36"/>
         <source>Replace With</source>
         <translation>Ersätt med</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="36"/>
+        <location filename="../src/controls/replacebar.cpp" line="40"/>
         <source>Replace</source>
         <translation>Ersätt</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="37"/>
+        <location filename="../src/controls/replacebar.cpp" line="42"/>
         <source>Skip</source>
         <translation>Skippa</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="38"/>
+        <location filename="../src/controls/replacebar.cpp" line="44"/>
         <source>Replace Rest</source>
         <translation>Ersätt resten</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="39"/>
+        <location filename="../src/controls/replacebar.cpp" line="46"/>
         <source>Replace All</source>
         <translation>Ersätt allt</translation>
     </message>
@@ -858,9 +909,9 @@
     <name>S:</name>
     <message>
         <location filename="../third/libiconv-1.16/src/iconv.c" line="103"/>
-        <source/>
+        <source></source>
         <comment>The first line of the short usage message.</comment>
-        <translation type="unfinished"/>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -891,34 +942,34 @@
         <translation>Fullskärm</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="484"/>
+        <location filename="../src/common/settings.cpp" line="491"/>
         <source>This shortcut conflicts with system shortcut %1</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="487"/>
+        <location filename="../src/common/settings.cpp" line="494"/>
         <source>This shortcut conflicts with %1, click on Replace to make this shortcut effective immediately</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="682"/>
-        <location filename="../src/common/settings.cpp" line="695"/>
-        <location filename="../src/common/settings.cpp" line="704"/>
+        <location filename="../src/common/settings.cpp" line="689"/>
+        <location filename="../src/common/settings.cpp" line="702"/>
+        <location filename="../src/common/settings.cpp" line="711"/>
         <source>The shortcut %1 is invalid, please set another one.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="736"/>
+        <location filename="../src/common/settings.cpp" line="743"/>
         <source>Cancel</source>
         <translation>Avbryt</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="737"/>
+        <location filename="../src/common/settings.cpp" line="744"/>
         <source>Replace</source>
         <translation>Ersätt</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="740"/>
+        <location filename="../src/common/settings.cpp" line="747"/>
         <source>OK</source>
         <translation>Ok</translation>
     </message>
@@ -926,7 +977,7 @@
 <context>
     <name>StartManager</name>
     <message>
-        <location filename="../src/startmanager.cpp" line="411"/>
+        <location filename="../src/startmanager.cpp" line="425"/>
         <source>Untitled %1</source>
         <translation>Namnlös %1</translation>
     </message>
@@ -934,32 +985,32 @@
 <context>
     <name>Tabbar</name>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="641"/>
+        <location filename="../src/controls/tabbar.cpp" line="678"/>
         <source>Close tab</source>
         <translation>Stäng flik</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="642"/>
+        <location filename="../src/controls/tabbar.cpp" line="680"/>
         <source>Close other tabs</source>
         <translation>Stäng andra flikar</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="643"/>
+        <location filename="../src/controls/tabbar.cpp" line="682"/>
         <source>More options</source>
         <translation>Fler alternativ</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="644"/>
+        <location filename="../src/controls/tabbar.cpp" line="684"/>
         <source>Close tabs to the left</source>
         <translation>Stäng flikar till vänster</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="645"/>
+        <location filename="../src/controls/tabbar.cpp" line="686"/>
         <source>Close tabs to the right</source>
         <translation>Stäng flikar till höger</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="646"/>
+        <location filename="../src/controls/tabbar.cpp" line="688"/>
         <source>Close unmodified tabs</source>
         <translation>Stäng oförändrade flikar</translation>
     </message>
@@ -967,263 +1018,280 @@
 <context>
     <name>TextEdit</name>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="305"/>
+        <location filename="../src/editor/dtextedit.cpp" line="388"/>
         <source>Undo</source>
         <translation>Ångra</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="306"/>
+        <location filename="../src/editor/dtextedit.cpp" line="390"/>
         <source>Redo</source>
         <translation>Upprepa</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="307"/>
+        <location filename="../src/editor/dtextedit.cpp" line="392"/>
         <source>Cut</source>
         <translation>Klipp ut</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="308"/>
+        <location filename="../src/editor/dtextedit.cpp" line="394"/>
         <source>Copy</source>
         <translation>Kopiera</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="309"/>
+        <location filename="../src/editor/dtextedit.cpp" line="396"/>
         <source>Paste</source>
         <translation>Klistra in</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="310"/>
+        <location filename="../src/editor/dtextedit.cpp" line="398"/>
         <source>Delete</source>
         <translation>Radera</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="311"/>
+        <location filename="../src/editor/dtextedit.cpp" line="400"/>
         <source>Select All</source>
         <translation>Markera Allt</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="312"/>
-        <location filename="../src/widgets/window.cpp" line="535"/>
+        <location filename="../src/editor/dtextedit.cpp" line="402"/>
+        <location filename="../src/widgets/window.cpp" line="556"/>
         <source>Find</source>
         <translation>Hitta</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="313"/>
-        <location filename="../src/widgets/window.cpp" line="536"/>
+        <location filename="../src/editor/dtextedit.cpp" line="404"/>
+        <location filename="../src/widgets/window.cpp" line="558"/>
         <source>Replace</source>
         <translation>Ersätt</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="314"/>
+        <location filename="../src/editor/dtextedit.cpp" line="406"/>
         <source>Go to Line</source>
         <translation>Gå till Rad</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="315"/>
-        <source>Turn on Read-Only mode</source>
-        <translation>Aktivera Skrivskyddat läge</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="316"/>
-        <source>Turn off Read-Only mode</source>
-        <translation>Stäng av Skrivskyddat läge</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="317"/>
+        <location filename="../src/editor/dtextedit.cpp" line="415"/>
         <source>Fullscreen</source>
         <translation>Fullskärm</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="318"/>
+        <location filename="../src/editor/dtextedit.cpp" line="417"/>
         <source>Exit fullscreen</source>
         <translation>Stäng fullskärm</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="319"/>
+        <location filename="../src/editor/dtextedit.cpp" line="419"/>
         <source>Display in file manager</source>
         <translation>Visa i filhanteraren</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="320"/>
-        <location filename="../src/editor/dtextedit.cpp" line="374"/>
+        <location filename="../src/editor/dtextedit.cpp" line="421"/>
+        <location filename="../src/editor/dtextedit.cpp" line="493"/>
         <source>Add Comment</source>
         <translation>Lägg till kommentar</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="321"/>
+        <location filename="../src/editor/dtextedit.cpp" line="423"/>
         <source>Text to Speech</source>
         <translation>Text till tal</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="322"/>
-        <source>Stop reading</source>
-        <translation>Stoppa läsning</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="323"/>
+        <location filename="../src/editor/dtextedit.cpp" line="425"/>
         <source>Speech to Text</source>
         <translation>Tal till text</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="324"/>
+        <location filename="../src/editor/dtextedit.cpp" line="427"/>
         <source>Translate</source>
         <translation>Översätt</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="325"/>
+        <location filename="../src/editor/dtextedit.cpp" line="429"/>
         <source>Column Mode</source>
         <translation>Kolumnläge</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="326"/>
+        <location filename="../src/editor/dtextedit.cpp" line="431"/>
         <source>Add bookmark</source>
         <translation>Lägg till bokmärke</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="327"/>
+        <location filename="../src/editor/dtextedit.cpp" line="433"/>
         <source>Remove Bookmark</source>
         <translation>Ta bort bokmärke</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="328"/>
+        <location filename="../src/editor/dtextedit.cpp" line="435"/>
         <source>Previous bookmark</source>
         <translation>Föregående bokmärke</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="329"/>
+        <location filename="../src/editor/dtextedit.cpp" line="437"/>
         <source>Next bookmark</source>
         <translation>Nästa bokmärke</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="330"/>
+        <location filename="../src/editor/dtextedit.cpp" line="439"/>
         <source>Remove All Bookmarks</source>
         <translation>Ta bort alla bokmärken</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="331"/>
+        <location filename="../src/editor/dtextedit.cpp" line="441"/>
         <source>Fold All</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="332"/>
+        <location filename="../src/editor/dtextedit.cpp" line="443"/>
         <source>Fold Current Level</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="333"/>
+        <location filename="../src/editor/dtextedit.cpp" line="445"/>
         <source>Unfold All</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="334"/>
+        <location filename="../src/editor/dtextedit.cpp" line="447"/>
         <source>Unfold Current Level</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="339"/>
+        <location filename="../src/editor/dtextedit.cpp" line="453"/>
         <source>Color Mark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="343"/>
+        <location filename="../src/editor/dtextedit.cpp" line="458"/>
         <source>Clear All Marks</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="344"/>
+        <location filename="../src/editor/dtextedit.cpp" line="460"/>
         <source>Clear Last Mark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="353"/>
+        <location filename="../src/editor/dtextedit.cpp" line="470"/>
         <source>Mark</source>
         <translation>Markera</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="366"/>
+        <location filename="../src/editor/dtextedit.cpp" line="484"/>
         <source>Mark All</source>
         <translation>Markera allt</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="375"/>
+        <location filename="../src/editor/dtextedit.cpp" line="494"/>
         <source>Remove Comment</source>
         <translation>Ta bort kommentar</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3208"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3211"/>
+        <location filename="../src/editor/dtextedit.cpp" line="543"/>
+        <source>View Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="3531"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3534"/>
         <source>Copy failed: not enough memory</source>
         <translation>Kopiering misslyckades: slut på minne</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3333"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3335"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3656"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3658"/>
         <source>Press ALT and click lines to edit in column mode</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="418"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9574"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9576"/>
+        <source>No audio output device was detected. Please ensure your speakers or headphones are properly connected and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="9583"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9585"/>
+        <source>No audio input device was detected. Please ensure your speakers or headphones are properly connected and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="534"/>
         <source>Change Case</source>
         <translation>Versaler/Gemener</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="419"/>
+        <location filename="../src/editor/dtextedit.cpp" line="409"/>
+        <source>Edit Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="411"/>
+        <source>Read View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="413"/>
+        <source>Live Preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="535"/>
         <source>Upper Case</source>
         <translation>Versaler</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="420"/>
+        <location filename="../src/editor/dtextedit.cpp" line="536"/>
         <source>Lower Case</source>
         <translation>Gemener</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="421"/>
+        <location filename="../src/editor/dtextedit.cpp" line="537"/>
         <source>Capitalize</source>
         <translation>Versal begynnelsebokstav</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="78"/>
+        <location filename="../src/widgets/bottombar.cpp" line="110"/>
         <source>None</source>
         <translation>Inga</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1363"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1490"/>
         <source>Selected line(s) copied</source>
         <translation>Markerade rad(er) kopierade</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1370"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1497"/>
         <source>Current line copied</source>
         <translation>Aktuell rad kopierad</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1400"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1527"/>
         <source>Selected line(s) clipped</source>
         <translation>Markerade rad(er) utklippta</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1412"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1539"/>
         <source>Current line clipped</source>
         <translation>Aktuell rad utklippt</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3227"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3230"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3550"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3553"/>
         <source>Paste failed: not enough memory</source>
         <translation>Inklistring misslyckades: slut på minne</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="4548"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4873"/>
         <source>Read-Only mode is off</source>
         <translation>Skrivskyddat läge är av</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="4560"/>
-        <location filename="../src/editor/dtextedit.cpp" line="4584"/>
-        <location filename="../src/editor/dtextedit.cpp" line="7896"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8007"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8015"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8026"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4885"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4909"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8236"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8347"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8355"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8366"/>
         <source>Read-Only mode is on</source>
         <translation>Skrivskyddat läge är på</translation>
     </message>
@@ -1231,138 +1299,175 @@
 <context>
     <name>WarningNotices</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="24"/>
+        <location filename="../src/controls/warningnotices.cpp" line="25"/>
         <source>Reload</source>
         <translation>Ladda om</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/warningnotices.cpp" line="29"/>
+        <source>Edit Anyway</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>Window</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="25"/>
-        <location filename="../src/widgets/window.cpp" line="531"/>
+        <location filename="../src/controls/warningnotices.cpp" line="27"/>
+        <location filename="../src/widgets/window.cpp" line="548"/>
         <source>Save as</source>
         <translation>Spara som</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="527"/>
+        <location filename="../src/widgets/window.cpp" line="540"/>
         <source>New window</source>
         <translation>Nytt fönster</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="528"/>
+        <location filename="../src/widgets/window.cpp" line="542"/>
         <source>New tab</source>
         <translation>Ny flik</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="529"/>
+        <location filename="../src/widgets/window.cpp" line="544"/>
         <source>Open file</source>
         <translation>Öppna fil</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="530"/>
-        <location filename="../src/widgets/window.cpp" line="3545"/>
+        <location filename="../src/widgets/window.cpp" line="546"/>
+        <location filename="../src/widgets/window.cpp" line="3950"/>
         <source>Save</source>
         <translation>Spara</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="532"/>
+        <location filename="../src/widgets/window.cpp" line="550"/>
         <source>Print</source>
         <translation>Skriv ut</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="533"/>
+        <location filename="../src/widgets/window.cpp" line="552"/>
         <source>Switch theme</source>
         <translation>Byta tema</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="534"/>
-        <location filename="../src/widgets/window.cpp" line="2448"/>
+        <location filename="../src/widgets/window.cpp" line="554"/>
+        <location filename="../src/widgets/window.cpp" line="2641"/>
         <source>Settings</source>
         <translation>Inställningar</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="666"/>
-        <location filename="../src/widgets/window.cpp" line="3845"/>
+        <location filename="../src/widgets/window.cpp" line="696"/>
+        <location filename="../src/widgets/window.cpp" line="4250"/>
         <source>Read-Only</source>
         <translation>Skrivskyddad</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="687"/>
+        <location filename="../src/widgets/window.cpp" line="719"/>
         <source>You do not have permission to open %1</source>
         <translation>Du har ej behörighet för att öppna %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="738"/>
-        <location filename="../src/widgets/window.cpp" line="2963"/>
+        <location filename="../src/widgets/window.cpp" line="773"/>
+        <location filename="../src/widgets/window.cpp" line="3266"/>
         <source>Invalid file: %1</source>
         <translation>Ogiltig fil: %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="903"/>
-        <location filename="../src/widgets/window.cpp" line="956"/>
+        <location filename="../src/widgets/window.cpp" line="957"/>
+        <location filename="../src/widgets/window.cpp" line="1050"/>
+        <location filename="../src/widgets/window.cpp" line="3217"/>
         <source>Do you want to save this file?</source>
         <translation>Vill du spara denna filen?</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1290"/>
+        <location filename="../src/widgets/window.cpp" line="1381"/>
+        <source>Invalid characters detected while saving &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1382"/>
+        <source>If you force save this file, it may cause file corruption. Still want to save?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1386"/>
+        <source>Don&apos;t Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1387"/>
+        <source>Save As</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1388"/>
+        <source>Save Anyway</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1456"/>
         <source>You do not have permission to save %1</source>
         <translation>Du har ej behörighet för att spara %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1312"/>
+        <location filename="../src/widgets/window.cpp" line="1428"/>
+        <location filename="../src/widgets/window.cpp" line="1478"/>
         <source>Saved successfully</source>
         <translation>Sparat</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1354"/>
-        <location filename="../src/widgets/window.cpp" line="1481"/>
-        <location filename="../src/widgets/window.cpp" line="1529"/>
+        <location filename="../src/widgets/window.cpp" line="1520"/>
+        <location filename="../src/widgets/window.cpp" line="1665"/>
+        <location filename="../src/widgets/window.cpp" line="1713"/>
         <source>Save File</source>
         <translation>Spara fil</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1483"/>
+        <location filename="../src/widgets/window.cpp" line="1569"/>
+        <source>Cannot save as the original file in preview mode. Please choose a different path.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1667"/>
         <source>Encoding</source>
         <translation>Kodning</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1773"/>
+        <location filename="../src/widgets/window.cpp" line="1957"/>
         <source>Read-Only mode is on</source>
         <translation>Skrivskyddat läge är på</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2322"/>
+        <location filename="../src/widgets/window.cpp" line="2511"/>
         <source>Current location remembered</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2398"/>
+        <location filename="../src/widgets/window.cpp" line="2591"/>
         <source>Ctrl+&apos;=&apos;</source>
         <translation>Ctrl+&apos;=&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2401"/>
+        <location filename="../src/widgets/window.cpp" line="2594"/>
         <source>Ctrl+&apos;-&apos;</source>
         <translation>Ctrl+&apos;-&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2430"/>
+        <location filename="../src/widgets/window.cpp" line="2623"/>
         <source>Editor</source>
         <translation>Editor</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3061"/>
+        <location filename="../src/widgets/window.cpp" line="3436"/>
         <source>Untitled %1</source>
         <translation>Namnlös %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3543"/>
+        <location filename="../src/widgets/window.cpp" line="3948"/>
         <source>Cancel</source>
         <translation>Avbryt</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3544"/>
+        <location filename="../src/widgets/window.cpp" line="3949"/>
         <source>Discard</source>
         <translation>Förkasta</translation>
     </message>

--- a/translations/deepin-editor_tr.ts
+++ b/translations/deepin-editor_tr.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="tr">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="tr">
 <context>
     <name>BottomBar</name>
     <message>
@@ -17,17 +19,36 @@
         <translation>%1 Karakter</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="44"/>
+        <location filename="../src/widgets/bottombar.cpp" line="47"/>
         <source>Loading:</source>
         <translation>Yükleme:</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="73"/>
+        <location filename="../src/widgets/bottombar.cpp" line="91"/>
+        <location filename="../src/widgets/bottombar.cpp" line="499"/>
+        <source>Edit Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="74"/>
+        <location filename="../src/widgets/bottombar.cpp" line="489"/>
+        <source>Read View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="75"/>
+        <location filename="../src/widgets/bottombar.cpp" line="493"/>
+        <source>Live Preview</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DDropdownMenu</name>
     <message>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="362"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="420"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="425"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="363"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="421"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="426"/>
         <source>None</source>
         <translation>Yok</translation>
     </message>
@@ -35,68 +56,57 @@
 <context>
     <name>EditWrapper</name>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="292"/>
-        <location filename="../src/editor/editwrapper.cpp" line="365"/>
-        <location filename="../src/editor/editwrapper.cpp" line="521"/>
-        <location filename="../src/editor/editwrapper.cpp" line="751"/>
+        <location filename="../src/editor/editwrapper.cpp" line="355"/>
+        <location filename="../src/editor/editwrapper.cpp" line="429"/>
+        <location filename="../src/editor/editwrapper.cpp" line="595"/>
+        <location filename="../src/editor/editwrapper.cpp" line="887"/>
         <source>Save</source>
         <translation>Kaydet</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="516"/>
+        <location filename="../src/editor/editwrapper.cpp" line="590"/>
         <source>Do you want to save this file?</source>
         <translation>Bu dosyayı kaydetmek ister misiniz?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="363"/>
-        <location filename="../src/editor/editwrapper.cpp" line="519"/>
+        <location filename="../src/editor/editwrapper.cpp" line="427"/>
+        <location filename="../src/editor/editwrapper.cpp" line="593"/>
         <source>Cancel</source>
         <translation>İptal</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="360"/>
+        <location filename="../src/editor/editwrapper.cpp" line="424"/>
         <source>Encoding changed. Do you want to save the file now?</source>
         <translation>Kodlama değişti. Dosyayı şimdi kaydetmek istiyor musunuz?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="520"/>
+        <location filename="../src/editor/editwrapper.cpp" line="594"/>
         <source>Discard</source>
         <translation>Yoksay</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="274"/>
-        <location filename="../src/editor/editwrapper.cpp" line="620"/>
+        <location filename="../src/editor/editwrapper.cpp" line="1121"/>
+        <source>The file contains invalid characters (NUL). Preview mode is read-only.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="337"/>
+        <location filename="../src/editor/editwrapper.cpp" line="705"/>
         <source>You do not have permission to save %1</source>
         <translation>%1 dosyasını kaydetme izniniz yok</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="836"/>
+        <location filename="../src/editor/editwrapper.cpp" line="987"/>
         <source>File removed on the disk. Save it now?</source>
         <translation>Dosya diskten silinmiş. Şimdi kaydetmek ister misiniz?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="842"/>
+        <location filename="../src/editor/editwrapper.cpp" line="993"/>
         <source>File has changed on disk. Reload?</source>
         <translation>Disk üzerindeki dosya değişmiş. Yeniden yüklensin mi?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="884"/>
-        <location filename="../src/widgets/bottombar.cpp" line="74"/>
-        <source>INSERT</source>
-        <translation>EKLE</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="888"/>
-        <source>OVERWRITE</source>
-        <translation>ÜZERİNE YAZ</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="892"/>
-        <source>R/O</source>
-        <translation>S/O</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="1618"/>
+        <location filename="../src/editor/editwrapper.cpp" line="1806"/>
         <source>The file cannot be read, which may be too large or has been damaged!</source>
         <translation>Dosya okunamıyor, büyük olabilir veya hasarlı olabilir!</translation>
     </message>
@@ -109,17 +119,17 @@
         <translation>Bul</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="36"/>
+        <location filename="../src/controls/findbar.cpp" line="38"/>
         <source>Previous</source>
         <translation>Önceki</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="37"/>
+        <location filename="../src/controls/findbar.cpp" line="40"/>
         <source>Next</source>
         <translation>Sonraki</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="38"/>
+        <location filename="../src/controls/findbar.cpp" line="42"/>
         <source>Replace</source>
         <translation>Değiştir</translation>
     </message>
@@ -127,9 +137,17 @@
 <context>
     <name>JumpLineBar</name>
     <message>
-        <location filename="../src/controls/jumplinebar.cpp" line="45"/>
+        <location filename="../src/controls/jumplinebar.cpp" line="46"/>
         <source>Go to Line: </source>
         <translation>Şu Satıra Git:</translation>
+    </message>
+</context>
+<context>
+    <name>LineBar</name>
+    <message>
+        <location filename="../src/controls/linebar.cpp" line="144"/>
+        <source>第%1/%2项</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -146,19 +164,47 @@
     </message>
 </context>
 <context>
+    <name>MarkdownBridge</name>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="37"/>
+        <source>Collapse code block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="38"/>
+        <source>Expand code block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="39"/>
+        <source>Copy code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="40"/>
+        <source>Expand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="42"/>
+        <source>%1 line(s) of code collapsed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PathSettingWgt</name>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="84"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="90"/>
         <source>Remember the last used path</source>
         <translation>Son kullanılan yolu hatırla</translation>
     </message>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="85"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="91"/>
         <source>Same path as the current file</source>
         <translation>Mevcut dosyanın aynı yolunu kullan</translation>
     </message>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="86"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="92"/>
         <source>Customize the default path</source>
         <translation>Varsayılan yolu özelleştir</translation>
     </message>
@@ -171,15 +217,20 @@
         <translation>Metin Düzenleyici</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="294"/>
-        <location filename="../src/editor/editwrapper.cpp" line="761"/>
-        <location filename="../src/editor/editwrapper.cpp" line="776"/>
-        <location filename="../src/widgets/window.cpp" line="1362"/>
-        <location filename="../src/widgets/window.cpp" line="1390"/>
-        <location filename="../src/widgets/window.cpp" line="1531"/>
-        <location filename="../src/widgets/window.cpp" line="1548"/>
+        <location filename="../src/editor/editwrapper.cpp" line="357"/>
+        <location filename="../src/editor/editwrapper.cpp" line="897"/>
+        <location filename="../src/editor/editwrapper.cpp" line="912"/>
+        <location filename="../src/widgets/window.cpp" line="1528"/>
+        <location filename="../src/widgets/window.cpp" line="1556"/>
+        <location filename="../src/widgets/window.cpp" line="1715"/>
+        <location filename="../src/widgets/window.cpp" line="1732"/>
         <source>Encoding</source>
         <translation>Kodlama</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="2001"/>
+        <source>视图模式</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="11"/>
@@ -215,7 +266,7 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="18"/>
         <location filename="../src/controls/settingsdialog.cpp" line="96"/>
-        <location filename="../src/widgets/window.cpp" line="2388"/>
+        <location filename="../src/widgets/window.cpp" line="2581"/>
         <source>Window</source>
         <translation>Pencere</translation>
     </message>
@@ -755,68 +806,68 @@
         <translation>Vietnamca</translation>
     </message>
     <message>
-        <location filename="../src/startmanager.cpp" line="971"/>
+        <location filename="../src/startmanager.cpp" line="1035"/>
         <source>File not saved</source>
         <translation>Dosya kaydedilmedi</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1532"/>
-        <location filename="../src/widgets/window.cpp" line="1549"/>
+        <location filename="../src/widgets/window.cpp" line="1716"/>
+        <location filename="../src/widgets/window.cpp" line="1733"/>
         <source>Line Endings</source>
         <translation>Satır Sonları</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="243"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="379"/>
         <source>Please install &apos;UOS AI&apos; from the App Store before using</source>
         <translation>Kullanmadan önce &apos;UOS AI&apos; uygulamasını Uygulama Mağazasından yükleyin</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="245"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="381"/>
         <source>No audio input device detected. Please check and try again</source>
         <translation>Ses girdi cihazı tespit edilemedi. Lütfen kontrol edip tekrar deneyin</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="247"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="383"/>
         <source>No audio output device detected. Please check and try again</source>
         <translation>Ses çıktı cihazı tespit edilemedi. Lütfen kontrol edip tekrar deneyin</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="69"/>
+        <location filename="../src/common/text_file_saver.cpp" line="74"/>
         <source>File path is empty</source>
         <translation>Dosya yolu boş</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="155"/>
+        <location filename="../src/common/text_file_saver.cpp" line="153"/>
         <source>Insufficient memory to load document content</source>
         <translation>Belge içeriğini yüklemek için yeterli bellek yok</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="177"/>
+        <location filename="../src/common/text_file_saver.cpp" line="178"/>
         <source>Insufficient memory for encoding conversion</source>
         <translation>Kodlama dönüştürmesi için yeterli bellek yok</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="183"/>
+        <location filename="../src/common/text_file_saver.cpp" line="184"/>
         <source>Encoding conversion failed</source>
         <translation>Kodlama dönüştürmesi başarısız oldu</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="189"/>
+        <location filename="../src/common/text_file_saver.cpp" line="190"/>
         <source>Converted content is empty</source>
         <translation>Dönüştürülen içerik boş</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="207"/>
+        <location filename="../src/common/text_file_saver.cpp" line="208"/>
         <source>Memory allocation failed</source>
         <translation>Bellek ayırma başarısız oldu</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="211"/>
+        <location filename="../src/common/text_file_saver.cpp" line="212"/>
         <source>Error occurred: %1</source>
         <translation>&apos;Hata oluştu: %1&apos;</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="215"/>
+        <location filename="../src/common/text_file_saver.cpp" line="216"/>
         <source>Unknown error occurred</source>
         <translation>Bilinmeyen bir hata oluştu</translation>
     </message>
@@ -829,27 +880,27 @@
         <translation>Bul</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="34"/>
+        <location filename="../src/controls/replacebar.cpp" line="36"/>
         <source>Replace With</source>
         <translation>Şununla Değiştir</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="36"/>
+        <location filename="../src/controls/replacebar.cpp" line="40"/>
         <source>Replace</source>
         <translation>Değiştir</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="37"/>
+        <location filename="../src/controls/replacebar.cpp" line="42"/>
         <source>Skip</source>
         <translation>Atla</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="38"/>
+        <location filename="../src/controls/replacebar.cpp" line="44"/>
         <source>Replace Rest</source>
         <translation>Kalanları Değiştir</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="39"/>
+        <location filename="../src/controls/replacebar.cpp" line="46"/>
         <source>Replace All</source>
         <translation>Tümünü Değiştir</translation>
     </message>
@@ -858,9 +909,9 @@
     <name>S:</name>
     <message>
         <location filename="../third/libiconv-1.16/src/iconv.c" line="103"/>
-        <source/>
+        <source></source>
         <comment>The first line of the short usage message.</comment>
-        <translation type="unfinished"/>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -891,34 +942,34 @@
         <translation>Tam ekran</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="484"/>
+        <location filename="../src/common/settings.cpp" line="491"/>
         <source>This shortcut conflicts with system shortcut %1</source>
         <translation>Bu kısayol, %1 sistem kısayolu ile çakışıyor</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="487"/>
+        <location filename="../src/common/settings.cpp" line="494"/>
         <source>This shortcut conflicts with %1, click on Replace to make this shortcut effective immediately</source>
         <translation>Bu kısayol %1 ile çakışıyor, bu kısayolu hemen etkin hale getirmek için Değiştire tıklayın</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="682"/>
-        <location filename="../src/common/settings.cpp" line="695"/>
-        <location filename="../src/common/settings.cpp" line="704"/>
+        <location filename="../src/common/settings.cpp" line="689"/>
+        <location filename="../src/common/settings.cpp" line="702"/>
+        <location filename="../src/common/settings.cpp" line="711"/>
         <source>The shortcut %1 is invalid, please set another one.</source>
         <translation>%1 kısayolu geçersiz, lütfen başka bir tane ayarlayın.</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="736"/>
+        <location filename="../src/common/settings.cpp" line="743"/>
         <source>Cancel</source>
         <translation>İptal</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="737"/>
+        <location filename="../src/common/settings.cpp" line="744"/>
         <source>Replace</source>
         <translation>Değiştir</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="740"/>
+        <location filename="../src/common/settings.cpp" line="747"/>
         <source>OK</source>
         <translation>Tamam</translation>
     </message>
@@ -926,7 +977,7 @@
 <context>
     <name>StartManager</name>
     <message>
-        <location filename="../src/startmanager.cpp" line="411"/>
+        <location filename="../src/startmanager.cpp" line="425"/>
         <source>Untitled %1</source>
         <translation>Başlıksız %1</translation>
     </message>
@@ -934,32 +985,32 @@
 <context>
     <name>Tabbar</name>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="641"/>
+        <location filename="../src/controls/tabbar.cpp" line="678"/>
         <source>Close tab</source>
         <translation>Sekmeyi kapat</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="642"/>
+        <location filename="../src/controls/tabbar.cpp" line="680"/>
         <source>Close other tabs</source>
         <translation>Diğer sekmeleri kapat</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="643"/>
+        <location filename="../src/controls/tabbar.cpp" line="682"/>
         <source>More options</source>
         <translation>Daha fazla seçenek</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="644"/>
+        <location filename="../src/controls/tabbar.cpp" line="684"/>
         <source>Close tabs to the left</source>
         <translation>Soldaki sekmeleri kapat</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="645"/>
+        <location filename="../src/controls/tabbar.cpp" line="686"/>
         <source>Close tabs to the right</source>
         <translation>Sağdaki sekmeleri kapat</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="646"/>
+        <location filename="../src/controls/tabbar.cpp" line="688"/>
         <source>Close unmodified tabs</source>
         <translation>Değiştirilmemiş sekmeleri kapat</translation>
     </message>
@@ -967,263 +1018,280 @@
 <context>
     <name>TextEdit</name>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="305"/>
+        <location filename="../src/editor/dtextedit.cpp" line="388"/>
         <source>Undo</source>
         <translation>Geri al</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="306"/>
+        <location filename="../src/editor/dtextedit.cpp" line="390"/>
         <source>Redo</source>
         <translation>Yinele</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="307"/>
+        <location filename="../src/editor/dtextedit.cpp" line="392"/>
         <source>Cut</source>
         <translation>Kes</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="308"/>
+        <location filename="../src/editor/dtextedit.cpp" line="394"/>
         <source>Copy</source>
         <translation>Kopyala</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="309"/>
+        <location filename="../src/editor/dtextedit.cpp" line="396"/>
         <source>Paste</source>
         <translation>Yapıştır</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="310"/>
+        <location filename="../src/editor/dtextedit.cpp" line="398"/>
         <source>Delete</source>
         <translation>Sil</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="311"/>
+        <location filename="../src/editor/dtextedit.cpp" line="400"/>
         <source>Select All</source>
         <translation>Tümünü Seç</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="312"/>
-        <location filename="../src/widgets/window.cpp" line="535"/>
+        <location filename="../src/editor/dtextedit.cpp" line="402"/>
+        <location filename="../src/widgets/window.cpp" line="556"/>
         <source>Find</source>
         <translation>Bul</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="313"/>
-        <location filename="../src/widgets/window.cpp" line="536"/>
+        <location filename="../src/editor/dtextedit.cpp" line="404"/>
+        <location filename="../src/widgets/window.cpp" line="558"/>
         <source>Replace</source>
         <translation>Değiştir</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="314"/>
+        <location filename="../src/editor/dtextedit.cpp" line="406"/>
         <source>Go to Line</source>
         <translation>Şu Satıra Git</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="315"/>
-        <source>Turn on Read-Only mode</source>
-        <translation>Salt Okunur Kipi Aç</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="316"/>
-        <source>Turn off Read-Only mode</source>
-        <translation>Salt Okunur Kipi Kapat</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="317"/>
+        <location filename="../src/editor/dtextedit.cpp" line="415"/>
         <source>Fullscreen</source>
         <translation>Tam ekran</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="318"/>
+        <location filename="../src/editor/dtextedit.cpp" line="417"/>
         <source>Exit fullscreen</source>
         <translation>Tam ekrandan çık</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="319"/>
+        <location filename="../src/editor/dtextedit.cpp" line="419"/>
         <source>Display in file manager</source>
         <translation>Dosya yöneticisinde görüntüle</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="320"/>
-        <location filename="../src/editor/dtextedit.cpp" line="374"/>
+        <location filename="../src/editor/dtextedit.cpp" line="421"/>
+        <location filename="../src/editor/dtextedit.cpp" line="493"/>
         <source>Add Comment</source>
         <translation>Yorum Ekle</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="321"/>
+        <location filename="../src/editor/dtextedit.cpp" line="423"/>
         <source>Text to Speech</source>
         <translation>Yazıdan Konuşmaya</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="322"/>
-        <source>Stop reading</source>
-        <translation>Okumayı durdur</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="323"/>
+        <location filename="../src/editor/dtextedit.cpp" line="425"/>
         <source>Speech to Text</source>
         <translation>Konuşmadan Yazıya</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="324"/>
+        <location filename="../src/editor/dtextedit.cpp" line="427"/>
         <source>Translate</source>
         <translation>Çeviri</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="325"/>
+        <location filename="../src/editor/dtextedit.cpp" line="429"/>
         <source>Column Mode</source>
         <translation>Sütun Kipi</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="326"/>
+        <location filename="../src/editor/dtextedit.cpp" line="431"/>
         <source>Add bookmark</source>
         <translation>Yer imlerine ekle</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="327"/>
+        <location filename="../src/editor/dtextedit.cpp" line="433"/>
         <source>Remove Bookmark</source>
         <translation>Yer İmini Kaldır</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="328"/>
+        <location filename="../src/editor/dtextedit.cpp" line="435"/>
         <source>Previous bookmark</source>
         <translation>Önceki yer imi</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="329"/>
+        <location filename="../src/editor/dtextedit.cpp" line="437"/>
         <source>Next bookmark</source>
         <translation>Sonraki yer imi</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="330"/>
+        <location filename="../src/editor/dtextedit.cpp" line="439"/>
         <source>Remove All Bookmarks</source>
         <translation>Tüm Yer İmlerini Kaldır</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="331"/>
+        <location filename="../src/editor/dtextedit.cpp" line="441"/>
         <source>Fold All</source>
         <translation>Tümünü Katla</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="332"/>
+        <location filename="../src/editor/dtextedit.cpp" line="443"/>
         <source>Fold Current Level</source>
         <translation>Mevcut Seviyeyi Katla</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="333"/>
+        <location filename="../src/editor/dtextedit.cpp" line="445"/>
         <source>Unfold All</source>
         <translation>Tümünü Katlama</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="334"/>
+        <location filename="../src/editor/dtextedit.cpp" line="447"/>
         <source>Unfold Current Level</source>
         <translation>Mevcut Seviyeyi Katlama</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="339"/>
+        <location filename="../src/editor/dtextedit.cpp" line="453"/>
         <source>Color Mark</source>
         <translation>Renk İşareti</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="343"/>
+        <location filename="../src/editor/dtextedit.cpp" line="458"/>
         <source>Clear All Marks</source>
         <translation>Tüm İşaretleri Temizle</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="344"/>
+        <location filename="../src/editor/dtextedit.cpp" line="460"/>
         <source>Clear Last Mark</source>
         <translation>Son İşareti Temizle</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="353"/>
+        <location filename="../src/editor/dtextedit.cpp" line="470"/>
         <source>Mark</source>
         <translation>İşaretle</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="366"/>
+        <location filename="../src/editor/dtextedit.cpp" line="484"/>
         <source>Mark All</source>
         <translation>Tümünü İşaretle</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="375"/>
+        <location filename="../src/editor/dtextedit.cpp" line="494"/>
         <source>Remove Comment</source>
         <translation>Yorumu Kaldır</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3208"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3211"/>
+        <location filename="../src/editor/dtextedit.cpp" line="543"/>
+        <source>View Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="3531"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3534"/>
         <source>Copy failed: not enough memory</source>
         <translation>Kopyalama başarısız: yeterli bellek yok</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3333"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3335"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3656"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3658"/>
         <source>Press ALT and click lines to edit in column mode</source>
         <translation>Sütun kipinde düzenlemek için ALT tuşuna bas ve satırları tıkla</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="418"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9574"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9576"/>
+        <source>No audio output device was detected. Please ensure your speakers or headphones are properly connected and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="9583"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9585"/>
+        <source>No audio input device was detected. Please ensure your speakers or headphones are properly connected and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="534"/>
         <source>Change Case</source>
         <translation>Büyük Küçük Harfi Değiştir</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="419"/>
+        <location filename="../src/editor/dtextedit.cpp" line="409"/>
+        <source>Edit Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="411"/>
+        <source>Read View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="413"/>
+        <source>Live Preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="535"/>
         <source>Upper Case</source>
         <translation>Büyük Harf</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="420"/>
+        <location filename="../src/editor/dtextedit.cpp" line="536"/>
         <source>Lower Case</source>
         <translation>Küçük Harf</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="421"/>
+        <location filename="../src/editor/dtextedit.cpp" line="537"/>
         <source>Capitalize</source>
         <translation>İlk Harfleri Büyüt</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="78"/>
+        <location filename="../src/widgets/bottombar.cpp" line="110"/>
         <source>None</source>
         <translation>Yok</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1363"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1490"/>
         <source>Selected line(s) copied</source>
         <translation>Seçilen satır(lar) kopyalandı</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1370"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1497"/>
         <source>Current line copied</source>
         <translation>Mevcut satır kopyalandı</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1400"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1527"/>
         <source>Selected line(s) clipped</source>
         <translation>Seçilen satır(lar) kırpıldı</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1412"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1539"/>
         <source>Current line clipped</source>
         <translation>Mevcut satır kopyalandı</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3227"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3230"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3550"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3553"/>
         <source>Paste failed: not enough memory</source>
         <translation>Yapıştırılamadı: yeterli bellek yok</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="4548"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4873"/>
         <source>Read-Only mode is off</source>
         <translation>Salt okunur kip kapalı</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="4560"/>
-        <location filename="../src/editor/dtextedit.cpp" line="4584"/>
-        <location filename="../src/editor/dtextedit.cpp" line="7896"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8007"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8015"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8026"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4885"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4909"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8236"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8347"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8355"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8366"/>
         <source>Read-Only mode is on</source>
         <translation>Salt okunur kip açık</translation>
     </message>
@@ -1231,138 +1299,175 @@
 <context>
     <name>WarningNotices</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="24"/>
+        <location filename="../src/controls/warningnotices.cpp" line="25"/>
         <source>Reload</source>
         <translation>Yeniden yükle</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/warningnotices.cpp" line="29"/>
+        <source>Edit Anyway</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>Window</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="25"/>
-        <location filename="../src/widgets/window.cpp" line="531"/>
+        <location filename="../src/controls/warningnotices.cpp" line="27"/>
+        <location filename="../src/widgets/window.cpp" line="548"/>
         <source>Save as</source>
         <translation>Farklı kaydet</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="527"/>
+        <location filename="../src/widgets/window.cpp" line="540"/>
         <source>New window</source>
         <translation>Yeni pencere</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="528"/>
+        <location filename="../src/widgets/window.cpp" line="542"/>
         <source>New tab</source>
         <translation>Yeni sekme</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="529"/>
+        <location filename="../src/widgets/window.cpp" line="544"/>
         <source>Open file</source>
         <translation>Dosya aç</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="530"/>
-        <location filename="../src/widgets/window.cpp" line="3545"/>
+        <location filename="../src/widgets/window.cpp" line="546"/>
+        <location filename="../src/widgets/window.cpp" line="3950"/>
         <source>Save</source>
         <translation>Kaydet</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="532"/>
+        <location filename="../src/widgets/window.cpp" line="550"/>
         <source>Print</source>
         <translation>Yazdır</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="533"/>
+        <location filename="../src/widgets/window.cpp" line="552"/>
         <source>Switch theme</source>
         <translation>Temayı değiştir</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="534"/>
-        <location filename="../src/widgets/window.cpp" line="2448"/>
+        <location filename="../src/widgets/window.cpp" line="554"/>
+        <location filename="../src/widgets/window.cpp" line="2641"/>
         <source>Settings</source>
         <translation>Ayarlar</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="666"/>
-        <location filename="../src/widgets/window.cpp" line="3845"/>
+        <location filename="../src/widgets/window.cpp" line="696"/>
+        <location filename="../src/widgets/window.cpp" line="4250"/>
         <source>Read-Only</source>
         <translation>Salt Okunur</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="687"/>
+        <location filename="../src/widgets/window.cpp" line="719"/>
         <source>You do not have permission to open %1</source>
         <translation>%1 dosyasını açma izniniz yok</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="738"/>
-        <location filename="../src/widgets/window.cpp" line="2963"/>
+        <location filename="../src/widgets/window.cpp" line="773"/>
+        <location filename="../src/widgets/window.cpp" line="3266"/>
         <source>Invalid file: %1</source>
         <translation>Geçersiz dosya: %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="903"/>
-        <location filename="../src/widgets/window.cpp" line="956"/>
+        <location filename="../src/widgets/window.cpp" line="957"/>
+        <location filename="../src/widgets/window.cpp" line="1050"/>
+        <location filename="../src/widgets/window.cpp" line="3217"/>
         <source>Do you want to save this file?</source>
         <translation>Bu dosyayı kaydetmek ister misiniz?</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1290"/>
+        <location filename="../src/widgets/window.cpp" line="1381"/>
+        <source>Invalid characters detected while saving &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1382"/>
+        <source>If you force save this file, it may cause file corruption. Still want to save?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1386"/>
+        <source>Don&apos;t Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1387"/>
+        <source>Save As</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1388"/>
+        <source>Save Anyway</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1456"/>
         <source>You do not have permission to save %1</source>
         <translation>%1 dosyasını kaydetme izniniz yok</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1312"/>
+        <location filename="../src/widgets/window.cpp" line="1428"/>
+        <location filename="../src/widgets/window.cpp" line="1478"/>
         <source>Saved successfully</source>
         <translation>Başarıyla kaydedildi</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1354"/>
-        <location filename="../src/widgets/window.cpp" line="1481"/>
-        <location filename="../src/widgets/window.cpp" line="1529"/>
+        <location filename="../src/widgets/window.cpp" line="1520"/>
+        <location filename="../src/widgets/window.cpp" line="1665"/>
+        <location filename="../src/widgets/window.cpp" line="1713"/>
         <source>Save File</source>
         <translation>Dosyayı Kaydet</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1483"/>
+        <location filename="../src/widgets/window.cpp" line="1569"/>
+        <source>Cannot save as the original file in preview mode. Please choose a different path.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1667"/>
         <source>Encoding</source>
         <translation>Kodlama</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1773"/>
+        <location filename="../src/widgets/window.cpp" line="1957"/>
         <source>Read-Only mode is on</source>
         <translation>Salt okunur kip açık</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2322"/>
+        <location filename="../src/widgets/window.cpp" line="2511"/>
         <source>Current location remembered</source>
         <translation>Mevcut konum hatırlandı</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2398"/>
+        <location filename="../src/widgets/window.cpp" line="2591"/>
         <source>Ctrl+&apos;=&apos;</source>
         <translation>Ctrl+&apos;=&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2401"/>
+        <location filename="../src/widgets/window.cpp" line="2594"/>
         <source>Ctrl+&apos;-&apos;</source>
         <translation>Ctrl+&apos;-&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2430"/>
+        <location filename="../src/widgets/window.cpp" line="2623"/>
         <source>Editor</source>
         <translation>Düzenleyici</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3061"/>
+        <location filename="../src/widgets/window.cpp" line="3436"/>
         <source>Untitled %1</source>
         <translation>Başlıksız %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3543"/>
+        <location filename="../src/widgets/window.cpp" line="3948"/>
         <source>Cancel</source>
         <translation>İptal</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3544"/>
+        <location filename="../src/widgets/window.cpp" line="3949"/>
         <source>Discard</source>
         <translation>Yoksay</translation>
     </message>

--- a/translations/deepin-editor_ug.ts
+++ b/translations/deepin-editor_ug.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ug">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ug">
 <context>
     <name>BottomBar</name>
     <message>
@@ -17,17 +19,36 @@
         <translation>ھەرپ-بەلگە سانى %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="44"/>
+        <location filename="../src/widgets/bottombar.cpp" line="47"/>
         <source>Loading:</source>
         <translation>ھۆججەت يۈكلىنىۋاتىدۇ:</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="73"/>
+        <location filename="../src/widgets/bottombar.cpp" line="91"/>
+        <location filename="../src/widgets/bottombar.cpp" line="499"/>
+        <source>Edit Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="74"/>
+        <location filename="../src/widgets/bottombar.cpp" line="489"/>
+        <source>Read View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="75"/>
+        <location filename="../src/widgets/bottombar.cpp" line="493"/>
+        <source>Live Preview</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DDropdownMenu</name>
     <message>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="362"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="420"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="425"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="363"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="421"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="426"/>
         <source>None</source>
         <translation>يوق</translation>
     </message>
@@ -35,68 +56,57 @@
 <context>
     <name>EditWrapper</name>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="292"/>
-        <location filename="../src/editor/editwrapper.cpp" line="365"/>
-        <location filename="../src/editor/editwrapper.cpp" line="521"/>
-        <location filename="../src/editor/editwrapper.cpp" line="751"/>
+        <location filename="../src/editor/editwrapper.cpp" line="355"/>
+        <location filename="../src/editor/editwrapper.cpp" line="429"/>
+        <location filename="../src/editor/editwrapper.cpp" line="595"/>
+        <location filename="../src/editor/editwrapper.cpp" line="887"/>
         <source>Save</source>
         <translation>ساقلاش</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="516"/>
+        <location filename="../src/editor/editwrapper.cpp" line="590"/>
         <source>Do you want to save this file?</source>
         <translation>بۇ ھۆججەتنى ساقلامسىز؟</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="363"/>
-        <location filename="../src/editor/editwrapper.cpp" line="519"/>
+        <location filename="../src/editor/editwrapper.cpp" line="427"/>
+        <location filename="../src/editor/editwrapper.cpp" line="593"/>
         <source>Cancel</source>
         <translation>بىكار قىلىش</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="360"/>
+        <location filename="../src/editor/editwrapper.cpp" line="424"/>
         <source>Encoding changed. Do you want to save the file now?</source>
         <translation>ھۆججەت كودلاش ئۇسۇلى ئۆزگەرتىلدى، ئۇنى ئاۋۋال ساقلىماقچىمۇ؟</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="520"/>
+        <location filename="../src/editor/editwrapper.cpp" line="594"/>
         <source>Discard</source>
         <translation>ساقلىمايمەن</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="274"/>
-        <location filename="../src/editor/editwrapper.cpp" line="620"/>
+        <location filename="../src/editor/editwrapper.cpp" line="1121"/>
+        <source>The file contains invalid characters (NUL). Preview mode is read-only.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="337"/>
+        <location filename="../src/editor/editwrapper.cpp" line="705"/>
         <source>You do not have permission to save %1</source>
         <translation>%1نى ساقلاش ھوقۇقىڭىز يوق</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="836"/>
+        <location filename="../src/editor/editwrapper.cpp" line="987"/>
         <source>File removed on the disk. Save it now?</source>
         <translation>دىسكىدىكى ئەسلى ھۆججەت ئۆچۈرۈلدى، قايتا ساقلىماقچىمۇ؟</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="842"/>
+        <location filename="../src/editor/editwrapper.cpp" line="993"/>
         <source>File has changed on disk. Reload?</source>
         <translation>دىسكىدىكى ئەسلى ھۆججەت ئۆزگەرتىلدى، قايتا يۈكلىمەكچىمۇ؟</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="884"/>
-        <location filename="../src/widgets/bottombar.cpp" line="74"/>
-        <source>INSERT</source>
-        <translation>كىرگۈزۈش</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="888"/>
-        <source>OVERWRITE</source>
-        <translation>باستۇرۇش</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="892"/>
-        <source>R/O</source>
-        <translation>پەقەت ئوقۇش</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="1618"/>
+        <location filename="../src/editor/editwrapper.cpp" line="1806"/>
         <source>The file cannot be read, which may be too large or has been damaged!</source>
         <translation>بۇ ھۆججەتنى ئوقۇغىلى بولمىدى، ھۆججەت بەك چوڭ ياكى بۇزۇلۇپ كەتكەن</translation>
     </message>
@@ -109,17 +119,17 @@
         <translation>ئىزدەش</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="36"/>
+        <location filename="../src/controls/findbar.cpp" line="38"/>
         <source>Previous</source>
         <translation>ئالدىنقىسى</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="37"/>
+        <location filename="../src/controls/findbar.cpp" line="40"/>
         <source>Next</source>
         <translation>كېيىنكىسى</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="38"/>
+        <location filename="../src/controls/findbar.cpp" line="42"/>
         <source>Replace</source>
         <translation>ئالماشتۇرۇش</translation>
     </message>
@@ -127,9 +137,17 @@
 <context>
     <name>JumpLineBar</name>
     <message>
-        <location filename="../src/controls/jumplinebar.cpp" line="45"/>
+        <location filename="../src/controls/jumplinebar.cpp" line="46"/>
         <source>Go to Line: </source>
         <translation>سەكرەش:</translation>
+    </message>
+</context>
+<context>
+    <name>LineBar</name>
+    <message>
+        <location filename="../src/controls/linebar.cpp" line="144"/>
+        <source>第%1/%2项</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -146,19 +164,47 @@
     </message>
 </context>
 <context>
+    <name>MarkdownBridge</name>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="37"/>
+        <source>Collapse code block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="38"/>
+        <source>Expand code block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="39"/>
+        <source>Copy code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="40"/>
+        <source>Expand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="42"/>
+        <source>%1 line(s) of code collapsed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PathSettingWgt</name>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="84"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="90"/>
         <source>Remember the last used path</source>
         <translation>ئەڭ ئاخىرقى مەشغۇلات مۇندەرىجىسىنى ئەستە ساقلىسۇن</translation>
     </message>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="85"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="91"/>
         <source>Same path as the current file</source>
         <translation>ھازىرقى ھۆججەت بىلەن بىردەكلىكنى ساقلىسۇن</translation>
     </message>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="86"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="92"/>
         <source>Customize the default path</source>
         <translation>مەشغۇلات مۇندەرىجىسى بەلگىلەش</translation>
     </message>
@@ -171,15 +217,20 @@
         <translation>تېكىست تەھرىرلىگۈچ</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="294"/>
-        <location filename="../src/editor/editwrapper.cpp" line="761"/>
-        <location filename="../src/editor/editwrapper.cpp" line="776"/>
-        <location filename="../src/widgets/window.cpp" line="1362"/>
-        <location filename="../src/widgets/window.cpp" line="1390"/>
-        <location filename="../src/widgets/window.cpp" line="1531"/>
-        <location filename="../src/widgets/window.cpp" line="1548"/>
+        <location filename="../src/editor/editwrapper.cpp" line="357"/>
+        <location filename="../src/editor/editwrapper.cpp" line="897"/>
+        <location filename="../src/editor/editwrapper.cpp" line="912"/>
+        <location filename="../src/widgets/window.cpp" line="1528"/>
+        <location filename="../src/widgets/window.cpp" line="1556"/>
+        <location filename="../src/widgets/window.cpp" line="1715"/>
+        <location filename="../src/widgets/window.cpp" line="1732"/>
         <source>Encoding</source>
         <translation>كودلاش</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="2001"/>
+        <source>视图模式</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="11"/>
@@ -215,7 +266,7 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="18"/>
         <location filename="../src/controls/settingsdialog.cpp" line="96"/>
-        <location filename="../src/widgets/window.cpp" line="2388"/>
+        <location filename="../src/widgets/window.cpp" line="2581"/>
         <source>Window</source>
         <translation>كۆزنەك</translation>
     </message>
@@ -755,68 +806,68 @@
         <translation>ۋېيتنامچە</translation>
     </message>
     <message>
-        <location filename="../src/startmanager.cpp" line="971"/>
+        <location filename="../src/startmanager.cpp" line="1035"/>
         <source>File not saved</source>
         <translation>ھۆججەت ساقلانمىغان</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1532"/>
-        <location filename="../src/widgets/window.cpp" line="1549"/>
+        <location filename="../src/widgets/window.cpp" line="1716"/>
+        <location filename="../src/widgets/window.cpp" line="1733"/>
         <source>Line Endings</source>
         <translation>قۇر تاشلاش بەلگىسى</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="243"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="379"/>
         <source>Please install &apos;UOS AI&apos; from the App Store before using</source>
         <translation>ئۇنى ئاستىلەش چۈشىنىش ئۈچۈن &apos;UOS AI&apos; نى ئەپ سىتى ئاستىدىن سېنىشلىق كېرەك</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="245"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="381"/>
         <source>No audio input device detected. Please check and try again</source>
         <translation>ئەپسىلەش كىرەكلىك ھەجىمەتىنى ھەققىدە تەسىر قىلمىغان. تەسىر قىلىڭ ۋە ھەققىدە كېرەك</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="247"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="383"/>
         <source>No audio output device detected. Please check and try again</source>
         <translation>ئەپسىلەش چыغىش ھەجىمەتىنى ھەققىدە تەسىر قىلمىغان. تەسىر قىلىڭ ۋە ھەققىدە كېرەك</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="69"/>
+        <location filename="../src/common/text_file_saver.cpp" line="74"/>
         <source>File path is empty</source>
         <translation>ھۆججەت يولى ھەققىدە كۆرۈنگۈچ</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="155"/>
+        <location filename="../src/common/text_file_saver.cpp" line="153"/>
         <source>Insufficient memory to load document content</source>
         <translation>ھۆججەت مېنىسىنى چۈشىنىش چۈشىنىشلىق مېمىرىيىسى ھەققىدە كۆرۈنگۈچ</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="177"/>
+        <location filename="../src/common/text_file_saver.cpp" line="178"/>
         <source>Insufficient memory for encoding conversion</source>
         <translation>كىرەكلىك مېمىرىيىسى ھەققىدە كۆرۈنگۈچ</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="183"/>
+        <location filename="../src/common/text_file_saver.cpp" line="184"/>
         <source>Encoding conversion failed</source>
         <translation>كىرەكلىك ھەجىمەتىنى تەسىر قىلغان</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="189"/>
+        <location filename="../src/common/text_file_saver.cpp" line="190"/>
         <source>Converted content is empty</source>
         <translation>تەسىر قىلغان مېنىسىنى ھەققىدە كۆرۈنگۈچ</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="207"/>
+        <location filename="../src/common/text_file_saver.cpp" line="208"/>
         <source>Memory allocation failed</source>
         <translation>مېمىرىيىسى تەسىر قىلغان</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="211"/>
+        <location filename="../src/common/text_file_saver.cpp" line="212"/>
         <source>Error occurred: %1</source>
         <translation>تەسىر قىلغان: %1</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="215"/>
+        <location filename="../src/common/text_file_saver.cpp" line="216"/>
         <source>Unknown error occurred</source>
         <translation>نىشانلىق تەسىر قىلمىغان</translation>
     </message>
@@ -829,27 +880,27 @@
         <translation>ئىزدەش</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="34"/>
+        <location filename="../src/controls/replacebar.cpp" line="36"/>
         <source>Replace With</source>
         <translation>غا ئالماشتۇرۇش</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="36"/>
+        <location filename="../src/controls/replacebar.cpp" line="40"/>
         <source>Replace</source>
         <translation>ئالماشتۇرۇش</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="37"/>
+        <location filename="../src/controls/replacebar.cpp" line="42"/>
         <source>Skip</source>
         <translation>ئاتلاش</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="38"/>
+        <location filename="../src/controls/replacebar.cpp" line="44"/>
         <source>Replace Rest</source>
         <translation>قالغانلىرىنى ئالماشتۇرۇش</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="39"/>
+        <location filename="../src/controls/replacebar.cpp" line="46"/>
         <source>Replace All</source>
         <translation>ھەممىنى ئالماشتۇرۇش</translation>
     </message>
@@ -858,9 +909,9 @@
     <name>S:</name>
     <message>
         <location filename="../third/libiconv-1.16/src/iconv.c" line="103"/>
-        <source/>
+        <source></source>
         <comment>The first line of the short usage message.</comment>
-        <translation type="unfinished"/>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -891,34 +942,34 @@
         <translation>پۈتۈن ئېكران</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="484"/>
+        <location filename="../src/common/settings.cpp" line="491"/>
         <source>This shortcut conflicts with system shortcut %1</source>
         <translation>بۇ تېزلەتمە سىستېما تېزلەتمىسى %1 بىلەن توقۇنۇشىدۇ</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="487"/>
+        <location filename="../src/common/settings.cpp" line="494"/>
         <source>This shortcut conflicts with %1, click on Replace to make this shortcut effective immediately</source>
         <translation>بۇ تېزلەتمە %1 بىلەن توقۇنۇشىدۇ، ئالماشتۇرۇشنى بېسىپ بۇ تېزلەتمنى ئۈنۈملۈك قىلىڭ</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="682"/>
-        <location filename="../src/common/settings.cpp" line="695"/>
-        <location filename="../src/common/settings.cpp" line="704"/>
+        <location filename="../src/common/settings.cpp" line="689"/>
+        <location filename="../src/common/settings.cpp" line="702"/>
+        <location filename="../src/common/settings.cpp" line="711"/>
         <source>The shortcut %1 is invalid, please set another one.</source>
         <translation>%1 ئۈنۈمسىز، قايتا بەلگىلەڭ</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="736"/>
+        <location filename="../src/common/settings.cpp" line="743"/>
         <source>Cancel</source>
         <translation>بىكار قىلىش</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="737"/>
+        <location filename="../src/common/settings.cpp" line="744"/>
         <source>Replace</source>
         <translation>ئالماشتۇرۇش</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="740"/>
+        <location filename="../src/common/settings.cpp" line="747"/>
         <source>OK</source>
         <translation>ھەئە</translation>
     </message>
@@ -926,7 +977,7 @@
 <context>
     <name>StartManager</name>
     <message>
-        <location filename="../src/startmanager.cpp" line="411"/>
+        <location filename="../src/startmanager.cpp" line="425"/>
         <source>Untitled %1</source>
         <translation>%1نىڭ نامىنى ئۆزگەتىش</translation>
     </message>
@@ -934,32 +985,32 @@
 <context>
     <name>Tabbar</name>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="641"/>
+        <location filename="../src/controls/tabbar.cpp" line="678"/>
         <source>Close tab</source>
         <translation>خەتكۈچنى تاقاش</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="642"/>
+        <location filename="../src/controls/tabbar.cpp" line="680"/>
         <source>Close other tabs</source>
         <translation>باشقا خەتكۈچنى تاقاش</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="643"/>
+        <location filename="../src/controls/tabbar.cpp" line="682"/>
         <source>More options</source>
         <translation>تېخىمۇ كۆپ تاقاش ئۇسۇلى</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="644"/>
+        <location filename="../src/controls/tabbar.cpp" line="684"/>
         <source>Close tabs to the left</source>
         <translation>سولدىكى بارلىق خەتكۈچنى تاقاش</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="645"/>
+        <location filename="../src/controls/tabbar.cpp" line="686"/>
         <source>Close tabs to the right</source>
         <translation>ئوڭدىكى بارلىق خەتكۈچنى تاقاش</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="646"/>
+        <location filename="../src/controls/tabbar.cpp" line="688"/>
         <source>Close unmodified tabs</source>
         <translation>ئۆزگەرتىلمىگەن بارلىق خەتكۈچنى تاقاش</translation>
     </message>
@@ -967,263 +1018,280 @@
 <context>
     <name>TextEdit</name>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="305"/>
+        <location filename="../src/editor/dtextedit.cpp" line="388"/>
         <source>Undo</source>
         <translation>ئەمەلدىن قالدۇرۇش</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="306"/>
+        <location filename="../src/editor/dtextedit.cpp" line="390"/>
         <source>Redo</source>
         <translation>قايتا</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="307"/>
+        <location filename="../src/editor/dtextedit.cpp" line="392"/>
         <source>Cut</source>
         <translation>چاپلاش</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="308"/>
+        <location filename="../src/editor/dtextedit.cpp" line="394"/>
         <source>Copy</source>
         <translation>كۆچۈرۈش</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="309"/>
+        <location filename="../src/editor/dtextedit.cpp" line="396"/>
         <source>Paste</source>
         <translation>چاپلاش</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="310"/>
+        <location filename="../src/editor/dtextedit.cpp" line="398"/>
         <source>Delete</source>
         <translation>ئۆچۈرۈش</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="311"/>
+        <location filename="../src/editor/dtextedit.cpp" line="400"/>
         <source>Select All</source>
         <translation>ھەممىنى</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="312"/>
-        <location filename="../src/widgets/window.cpp" line="535"/>
+        <location filename="../src/editor/dtextedit.cpp" line="402"/>
+        <location filename="../src/widgets/window.cpp" line="556"/>
         <source>Find</source>
         <translation>ئىزدەش</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="313"/>
-        <location filename="../src/widgets/window.cpp" line="536"/>
+        <location filename="../src/editor/dtextedit.cpp" line="404"/>
+        <location filename="../src/widgets/window.cpp" line="558"/>
         <source>Replace</source>
         <translation>ئالماشتۇرۇش</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="314"/>
+        <location filename="../src/editor/dtextedit.cpp" line="406"/>
         <source>Go to Line</source>
         <translation>سەكرەش</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="315"/>
-        <source>Turn on Read-Only mode</source>
-        <translation>پەقەت ئوقۇيدىغان ھالەتنى ئېچىش</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="316"/>
-        <source>Turn off Read-Only mode</source>
-        <translation>پەقەت ئوقۇيدىغان ھالەتنى تاقاش</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="317"/>
+        <location filename="../src/editor/dtextedit.cpp" line="415"/>
         <source>Fullscreen</source>
         <translation>پۈتۈن ئېكران</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="318"/>
+        <location filename="../src/editor/dtextedit.cpp" line="417"/>
         <source>Exit fullscreen</source>
         <translation>پۈتۈن ئېكراندىن چېكىنىش</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="319"/>
+        <location filename="../src/editor/dtextedit.cpp" line="419"/>
         <source>Display in file manager</source>
         <translation>ھۆججەت باشقۇرغۇچتا كۆرسىتىش</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="320"/>
-        <location filename="../src/editor/dtextedit.cpp" line="374"/>
+        <location filename="../src/editor/dtextedit.cpp" line="421"/>
+        <location filename="../src/editor/dtextedit.cpp" line="493"/>
         <source>Add Comment</source>
         <translation>ئىزاھات قوشۇش</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="321"/>
+        <location filename="../src/editor/dtextedit.cpp" line="423"/>
         <source>Text to Speech</source>
         <translation>تېكىستنى ئاۋازغا ئايلاندۇرۇش</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="322"/>
-        <source>Stop reading</source>
-        <translation>ئوقۇشنى توختىتىش</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="323"/>
+        <location filename="../src/editor/dtextedit.cpp" line="425"/>
         <source>Speech to Text</source>
         <translation>ئاۋازنى تېكىستكە ئايلاندۇرۇش</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="324"/>
+        <location filename="../src/editor/dtextedit.cpp" line="427"/>
         <source>Translate</source>
         <translation>تەرجىمان</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="325"/>
+        <location filename="../src/editor/dtextedit.cpp" line="429"/>
         <source>Column Mode</source>
         <translation>ئىستون تەھرىرلەش ھالىتى</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="326"/>
+        <location filename="../src/editor/dtextedit.cpp" line="431"/>
         <source>Add bookmark</source>
         <translation>خەتكۈچ قوشۇش</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="327"/>
+        <location filename="../src/editor/dtextedit.cpp" line="433"/>
         <source>Remove Bookmark</source>
         <translation>خەتكۈچ چىقىرىۋېتىش</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="328"/>
+        <location filename="../src/editor/dtextedit.cpp" line="435"/>
         <source>Previous bookmark</source>
         <translation>ئالدىنقى خەتكۈچ</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="329"/>
+        <location filename="../src/editor/dtextedit.cpp" line="437"/>
         <source>Next bookmark</source>
         <translation>كېيىنكى خەتكۈچ</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="330"/>
+        <location filename="../src/editor/dtextedit.cpp" line="439"/>
         <source>Remove All Bookmarks</source>
         <translation>بارلىق خەتكۈچنى چىقىرىۋېتىش</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="331"/>
+        <location filename="../src/editor/dtextedit.cpp" line="441"/>
         <source>Fold All</source>
         <translation>بارلىق قاتلامنى قاتلاش</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="332"/>
+        <location filename="../src/editor/dtextedit.cpp" line="443"/>
         <source>Fold Current Level</source>
         <translation>ھازىرقى قاتلامنى قاتلاش</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="333"/>
+        <location filename="../src/editor/dtextedit.cpp" line="445"/>
         <source>Unfold All</source>
         <translation>بارلىق قاتلامنى ئېچىش</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="334"/>
+        <location filename="../src/editor/dtextedit.cpp" line="447"/>
         <source>Unfold Current Level</source>
         <translation>ھازىرقى قاتلامنى ئېچىش</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="339"/>
+        <location filename="../src/editor/dtextedit.cpp" line="453"/>
         <source>Color Mark</source>
         <translation>رەڭ بەلگىسى</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="343"/>
+        <location filename="../src/editor/dtextedit.cpp" line="458"/>
         <source>Clear All Marks</source>
         <translation>بارلىق بەلگىلەرنى چىقىرىۋېتىش</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="344"/>
+        <location filename="../src/editor/dtextedit.cpp" line="460"/>
         <source>Clear Last Mark</source>
         <translation>ئالدىنقى بەلگىنى چىقىرىۋېتىش</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="353"/>
+        <location filename="../src/editor/dtextedit.cpp" line="470"/>
         <source>Mark</source>
         <translation>بەلگە قويۇش</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="366"/>
+        <location filename="../src/editor/dtextedit.cpp" line="484"/>
         <source>Mark All</source>
         <translation>ھەممىسىگە بەلگە قويۇش</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="375"/>
+        <location filename="../src/editor/dtextedit.cpp" line="494"/>
         <source>Remove Comment</source>
         <translation>ئىزاھاتنى بىكار قىلىش</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3208"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3211"/>
+        <location filename="../src/editor/dtextedit.cpp" line="543"/>
+        <source>View Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="3531"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3534"/>
         <source>Copy failed: not enough memory</source>
         <translation>ئىچكى ساقلىغۇچ يېتىشمىدى، كۆچۈرەلمىدى</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3333"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3335"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3656"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3658"/>
         <source>Press ALT and click lines to edit in column mode</source>
         <translation>ئىستون تەھرىرلەش ھالىتىنى ئالماشتۇرۇش ئۈچۈن ALT   بىلەن مائۇسنى ئىشلىتىڭ</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="418"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9574"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9576"/>
+        <source>No audio output device was detected. Please ensure your speakers or headphones are properly connected and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="9583"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9585"/>
+        <source>No audio input device was detected. Please ensure your speakers or headphones are properly connected and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="534"/>
         <source>Change Case</source>
         <translation>چوڭ-كىچىك يېزىلىشىنى ئالماشتۇرۇش</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="419"/>
+        <location filename="../src/editor/dtextedit.cpp" line="409"/>
+        <source>Edit Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="411"/>
+        <source>Read View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="413"/>
+        <source>Live Preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="535"/>
         <source>Upper Case</source>
         <translation>چوڭ يېزىلىش</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="420"/>
+        <location filename="../src/editor/dtextedit.cpp" line="536"/>
         <source>Lower Case</source>
         <translation>كىچىك يېزىلىش</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="421"/>
+        <location filename="../src/editor/dtextedit.cpp" line="537"/>
         <source>Capitalize</source>
         <translation>1-ھەرپ چوڭ يېزىلسۇن</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="78"/>
+        <location filename="../src/widgets/bottombar.cpp" line="110"/>
         <source>None</source>
         <translation>يوق</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1363"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1490"/>
         <source>Selected line(s) copied</source>
         <translation>تاللانغان قۇر چاپلاش تاختىسىغا كۆچۈرۈلدى</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1370"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1497"/>
         <source>Current line copied</source>
         <translation>نۆۋەتتىكى قۇر چاپلاش تاختىسىغا كۆچۈرۈلدى</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1400"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1527"/>
         <source>Selected line(s) clipped</source>
         <translation>تاللانغان قۇر چاپلاش تاختىسىغا كېسىلدى</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1412"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1539"/>
         <source>Current line clipped</source>
         <translation>نۆۋەتتىكى قۇر چاپلاش تاختىسىغا كېسىلدى</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3227"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3230"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3550"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3553"/>
         <source>Paste failed: not enough memory</source>
         <translation>ئىچكى ساقلىغۇچ يېتىشمىدى، چاپلانمىدى</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="4548"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4873"/>
         <source>Read-Only mode is off</source>
         <translation>پەقەت ئوقۇيدىغان ھالەت تاقالدى</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="4560"/>
-        <location filename="../src/editor/dtextedit.cpp" line="4584"/>
-        <location filename="../src/editor/dtextedit.cpp" line="7896"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8007"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8015"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8026"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4885"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4909"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8236"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8347"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8355"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8366"/>
         <source>Read-Only mode is on</source>
         <translation>پەقەت ئوقۇيدىغان ھالەتنى ئېچىلدى</translation>
     </message>
@@ -1231,138 +1299,175 @@
 <context>
     <name>WarningNotices</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="24"/>
+        <location filename="../src/controls/warningnotices.cpp" line="25"/>
         <source>Reload</source>
         <translation>قايتا كىرگۈزۈڭ</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/warningnotices.cpp" line="29"/>
+        <source>Edit Anyway</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>Window</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="25"/>
-        <location filename="../src/widgets/window.cpp" line="531"/>
+        <location filename="../src/controls/warningnotices.cpp" line="27"/>
+        <location filename="../src/widgets/window.cpp" line="548"/>
         <source>Save as</source>
         <translation>باشقا ساقلاش</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="527"/>
+        <location filename="../src/widgets/window.cpp" line="540"/>
         <source>New window</source>
         <translation>يېڭى كۆزنەك</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="528"/>
+        <location filename="../src/widgets/window.cpp" line="542"/>
         <source>New tab</source>
         <translation>يېڭى خەتكۈچ</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="529"/>
+        <location filename="../src/widgets/window.cpp" line="544"/>
         <source>Open file</source>
         <translation>ئېچىش</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="530"/>
-        <location filename="../src/widgets/window.cpp" line="3545"/>
+        <location filename="../src/widgets/window.cpp" line="546"/>
+        <location filename="../src/widgets/window.cpp" line="3950"/>
         <source>Save</source>
         <translation>ساقلاش</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="532"/>
+        <location filename="../src/widgets/window.cpp" line="550"/>
         <source>Print</source>
         <translation>بېسىش</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="533"/>
+        <location filename="../src/widgets/window.cpp" line="552"/>
         <source>Switch theme</source>
         <translation>ئۇسلۇب ئالماشتۇرۇش</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="534"/>
-        <location filename="../src/widgets/window.cpp" line="2448"/>
+        <location filename="../src/widgets/window.cpp" line="554"/>
+        <location filename="../src/widgets/window.cpp" line="2641"/>
         <source>Settings</source>
         <translation>تەڭشەك</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="666"/>
-        <location filename="../src/widgets/window.cpp" line="3845"/>
+        <location filename="../src/widgets/window.cpp" line="696"/>
+        <location filename="../src/widgets/window.cpp" line="4250"/>
         <source>Read-Only</source>
         <translation>پەقەت ئوقۇيدىغان قىلىش</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="687"/>
+        <location filename="../src/widgets/window.cpp" line="719"/>
         <source>You do not have permission to open %1</source>
         <translation>%1نى ئېچىش ھوقۇقىڭىز يوق</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="738"/>
-        <location filename="../src/widgets/window.cpp" line="2963"/>
+        <location filename="../src/widgets/window.cpp" line="773"/>
+        <location filename="../src/widgets/window.cpp" line="3266"/>
         <source>Invalid file: %1</source>
         <translation>ئۈنۈمسىز ھۆججەت: %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="903"/>
-        <location filename="../src/widgets/window.cpp" line="956"/>
+        <location filename="../src/widgets/window.cpp" line="957"/>
+        <location filename="../src/widgets/window.cpp" line="1050"/>
+        <location filename="../src/widgets/window.cpp" line="3217"/>
         <source>Do you want to save this file?</source>
         <translation>بۇ ھۆججەتنى ساقلامسىز؟</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1290"/>
+        <location filename="../src/widgets/window.cpp" line="1381"/>
+        <source>Invalid characters detected while saving &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1382"/>
+        <source>If you force save this file, it may cause file corruption. Still want to save?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1386"/>
+        <source>Don&apos;t Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1387"/>
+        <source>Save As</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1388"/>
+        <source>Save Anyway</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1456"/>
         <source>You do not have permission to save %1</source>
         <translation>%1نى ساقلاش ھوقۇقىڭىز يوق</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1312"/>
+        <location filename="../src/widgets/window.cpp" line="1428"/>
+        <location filename="../src/widgets/window.cpp" line="1478"/>
         <source>Saved successfully</source>
         <translation>ھۆججەت ساقلاندى</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1354"/>
-        <location filename="../src/widgets/window.cpp" line="1481"/>
-        <location filename="../src/widgets/window.cpp" line="1529"/>
+        <location filename="../src/widgets/window.cpp" line="1520"/>
+        <location filename="../src/widgets/window.cpp" line="1665"/>
+        <location filename="../src/widgets/window.cpp" line="1713"/>
         <source>Save File</source>
         <translation>ساقلاش</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1483"/>
+        <location filename="../src/widgets/window.cpp" line="1569"/>
+        <source>Cannot save as the original file in preview mode. Please choose a different path.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1667"/>
         <source>Encoding</source>
         <translation>كودلاش</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1773"/>
+        <location filename="../src/widgets/window.cpp" line="1957"/>
         <source>Read-Only mode is on</source>
         <translation>پەقەت ئوقۇيدىغان ھالەتنى ئېچىلدى</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2322"/>
+        <location filename="../src/widgets/window.cpp" line="2511"/>
         <source>Current location remembered</source>
         <translation>نۆۋەتتىكى ئورۇن ئەستە ساقلاندى</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2398"/>
+        <location filename="../src/widgets/window.cpp" line="2591"/>
         <source>Ctrl+&apos;=&apos;</source>
         <translation>Ctrl+&apos;=&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2401"/>
+        <location filename="../src/widgets/window.cpp" line="2594"/>
         <source>Ctrl+&apos;-&apos;</source>
         <translation>Ctrl+&apos;-&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2430"/>
+        <location filename="../src/widgets/window.cpp" line="2623"/>
         <source>Editor</source>
         <translation>تەھرىرلەش</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3061"/>
+        <location filename="../src/widgets/window.cpp" line="3436"/>
         <source>Untitled %1</source>
         <translation>%1نىڭ نامىنى ئۆزگەتىش</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3543"/>
+        <location filename="../src/widgets/window.cpp" line="3948"/>
         <source>Cancel</source>
         <translation>بىكار قىلىش</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3544"/>
+        <location filename="../src/widgets/window.cpp" line="3949"/>
         <source>Discard</source>
         <translation>ساقلىمايمەن</translation>
     </message>

--- a/translations/deepin-editor_uk.ts
+++ b/translations/deepin-editor_uk.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="uk">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="uk">
 <context>
     <name>BottomBar</name>
     <message>
@@ -17,17 +19,36 @@
         <translation>%1 символів</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="44"/>
+        <location filename="../src/widgets/bottombar.cpp" line="47"/>
         <source>Loading:</source>
         <translation>Завантаження:</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="73"/>
+        <location filename="../src/widgets/bottombar.cpp" line="91"/>
+        <location filename="../src/widgets/bottombar.cpp" line="499"/>
+        <source>Edit Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="74"/>
+        <location filename="../src/widgets/bottombar.cpp" line="489"/>
+        <source>Read View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="75"/>
+        <location filename="../src/widgets/bottombar.cpp" line="493"/>
+        <source>Live Preview</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DDropdownMenu</name>
     <message>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="362"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="420"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="425"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="363"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="421"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="426"/>
         <source>None</source>
         <translation>Ніякий</translation>
     </message>
@@ -35,68 +56,57 @@
 <context>
     <name>EditWrapper</name>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="292"/>
-        <location filename="../src/editor/editwrapper.cpp" line="365"/>
-        <location filename="../src/editor/editwrapper.cpp" line="521"/>
-        <location filename="../src/editor/editwrapper.cpp" line="751"/>
+        <location filename="../src/editor/editwrapper.cpp" line="355"/>
+        <location filename="../src/editor/editwrapper.cpp" line="429"/>
+        <location filename="../src/editor/editwrapper.cpp" line="595"/>
+        <location filename="../src/editor/editwrapper.cpp" line="887"/>
         <source>Save</source>
         <translation>Зберегти</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="516"/>
+        <location filename="../src/editor/editwrapper.cpp" line="590"/>
         <source>Do you want to save this file?</source>
         <translation>Хочете зберегти цей файл?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="363"/>
-        <location filename="../src/editor/editwrapper.cpp" line="519"/>
+        <location filename="../src/editor/editwrapper.cpp" line="427"/>
+        <location filename="../src/editor/editwrapper.cpp" line="593"/>
         <source>Cancel</source>
         <translation>Скасувати</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="360"/>
+        <location filename="../src/editor/editwrapper.cpp" line="424"/>
         <source>Encoding changed. Do you want to save the file now?</source>
         <translation>Кодування змінено. Хочете зберегти файл зараз?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="520"/>
+        <location filename="../src/editor/editwrapper.cpp" line="594"/>
         <source>Discard</source>
         <translation>Відкинути</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="274"/>
-        <location filename="../src/editor/editwrapper.cpp" line="620"/>
+        <location filename="../src/editor/editwrapper.cpp" line="1121"/>
+        <source>The file contains invalid characters (NUL). Preview mode is read-only.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="337"/>
+        <location filename="../src/editor/editwrapper.cpp" line="705"/>
         <source>You do not have permission to save %1</source>
         <translation>У вас немає прав на збереження %1</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="836"/>
+        <location filename="../src/editor/editwrapper.cpp" line="987"/>
         <source>File removed on the disk. Save it now?</source>
         <translation>Файл вилучено з диска. Зберегти його?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="842"/>
+        <location filename="../src/editor/editwrapper.cpp" line="993"/>
         <source>File has changed on disk. Reload?</source>
         <translation>Файл на диску був змінений. Перезавантажити?</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="884"/>
-        <location filename="../src/widgets/bottombar.cpp" line="74"/>
-        <source>INSERT</source>
-        <translation>ВСТАВЛЯТИ</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="888"/>
-        <source>OVERWRITE</source>
-        <translation>ПЕРЕЗАПИСУВАТИ</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="892"/>
-        <source>R/O</source>
-        <translation>ЛИШЕ ЧИТАННЯ</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="1618"/>
+        <location filename="../src/editor/editwrapper.cpp" line="1806"/>
         <source>The file cannot be read, which may be too large or has been damaged!</source>
         <translation>Файл не може бути прочитано. Він може бути надто великим або пошкодженим!</translation>
     </message>
@@ -109,17 +119,17 @@
         <translation>Знайти</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="36"/>
+        <location filename="../src/controls/findbar.cpp" line="38"/>
         <source>Previous</source>
         <translation>Попереднє</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="37"/>
+        <location filename="../src/controls/findbar.cpp" line="40"/>
         <source>Next</source>
         <translation>Наступне</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="38"/>
+        <location filename="../src/controls/findbar.cpp" line="42"/>
         <source>Replace</source>
         <translation>Замінити</translation>
     </message>
@@ -127,9 +137,17 @@
 <context>
     <name>JumpLineBar</name>
     <message>
-        <location filename="../src/controls/jumplinebar.cpp" line="45"/>
+        <location filename="../src/controls/jumplinebar.cpp" line="46"/>
         <source>Go to Line: </source>
         <translation>Перейти до рядка:</translation>
+    </message>
+</context>
+<context>
+    <name>LineBar</name>
+    <message>
+        <location filename="../src/controls/linebar.cpp" line="144"/>
+        <source>第%1/%2项</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -146,19 +164,47 @@
     </message>
 </context>
 <context>
+    <name>MarkdownBridge</name>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="37"/>
+        <source>Collapse code block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="38"/>
+        <source>Expand code block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="39"/>
+        <source>Copy code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="40"/>
+        <source>Expand</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="42"/>
+        <source>%1 line(s) of code collapsed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PathSettingWgt</name>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="84"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="90"/>
         <source>Remember the last used path</source>
         <translation>Запам&apos;ятовувати останній використаний шлях</translation>
     </message>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="85"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="91"/>
         <source>Same path as the current file</source>
         <translation>Той самий шлях, що і для поточного файла</translation>
     </message>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="86"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="92"/>
         <source>Customize the default path</source>
         <translation>Налаштувати типовий шлях</translation>
     </message>
@@ -171,15 +217,20 @@
         <translation>Текстовий редактор</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="294"/>
-        <location filename="../src/editor/editwrapper.cpp" line="761"/>
-        <location filename="../src/editor/editwrapper.cpp" line="776"/>
-        <location filename="../src/widgets/window.cpp" line="1362"/>
-        <location filename="../src/widgets/window.cpp" line="1390"/>
-        <location filename="../src/widgets/window.cpp" line="1531"/>
-        <location filename="../src/widgets/window.cpp" line="1548"/>
+        <location filename="../src/editor/editwrapper.cpp" line="357"/>
+        <location filename="../src/editor/editwrapper.cpp" line="897"/>
+        <location filename="../src/editor/editwrapper.cpp" line="912"/>
+        <location filename="../src/widgets/window.cpp" line="1528"/>
+        <location filename="../src/widgets/window.cpp" line="1556"/>
+        <location filename="../src/widgets/window.cpp" line="1715"/>
+        <location filename="../src/widgets/window.cpp" line="1732"/>
         <source>Encoding</source>
         <translation>Кодування</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="2001"/>
+        <source>视图模式</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="11"/>
@@ -215,7 +266,7 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="18"/>
         <location filename="../src/controls/settingsdialog.cpp" line="96"/>
-        <location filename="../src/widgets/window.cpp" line="2388"/>
+        <location filename="../src/widgets/window.cpp" line="2581"/>
         <source>Window</source>
         <translation>Вікно</translation>
     </message>
@@ -755,68 +806,68 @@
         <translation>В&apos;єтнамська</translation>
     </message>
     <message>
-        <location filename="../src/startmanager.cpp" line="971"/>
+        <location filename="../src/startmanager.cpp" line="1035"/>
         <source>File not saved</source>
         <translation>Файл не збережено</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1532"/>
-        <location filename="../src/widgets/window.cpp" line="1549"/>
+        <location filename="../src/widgets/window.cpp" line="1716"/>
+        <location filename="../src/widgets/window.cpp" line="1733"/>
         <source>Line Endings</source>
         <translation>Символ закінчення рядка</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="243"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="379"/>
         <source>Please install &apos;UOS AI&apos; from the App Store before using</source>
         <translation>Будь ласка, встановіть &apos;UOS AI&apos; з App Store перед використанням</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="245"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="381"/>
         <source>No audio input device detected. Please check and try again</source>
         <translation>Не виявлено вхідного аудіопристрою. Будь ласка, перевірте та спробуйте знову</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="247"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="383"/>
         <source>No audio output device detected. Please check and try again</source>
         <translation>Не виявлено вихідного аудіопристрою. Будь ласка, перевірте та спробуйте знову</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="69"/>
+        <location filename="../src/common/text_file_saver.cpp" line="74"/>
         <source>File path is empty</source>
         <translation>Шлях файлу порожній</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="155"/>
+        <location filename="../src/common/text_file_saver.cpp" line="153"/>
         <source>Insufficient memory to load document content</source>
         <translation>Недостатньо пам&apos;яті для завантаження вмісту документа</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="177"/>
+        <location filename="../src/common/text_file_saver.cpp" line="178"/>
         <source>Insufficient memory for encoding conversion</source>
         <translation>Недостатньо пам&apos;яті для перетворення кодування</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="183"/>
+        <location filename="../src/common/text_file_saver.cpp" line="184"/>
         <source>Encoding conversion failed</source>
         <translation>Перетворення кодування не вдалося</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="189"/>
+        <location filename="../src/common/text_file_saver.cpp" line="190"/>
         <source>Converted content is empty</source>
         <translation>Перетворені дані порожні</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="207"/>
+        <location filename="../src/common/text_file_saver.cpp" line="208"/>
         <source>Memory allocation failed</source>
         <translation>Не вдалося виділити пам&apos;ять</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="211"/>
+        <location filename="../src/common/text_file_saver.cpp" line="212"/>
         <source>Error occurred: %1</source>
         <translation>Сталася помилка: %1</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="215"/>
+        <location filename="../src/common/text_file_saver.cpp" line="216"/>
         <source>Unknown error occurred</source>
         <translation>Сталася невідома помилка</translation>
     </message>
@@ -829,27 +880,27 @@
         <translation>Знайти</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="34"/>
+        <location filename="../src/controls/replacebar.cpp" line="36"/>
         <source>Replace With</source>
         <translation>Замінити на</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="36"/>
+        <location filename="../src/controls/replacebar.cpp" line="40"/>
         <source>Replace</source>
         <translation>Замінити</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="37"/>
+        <location filename="../src/controls/replacebar.cpp" line="42"/>
         <source>Skip</source>
         <translation>Пропустити</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="38"/>
+        <location filename="../src/controls/replacebar.cpp" line="44"/>
         <source>Replace Rest</source>
         <translation>Замінити решту</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="39"/>
+        <location filename="../src/controls/replacebar.cpp" line="46"/>
         <source>Replace All</source>
         <translation>Замінити все</translation>
     </message>
@@ -858,9 +909,9 @@
     <name>S:</name>
     <message>
         <location filename="../third/libiconv-1.16/src/iconv.c" line="103"/>
-        <source/>
+        <source></source>
         <comment>The first line of the short usage message.</comment>
-        <translation type="unfinished"/>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -891,34 +942,34 @@
         <translation>На весь екран</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="484"/>
+        <location filename="../src/common/settings.cpp" line="491"/>
         <source>This shortcut conflicts with system shortcut %1</source>
         <translation>Це клавіатурне скорочення конфліктує із загальносистемним скороченням %1</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="487"/>
+        <location filename="../src/common/settings.cpp" line="494"/>
         <source>This shortcut conflicts with %1, click on Replace to make this shortcut effective immediately</source>
         <translation>Це клавіатурне скорочення конфліктує з %1. Натисніть кнопку «Замінити», щоб це клавіатурне скорочення набуло чинності негайно.</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="682"/>
-        <location filename="../src/common/settings.cpp" line="695"/>
-        <location filename="../src/common/settings.cpp" line="704"/>
+        <location filename="../src/common/settings.cpp" line="689"/>
+        <location filename="../src/common/settings.cpp" line="702"/>
+        <location filename="../src/common/settings.cpp" line="711"/>
         <source>The shortcut %1 is invalid, please set another one.</source>
         <translation>Скорочення %1 є некоректним. Будь ласка, встановіть інше.</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="736"/>
+        <location filename="../src/common/settings.cpp" line="743"/>
         <source>Cancel</source>
         <translation>Скасувати</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="737"/>
+        <location filename="../src/common/settings.cpp" line="744"/>
         <source>Replace</source>
         <translation>Замінити</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="740"/>
+        <location filename="../src/common/settings.cpp" line="747"/>
         <source>OK</source>
         <translation>Гаразд</translation>
     </message>
@@ -926,7 +977,7 @@
 <context>
     <name>StartManager</name>
     <message>
-        <location filename="../src/startmanager.cpp" line="411"/>
+        <location filename="../src/startmanager.cpp" line="425"/>
         <source>Untitled %1</source>
         <translation>Без назви %1</translation>
     </message>
@@ -934,32 +985,32 @@
 <context>
     <name>Tabbar</name>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="641"/>
+        <location filename="../src/controls/tabbar.cpp" line="678"/>
         <source>Close tab</source>
         <translation>Закрити вкладку</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="642"/>
+        <location filename="../src/controls/tabbar.cpp" line="680"/>
         <source>Close other tabs</source>
         <translation>Закрити інші вкладки</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="643"/>
+        <location filename="../src/controls/tabbar.cpp" line="682"/>
         <source>More options</source>
         <translation>Додаткові параметри</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="644"/>
+        <location filename="../src/controls/tabbar.cpp" line="684"/>
         <source>Close tabs to the left</source>
         <translation>Закрити вкладки ліворуч</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="645"/>
+        <location filename="../src/controls/tabbar.cpp" line="686"/>
         <source>Close tabs to the right</source>
         <translation>Закрити вкладки праворуч</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="646"/>
+        <location filename="../src/controls/tabbar.cpp" line="688"/>
         <source>Close unmodified tabs</source>
         <translation>Закрити вкладки без змін</translation>
     </message>
@@ -967,263 +1018,280 @@
 <context>
     <name>TextEdit</name>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="305"/>
+        <location filename="../src/editor/dtextedit.cpp" line="388"/>
         <source>Undo</source>
         <translation>Скасувати</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="306"/>
+        <location filename="../src/editor/dtextedit.cpp" line="390"/>
         <source>Redo</source>
         <translation>Повторити</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="307"/>
+        <location filename="../src/editor/dtextedit.cpp" line="392"/>
         <source>Cut</source>
         <translation>Вирізати</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="308"/>
+        <location filename="../src/editor/dtextedit.cpp" line="394"/>
         <source>Copy</source>
         <translation>Копіювати</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="309"/>
+        <location filename="../src/editor/dtextedit.cpp" line="396"/>
         <source>Paste</source>
         <translation>Вставити</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="310"/>
+        <location filename="../src/editor/dtextedit.cpp" line="398"/>
         <source>Delete</source>
         <translation>Видалити</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="311"/>
+        <location filename="../src/editor/dtextedit.cpp" line="400"/>
         <source>Select All</source>
         <translation>Вибрати все</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="312"/>
-        <location filename="../src/widgets/window.cpp" line="535"/>
+        <location filename="../src/editor/dtextedit.cpp" line="402"/>
+        <location filename="../src/widgets/window.cpp" line="556"/>
         <source>Find</source>
         <translation>Знайти</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="313"/>
-        <location filename="../src/widgets/window.cpp" line="536"/>
+        <location filename="../src/editor/dtextedit.cpp" line="404"/>
+        <location filename="../src/widgets/window.cpp" line="558"/>
         <source>Replace</source>
         <translation>Замінити</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="314"/>
+        <location filename="../src/editor/dtextedit.cpp" line="406"/>
         <source>Go to Line</source>
         <translation>Перейти до рядка</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="315"/>
-        <source>Turn on Read-Only mode</source>
-        <translation>Увімкнути режим лише для читання</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="316"/>
-        <source>Turn off Read-Only mode</source>
-        <translation>Вимкнути режим лише для читання</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="317"/>
+        <location filename="../src/editor/dtextedit.cpp" line="415"/>
         <source>Fullscreen</source>
         <translation>На весь екран</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="318"/>
+        <location filename="../src/editor/dtextedit.cpp" line="417"/>
         <source>Exit fullscreen</source>
         <translation>Вийти з повноекранного режиму</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="319"/>
+        <location filename="../src/editor/dtextedit.cpp" line="419"/>
         <source>Display in file manager</source>
         <translation>Показати у файловому менеджері</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="320"/>
-        <location filename="../src/editor/dtextedit.cpp" line="374"/>
+        <location filename="../src/editor/dtextedit.cpp" line="421"/>
+        <location filename="../src/editor/dtextedit.cpp" line="493"/>
         <source>Add Comment</source>
         <translation>Додати коментування</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="321"/>
+        <location filename="../src/editor/dtextedit.cpp" line="423"/>
         <source>Text to Speech</source>
         <translation>Озвучення тексту</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="322"/>
-        <source>Stop reading</source>
-        <translation>Припинити читання</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="323"/>
+        <location filename="../src/editor/dtextedit.cpp" line="425"/>
         <source>Speech to Text</source>
         <translation>Перетворення звуку на текст</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="324"/>
+        <location filename="../src/editor/dtextedit.cpp" line="427"/>
         <source>Translate</source>
         <translation>Перекласти</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="325"/>
+        <location filename="../src/editor/dtextedit.cpp" line="429"/>
         <source>Column Mode</source>
         <translation>Режим стовпчиків</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="326"/>
+        <location filename="../src/editor/dtextedit.cpp" line="431"/>
         <source>Add bookmark</source>
         <translation>Додати закладку</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="327"/>
+        <location filename="../src/editor/dtextedit.cpp" line="433"/>
         <source>Remove Bookmark</source>
         <translation>Вилучити закладку</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="328"/>
+        <location filename="../src/editor/dtextedit.cpp" line="435"/>
         <source>Previous bookmark</source>
         <translation>Попередня закладка</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="329"/>
+        <location filename="../src/editor/dtextedit.cpp" line="437"/>
         <source>Next bookmark</source>
         <translation>Наступна закладка</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="330"/>
+        <location filename="../src/editor/dtextedit.cpp" line="439"/>
         <source>Remove All Bookmarks</source>
         <translation>Вилучити усі закладки</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="331"/>
+        <location filename="../src/editor/dtextedit.cpp" line="441"/>
         <source>Fold All</source>
         <translation>Згорнути усе</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="332"/>
+        <location filename="../src/editor/dtextedit.cpp" line="443"/>
         <source>Fold Current Level</source>
         <translation>Згорнути поточний рівень</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="333"/>
+        <location filename="../src/editor/dtextedit.cpp" line="445"/>
         <source>Unfold All</source>
         <translation>Розгорнути усе</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="334"/>
+        <location filename="../src/editor/dtextedit.cpp" line="447"/>
         <source>Unfold Current Level</source>
         <translation>Розгорнути поточний рівень</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="339"/>
+        <location filename="../src/editor/dtextedit.cpp" line="453"/>
         <source>Color Mark</source>
         <translation>Кольорова позначка</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="343"/>
+        <location filename="../src/editor/dtextedit.cpp" line="458"/>
         <source>Clear All Marks</source>
         <translation>Вилучити усі позначки</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="344"/>
+        <location filename="../src/editor/dtextedit.cpp" line="460"/>
         <source>Clear Last Mark</source>
         <translation>Вилучити останню позначку</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="353"/>
+        <location filename="../src/editor/dtextedit.cpp" line="470"/>
         <source>Mark</source>
         <translation>Позначити</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="366"/>
+        <location filename="../src/editor/dtextedit.cpp" line="484"/>
         <source>Mark All</source>
         <translation>Позначити усе</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="375"/>
+        <location filename="../src/editor/dtextedit.cpp" line="494"/>
         <source>Remove Comment</source>
         <translation>Вилучити коментування</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3208"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3211"/>
+        <location filename="../src/editor/dtextedit.cpp" line="543"/>
+        <source>View Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="3531"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3534"/>
         <source>Copy failed: not enough memory</source>
         <translation>Не вдалося скопіювати: недостатньо пам&apos;яті</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3333"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3335"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3656"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3658"/>
         <source>Press ALT and click lines to edit in column mode</source>
         <translation>Натисніть клавішу Alt і клацайте на рядках, щоб редагувати текст у режимі стовпчиків</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="418"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9574"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9576"/>
+        <source>No audio output device was detected. Please ensure your speakers or headphones are properly connected and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="9583"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9585"/>
+        <source>No audio input device was detected. Please ensure your speakers or headphones are properly connected and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="534"/>
         <source>Change Case</source>
         <translation>Змінити регістр</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="419"/>
+        <location filename="../src/editor/dtextedit.cpp" line="409"/>
+        <source>Edit Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="411"/>
+        <source>Read View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="413"/>
+        <source>Live Preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="535"/>
         <source>Upper Case</source>
         <translation>Верхній регістр</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="420"/>
+        <location filename="../src/editor/dtextedit.cpp" line="536"/>
         <source>Lower Case</source>
         <translation>Нижній регістр</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="421"/>
+        <location filename="../src/editor/dtextedit.cpp" line="537"/>
         <source>Capitalize</source>
         <translation>Починати з великої літери</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="78"/>
+        <location filename="../src/widgets/bottombar.cpp" line="110"/>
         <source>None</source>
         <translation>Ніякий</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1363"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1490"/>
         <source>Selected line(s) copied</source>
         <translation>Вибрані рядки(ок) скопійовано</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1370"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1497"/>
         <source>Current line copied</source>
         <translation>Поточний рядок скопійовано</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1400"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1527"/>
         <source>Selected line(s) clipped</source>
         <translation>Вибрані рядки(ок) вирізано</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1412"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1539"/>
         <source>Current line clipped</source>
         <translation>Поточний рядок вирізано</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3227"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3230"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3550"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3553"/>
         <source>Paste failed: not enough memory</source>
         <translation>Не вдалося вставити: недостатньо пам&apos;яті</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="4548"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4873"/>
         <source>Read-Only mode is off</source>
         <translation>Режим лише для читання вимкнено</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="4560"/>
-        <location filename="../src/editor/dtextedit.cpp" line="4584"/>
-        <location filename="../src/editor/dtextedit.cpp" line="7896"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8007"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8015"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8026"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4885"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4909"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8236"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8347"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8355"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8366"/>
         <source>Read-Only mode is on</source>
         <translation>Режим лише для читання увімкнено</translation>
     </message>
@@ -1231,138 +1299,175 @@
 <context>
     <name>WarningNotices</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="24"/>
+        <location filename="../src/controls/warningnotices.cpp" line="25"/>
         <source>Reload</source>
         <translation>Перезавантажити</translation>
+    </message>
+    <message>
+        <location filename="../src/controls/warningnotices.cpp" line="29"/>
+        <source>Edit Anyway</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>Window</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="25"/>
-        <location filename="../src/widgets/window.cpp" line="531"/>
+        <location filename="../src/controls/warningnotices.cpp" line="27"/>
+        <location filename="../src/widgets/window.cpp" line="548"/>
         <source>Save as</source>
         <translation>Зберегти як</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="527"/>
+        <location filename="../src/widgets/window.cpp" line="540"/>
         <source>New window</source>
         <translation>Нове вікно</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="528"/>
+        <location filename="../src/widgets/window.cpp" line="542"/>
         <source>New tab</source>
         <translation>Нова вкладка</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="529"/>
+        <location filename="../src/widgets/window.cpp" line="544"/>
         <source>Open file</source>
         <translation>Відкрити файл</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="530"/>
-        <location filename="../src/widgets/window.cpp" line="3545"/>
+        <location filename="../src/widgets/window.cpp" line="546"/>
+        <location filename="../src/widgets/window.cpp" line="3950"/>
         <source>Save</source>
         <translation>Зберегти</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="532"/>
+        <location filename="../src/widgets/window.cpp" line="550"/>
         <source>Print</source>
         <translation>Друк</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="533"/>
+        <location filename="../src/widgets/window.cpp" line="552"/>
         <source>Switch theme</source>
         <translation>Змінити тему</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="534"/>
-        <location filename="../src/widgets/window.cpp" line="2448"/>
+        <location filename="../src/widgets/window.cpp" line="554"/>
+        <location filename="../src/widgets/window.cpp" line="2641"/>
         <source>Settings</source>
         <translation>Налаштування</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="666"/>
-        <location filename="../src/widgets/window.cpp" line="3845"/>
+        <location filename="../src/widgets/window.cpp" line="696"/>
+        <location filename="../src/widgets/window.cpp" line="4250"/>
         <source>Read-Only</source>
         <translation>Лише читання</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="687"/>
+        <location filename="../src/widgets/window.cpp" line="719"/>
         <source>You do not have permission to open %1</source>
         <translation>У вас немає прав на відкриття %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="738"/>
-        <location filename="../src/widgets/window.cpp" line="2963"/>
+        <location filename="../src/widgets/window.cpp" line="773"/>
+        <location filename="../src/widgets/window.cpp" line="3266"/>
         <source>Invalid file: %1</source>
         <translation>Некоректний файл: %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="903"/>
-        <location filename="../src/widgets/window.cpp" line="956"/>
+        <location filename="../src/widgets/window.cpp" line="957"/>
+        <location filename="../src/widgets/window.cpp" line="1050"/>
+        <location filename="../src/widgets/window.cpp" line="3217"/>
         <source>Do you want to save this file?</source>
         <translation>Хочете зберегти цей файл?</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1290"/>
+        <location filename="../src/widgets/window.cpp" line="1381"/>
+        <source>Invalid characters detected while saving &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1382"/>
+        <source>If you force save this file, it may cause file corruption. Still want to save?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1386"/>
+        <source>Don&apos;t Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1387"/>
+        <source>Save As</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1388"/>
+        <source>Save Anyway</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1456"/>
         <source>You do not have permission to save %1</source>
         <translation>У вас немає прав на збереження %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1312"/>
+        <location filename="../src/widgets/window.cpp" line="1428"/>
+        <location filename="../src/widgets/window.cpp" line="1478"/>
         <source>Saved successfully</source>
         <translation>Успішно збережено</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1354"/>
-        <location filename="../src/widgets/window.cpp" line="1481"/>
-        <location filename="../src/widgets/window.cpp" line="1529"/>
+        <location filename="../src/widgets/window.cpp" line="1520"/>
+        <location filename="../src/widgets/window.cpp" line="1665"/>
+        <location filename="../src/widgets/window.cpp" line="1713"/>
         <source>Save File</source>
         <translation>Зберегти файл</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1483"/>
+        <location filename="../src/widgets/window.cpp" line="1569"/>
+        <source>Cannot save as the original file in preview mode. Please choose a different path.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/window.cpp" line="1667"/>
         <source>Encoding</source>
         <translation>Кодування</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1773"/>
+        <location filename="../src/widgets/window.cpp" line="1957"/>
         <source>Read-Only mode is on</source>
         <translation>Режим лише для читання увімкнено</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2322"/>
+        <location filename="../src/widgets/window.cpp" line="2511"/>
         <source>Current location remembered</source>
         <translation>Програма запам&apos;ятала поточне місце</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2398"/>
+        <location filename="../src/widgets/window.cpp" line="2591"/>
         <source>Ctrl+&apos;=&apos;</source>
         <translation>Ctrl+&apos;=&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2401"/>
+        <location filename="../src/widgets/window.cpp" line="2594"/>
         <source>Ctrl+&apos;-&apos;</source>
         <translation>Ctrl+&apos;-&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2430"/>
+        <location filename="../src/widgets/window.cpp" line="2623"/>
         <source>Editor</source>
         <translation>Редактор</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3061"/>
+        <location filename="../src/widgets/window.cpp" line="3436"/>
         <source>Untitled %1</source>
         <translation>Без назви %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3543"/>
+        <location filename="../src/widgets/window.cpp" line="3948"/>
         <source>Cancel</source>
         <translation>Скасувати</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3544"/>
+        <location filename="../src/widgets/window.cpp" line="3949"/>
         <source>Discard</source>
         <translation>Відкинути</translation>
     </message>

--- a/translations/deepin-editor_zh_CN.ts
+++ b/translations/deepin-editor_zh_CN.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="zh_CN">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_CN">
 <context>
     <name>BottomBar</name>
     <message>
@@ -17,17 +19,36 @@
         <translation>字数 %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="44"/>
+        <location filename="../src/widgets/bottombar.cpp" line="47"/>
         <source>Loading:</source>
         <translation>文件加载中：</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="73"/>
+        <location filename="../src/widgets/bottombar.cpp" line="91"/>
+        <location filename="../src/widgets/bottombar.cpp" line="499"/>
+        <source>Edit Mode</source>
+        <translation>编辑模式</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="74"/>
+        <location filename="../src/widgets/bottombar.cpp" line="489"/>
+        <source>Read View</source>
+        <translation>查看视图</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="75"/>
+        <location filename="../src/widgets/bottombar.cpp" line="493"/>
+        <source>Live Preview</source>
+        <translation>实时预览</translation>
     </message>
 </context>
 <context>
     <name>DDropdownMenu</name>
     <message>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="362"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="420"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="425"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="363"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="421"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="426"/>
         <source>None</source>
         <translation>无</translation>
     </message>
@@ -35,73 +56,57 @@
 <context>
     <name>EditWrapper</name>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="292"/>
-        <location filename="../src/editor/editwrapper.cpp" line="365"/>
-        <location filename="../src/editor/editwrapper.cpp" line="521"/>
-        <location filename="../src/editor/editwrapper.cpp" line="751"/>
+        <location filename="../src/editor/editwrapper.cpp" line="355"/>
+        <location filename="../src/editor/editwrapper.cpp" line="429"/>
+        <location filename="../src/editor/editwrapper.cpp" line="595"/>
+        <location filename="../src/editor/editwrapper.cpp" line="887"/>
         <source>Save</source>
         <translation>保存</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="516"/>
+        <location filename="../src/editor/editwrapper.cpp" line="590"/>
         <source>Do you want to save this file?</source>
         <translation>您是否要保存此文件？</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="363"/>
-        <location filename="../src/editor/editwrapper.cpp" line="519"/>
+        <location filename="../src/editor/editwrapper.cpp" line="427"/>
+        <location filename="../src/editor/editwrapper.cpp" line="593"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="360"/>
+        <location filename="../src/editor/editwrapper.cpp" line="424"/>
         <source>Encoding changed. Do you want to save the file now?</source>
         <translation>文件编码已更改，是否先进行保存？</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="520"/>
+        <location filename="../src/editor/editwrapper.cpp" line="594"/>
         <source>Discard</source>
         <translation>不保存</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="274"/>
-        <location filename="../src/editor/editwrapper.cpp" line="620"/>
+        <location filename="../src/editor/editwrapper.cpp" line="337"/>
+        <location filename="../src/editor/editwrapper.cpp" line="705"/>
         <source>You do not have permission to save %1</source>
         <translation>您没有权限保存%1</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="836"/>
+        <location filename="../src/editor/editwrapper.cpp" line="987"/>
         <source>File removed on the disk. Save it now?</source>
         <translation>磁盘中的原文件已被移除，是否另存？</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="842"/>
+        <location filename="../src/editor/editwrapper.cpp" line="993"/>
         <source>File has changed on disk. Reload?</source>
         <translation>磁盘中的原文件已被修改，是否重新载入？</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="884"/>
-        <location filename="../src/widgets/bottombar.cpp" line="74"/>
-        <source>INSERT</source>
-        <translation>插入</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="888"/>
-        <source>OVERWRITE</source>
-        <translation>覆盖</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="892"/>
-        <source>R/O</source>
-        <translation>只读</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="1618"/>
+        <location filename="../src/editor/editwrapper.cpp" line="1806"/>
         <source>The file cannot be read, which may be too large or has been damaged!</source>
         <translation>无法读取该文件，文件可能过大或损坏</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="1020"/>
+        <location filename="../src/editor/editwrapper.cpp" line="1121"/>
         <source>The file contains invalid characters (NUL). Preview mode is read-only.</source>
         <translation>文件包含无效字符（NUL）。预览模式为只读。</translation>
     </message>
@@ -114,17 +119,17 @@
         <translation>查找</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="36"/>
+        <location filename="../src/controls/findbar.cpp" line="38"/>
         <source>Previous</source>
         <translation>上一个</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="37"/>
+        <location filename="../src/controls/findbar.cpp" line="40"/>
         <source>Next</source>
         <translation>下一个</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="38"/>
+        <location filename="../src/controls/findbar.cpp" line="42"/>
         <source>Replace</source>
         <translation>替换</translation>
     </message>
@@ -132,7 +137,7 @@
 <context>
     <name>JumpLineBar</name>
     <message>
-        <location filename="../src/controls/jumplinebar.cpp" line="45"/>
+        <location filename="../src/controls/jumplinebar.cpp" line="46"/>
         <source>Go to Line: </source>
         <translation>跳到行：</translation>
     </message>
@@ -140,7 +145,7 @@
 <context>
     <name>LineBar</name>
     <message>
-        <location filename="../src/controls/linebar.cpp" line="117"/>
+        <location filename="../src/controls/linebar.cpp" line="144"/>
         <source>第%1/%2项</source>
         <translation>第%1/%2项</translation>
     </message>
@@ -159,19 +164,47 @@
     </message>
 </context>
 <context>
+    <name>MarkdownBridge</name>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="37"/>
+        <source>Collapse code block</source>
+        <translation>折叠代码块</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="38"/>
+        <source>Expand code block</source>
+        <translation>展开代码块</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="39"/>
+        <source>Copy code</source>
+        <translation>复制代码</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="40"/>
+        <source>Expand</source>
+        <translation>展开</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="42"/>
+        <source>%1 line(s) of code collapsed</source>
+        <translation>已折叠 %1 行代码</translation>
+    </message>
+</context>
+<context>
     <name>PathSettingWgt</name>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="84"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="90"/>
         <source>Remember the last used path</source>
         <translation>记住最后的操作路径</translation>
     </message>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="85"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="91"/>
         <source>Same path as the current file</source>
         <translation>与当前文件保持一致</translation>
     </message>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="86"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="92"/>
         <source>Customize the default path</source>
         <translation>自定义操作路径</translation>
     </message>
@@ -184,15 +217,20 @@
         <translation>文本编辑器</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="294"/>
-        <location filename="../src/editor/editwrapper.cpp" line="761"/>
-        <location filename="../src/editor/editwrapper.cpp" line="776"/>
-        <location filename="../src/widgets/window.cpp" line="1362"/>
-        <location filename="../src/widgets/window.cpp" line="1390"/>
-        <location filename="../src/widgets/window.cpp" line="1531"/>
-        <location filename="../src/widgets/window.cpp" line="1548"/>
+        <location filename="../src/editor/editwrapper.cpp" line="357"/>
+        <location filename="../src/editor/editwrapper.cpp" line="897"/>
+        <location filename="../src/editor/editwrapper.cpp" line="912"/>
+        <location filename="../src/widgets/window.cpp" line="1528"/>
+        <location filename="../src/widgets/window.cpp" line="1556"/>
+        <location filename="../src/widgets/window.cpp" line="1715"/>
+        <location filename="../src/widgets/window.cpp" line="1732"/>
         <source>Encoding</source>
         <translation>编码</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="2001"/>
+        <source>视图模式</source>
+        <translation>视图模式</translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="11"/>
@@ -228,7 +266,7 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="18"/>
         <location filename="../src/controls/settingsdialog.cpp" line="96"/>
-        <location filename="../src/widgets/window.cpp" line="2388"/>
+        <location filename="../src/widgets/window.cpp" line="2581"/>
         <source>Window</source>
         <translation>窗口</translation>
     </message>
@@ -768,68 +806,68 @@
         <translation>越南语</translation>
     </message>
     <message>
-        <location filename="../src/startmanager.cpp" line="971"/>
+        <location filename="../src/startmanager.cpp" line="1035"/>
         <source>File not saved</source>
         <translation>文件未保存</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1532"/>
-        <location filename="../src/widgets/window.cpp" line="1549"/>
+        <location filename="../src/widgets/window.cpp" line="1716"/>
+        <location filename="../src/widgets/window.cpp" line="1733"/>
         <source>Line Endings</source>
         <translation>换行符</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="243"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="379"/>
         <source>Please install &apos;UOS AI&apos; from the App Store before using</source>
         <translation>请前往应用商店安装“UOS AI”后再使用</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="245"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="381"/>
         <source>No audio input device detected. Please check and try again</source>
         <translation>未检测到音频输入设备，请检查后重试</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="247"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="383"/>
         <source>No audio output device detected. Please check and try again</source>
         <translation>未检测到音频输出设备，请检查后重试</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="69"/>
+        <location filename="../src/common/text_file_saver.cpp" line="74"/>
         <source>File path is empty</source>
         <translation>文件路径为空</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="155"/>
+        <location filename="../src/common/text_file_saver.cpp" line="153"/>
         <source>Insufficient memory to load document content</source>
         <translation>内存不足，无法加载文档内容</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="177"/>
+        <location filename="../src/common/text_file_saver.cpp" line="178"/>
         <source>Insufficient memory for encoding conversion</source>
         <translation>内存不足，无法进行编码转换</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="183"/>
+        <location filename="../src/common/text_file_saver.cpp" line="184"/>
         <source>Encoding conversion failed</source>
         <translation>编码转换失败</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="189"/>
+        <location filename="../src/common/text_file_saver.cpp" line="190"/>
         <source>Converted content is empty</source>
         <translation>转换后的内容为空</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="207"/>
+        <location filename="../src/common/text_file_saver.cpp" line="208"/>
         <source>Memory allocation failed</source>
         <translation>内存分配失败</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="211"/>
+        <location filename="../src/common/text_file_saver.cpp" line="212"/>
         <source>Error occurred: %1</source>
         <translation>发生错误: %1</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="215"/>
+        <location filename="../src/common/text_file_saver.cpp" line="216"/>
         <source>Unknown error occurred</source>
         <translation>发生未知错误</translation>
     </message>
@@ -842,27 +880,27 @@
         <translation>查找</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="34"/>
+        <location filename="../src/controls/replacebar.cpp" line="36"/>
         <source>Replace With</source>
         <translation>替换为</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="36"/>
+        <location filename="../src/controls/replacebar.cpp" line="40"/>
         <source>Replace</source>
         <translation>替换</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="37"/>
+        <location filename="../src/controls/replacebar.cpp" line="42"/>
         <source>Skip</source>
         <translation>跳过</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="38"/>
+        <location filename="../src/controls/replacebar.cpp" line="44"/>
         <source>Replace Rest</source>
         <translation>剩余替换</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="39"/>
+        <location filename="../src/controls/replacebar.cpp" line="46"/>
         <source>Replace All</source>
         <translation>全部替换</translation>
     </message>
@@ -871,9 +909,9 @@
     <name>S:</name>
     <message>
         <location filename="../third/libiconv-1.16/src/iconv.c" line="103"/>
-        <source/>
+        <source></source>
         <comment>The first line of the short usage message.</comment>
-        <translation type="unfinished"/>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -904,34 +942,34 @@
         <translation>全屏</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="484"/>
+        <location filename="../src/common/settings.cpp" line="491"/>
         <source>This shortcut conflicts with system shortcut %1</source>
         <translation>此快捷键与系统快捷键%1冲突</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="487"/>
+        <location filename="../src/common/settings.cpp" line="494"/>
         <source>This shortcut conflicts with %1, click on Replace to make this shortcut effective immediately</source>
         <translation>此快捷键与%1冲突，点击替换使这个快捷键立即生效</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="682"/>
-        <location filename="../src/common/settings.cpp" line="695"/>
-        <location filename="../src/common/settings.cpp" line="704"/>
+        <location filename="../src/common/settings.cpp" line="689"/>
+        <location filename="../src/common/settings.cpp" line="702"/>
+        <location filename="../src/common/settings.cpp" line="711"/>
         <source>The shortcut %1 is invalid, please set another one.</source>
         <translation>%1为无效快捷键，请重新设置</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="736"/>
+        <location filename="../src/common/settings.cpp" line="743"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="737"/>
+        <location filename="../src/common/settings.cpp" line="744"/>
         <source>Replace</source>
         <translation>替换</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="740"/>
+        <location filename="../src/common/settings.cpp" line="747"/>
         <source>OK</source>
         <translation>确定</translation>
     </message>
@@ -939,7 +977,7 @@
 <context>
     <name>StartManager</name>
     <message>
-        <location filename="../src/startmanager.cpp" line="411"/>
+        <location filename="../src/startmanager.cpp" line="425"/>
         <source>Untitled %1</source>
         <translation>未命名文档%1</translation>
     </message>
@@ -947,32 +985,32 @@
 <context>
     <name>Tabbar</name>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="641"/>
+        <location filename="../src/controls/tabbar.cpp" line="678"/>
         <source>Close tab</source>
         <translation>关闭标签页</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="642"/>
+        <location filename="../src/controls/tabbar.cpp" line="680"/>
         <source>Close other tabs</source>
         <translation>关闭其他标签页</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="643"/>
+        <location filename="../src/controls/tabbar.cpp" line="682"/>
         <source>More options</source>
         <translation>更多关闭方式</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="644"/>
+        <location filename="../src/controls/tabbar.cpp" line="684"/>
         <source>Close tabs to the left</source>
         <translation>关闭左侧所有标签页</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="645"/>
+        <location filename="../src/controls/tabbar.cpp" line="686"/>
         <source>Close tabs to the right</source>
         <translation>关闭右侧所有标签页</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="646"/>
+        <location filename="../src/controls/tabbar.cpp" line="688"/>
         <source>Close unmodified tabs</source>
         <translation>关闭所有未修改标签页</translation>
     </message>
@@ -980,263 +1018,280 @@
 <context>
     <name>TextEdit</name>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="305"/>
+        <location filename="../src/editor/dtextedit.cpp" line="388"/>
         <source>Undo</source>
         <translation>撤销</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="306"/>
+        <location filename="../src/editor/dtextedit.cpp" line="390"/>
         <source>Redo</source>
         <translation>重做</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="307"/>
+        <location filename="../src/editor/dtextedit.cpp" line="392"/>
         <source>Cut</source>
         <translation>剪切</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="308"/>
+        <location filename="../src/editor/dtextedit.cpp" line="394"/>
         <source>Copy</source>
         <translation>复制</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="309"/>
+        <location filename="../src/editor/dtextedit.cpp" line="396"/>
         <source>Paste</source>
         <translation>粘贴</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="310"/>
+        <location filename="../src/editor/dtextedit.cpp" line="398"/>
         <source>Delete</source>
         <translation>删除</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="311"/>
+        <location filename="../src/editor/dtextedit.cpp" line="400"/>
         <source>Select All</source>
         <translation>全选</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="312"/>
-        <location filename="../src/widgets/window.cpp" line="535"/>
+        <location filename="../src/editor/dtextedit.cpp" line="402"/>
+        <location filename="../src/widgets/window.cpp" line="556"/>
         <source>Find</source>
         <translation>查找</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="313"/>
-        <location filename="../src/widgets/window.cpp" line="536"/>
+        <location filename="../src/editor/dtextedit.cpp" line="404"/>
+        <location filename="../src/widgets/window.cpp" line="558"/>
         <source>Replace</source>
         <translation>替换</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="314"/>
+        <location filename="../src/editor/dtextedit.cpp" line="406"/>
         <source>Go to Line</source>
         <translation>跳到行</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="315"/>
-        <source>Turn on Read-Only mode</source>
-        <translation>开启只读模式</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="316"/>
-        <source>Turn off Read-Only mode</source>
-        <translation>关闭只读模式</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="317"/>
+        <location filename="../src/editor/dtextedit.cpp" line="415"/>
         <source>Fullscreen</source>
         <translation>全屏</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="318"/>
+        <location filename="../src/editor/dtextedit.cpp" line="417"/>
         <source>Exit fullscreen</source>
         <translation>退出全屏</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="319"/>
+        <location filename="../src/editor/dtextedit.cpp" line="419"/>
         <source>Display in file manager</source>
         <translation>在文件管理器中显示</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="320"/>
-        <location filename="../src/editor/dtextedit.cpp" line="374"/>
+        <location filename="../src/editor/dtextedit.cpp" line="421"/>
+        <location filename="../src/editor/dtextedit.cpp" line="493"/>
         <source>Add Comment</source>
         <translation>添加注释</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="321"/>
+        <location filename="../src/editor/dtextedit.cpp" line="423"/>
         <source>Text to Speech</source>
         <translation>语音朗读</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="322"/>
-        <source>Stop reading</source>
-        <translation>停止朗读</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="323"/>
+        <location filename="../src/editor/dtextedit.cpp" line="425"/>
         <source>Speech to Text</source>
         <translation>语音听写</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="324"/>
+        <location filename="../src/editor/dtextedit.cpp" line="427"/>
         <source>Translate</source>
         <translation>文本翻译</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="325"/>
+        <location filename="../src/editor/dtextedit.cpp" line="429"/>
         <source>Column Mode</source>
         <translation>列编辑模式</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="326"/>
+        <location filename="../src/editor/dtextedit.cpp" line="431"/>
         <source>Add bookmark</source>
         <translation>添加书签</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="327"/>
+        <location filename="../src/editor/dtextedit.cpp" line="433"/>
         <source>Remove Bookmark</source>
         <translation>清除书签</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="328"/>
+        <location filename="../src/editor/dtextedit.cpp" line="435"/>
         <source>Previous bookmark</source>
         <translation>上一个书签</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="329"/>
+        <location filename="../src/editor/dtextedit.cpp" line="437"/>
         <source>Next bookmark</source>
         <translation>下一个书签</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="330"/>
+        <location filename="../src/editor/dtextedit.cpp" line="439"/>
         <source>Remove All Bookmarks</source>
         <translation>清除所有书签</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="331"/>
+        <location filename="../src/editor/dtextedit.cpp" line="441"/>
         <source>Fold All</source>
         <translation>折叠所有层次</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="332"/>
+        <location filename="../src/editor/dtextedit.cpp" line="443"/>
         <source>Fold Current Level</source>
         <translation>折叠当前层次</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="333"/>
+        <location filename="../src/editor/dtextedit.cpp" line="445"/>
         <source>Unfold All</source>
         <translation>展开所有层次</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="334"/>
+        <location filename="../src/editor/dtextedit.cpp" line="447"/>
         <source>Unfold Current Level</source>
         <translation>展开当前层次</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="339"/>
+        <location filename="../src/editor/dtextedit.cpp" line="453"/>
         <source>Color Mark</source>
         <translation>颜色标记</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="343"/>
+        <location filename="../src/editor/dtextedit.cpp" line="458"/>
         <source>Clear All Marks</source>
         <translation>清除所有标记</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="344"/>
+        <location filename="../src/editor/dtextedit.cpp" line="460"/>
         <source>Clear Last Mark</source>
         <translation>清除上次标记</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="353"/>
+        <location filename="../src/editor/dtextedit.cpp" line="470"/>
         <source>Mark</source>
         <translation>添加标记</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="366"/>
+        <location filename="../src/editor/dtextedit.cpp" line="484"/>
         <source>Mark All</source>
         <translation>标记所有</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="375"/>
+        <location filename="../src/editor/dtextedit.cpp" line="494"/>
         <source>Remove Comment</source>
         <translation>取消注释</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3208"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3211"/>
+        <location filename="../src/editor/dtextedit.cpp" line="543"/>
+        <source>View Mode</source>
+        <translation>视图模式</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="3531"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3534"/>
         <source>Copy failed: not enough memory</source>
         <translation>内存不足，复制失败</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3333"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3335"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3656"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3658"/>
         <source>Press ALT and click lines to edit in column mode</source>
         <translation>请使用ALT+鼠标点选切换列编辑模式</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="418"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9574"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9576"/>
+        <source>No audio output device was detected. Please ensure your speakers or headphones are properly connected and try again.</source>
+        <translation>未检测到音频输出设备，请确保扬声器或耳机已正确连接后重试</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="9583"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9585"/>
+        <source>No audio input device was detected. Please ensure your speakers or headphones are properly connected and try again.</source>
+        <translation>未检测到音频输入设备，请确保扬声器或耳机已正确连接后重试</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="534"/>
         <source>Change Case</source>
         <translation>切换大小写</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="419"/>
+        <location filename="../src/editor/dtextedit.cpp" line="409"/>
+        <source>Edit Mode</source>
+        <translation>编辑模式</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="411"/>
+        <source>Read View</source>
+        <translation>查看视图</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="413"/>
+        <source>Live Preview</source>
+        <translation>实时预览</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="535"/>
         <source>Upper Case</source>
         <translation>大写</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="420"/>
+        <location filename="../src/editor/dtextedit.cpp" line="536"/>
         <source>Lower Case</source>
         <translation>小写</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="421"/>
+        <location filename="../src/editor/dtextedit.cpp" line="537"/>
         <source>Capitalize</source>
         <translation>首字母大写</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="78"/>
+        <location filename="../src/widgets/bottombar.cpp" line="110"/>
         <source>None</source>
         <translation>无</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1363"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1490"/>
         <source>Selected line(s) copied</source>
         <translation>已复制选中行到剪贴板</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1370"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1497"/>
         <source>Current line copied</source>
         <translation>已复制当前行到剪贴板</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1400"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1527"/>
         <source>Selected line(s) clipped</source>
         <translation>已剪切选中行到剪贴板</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1412"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1539"/>
         <source>Current line clipped</source>
         <translation>已剪切当前行到剪贴板</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3227"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3230"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3550"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3553"/>
         <source>Paste failed: not enough memory</source>
         <translation>内存不足，粘贴失败</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="4548"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4873"/>
         <source>Read-Only mode is off</source>
         <translation>只读模式已关闭</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="4560"/>
-        <location filename="../src/editor/dtextedit.cpp" line="4584"/>
-        <location filename="../src/editor/dtextedit.cpp" line="7896"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8007"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8015"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8026"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4885"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4909"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8236"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8347"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8355"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8366"/>
         <source>Read-Only mode is on</source>
         <translation>只读模式已开启</translation>
     </message>
@@ -1244,12 +1299,12 @@
 <context>
     <name>WarningNotices</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="24"/>
+        <location filename="../src/controls/warningnotices.cpp" line="25"/>
         <source>Reload</source>
         <translation>重新载入</translation>
     </message>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="26"/>
+        <location filename="../src/controls/warningnotices.cpp" line="29"/>
         <source>Edit Anyway</source>
         <translation>仍然编辑</translation>
     </message>
@@ -1257,160 +1312,162 @@
 <context>
     <name>Window</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="25"/>
-        <location filename="../src/widgets/window.cpp" line="531"/>
+        <location filename="../src/controls/warningnotices.cpp" line="27"/>
+        <location filename="../src/widgets/window.cpp" line="548"/>
         <source>Save as</source>
         <translation>另存为</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="527"/>
+        <location filename="../src/widgets/window.cpp" line="540"/>
         <source>New window</source>
         <translation>新窗口</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="528"/>
+        <location filename="../src/widgets/window.cpp" line="542"/>
         <source>New tab</source>
         <translation>新标签页</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="529"/>
+        <location filename="../src/widgets/window.cpp" line="544"/>
         <source>Open file</source>
         <translation>打开文件</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="530"/>
-        <location filename="../src/widgets/window.cpp" line="3545"/>
+        <location filename="../src/widgets/window.cpp" line="546"/>
+        <location filename="../src/widgets/window.cpp" line="3950"/>
         <source>Save</source>
         <translation>保存</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="532"/>
+        <location filename="../src/widgets/window.cpp" line="550"/>
         <source>Print</source>
         <translation>打印</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="533"/>
+        <location filename="../src/widgets/window.cpp" line="552"/>
         <source>Switch theme</source>
         <translation>切换主题</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="534"/>
-        <location filename="../src/widgets/window.cpp" line="2448"/>
+        <location filename="../src/widgets/window.cpp" line="554"/>
+        <location filename="../src/widgets/window.cpp" line="2641"/>
         <source>Settings</source>
         <translation>设置</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="666"/>
-        <location filename="../src/widgets/window.cpp" line="3845"/>
+        <location filename="../src/widgets/window.cpp" line="696"/>
+        <location filename="../src/widgets/window.cpp" line="4250"/>
         <source>Read-Only</source>
         <translation>只读</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="687"/>
+        <location filename="../src/widgets/window.cpp" line="719"/>
         <source>You do not have permission to open %1</source>
         <translation>您没有权限打开%1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="738"/>
-        <location filename="../src/widgets/window.cpp" line="2963"/>
+        <location filename="../src/widgets/window.cpp" line="773"/>
+        <location filename="../src/widgets/window.cpp" line="3266"/>
         <source>Invalid file: %1</source>
         <translation>无效文件：%1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="903"/>
-        <location filename="../src/widgets/window.cpp" line="956"/>
+        <location filename="../src/widgets/window.cpp" line="957"/>
+        <location filename="../src/widgets/window.cpp" line="1050"/>
+        <location filename="../src/widgets/window.cpp" line="3217"/>
         <source>Do you want to save this file?</source>
         <translation>您是否要保存此文件？</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1290"/>
+        <location filename="../src/widgets/window.cpp" line="1456"/>
         <source>You do not have permission to save %1</source>
         <translation>您没有权限保存%1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1312"/>
+        <location filename="../src/widgets/window.cpp" line="1428"/>
+        <location filename="../src/widgets/window.cpp" line="1478"/>
         <source>Saved successfully</source>
         <translation>文件已保存</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1354"/>
-        <location filename="../src/widgets/window.cpp" line="1481"/>
-        <location filename="../src/widgets/window.cpp" line="1529"/>
+        <location filename="../src/widgets/window.cpp" line="1520"/>
+        <location filename="../src/widgets/window.cpp" line="1665"/>
+        <location filename="../src/widgets/window.cpp" line="1713"/>
         <source>Save File</source>
         <translation>保存</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1483"/>
+        <location filename="../src/widgets/window.cpp" line="1667"/>
         <source>Encoding</source>
         <translation>编码</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1773"/>
+        <location filename="../src/widgets/window.cpp" line="1957"/>
         <source>Read-Only mode is on</source>
         <translation>只读模式已开启</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2322"/>
+        <location filename="../src/widgets/window.cpp" line="2511"/>
         <source>Current location remembered</source>
         <translation>已记住当前位置</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2398"/>
+        <location filename="../src/widgets/window.cpp" line="2591"/>
         <source>Ctrl+&apos;=&apos;</source>
         <translation>Ctrl+&apos;=&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2401"/>
+        <location filename="../src/widgets/window.cpp" line="2594"/>
         <source>Ctrl+&apos;-&apos;</source>
         <translation>Ctrl+&apos;-&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2430"/>
+        <location filename="../src/widgets/window.cpp" line="2623"/>
         <source>Editor</source>
         <translation>编辑</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3061"/>
+        <location filename="../src/widgets/window.cpp" line="3436"/>
         <source>Untitled %1</source>
         <translation>未命名文档%1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3543"/>
+        <location filename="../src/widgets/window.cpp" line="3948"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3544"/>
+        <location filename="../src/widgets/window.cpp" line="3949"/>
         <source>Discard</source>
         <translation>不保存</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1317"/>
-        <source>Invalid characters detected while saving "%1"</source>
-        <translation>保存"%1"时检测到无效字符</translation>
+        <location filename="../src/widgets/window.cpp" line="1381"/>
+        <source>Invalid characters detected while saving &quot;%1&quot;</source>
+        <translation>保存&quot;%1&quot;时检测到无效字符</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1318"/>
+        <location filename="../src/widgets/window.cpp" line="1382"/>
         <source>If you force save this file, it may cause file corruption. Still want to save?</source>
         <translation>强制保存此文件可能导致文件损坏。仍然要保存吗？</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1321"/>
+        <location filename="../src/widgets/window.cpp" line="1386"/>
         <source>Don&apos;t Save</source>
         <translation>不保存</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1322"/>
+        <location filename="../src/widgets/window.cpp" line="1387"/>
         <source>Save As</source>
         <translation>另存为</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1323"/>
+        <location filename="../src/widgets/window.cpp" line="1388"/>
         <source>Save Anyway</source>
         <translation>强制保存</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1521"/>
+        <location filename="../src/widgets/window.cpp" line="1569"/>
         <source>Cannot save as the original file in preview mode. Please choose a different path.</source>
         <translation>预览模式下不能另存为原文件。请选择其他路径。</translation>
     </message>

--- a/translations/deepin-editor_zh_HK.ts
+++ b/translations/deepin-editor_zh_HK.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="zh_HK">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_HK">
 <context>
     <name>BottomBar</name>
     <message>
@@ -17,17 +19,36 @@
         <translation>字數 %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="44"/>
+        <location filename="../src/widgets/bottombar.cpp" line="47"/>
         <source>Loading:</source>
         <translation>文件加載中：</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="73"/>
+        <location filename="../src/widgets/bottombar.cpp" line="91"/>
+        <location filename="../src/widgets/bottombar.cpp" line="499"/>
+        <source>Edit Mode</source>
+        <translation>編輯模式</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="74"/>
+        <location filename="../src/widgets/bottombar.cpp" line="489"/>
+        <source>Read View</source>
+        <translation>查看視圖</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="75"/>
+        <location filename="../src/widgets/bottombar.cpp" line="493"/>
+        <source>Live Preview</source>
+        <translation>即時預覽</translation>
     </message>
 </context>
 <context>
     <name>DDropdownMenu</name>
     <message>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="362"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="420"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="425"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="363"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="421"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="426"/>
         <source>None</source>
         <translation>無</translation>
     </message>
@@ -35,73 +56,57 @@
 <context>
     <name>EditWrapper</name>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="292"/>
-        <location filename="../src/editor/editwrapper.cpp" line="365"/>
-        <location filename="../src/editor/editwrapper.cpp" line="521"/>
-        <location filename="../src/editor/editwrapper.cpp" line="751"/>
+        <location filename="../src/editor/editwrapper.cpp" line="355"/>
+        <location filename="../src/editor/editwrapper.cpp" line="429"/>
+        <location filename="../src/editor/editwrapper.cpp" line="595"/>
+        <location filename="../src/editor/editwrapper.cpp" line="887"/>
         <source>Save</source>
         <translation>保存</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="516"/>
+        <location filename="../src/editor/editwrapper.cpp" line="590"/>
         <source>Do you want to save this file?</source>
         <translation>您是否要保存此文件？</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="363"/>
-        <location filename="../src/editor/editwrapper.cpp" line="519"/>
+        <location filename="../src/editor/editwrapper.cpp" line="427"/>
+        <location filename="../src/editor/editwrapper.cpp" line="593"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="360"/>
+        <location filename="../src/editor/editwrapper.cpp" line="424"/>
         <source>Encoding changed. Do you want to save the file now?</source>
         <translation>文件編碼已更改，是否先進行保存？</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="520"/>
+        <location filename="../src/editor/editwrapper.cpp" line="594"/>
         <source>Discard</source>
         <translation>不保存</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="274"/>
-        <location filename="../src/editor/editwrapper.cpp" line="620"/>
+        <location filename="../src/editor/editwrapper.cpp" line="337"/>
+        <location filename="../src/editor/editwrapper.cpp" line="705"/>
         <source>You do not have permission to save %1</source>
         <translation>您沒有權限保存%1</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="836"/>
+        <location filename="../src/editor/editwrapper.cpp" line="987"/>
         <source>File removed on the disk. Save it now?</source>
         <translation>磁盤中的原文件已被移除，是否另存？</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="842"/>
+        <location filename="../src/editor/editwrapper.cpp" line="993"/>
         <source>File has changed on disk. Reload?</source>
         <translation>磁盤中的原文件已被修改，是否重新載入？</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="884"/>
-        <location filename="../src/widgets/bottombar.cpp" line="74"/>
-        <source>INSERT</source>
-        <translation>插入</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="888"/>
-        <source>OVERWRITE</source>
-        <translation>覆蓋</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="892"/>
-        <source>R/O</source>
-        <translation>只讀</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="1618"/>
+        <location filename="../src/editor/editwrapper.cpp" line="1806"/>
         <source>The file cannot be read, which may be too large or has been damaged!</source>
         <translation>無法讀取該文件，文件可能過大或損壞</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="1020"/>
+        <location filename="../src/editor/editwrapper.cpp" line="1121"/>
         <source>The file contains invalid characters (NUL). Preview mode is read-only.</source>
         <translation>文件包含無效字元（NUL）。預覽模式為唯讀。</translation>
     </message>
@@ -114,17 +119,17 @@
         <translation>查找</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="36"/>
+        <location filename="../src/controls/findbar.cpp" line="38"/>
         <source>Previous</source>
         <translation>上一個</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="37"/>
+        <location filename="../src/controls/findbar.cpp" line="40"/>
         <source>Next</source>
         <translation>下一個</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="38"/>
+        <location filename="../src/controls/findbar.cpp" line="42"/>
         <source>Replace</source>
         <translation>替換</translation>
     </message>
@@ -132,7 +137,7 @@
 <context>
     <name>JumpLineBar</name>
     <message>
-        <location filename="../src/controls/jumplinebar.cpp" line="45"/>
+        <location filename="../src/controls/jumplinebar.cpp" line="46"/>
         <source>Go to Line: </source>
         <translation>跳到行：</translation>
     </message>
@@ -140,7 +145,7 @@
 <context>
     <name>LineBar</name>
     <message>
-        <location filename="../src/controls/linebar.cpp" line="117"/>
+        <location filename="../src/controls/linebar.cpp" line="144"/>
         <source>第%1/%2项</source>
         <translation>第%1/%2項</translation>
     </message>
@@ -159,19 +164,47 @@
     </message>
 </context>
 <context>
+    <name>MarkdownBridge</name>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="37"/>
+        <source>Collapse code block</source>
+        <translation>摺疊代碼區塊</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="38"/>
+        <source>Expand code block</source>
+        <translation>展開代碼區塊</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="39"/>
+        <source>Copy code</source>
+        <translation>複製代碼</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="40"/>
+        <source>Expand</source>
+        <translation>展開</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="42"/>
+        <source>%1 line(s) of code collapsed</source>
+        <translation>已摺疊 %1 行代碼</translation>
+    </message>
+</context>
+<context>
     <name>PathSettingWgt</name>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="84"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="90"/>
         <source>Remember the last used path</source>
         <translation>記住最後的操作路徑</translation>
     </message>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="85"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="91"/>
         <source>Same path as the current file</source>
         <translation>與當前文件保持一致</translation>
     </message>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="86"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="92"/>
         <source>Customize the default path</source>
         <translation>自定義操作路徑</translation>
     </message>
@@ -184,15 +217,20 @@
         <translation>文本編輯器</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="294"/>
-        <location filename="../src/editor/editwrapper.cpp" line="761"/>
-        <location filename="../src/editor/editwrapper.cpp" line="776"/>
-        <location filename="../src/widgets/window.cpp" line="1362"/>
-        <location filename="../src/widgets/window.cpp" line="1390"/>
-        <location filename="../src/widgets/window.cpp" line="1531"/>
-        <location filename="../src/widgets/window.cpp" line="1548"/>
+        <location filename="../src/editor/editwrapper.cpp" line="357"/>
+        <location filename="../src/editor/editwrapper.cpp" line="897"/>
+        <location filename="../src/editor/editwrapper.cpp" line="912"/>
+        <location filename="../src/widgets/window.cpp" line="1528"/>
+        <location filename="../src/widgets/window.cpp" line="1556"/>
+        <location filename="../src/widgets/window.cpp" line="1715"/>
+        <location filename="../src/widgets/window.cpp" line="1732"/>
         <source>Encoding</source>
         <translation>編碼</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="2001"/>
+        <source>视图模式</source>
+        <translation>視圖模式</translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="11"/>
@@ -228,7 +266,7 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="18"/>
         <location filename="../src/controls/settingsdialog.cpp" line="96"/>
-        <location filename="../src/widgets/window.cpp" line="2388"/>
+        <location filename="../src/widgets/window.cpp" line="2581"/>
         <source>Window</source>
         <translation>窗口</translation>
     </message>
@@ -768,68 +806,68 @@
         <translation>越南語</translation>
     </message>
     <message>
-        <location filename="../src/startmanager.cpp" line="971"/>
+        <location filename="../src/startmanager.cpp" line="1035"/>
         <source>File not saved</source>
         <translation>文件未保存</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1532"/>
-        <location filename="../src/widgets/window.cpp" line="1549"/>
+        <location filename="../src/widgets/window.cpp" line="1716"/>
+        <location filename="../src/widgets/window.cpp" line="1733"/>
         <source>Line Endings</source>
         <translation>換行符</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="243"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="379"/>
         <source>Please install &apos;UOS AI&apos; from the App Store before using</source>
         <translation>請前往應用商店安裝“UOS AI”後再使用</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="245"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="381"/>
         <source>No audio input device detected. Please check and try again</source>
         <translation>未檢測到音頻輸入設備，請檢查後重試</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="247"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="383"/>
         <source>No audio output device detected. Please check and try again</source>
         <translation>未檢測到音頻輸出設備，請檢查後重試</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="69"/>
+        <location filename="../src/common/text_file_saver.cpp" line="74"/>
         <source>File path is empty</source>
         <translation>文件路徑為空</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="155"/>
+        <location filename="../src/common/text_file_saver.cpp" line="153"/>
         <source>Insufficient memory to load document content</source>
         <translation>內存不足，無法加載文檔內容</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="177"/>
+        <location filename="../src/common/text_file_saver.cpp" line="178"/>
         <source>Insufficient memory for encoding conversion</source>
         <translation>內存不足，無法進行編碼轉換</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="183"/>
+        <location filename="../src/common/text_file_saver.cpp" line="184"/>
         <source>Encoding conversion failed</source>
         <translation>編碼轉換失敗</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="189"/>
+        <location filename="../src/common/text_file_saver.cpp" line="190"/>
         <source>Converted content is empty</source>
         <translation>轉換後的內容為空</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="207"/>
+        <location filename="../src/common/text_file_saver.cpp" line="208"/>
         <source>Memory allocation failed</source>
         <translation>內存分配失敗</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="211"/>
+        <location filename="../src/common/text_file_saver.cpp" line="212"/>
         <source>Error occurred: %1</source>
         <translation>發生錯誤: %1</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="215"/>
+        <location filename="../src/common/text_file_saver.cpp" line="216"/>
         <source>Unknown error occurred</source>
         <translation>發生未知錯誤</translation>
     </message>
@@ -842,27 +880,27 @@
         <translation>查找</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="34"/>
+        <location filename="../src/controls/replacebar.cpp" line="36"/>
         <source>Replace With</source>
         <translation>替換為</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="36"/>
+        <location filename="../src/controls/replacebar.cpp" line="40"/>
         <source>Replace</source>
         <translation>替換</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="37"/>
+        <location filename="../src/controls/replacebar.cpp" line="42"/>
         <source>Skip</source>
         <translation>跳過</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="38"/>
+        <location filename="../src/controls/replacebar.cpp" line="44"/>
         <source>Replace Rest</source>
         <translation>剩餘替換</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="39"/>
+        <location filename="../src/controls/replacebar.cpp" line="46"/>
         <source>Replace All</source>
         <translation>全部替換</translation>
     </message>
@@ -871,9 +909,9 @@
     <name>S:</name>
     <message>
         <location filename="../third/libiconv-1.16/src/iconv.c" line="103"/>
-        <source/>
+        <source></source>
         <comment>The first line of the short usage message.</comment>
-        <translation type="unfinished"/>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -904,34 +942,34 @@
         <translation>全螢幕</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="484"/>
+        <location filename="../src/common/settings.cpp" line="491"/>
         <source>This shortcut conflicts with system shortcut %1</source>
         <translation>此快捷鍵與系統快捷鍵%1衝突</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="487"/>
+        <location filename="../src/common/settings.cpp" line="494"/>
         <source>This shortcut conflicts with %1, click on Replace to make this shortcut effective immediately</source>
         <translation>此快捷鍵與%1衝突，點擊替換使這個快捷鍵立即生效</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="682"/>
-        <location filename="../src/common/settings.cpp" line="695"/>
-        <location filename="../src/common/settings.cpp" line="704"/>
+        <location filename="../src/common/settings.cpp" line="689"/>
+        <location filename="../src/common/settings.cpp" line="702"/>
+        <location filename="../src/common/settings.cpp" line="711"/>
         <source>The shortcut %1 is invalid, please set another one.</source>
         <translation>%1為無效快捷鍵，請重新設置</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="736"/>
+        <location filename="../src/common/settings.cpp" line="743"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="737"/>
+        <location filename="../src/common/settings.cpp" line="744"/>
         <source>Replace</source>
         <translation>替換</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="740"/>
+        <location filename="../src/common/settings.cpp" line="747"/>
         <source>OK</source>
         <translation>確定</translation>
     </message>
@@ -939,7 +977,7 @@
 <context>
     <name>StartManager</name>
     <message>
-        <location filename="../src/startmanager.cpp" line="411"/>
+        <location filename="../src/startmanager.cpp" line="425"/>
         <source>Untitled %1</source>
         <translation>未命名文檔%1</translation>
     </message>
@@ -947,32 +985,32 @@
 <context>
     <name>Tabbar</name>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="641"/>
+        <location filename="../src/controls/tabbar.cpp" line="678"/>
         <source>Close tab</source>
         <translation>關閉標籤頁</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="642"/>
+        <location filename="../src/controls/tabbar.cpp" line="680"/>
         <source>Close other tabs</source>
         <translation>關閉其他標籤頁</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="643"/>
+        <location filename="../src/controls/tabbar.cpp" line="682"/>
         <source>More options</source>
         <translation>更多關閉方式</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="644"/>
+        <location filename="../src/controls/tabbar.cpp" line="684"/>
         <source>Close tabs to the left</source>
         <translation>關閉左側所有標籤頁</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="645"/>
+        <location filename="../src/controls/tabbar.cpp" line="686"/>
         <source>Close tabs to the right</source>
         <translation>關閉右側所有標籤頁</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="646"/>
+        <location filename="../src/controls/tabbar.cpp" line="688"/>
         <source>Close unmodified tabs</source>
         <translation>關閉所有未修改標籤頁</translation>
     </message>
@@ -980,263 +1018,280 @@
 <context>
     <name>TextEdit</name>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="305"/>
+        <location filename="../src/editor/dtextedit.cpp" line="388"/>
         <source>Undo</source>
         <translation>撤銷</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="306"/>
+        <location filename="../src/editor/dtextedit.cpp" line="390"/>
         <source>Redo</source>
         <translation>重做</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="307"/>
+        <location filename="../src/editor/dtextedit.cpp" line="392"/>
         <source>Cut</source>
         <translation>剪切</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="308"/>
+        <location filename="../src/editor/dtextedit.cpp" line="394"/>
         <source>Copy</source>
         <translation>複製</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="309"/>
+        <location filename="../src/editor/dtextedit.cpp" line="396"/>
         <source>Paste</source>
         <translation>黏貼</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="310"/>
+        <location filename="../src/editor/dtextedit.cpp" line="398"/>
         <source>Delete</source>
         <translation>刪除</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="311"/>
+        <location filename="../src/editor/dtextedit.cpp" line="400"/>
         <source>Select All</source>
         <translation>全選</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="312"/>
-        <location filename="../src/widgets/window.cpp" line="535"/>
+        <location filename="../src/editor/dtextedit.cpp" line="402"/>
+        <location filename="../src/widgets/window.cpp" line="556"/>
         <source>Find</source>
         <translation>查找</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="313"/>
-        <location filename="../src/widgets/window.cpp" line="536"/>
+        <location filename="../src/editor/dtextedit.cpp" line="404"/>
+        <location filename="../src/widgets/window.cpp" line="558"/>
         <source>Replace</source>
         <translation>替換</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="314"/>
+        <location filename="../src/editor/dtextedit.cpp" line="406"/>
         <source>Go to Line</source>
         <translation>跳到行</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="315"/>
-        <source>Turn on Read-Only mode</source>
-        <translation>開啟只讀模式</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="316"/>
-        <source>Turn off Read-Only mode</source>
-        <translation>關閉只讀模式</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="317"/>
+        <location filename="../src/editor/dtextedit.cpp" line="415"/>
         <source>Fullscreen</source>
         <translation>全螢幕</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="318"/>
+        <location filename="../src/editor/dtextedit.cpp" line="417"/>
         <source>Exit fullscreen</source>
         <translation>退出全螢幕</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="319"/>
+        <location filename="../src/editor/dtextedit.cpp" line="419"/>
         <source>Display in file manager</source>
         <translation>在文件管理器中顯示</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="320"/>
-        <location filename="../src/editor/dtextedit.cpp" line="374"/>
+        <location filename="../src/editor/dtextedit.cpp" line="421"/>
+        <location filename="../src/editor/dtextedit.cpp" line="493"/>
         <source>Add Comment</source>
         <translation>添加注釋</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="321"/>
+        <location filename="../src/editor/dtextedit.cpp" line="423"/>
         <source>Text to Speech</source>
         <translation>語音朗讀</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="322"/>
-        <source>Stop reading</source>
-        <translation>停止朗讀</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="323"/>
+        <location filename="../src/editor/dtextedit.cpp" line="425"/>
         <source>Speech to Text</source>
         <translation>語音聽寫</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="324"/>
+        <location filename="../src/editor/dtextedit.cpp" line="427"/>
         <source>Translate</source>
         <translation>文本翻譯</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="325"/>
+        <location filename="../src/editor/dtextedit.cpp" line="429"/>
         <source>Column Mode</source>
         <translation>列編輯模式</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="326"/>
+        <location filename="../src/editor/dtextedit.cpp" line="431"/>
         <source>Add bookmark</source>
         <translation>添加書籤</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="327"/>
+        <location filename="../src/editor/dtextedit.cpp" line="433"/>
         <source>Remove Bookmark</source>
         <translation>清除書籤</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="328"/>
+        <location filename="../src/editor/dtextedit.cpp" line="435"/>
         <source>Previous bookmark</source>
         <translation>上一個書籤</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="329"/>
+        <location filename="../src/editor/dtextedit.cpp" line="437"/>
         <source>Next bookmark</source>
         <translation>下一個書籤</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="330"/>
+        <location filename="../src/editor/dtextedit.cpp" line="439"/>
         <source>Remove All Bookmarks</source>
         <translation>清除所有書籤</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="331"/>
+        <location filename="../src/editor/dtextedit.cpp" line="441"/>
         <source>Fold All</source>
         <translation>摺疊所有層次</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="332"/>
+        <location filename="../src/editor/dtextedit.cpp" line="443"/>
         <source>Fold Current Level</source>
         <translation>摺疊當前層次</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="333"/>
+        <location filename="../src/editor/dtextedit.cpp" line="445"/>
         <source>Unfold All</source>
         <translation>展開所有層次</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="334"/>
+        <location filename="../src/editor/dtextedit.cpp" line="447"/>
         <source>Unfold Current Level</source>
         <translation>展開當前層次</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="339"/>
+        <location filename="../src/editor/dtextedit.cpp" line="453"/>
         <source>Color Mark</source>
         <translation>顏色標記</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="343"/>
+        <location filename="../src/editor/dtextedit.cpp" line="458"/>
         <source>Clear All Marks</source>
         <translation>清除所有標記</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="344"/>
+        <location filename="../src/editor/dtextedit.cpp" line="460"/>
         <source>Clear Last Mark</source>
         <translation>清除上次標記</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="353"/>
+        <location filename="../src/editor/dtextedit.cpp" line="470"/>
         <source>Mark</source>
         <translation>添加標記</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="366"/>
+        <location filename="../src/editor/dtextedit.cpp" line="484"/>
         <source>Mark All</source>
         <translation>標記所有</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="375"/>
+        <location filename="../src/editor/dtextedit.cpp" line="494"/>
         <source>Remove Comment</source>
         <translation>取消注釋</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3208"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3211"/>
+        <location filename="../src/editor/dtextedit.cpp" line="543"/>
+        <source>View Mode</source>
+        <translation>視圖模式</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="3531"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3534"/>
         <source>Copy failed: not enough memory</source>
         <translation>內存不足，複製失敗</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3333"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3335"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3656"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3658"/>
         <source>Press ALT and click lines to edit in column mode</source>
         <translation>請使用ALT+鼠標點選切換列編輯模式</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="418"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9574"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9576"/>
+        <source>No audio output device was detected. Please ensure your speakers or headphones are properly connected and try again.</source>
+        <translation>未檢測到音頻輸出設備，請確保揚聲器或耳機已正確連接後重試</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="9583"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9585"/>
+        <source>No audio input device was detected. Please ensure your speakers or headphones are properly connected and try again.</source>
+        <translation>未檢測到音頻輸入設備，請確保揚聲器或耳機已正確連接後重試</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="534"/>
         <source>Change Case</source>
         <translation>切換大小寫</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="419"/>
+        <location filename="../src/editor/dtextedit.cpp" line="409"/>
+        <source>Edit Mode</source>
+        <translation>編輯模式</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="411"/>
+        <source>Read View</source>
+        <translation>查看視圖</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="413"/>
+        <source>Live Preview</source>
+        <translation>即時預覽</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="535"/>
         <source>Upper Case</source>
         <translation>大寫</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="420"/>
+        <location filename="../src/editor/dtextedit.cpp" line="536"/>
         <source>Lower Case</source>
         <translation>小寫</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="421"/>
+        <location filename="../src/editor/dtextedit.cpp" line="537"/>
         <source>Capitalize</source>
         <translation>首字母大寫</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="78"/>
+        <location filename="../src/widgets/bottombar.cpp" line="110"/>
         <source>None</source>
         <translation>無</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1363"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1490"/>
         <source>Selected line(s) copied</source>
         <translation>已複製選中行到剪貼板</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1370"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1497"/>
         <source>Current line copied</source>
         <translation>已複製當前行到剪貼板</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1400"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1527"/>
         <source>Selected line(s) clipped</source>
         <translation>已剪切選中行到剪貼板</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1412"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1539"/>
         <source>Current line clipped</source>
         <translation>已剪切當前行到剪貼板</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3227"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3230"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3550"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3553"/>
         <source>Paste failed: not enough memory</source>
         <translation>內存不足，黏貼失敗</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="4548"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4873"/>
         <source>Read-Only mode is off</source>
         <translation>只讀模式已關閉</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="4560"/>
-        <location filename="../src/editor/dtextedit.cpp" line="4584"/>
-        <location filename="../src/editor/dtextedit.cpp" line="7896"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8007"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8015"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8026"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4885"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4909"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8236"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8347"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8355"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8366"/>
         <source>Read-Only mode is on</source>
         <translation>只讀模式已開啟</translation>
     </message>
@@ -1244,12 +1299,12 @@
 <context>
     <name>WarningNotices</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="24"/>
+        <location filename="../src/controls/warningnotices.cpp" line="25"/>
         <source>Reload</source>
         <translation>重新載入</translation>
     </message>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="26"/>
+        <location filename="../src/controls/warningnotices.cpp" line="29"/>
         <source>Edit Anyway</source>
         <translation>仍然編輯</translation>
     </message>
@@ -1257,160 +1312,162 @@
 <context>
     <name>Window</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="25"/>
-        <location filename="../src/widgets/window.cpp" line="531"/>
+        <location filename="../src/controls/warningnotices.cpp" line="27"/>
+        <location filename="../src/widgets/window.cpp" line="548"/>
         <source>Save as</source>
         <translation>另存為</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="527"/>
+        <location filename="../src/widgets/window.cpp" line="540"/>
         <source>New window</source>
         <translation>新窗口</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="528"/>
+        <location filename="../src/widgets/window.cpp" line="542"/>
         <source>New tab</source>
         <translation>新標籤頁</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="529"/>
+        <location filename="../src/widgets/window.cpp" line="544"/>
         <source>Open file</source>
         <translation>打開文件</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="530"/>
-        <location filename="../src/widgets/window.cpp" line="3545"/>
+        <location filename="../src/widgets/window.cpp" line="546"/>
+        <location filename="../src/widgets/window.cpp" line="3950"/>
         <source>Save</source>
         <translation>保存</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="532"/>
+        <location filename="../src/widgets/window.cpp" line="550"/>
         <source>Print</source>
         <translation>打印</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="533"/>
+        <location filename="../src/widgets/window.cpp" line="552"/>
         <source>Switch theme</source>
         <translation>切換主題</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="534"/>
-        <location filename="../src/widgets/window.cpp" line="2448"/>
+        <location filename="../src/widgets/window.cpp" line="554"/>
+        <location filename="../src/widgets/window.cpp" line="2641"/>
         <source>Settings</source>
         <translation>設置</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="666"/>
-        <location filename="../src/widgets/window.cpp" line="3845"/>
+        <location filename="../src/widgets/window.cpp" line="696"/>
+        <location filename="../src/widgets/window.cpp" line="4250"/>
         <source>Read-Only</source>
         <translation>只讀</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="687"/>
+        <location filename="../src/widgets/window.cpp" line="719"/>
         <source>You do not have permission to open %1</source>
         <translation>您沒有權限打開%1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="738"/>
-        <location filename="../src/widgets/window.cpp" line="2963"/>
+        <location filename="../src/widgets/window.cpp" line="773"/>
+        <location filename="../src/widgets/window.cpp" line="3266"/>
         <source>Invalid file: %1</source>
         <translation>無效文件：%1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="903"/>
-        <location filename="../src/widgets/window.cpp" line="956"/>
+        <location filename="../src/widgets/window.cpp" line="957"/>
+        <location filename="../src/widgets/window.cpp" line="1050"/>
+        <location filename="../src/widgets/window.cpp" line="3217"/>
         <source>Do you want to save this file?</source>
         <translation>您是否要保存此文件？</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1290"/>
+        <location filename="../src/widgets/window.cpp" line="1456"/>
         <source>You do not have permission to save %1</source>
         <translation>您沒有權限保存%1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1312"/>
+        <location filename="../src/widgets/window.cpp" line="1428"/>
+        <location filename="../src/widgets/window.cpp" line="1478"/>
         <source>Saved successfully</source>
         <translation>文件已保存</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1354"/>
-        <location filename="../src/widgets/window.cpp" line="1481"/>
-        <location filename="../src/widgets/window.cpp" line="1529"/>
+        <location filename="../src/widgets/window.cpp" line="1520"/>
+        <location filename="../src/widgets/window.cpp" line="1665"/>
+        <location filename="../src/widgets/window.cpp" line="1713"/>
         <source>Save File</source>
         <translation>保存</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1483"/>
+        <location filename="../src/widgets/window.cpp" line="1667"/>
         <source>Encoding</source>
         <translation>編碼</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1773"/>
+        <location filename="../src/widgets/window.cpp" line="1957"/>
         <source>Read-Only mode is on</source>
         <translation>只讀模式已開啟</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2322"/>
+        <location filename="../src/widgets/window.cpp" line="2511"/>
         <source>Current location remembered</source>
         <translation>已記住當前位置</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2398"/>
+        <location filename="../src/widgets/window.cpp" line="2591"/>
         <source>Ctrl+&apos;=&apos;</source>
         <translation>Ctrl+&apos;=&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2401"/>
+        <location filename="../src/widgets/window.cpp" line="2594"/>
         <source>Ctrl+&apos;-&apos;</source>
         <translation>Ctrl+&apos;-&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2430"/>
+        <location filename="../src/widgets/window.cpp" line="2623"/>
         <source>Editor</source>
         <translation>編輯</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3061"/>
+        <location filename="../src/widgets/window.cpp" line="3436"/>
         <source>Untitled %1</source>
         <translation>未命名文檔%1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3543"/>
+        <location filename="../src/widgets/window.cpp" line="3948"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3544"/>
+        <location filename="../src/widgets/window.cpp" line="3949"/>
         <source>Discard</source>
         <translation>不保存</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1317"/>
-        <source>Invalid characters detected while saving "%1"</source>
+        <location filename="../src/widgets/window.cpp" line="1381"/>
+        <source>Invalid characters detected while saving &quot;%1&quot;</source>
         <translation>保存「%1」時偵測到無效字元</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1318"/>
+        <location filename="../src/widgets/window.cpp" line="1382"/>
         <source>If you force save this file, it may cause file corruption. Still want to save?</source>
         <translation>強制保存此文件可能導致文件損壞。仍然要保存嗎？</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1321"/>
+        <location filename="../src/widgets/window.cpp" line="1386"/>
         <source>Don&apos;t Save</source>
         <translation>不保存</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1322"/>
+        <location filename="../src/widgets/window.cpp" line="1387"/>
         <source>Save As</source>
         <translation>另存為</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1323"/>
+        <location filename="../src/widgets/window.cpp" line="1388"/>
         <source>Save Anyway</source>
         <translation>強制保存</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1521"/>
+        <location filename="../src/widgets/window.cpp" line="1569"/>
         <source>Cannot save as the original file in preview mode. Please choose a different path.</source>
         <translation>預覽模式下不能另存為原文件。請選擇其他路徑。</translation>
     </message>

--- a/translations/deepin-editor_zh_TW.ts
+++ b/translations/deepin-editor_zh_TW.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="zh_TW">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_TW">
 <context>
     <name>BottomBar</name>
     <message>
@@ -17,17 +19,36 @@
         <translation>字數 %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="44"/>
+        <location filename="../src/widgets/bottombar.cpp" line="47"/>
         <source>Loading:</source>
         <translation>文件載入中：</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="73"/>
+        <location filename="../src/widgets/bottombar.cpp" line="91"/>
+        <location filename="../src/widgets/bottombar.cpp" line="499"/>
+        <source>Edit Mode</source>
+        <translation>編輯模式</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="74"/>
+        <location filename="../src/widgets/bottombar.cpp" line="489"/>
+        <source>Read View</source>
+        <translation>查看視圖</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/bottombar.cpp" line="75"/>
+        <location filename="../src/widgets/bottombar.cpp" line="493"/>
+        <source>Live Preview</source>
+        <translation>即時預覽</translation>
     </message>
 </context>
 <context>
     <name>DDropdownMenu</name>
     <message>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="362"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="420"/>
-        <location filename="../src/widgets/ddropdownmenu.cpp" line="425"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="363"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="421"/>
+        <location filename="../src/widgets/ddropdownmenu.cpp" line="426"/>
         <source>None</source>
         <translation>無</translation>
     </message>
@@ -35,73 +56,57 @@
 <context>
     <name>EditWrapper</name>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="292"/>
-        <location filename="../src/editor/editwrapper.cpp" line="365"/>
-        <location filename="../src/editor/editwrapper.cpp" line="521"/>
-        <location filename="../src/editor/editwrapper.cpp" line="751"/>
+        <location filename="../src/editor/editwrapper.cpp" line="355"/>
+        <location filename="../src/editor/editwrapper.cpp" line="429"/>
+        <location filename="../src/editor/editwrapper.cpp" line="595"/>
+        <location filename="../src/editor/editwrapper.cpp" line="887"/>
         <source>Save</source>
         <translation>儲存</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="516"/>
+        <location filename="../src/editor/editwrapper.cpp" line="590"/>
         <source>Do you want to save this file?</source>
         <translation>您是否要儲存此文件？</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="363"/>
-        <location filename="../src/editor/editwrapper.cpp" line="519"/>
+        <location filename="../src/editor/editwrapper.cpp" line="427"/>
+        <location filename="../src/editor/editwrapper.cpp" line="593"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="360"/>
+        <location filename="../src/editor/editwrapper.cpp" line="424"/>
         <source>Encoding changed. Do you want to save the file now?</source>
         <translation>文件編碼已更改，是否先進行儲存？</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="520"/>
+        <location filename="../src/editor/editwrapper.cpp" line="594"/>
         <source>Discard</source>
         <translation>不儲存</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="274"/>
-        <location filename="../src/editor/editwrapper.cpp" line="620"/>
+        <location filename="../src/editor/editwrapper.cpp" line="337"/>
+        <location filename="../src/editor/editwrapper.cpp" line="705"/>
         <source>You do not have permission to save %1</source>
         <translation>您沒有權限儲存%1</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="836"/>
+        <location filename="../src/editor/editwrapper.cpp" line="987"/>
         <source>File removed on the disk. Save it now?</source>
         <translation>磁碟中的原文件已被移除，是否另存？</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="842"/>
+        <location filename="../src/editor/editwrapper.cpp" line="993"/>
         <source>File has changed on disk. Reload?</source>
         <translation>磁碟上的檔案已被更改。是否重新載入？</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="884"/>
-        <location filename="../src/widgets/bottombar.cpp" line="74"/>
-        <source>INSERT</source>
-        <translation>插入</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="888"/>
-        <source>OVERWRITE</source>
-        <translation>覆蓋</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="892"/>
-        <source>R/O</source>
-        <translation>唯讀</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/editwrapper.cpp" line="1618"/>
+        <location filename="../src/editor/editwrapper.cpp" line="1806"/>
         <source>The file cannot be read, which may be too large or has been damaged!</source>
         <translation>無法讀取該文件，文件可能過大或損壞</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="1020"/>
+        <location filename="../src/editor/editwrapper.cpp" line="1121"/>
         <source>The file contains invalid characters (NUL). Preview mode is read-only.</source>
         <translation>文件包含無效字元（NUL）。預覽模式為唯讀。</translation>
     </message>
@@ -114,17 +119,17 @@
         <translation>尋找</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="36"/>
+        <location filename="../src/controls/findbar.cpp" line="38"/>
         <source>Previous</source>
         <translation>上一個</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="37"/>
+        <location filename="../src/controls/findbar.cpp" line="40"/>
         <source>Next</source>
         <translation>下一個</translation>
     </message>
     <message>
-        <location filename="../src/controls/findbar.cpp" line="38"/>
+        <location filename="../src/controls/findbar.cpp" line="42"/>
         <source>Replace</source>
         <translation>取代</translation>
     </message>
@@ -132,7 +137,7 @@
 <context>
     <name>JumpLineBar</name>
     <message>
-        <location filename="../src/controls/jumplinebar.cpp" line="45"/>
+        <location filename="../src/controls/jumplinebar.cpp" line="46"/>
         <source>Go to Line: </source>
         <translation>跳到行：</translation>
     </message>
@@ -140,7 +145,7 @@
 <context>
     <name>LineBar</name>
     <message>
-        <location filename="../src/controls/linebar.cpp" line="117"/>
+        <location filename="../src/controls/linebar.cpp" line="144"/>
         <source>第%1/%2项</source>
         <translation>第%1/%2項</translation>
     </message>
@@ -159,19 +164,47 @@
     </message>
 </context>
 <context>
+    <name>MarkdownBridge</name>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="37"/>
+        <source>Collapse code block</source>
+        <translation>摺疊程式碼區塊</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="38"/>
+        <source>Expand code block</source>
+        <translation>展開程式碼區塊</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="39"/>
+        <source>Copy code</source>
+        <translation>複製程式碼</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="40"/>
+        <source>Expand</source>
+        <translation>展開</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/markdown/markdownbridge.h" line="42"/>
+        <source>%1 line(s) of code collapsed</source>
+        <translation>已摺疊 %1 行程式碼</translation>
+    </message>
+</context>
+<context>
     <name>PathSettingWgt</name>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="84"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="90"/>
         <source>Remember the last used path</source>
         <translation>記住最後的操作路徑</translation>
     </message>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="85"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="91"/>
         <source>Same path as the current file</source>
         <translation>與目前文件保持一致</translation>
     </message>
     <message>
-        <location filename="../src/widgets/pathsettintwgt.cpp" line="86"/>
+        <location filename="../src/widgets/pathsettintwgt.cpp" line="92"/>
         <source>Customize the default path</source>
         <translation>自訂操作路徑</translation>
     </message>
@@ -184,15 +217,20 @@
         <translation>文字編輯器</translation>
     </message>
     <message>
-        <location filename="../src/editor/editwrapper.cpp" line="294"/>
-        <location filename="../src/editor/editwrapper.cpp" line="761"/>
-        <location filename="../src/editor/editwrapper.cpp" line="776"/>
-        <location filename="../src/widgets/window.cpp" line="1362"/>
-        <location filename="../src/widgets/window.cpp" line="1390"/>
-        <location filename="../src/widgets/window.cpp" line="1531"/>
-        <location filename="../src/widgets/window.cpp" line="1548"/>
+        <location filename="../src/editor/editwrapper.cpp" line="357"/>
+        <location filename="../src/editor/editwrapper.cpp" line="897"/>
+        <location filename="../src/editor/editwrapper.cpp" line="912"/>
+        <location filename="../src/widgets/window.cpp" line="1528"/>
+        <location filename="../src/widgets/window.cpp" line="1556"/>
+        <location filename="../src/widgets/window.cpp" line="1715"/>
+        <location filename="../src/widgets/window.cpp" line="1732"/>
         <source>Encoding</source>
         <translation>編碼</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/editwrapper.cpp" line="2001"/>
+        <source>视图模式</source>
+        <translation>視圖模式</translation>
     </message>
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="11"/>
@@ -228,7 +266,7 @@
     <message>
         <location filename="../src/controls/settingsdialog.cpp" line="18"/>
         <location filename="../src/controls/settingsdialog.cpp" line="96"/>
-        <location filename="../src/widgets/window.cpp" line="2388"/>
+        <location filename="../src/widgets/window.cpp" line="2581"/>
         <source>Window</source>
         <translation>視窗</translation>
     </message>
@@ -768,68 +806,68 @@
         <translation>越南語</translation>
     </message>
     <message>
-        <location filename="../src/startmanager.cpp" line="971"/>
+        <location filename="../src/startmanager.cpp" line="1035"/>
         <source>File not saved</source>
         <translation>文件未儲存</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1532"/>
-        <location filename="../src/widgets/window.cpp" line="1549"/>
+        <location filename="../src/widgets/window.cpp" line="1716"/>
+        <location filename="../src/widgets/window.cpp" line="1733"/>
         <source>Line Endings</source>
         <translation>換行符</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="243"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="379"/>
         <source>Please install &apos;UOS AI&apos; from the App Store before using</source>
         <translation>請前往應用商店安裝“UOS AI”後再使用</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="245"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="381"/>
         <source>No audio input device detected. Please check and try again</source>
         <translation>未檢測到音頻輸入設備，請檢查後重試</translation>
     </message>
     <message>
-        <location filename="../src/common/iflytek_ai_assistant.cpp" line="247"/>
+        <location filename="../src/common/iflytek_ai_assistant.cpp" line="383"/>
         <source>No audio output device detected. Please check and try again</source>
         <translation>未檢測到音頻輸出設備，請檢查後重試</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="69"/>
+        <location filename="../src/common/text_file_saver.cpp" line="74"/>
         <source>File path is empty</source>
         <translation>檔案路徑為空</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="155"/>
+        <location filename="../src/common/text_file_saver.cpp" line="153"/>
         <source>Insufficient memory to load document content</source>
         <translation>記憶體不足，無法載入文件內容</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="177"/>
+        <location filename="../src/common/text_file_saver.cpp" line="178"/>
         <source>Insufficient memory for encoding conversion</source>
         <translation>記憶體不足，無法進行編碼轉換</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="183"/>
+        <location filename="../src/common/text_file_saver.cpp" line="184"/>
         <source>Encoding conversion failed</source>
         <translation>編碼轉換失敗</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="189"/>
+        <location filename="../src/common/text_file_saver.cpp" line="190"/>
         <source>Converted content is empty</source>
         <translation>轉換後的內容為空</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="207"/>
+        <location filename="../src/common/text_file_saver.cpp" line="208"/>
         <source>Memory allocation failed</source>
         <translation>記憶體分配失敗</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="211"/>
+        <location filename="../src/common/text_file_saver.cpp" line="212"/>
         <source>Error occurred: %1</source>
         <translation>發生錯誤: %1</translation>
     </message>
     <message>
-        <location filename="../src/common/text_file_saver.cpp" line="215"/>
+        <location filename="../src/common/text_file_saver.cpp" line="216"/>
         <source>Unknown error occurred</source>
         <translation>發生未知錯誤</translation>
     </message>
@@ -842,27 +880,27 @@
         <translation>尋找</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="34"/>
+        <location filename="../src/controls/replacebar.cpp" line="36"/>
         <source>Replace With</source>
         <translation>取代為</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="36"/>
+        <location filename="../src/controls/replacebar.cpp" line="40"/>
         <source>Replace</source>
         <translation>取代</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="37"/>
+        <location filename="../src/controls/replacebar.cpp" line="42"/>
         <source>Skip</source>
         <translation>跳過</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="38"/>
+        <location filename="../src/controls/replacebar.cpp" line="44"/>
         <source>Replace Rest</source>
         <translation>剩餘取代</translation>
     </message>
     <message>
-        <location filename="../src/controls/replacebar.cpp" line="39"/>
+        <location filename="../src/controls/replacebar.cpp" line="46"/>
         <source>Replace All</source>
         <translation>全部取代</translation>
     </message>
@@ -871,9 +909,9 @@
     <name>S:</name>
     <message>
         <location filename="../third/libiconv-1.16/src/iconv.c" line="103"/>
-        <source/>
+        <source></source>
         <comment>The first line of the short usage message.</comment>
-        <translation type="unfinished"/>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -904,34 +942,34 @@
         <translation>全螢幕</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="484"/>
+        <location filename="../src/common/settings.cpp" line="491"/>
         <source>This shortcut conflicts with system shortcut %1</source>
         <translation>此快捷鍵與系統快捷鍵%1衝突</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="487"/>
+        <location filename="../src/common/settings.cpp" line="494"/>
         <source>This shortcut conflicts with %1, click on Replace to make this shortcut effective immediately</source>
         <translation>此快捷鍵與%1衝突，點擊取代使這個快捷鍵立即生效</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="682"/>
-        <location filename="../src/common/settings.cpp" line="695"/>
-        <location filename="../src/common/settings.cpp" line="704"/>
+        <location filename="../src/common/settings.cpp" line="689"/>
+        <location filename="../src/common/settings.cpp" line="702"/>
+        <location filename="../src/common/settings.cpp" line="711"/>
         <source>The shortcut %1 is invalid, please set another one.</source>
         <translation>%1為無效快捷鍵，請重新設定</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="736"/>
+        <location filename="../src/common/settings.cpp" line="743"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="737"/>
+        <location filename="../src/common/settings.cpp" line="744"/>
         <source>Replace</source>
         <translation>取代</translation>
     </message>
     <message>
-        <location filename="../src/common/settings.cpp" line="740"/>
+        <location filename="../src/common/settings.cpp" line="747"/>
         <source>OK</source>
         <translation>確定</translation>
     </message>
@@ -939,7 +977,7 @@
 <context>
     <name>StartManager</name>
     <message>
-        <location filename="../src/startmanager.cpp" line="411"/>
+        <location filename="../src/startmanager.cpp" line="425"/>
         <source>Untitled %1</source>
         <translation>未命名文件%1</translation>
     </message>
@@ -947,32 +985,32 @@
 <context>
     <name>Tabbar</name>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="641"/>
+        <location filename="../src/controls/tabbar.cpp" line="678"/>
         <source>Close tab</source>
         <translation>關閉分頁</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="642"/>
+        <location filename="../src/controls/tabbar.cpp" line="680"/>
         <source>Close other tabs</source>
         <translation>關閉其他分頁</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="643"/>
+        <location filename="../src/controls/tabbar.cpp" line="682"/>
         <source>More options</source>
         <translation>更多關閉方式</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="644"/>
+        <location filename="../src/controls/tabbar.cpp" line="684"/>
         <source>Close tabs to the left</source>
         <translation>關閉左側所有分頁</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="645"/>
+        <location filename="../src/controls/tabbar.cpp" line="686"/>
         <source>Close tabs to the right</source>
         <translation>關閉右側所有分頁</translation>
     </message>
     <message>
-        <location filename="../src/controls/tabbar.cpp" line="646"/>
+        <location filename="../src/controls/tabbar.cpp" line="688"/>
         <source>Close unmodified tabs</source>
         <translation>關閉所有未修改分頁</translation>
     </message>
@@ -980,263 +1018,280 @@
 <context>
     <name>TextEdit</name>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="305"/>
+        <location filename="../src/editor/dtextedit.cpp" line="388"/>
         <source>Undo</source>
         <translation>復原</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="306"/>
+        <location filename="../src/editor/dtextedit.cpp" line="390"/>
         <source>Redo</source>
         <translation>重做</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="307"/>
+        <location filename="../src/editor/dtextedit.cpp" line="392"/>
         <source>Cut</source>
         <translation>剪下</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="308"/>
+        <location filename="../src/editor/dtextedit.cpp" line="394"/>
         <source>Copy</source>
         <translation>複製</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="309"/>
+        <location filename="../src/editor/dtextedit.cpp" line="396"/>
         <source>Paste</source>
         <translation>貼上</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="310"/>
+        <location filename="../src/editor/dtextedit.cpp" line="398"/>
         <source>Delete</source>
         <translation>刪除</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="311"/>
+        <location filename="../src/editor/dtextedit.cpp" line="400"/>
         <source>Select All</source>
         <translation>全選</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="312"/>
-        <location filename="../src/widgets/window.cpp" line="535"/>
+        <location filename="../src/editor/dtextedit.cpp" line="402"/>
+        <location filename="../src/widgets/window.cpp" line="556"/>
         <source>Find</source>
         <translation>尋找</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="313"/>
-        <location filename="../src/widgets/window.cpp" line="536"/>
+        <location filename="../src/editor/dtextedit.cpp" line="404"/>
+        <location filename="../src/widgets/window.cpp" line="558"/>
         <source>Replace</source>
         <translation>取代</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="314"/>
+        <location filename="../src/editor/dtextedit.cpp" line="406"/>
         <source>Go to Line</source>
         <translation>跳到行</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="315"/>
-        <source>Turn on Read-Only mode</source>
-        <translation>開啟唯讀模式</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="316"/>
-        <source>Turn off Read-Only mode</source>
-        <translation>關閉唯讀模式</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="317"/>
+        <location filename="../src/editor/dtextedit.cpp" line="415"/>
         <source>Fullscreen</source>
         <translation>全螢幕</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="318"/>
+        <location filename="../src/editor/dtextedit.cpp" line="417"/>
         <source>Exit fullscreen</source>
         <translation>退出全螢幕</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="319"/>
+        <location filename="../src/editor/dtextedit.cpp" line="419"/>
         <source>Display in file manager</source>
         <translation>在檔案管理器中顯示</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="320"/>
-        <location filename="../src/editor/dtextedit.cpp" line="374"/>
+        <location filename="../src/editor/dtextedit.cpp" line="421"/>
+        <location filename="../src/editor/dtextedit.cpp" line="493"/>
         <source>Add Comment</source>
         <translation>添加注釋</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="321"/>
+        <location filename="../src/editor/dtextedit.cpp" line="423"/>
         <source>Text to Speech</source>
         <translation>語音朗讀</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="322"/>
-        <source>Stop reading</source>
-        <translation>停止朗讀</translation>
-    </message>
-    <message>
-        <location filename="../src/editor/dtextedit.cpp" line="323"/>
+        <location filename="../src/editor/dtextedit.cpp" line="425"/>
         <source>Speech to Text</source>
         <translation>語音聽寫</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="324"/>
+        <location filename="../src/editor/dtextedit.cpp" line="427"/>
         <source>Translate</source>
         <translation>文字翻譯</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="325"/>
+        <location filename="../src/editor/dtextedit.cpp" line="429"/>
         <source>Column Mode</source>
         <translation>列編輯模式</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="326"/>
+        <location filename="../src/editor/dtextedit.cpp" line="431"/>
         <source>Add bookmark</source>
         <translation>添加書籤</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="327"/>
+        <location filename="../src/editor/dtextedit.cpp" line="433"/>
         <source>Remove Bookmark</source>
         <translation>清除書籤</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="328"/>
+        <location filename="../src/editor/dtextedit.cpp" line="435"/>
         <source>Previous bookmark</source>
         <translation>上一個書籤</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="329"/>
+        <location filename="../src/editor/dtextedit.cpp" line="437"/>
         <source>Next bookmark</source>
         <translation>下一個書籤</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="330"/>
+        <location filename="../src/editor/dtextedit.cpp" line="439"/>
         <source>Remove All Bookmarks</source>
         <translation>清除所有書籤</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="331"/>
+        <location filename="../src/editor/dtextedit.cpp" line="441"/>
         <source>Fold All</source>
         <translation>摺疊所有層次</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="332"/>
+        <location filename="../src/editor/dtextedit.cpp" line="443"/>
         <source>Fold Current Level</source>
         <translation>摺疊目前層次</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="333"/>
+        <location filename="../src/editor/dtextedit.cpp" line="445"/>
         <source>Unfold All</source>
         <translation>展開所有層次</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="334"/>
+        <location filename="../src/editor/dtextedit.cpp" line="447"/>
         <source>Unfold Current Level</source>
         <translation>展開目前層次</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="339"/>
+        <location filename="../src/editor/dtextedit.cpp" line="453"/>
         <source>Color Mark</source>
         <translation>顏色標記</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="343"/>
+        <location filename="../src/editor/dtextedit.cpp" line="458"/>
         <source>Clear All Marks</source>
         <translation>清除所有標記</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="344"/>
+        <location filename="../src/editor/dtextedit.cpp" line="460"/>
         <source>Clear Last Mark</source>
         <translation>清除上次標記</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="353"/>
+        <location filename="../src/editor/dtextedit.cpp" line="470"/>
         <source>Mark</source>
         <translation>添加標記</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="366"/>
+        <location filename="../src/editor/dtextedit.cpp" line="484"/>
         <source>Mark All</source>
         <translation>標記所有</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="375"/>
+        <location filename="../src/editor/dtextedit.cpp" line="494"/>
         <source>Remove Comment</source>
         <translation>取消注釋</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3208"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3211"/>
+        <location filename="../src/editor/dtextedit.cpp" line="543"/>
+        <source>View Mode</source>
+        <translation>視圖模式</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="3531"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3534"/>
         <source>Copy failed: not enough memory</source>
         <translation>記憶體不足，複製失敗</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3333"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3335"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3656"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3658"/>
         <source>Press ALT and click lines to edit in column mode</source>
         <translation>請使用ALT+滑鼠點選切換列編輯模式</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="418"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9574"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9576"/>
+        <source>No audio output device was detected. Please ensure your speakers or headphones are properly connected and try again.</source>
+        <translation>未檢測到音頻輸出設備，請確保揚聲器或耳機已正確連接後重試</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="9583"/>
+        <location filename="../src/editor/dtextedit.cpp" line="9585"/>
+        <source>No audio input device was detected. Please ensure your speakers or headphones are properly connected and try again.</source>
+        <translation>未檢測到音頻輸入設備，請確保揚聲器或耳機已正確連接後重試</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="534"/>
         <source>Change Case</source>
         <translation>切換大小寫</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="419"/>
+        <location filename="../src/editor/dtextedit.cpp" line="409"/>
+        <source>Edit Mode</source>
+        <translation>編輯模式</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="411"/>
+        <source>Read View</source>
+        <translation>查看視圖</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="413"/>
+        <source>Live Preview</source>
+        <translation>即時預覽</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/dtextedit.cpp" line="535"/>
         <source>Upper Case</source>
         <translation>大寫</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="420"/>
+        <location filename="../src/editor/dtextedit.cpp" line="536"/>
         <source>Lower Case</source>
         <translation>小寫</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="421"/>
+        <location filename="../src/editor/dtextedit.cpp" line="537"/>
         <source>Capitalize</source>
         <translation>首字母大寫</translation>
     </message>
     <message>
-        <location filename="../src/widgets/bottombar.cpp" line="78"/>
+        <location filename="../src/widgets/bottombar.cpp" line="110"/>
         <source>None</source>
         <translation>無</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1363"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1490"/>
         <source>Selected line(s) copied</source>
         <translation>已複製選中行到剪貼簿</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1370"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1497"/>
         <source>Current line copied</source>
         <translation>已複製目前行到剪貼簿</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1400"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1527"/>
         <source>Selected line(s) clipped</source>
         <translation>已剪下選中行到剪貼簿</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="1412"/>
+        <location filename="../src/editor/dtextedit.cpp" line="1539"/>
         <source>Current line clipped</source>
         <translation>已剪下目前行到剪貼簿</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="3227"/>
-        <location filename="../src/editor/dtextedit.cpp" line="3230"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3550"/>
+        <location filename="../src/editor/dtextedit.cpp" line="3553"/>
         <source>Paste failed: not enough memory</source>
         <translation>記憶體不足，貼上失敗</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="4548"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4873"/>
         <source>Read-Only mode is off</source>
         <translation>唯讀模式已關閉</translation>
     </message>
     <message>
-        <location filename="../src/editor/dtextedit.cpp" line="4560"/>
-        <location filename="../src/editor/dtextedit.cpp" line="4584"/>
-        <location filename="../src/editor/dtextedit.cpp" line="7896"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8007"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8015"/>
-        <location filename="../src/editor/dtextedit.cpp" line="8026"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4885"/>
+        <location filename="../src/editor/dtextedit.cpp" line="4909"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8236"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8347"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8355"/>
+        <location filename="../src/editor/dtextedit.cpp" line="8366"/>
         <source>Read-Only mode is on</source>
         <translation>唯讀模式已開啟</translation>
     </message>
@@ -1244,12 +1299,12 @@
 <context>
     <name>WarningNotices</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="24"/>
+        <location filename="../src/controls/warningnotices.cpp" line="25"/>
         <source>Reload</source>
         <translation>重新載入</translation>
     </message>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="26"/>
+        <location filename="../src/controls/warningnotices.cpp" line="29"/>
         <source>Edit Anyway</source>
         <translation>仍然編輯</translation>
     </message>
@@ -1257,160 +1312,162 @@
 <context>
     <name>Window</name>
     <message>
-        <location filename="../src/controls/warningnotices.cpp" line="25"/>
-        <location filename="../src/widgets/window.cpp" line="531"/>
+        <location filename="../src/controls/warningnotices.cpp" line="27"/>
+        <location filename="../src/widgets/window.cpp" line="548"/>
         <source>Save as</source>
         <translation>另存為</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="527"/>
+        <location filename="../src/widgets/window.cpp" line="540"/>
         <source>New window</source>
         <translation>新視窗</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="528"/>
+        <location filename="../src/widgets/window.cpp" line="542"/>
         <source>New tab</source>
         <translation>新分頁</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="529"/>
+        <location filename="../src/widgets/window.cpp" line="544"/>
         <source>Open file</source>
         <translation>打開文件</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="530"/>
-        <location filename="../src/widgets/window.cpp" line="3545"/>
+        <location filename="../src/widgets/window.cpp" line="546"/>
+        <location filename="../src/widgets/window.cpp" line="3950"/>
         <source>Save</source>
         <translation>儲存</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="532"/>
+        <location filename="../src/widgets/window.cpp" line="550"/>
         <source>Print</source>
         <translation>列印</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="533"/>
+        <location filename="../src/widgets/window.cpp" line="552"/>
         <source>Switch theme</source>
         <translation>切換主題</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="534"/>
-        <location filename="../src/widgets/window.cpp" line="2448"/>
+        <location filename="../src/widgets/window.cpp" line="554"/>
+        <location filename="../src/widgets/window.cpp" line="2641"/>
         <source>Settings</source>
         <translation>設定</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="666"/>
-        <location filename="../src/widgets/window.cpp" line="3845"/>
+        <location filename="../src/widgets/window.cpp" line="696"/>
+        <location filename="../src/widgets/window.cpp" line="4250"/>
         <source>Read-Only</source>
         <translation>唯讀</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="687"/>
+        <location filename="../src/widgets/window.cpp" line="719"/>
         <source>You do not have permission to open %1</source>
         <translation>您沒有權限打開%1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="738"/>
-        <location filename="../src/widgets/window.cpp" line="2963"/>
+        <location filename="../src/widgets/window.cpp" line="773"/>
+        <location filename="../src/widgets/window.cpp" line="3266"/>
         <source>Invalid file: %1</source>
         <translation>無效文件：%1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="903"/>
-        <location filename="../src/widgets/window.cpp" line="956"/>
+        <location filename="../src/widgets/window.cpp" line="957"/>
+        <location filename="../src/widgets/window.cpp" line="1050"/>
+        <location filename="../src/widgets/window.cpp" line="3217"/>
         <source>Do you want to save this file?</source>
         <translation>您是否要儲存此文件？</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1290"/>
+        <location filename="../src/widgets/window.cpp" line="1456"/>
         <source>You do not have permission to save %1</source>
         <translation>您沒有權限儲存%1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1312"/>
+        <location filename="../src/widgets/window.cpp" line="1428"/>
+        <location filename="../src/widgets/window.cpp" line="1478"/>
         <source>Saved successfully</source>
         <translation>文件已儲存</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1354"/>
-        <location filename="../src/widgets/window.cpp" line="1481"/>
-        <location filename="../src/widgets/window.cpp" line="1529"/>
+        <location filename="../src/widgets/window.cpp" line="1520"/>
+        <location filename="../src/widgets/window.cpp" line="1665"/>
+        <location filename="../src/widgets/window.cpp" line="1713"/>
         <source>Save File</source>
         <translation>儲存</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1483"/>
+        <location filename="../src/widgets/window.cpp" line="1667"/>
         <source>Encoding</source>
         <translation>編碼</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1773"/>
+        <location filename="../src/widgets/window.cpp" line="1957"/>
         <source>Read-Only mode is on</source>
         <translation>唯讀模式已開啟</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2322"/>
+        <location filename="../src/widgets/window.cpp" line="2511"/>
         <source>Current location remembered</source>
         <translation>已記住目前位置</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2398"/>
+        <location filename="../src/widgets/window.cpp" line="2591"/>
         <source>Ctrl+&apos;=&apos;</source>
         <translation>Ctrl+&apos;=&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2401"/>
+        <location filename="../src/widgets/window.cpp" line="2594"/>
         <source>Ctrl+&apos;-&apos;</source>
         <translation>Ctrl+&apos;-&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="2430"/>
+        <location filename="../src/widgets/window.cpp" line="2623"/>
         <source>Editor</source>
         <translation>編輯</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3061"/>
+        <location filename="../src/widgets/window.cpp" line="3436"/>
         <source>Untitled %1</source>
         <translation>未命名文件%1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3543"/>
+        <location filename="../src/widgets/window.cpp" line="3948"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="3544"/>
+        <location filename="../src/widgets/window.cpp" line="3949"/>
         <source>Discard</source>
         <translation>不儲存</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1317"/>
-        <source>Invalid characters detected while saving "%1"</source>
+        <location filename="../src/widgets/window.cpp" line="1381"/>
+        <source>Invalid characters detected while saving &quot;%1&quot;</source>
         <translation>儲存「%1」時偵測到無效字元</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1318"/>
+        <location filename="../src/widgets/window.cpp" line="1382"/>
         <source>If you force save this file, it may cause file corruption. Still want to save?</source>
         <translation>強制儲存此文件可能導致文件損壞。仍然要儲存嗎？</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1321"/>
+        <location filename="../src/widgets/window.cpp" line="1386"/>
         <source>Don&apos;t Save</source>
         <translation>不儲存</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1322"/>
+        <location filename="../src/widgets/window.cpp" line="1387"/>
         <source>Save As</source>
         <translation>另存為</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1323"/>
+        <location filename="../src/widgets/window.cpp" line="1388"/>
         <source>Save Anyway</source>
         <translation>強制儲存</translation>
     </message>
     <message>
-        <location filename="../src/widgets/window.cpp" line="1521"/>
+        <location filename="../src/widgets/window.cpp" line="1569"/>
         <source>Cannot save as the original file in preview mode. Please choose a different path.</source>
         <translation>預覽模式下不能另存為原文件。請選擇其他路徑。</translation>
     </message>


### PR DESCRIPTION
Refresh all 49 .ts files with lupdate (15 new strings for markdown view modes, code block header and audio device tips; 6 obsolete removed) and fill in the 15 new zh_CN/zh_HK/zh_TW translations.

使用 lupdate 刷新全部 49 个 .ts 文件（新增 markdown 视图模式、
代码块表头与音频设备提示共 15 条，移除 6 条过时条目），并补全
zh_CN/zh_HK/zh_TW 三语言 15 条新翻译。

Log: 更新翻译文件并补全中文三语言翻译
Influence: 中文环境（简体/繁体）下 Markdown 新功能界面文案完整显示，
其余语言待翻译社区后续补充，不影响现有功能。