### PR TITLE
feat: 补全 AT-SPI 无障碍名称

### DIFF
--- a/src/controls/linebar.cpp
+++ b/src/controls/linebar.cpp
@@ -43,6 +43,8 @@ LineBar::LineBar(DLineEdit *parent)
     m_matchCountLabel->hide();
 
     m_clearButton = new DIconButton(QStyle::SP_LineEditClearButton, lineEdit());
+    m_clearButton->setObjectName("ClearButton");
+    m_clearButton->setAccessibleName("ClearButton");
     m_clearButton->setFixedSize(s_nClearButtonSize, s_nClearButtonSize);
     m_clearButton->setIconSize(QSize(s_nClearButtonSize, s_nClearButtonSize));
     m_clearButton->setFocusPolicy(Qt::NoFocus);

--- a/src/editor/showflodcodewidget.cpp
+++ b/src/editor/showflodcodewidget.cpp
@@ -33,6 +33,8 @@ ShowFlodCodeWidget::ShowFlodCodeWidget(DWidget *parent)
     this->setGraphicsEffect(effert);
     QVBoxLayout *pSubLayout = new QVBoxLayout();
     m_pContentEdit = new DPlainTextEdit(this);
+    m_pContentEdit->setObjectName("PContentEdit");
+    m_pContentEdit->setAccessibleName("PContentEdit");
     m_pContentEdit->setWordWrapMode(QTextOption::WrapAnywhere);
     m_pContentEdit->setFrameStyle(0);
     m_pContentEdit->setReadOnly(true);

--- a/src/widgets/ColorSelectWdg.cpp
+++ b/src/widgets/ColorSelectWdg.cpp
@@ -197,6 +197,8 @@ void ColorSelectWdg::initWidget()
     if(!m_text.isEmpty()){
         qDebug() << "ColorSelectWdg initWidget, text is not empty, creating button";
         m_pButton = new DPushButton(m_text,this);
+        m_pButton->setObjectName("PButton");
+        m_pButton->setAccessibleName("PButton");
         m_pButton->setMinimumSize(80,25);
         m_pButton->setFlat(true);
         connect(m_pButton,&QPushButton::clicked,this,[this](){

--- a/src/widgets/bottombar.cpp
+++ b/src/widgets/bottombar.cpp
@@ -409,7 +409,9 @@ void BottomBar::initFormatMenu()
     m_formatMenu->setMenuActionGroup(actionGroup);
 
     m_unixAction = menu->addAction("Unix");
+    m_unixAction->setObjectName("UnixAction");
     m_windowsAction = menu->addAction("Windows");
+    m_windowsAction->setObjectName("WindowsAction");
     m_unixAction->setProperty(FormatActionType,EndlineFormat::Unix);
     m_windowsAction->setProperty(FormatActionType,EndlineFormat::Windows);
     actionGroup->addAction(m_unixAction);

--- a/src/widgets/ddropdownmenu.cpp
+++ b/src/widgets/ddropdownmenu.cpp
@@ -224,6 +224,8 @@ void DDropdownMenu::setMenu(DMenu *menu)
     qDebug() << "DDropdownMenu setMenu";
     deleteMenu();
     m_menu = menu;
+    m_menu->setObjectName("Menu");
+    m_menu->setAccessibleName("Menu");
 }
 
 void DDropdownMenu::deleteMenu()
@@ -242,6 +244,7 @@ void DDropdownMenu::setMenuActionGroup(QActionGroup *actionGroup)
     qDebug() << "DDropdownMenu setMenuActionGroup";
     deleteMenuActionGroup();
     m_actionGroup = actionGroup;
+    m_actionGroup->setObjectName("ActionGroup");
     qDebug() << "DDropdownMenu setMenuActionGroup end";
 }
 
@@ -329,6 +332,7 @@ DDropdownMenu *DDropdownMenu::createEncodeMenu()
                     m_pEncodeMenu->m_pActUtf8 = act;
                     act->setCheckable(true);
                     act->setChecked(true);
+                    m_pEncodeMenu->m_pActUtf8->setObjectName("PActUtf8");
                } else {
                     qDebug() << "Adding other action";
                     act->setCheckable(false);

--- a/src/widgets/pathsettintwgt.cpp
+++ b/src/widgets/pathsettintwgt.cpp
@@ -67,6 +67,7 @@ void PathSettingWgt::init()
     qDebug() << "PathSettingWgt init";
     QVBoxLayout* layout = new QVBoxLayout(this);
     m_group = new QButtonGroup(this);
+    m_group->setObjectName("Group");
     layout->setContentsMargins(0,0,0,0);
     m_curFileBox = new DCheckBox(this);
     m_curFileBox->setAccessibleName("SamePathAsCurrentFile");

--- a/src/widgets/window.cpp
+++ b/src/widgets/window.cpp
@@ -219,6 +219,8 @@ Window::Window(DMainWindow *parent)
       m_themePath(Settings::instance()->settings->option("advance.editor.theme")->value().toString())
 {
     qDebug() << "Window constructor called";
+    m_tabbar->setObjectName("Tabbar");
+    m_tabbar->setAccessibleName("Tabbar");
 
     qRegisterMetaType<TextEdit *>("TextEdit");
     m_rootSaveDBus = new DBusDaemon::dbus("com.deepin.editor.daemon", "/", QDBusConnection::systemBus(), this);
@@ -559,6 +561,8 @@ void Window::initTitlebar()
     replaceAction->setObjectName("Replace");
 
     m_menu->addAction(newWindowAction);
+    m_menu->setObjectName("Menu_2");
+    m_menu->setAccessibleName("Menu_2");
     m_menu->addAction(newTabAction);
     m_menu->addAction(openFileAction);
     m_menu->addSeparator();


### PR DESCRIPTION
## 概述

为缺失无障碍名称的交互控件添加 setObjectName/setAccessibleName 调用，提升 AT-SPI 覆盖率。

## 覆盖率对比

| 指标 | 补全前 | 补全后 |
| --- | --- | --- |
| 总控件数 | 65 | 65 |
| 已命名 | 48 | 59 |
| 缺失 | 17 | 6 |
| 覆盖率 | 73.8% | 90.8% |

## 修改文件 (7 files, +17 lines)

- src/controls/linebar.cpp
- src/editor/showflodcodewidget.cpp
- src/widgets/ColorSelectWdg.cpp
- src/widgets/bottombar.cpp
- src/widgets/ddropdownmenu.cpp
- src/widgets/pathsettintwgt.cpp
- src/widgets/window.cpp

## 验证

- 本地编译通过（cmake + make 100%）
- 补全后重新扫描验证覆盖率提升

## Summary by Sourcery

Enhancements:
- Add object and accessible names to previously unnamed controls, menus, actions, and groups to improve AT-SPI accessibility coverage.