### PR TITLE
fix(ui): adjust tabbar height for visual consistency

### DIFF
--- a/src/controls/tabbar.cpp
+++ b/src/controls/tabbar.cpp
@@ -21,7 +21,7 @@
 QPixmap *Tabbar::sm_pDragPixmap = nullptr;
 
 // 不同模式下的界面调整
-const int s_TabbarHeight = 40;
+const int s_TabbarHeight = 36;
 const int s_TabbarHeightCompact = 26;
 
 /**


### PR DESCRIPTION
- reduce the default tabbar height from 40px to 36px

Log: fix issue
Bug: https://pms.uniontech.com/bug-view-250089.html

## Summary by Sourcery

Bug Fixes:
- Fix inconsistent tabbar height by reducing it from 40px to 36px.