### PR TITLE
test: fix unit test crashes and alarm timeout breaking CI pipeline

### DIFF
--- a/src/editor/dtextedit.cpp
+++ b/src/editor/dtextedit.cpp
@@ -7258,10 +7258,10 @@ bool TextEdit::eventFilter(QObject *object, QEvent *event)
                 int handleKey = keyEvent->key();
 
                 // 使用Timer进行后续处理，避免在此处处理后，和基类的处理造成混淆
-                QTimer::singleShot(0, this, [ = ]() {
+                QTimer::singleShot(0, this, [this, handleKey, menuGuard = QPointer<DMenu>(m_colorMarkMenu)]() {
                     // 仅当 menu 可见时进行处理，当前仅处理Tab键
-                    if (m_colorMarkMenu->isVisible() && handleKey == Qt::Key_Tab) {
-                        QAction *currentAction = m_colorMarkMenu->activeAction();
+                    if (menuGuard && menuGuard->isVisible() && handleKey == Qt::Key_Tab) {
+                        QAction *currentAction = menuGuard->activeAction();
                         QAction *nextAction = nullptr;
                         int currentIndex = -1;
 
@@ -7318,7 +7318,7 @@ bool TextEdit::eventFilter(QObject *object, QEvent *event)
 
                         // 为找到的新item设置focus
                         if (nextAction != nullptr) {
-                            m_colorMarkMenu->setActiveAction(nextAction);
+                            menuGuard->setActiveAction(nextAction);
                         } else {
                             qWarning() << " can not find valid item , need check 'Mark Color Menu' tab order setting!";
                         }

--- a/tests/src/editor/ut_flashtween.cpp
+++ b/tests/src/editor/ut_flashtween.cpp
@@ -13,7 +13,8 @@ UT_FlashTween::UT_FlashTween()
 TEST(UT_FlashTween_startX, UT_FlashTween_startX)
 {
     FlashTween *a = new FlashTween();
-    FunSlideInertial b;
+    // 传入有效空操作回调，避免空 std::function 在定时器触发时抛出 bad_function_call
+    FunSlideInertial b = [](qreal) {};
     a->startX(1.1,1.1,1.1,1.1,b);
     int iRet = a->m_timerX->interval();
     ASSERT_TRUE(a->m_timerX->interval() == 15);
@@ -25,7 +26,8 @@ TEST(UT_FlashTween_startX, UT_FlashTween_startX)
 TEST(UT_FlashTween_startY, UT_FlashTween_startY)
 {
     FlashTween *a = new FlashTween();
-    FunSlideInertial b;
+    // 传入有效空操作回调，避免空 std::function 在定时器触发时抛出 bad_function_call
+    FunSlideInertial b = [](qreal) {};
     a->startY(1.1,1.1,1.1,1.1,b);
     int iRet = a->m_timerY->interval();
     ASSERT_TRUE(a->m_timerY->interval() == 15);
@@ -42,6 +44,10 @@ TEST(UT_FlashTween_activeX, UT_FlashTween_activeX)
     bool bRet = a->activeX();
     ASSERT_TRUE(bRet == true);
 
+    // 停止 0ms 循环定时器：回调 m_fSlideGestureX 为空 std::function，
+    // 若残留到后续测试的事件循环中触发会抛出 bad_function_call
+    a->m_timerX->stop();
+
     a->deleteLater();
 }
 
@@ -53,6 +59,9 @@ TEST(UT_FlashTween_activeY, UT_FlashTween_activeY)
     a->m_timerY->start();
     bool bRet = a->activeY();
     ASSERT_TRUE(bRet == true);
+
+    // 同 activeX：停止 0ms 循环定时器，避免空回调在后续测试中触发
+    a->m_timerY->stop();
 
     a->deleteLater();
 }

--- a/tests/src/editor/ut_textedit.cpp
+++ b/tests/src/editor/ut_textedit.cpp
@@ -11075,6 +11075,11 @@ TEST(UT_test_textedit_eventFilter, eventFilter_ColorMarkMenuTabLambda)
 
     edit->eventFilter(edit->m_colorMarkMenu, e);
 
+    // Deliver the deferred QTimer::singleShot(0, ...) invocation posted to
+    // `edit` while the menu is still alive, so no dangling dereference can
+    // fire later inside another test's event loop.
+    QCoreApplication::sendPostedEvents(edit, 0);
+
     // Fire the singleShot timer's lambda by emitting timeout directly
     for (QTimer *t : edit->findChildren<QTimer *>()) {
         if (t->isSingleShot()) {
@@ -11085,6 +11090,7 @@ TEST(UT_test_textedit_eventFilter, eventFilter_ColorMarkMenuTabLambda)
 
     delete e;
     delete edit->m_colorMarkMenu;
+    edit->m_colorMarkMenu = nullptr;
     edit->deleteLater();
     wra->deleteLater();
 }

--- a/tests/src/ut_coverage_gap.cpp
+++ b/tests/src/ut_coverage_gap.cpp
@@ -356,10 +356,10 @@ TEST(UT_CoverageGap_EditorApp, Notify_QCheckBox)
     EXPECT_TRUE(ret);
     QTest::qWait(100);  // let pressSpace timer fire
 
-    delete checkbox;
     delete e;
-    // Intentionally leak app: destroying a second QApplication sets qApp=null,
-    // breaking all subsequent tests. Process exits via _Exit() anyway.
+    // Intentionally leak checkbox AND app: pressSpace() 的 80ms 定时器裸捕获该控件，
+    // 负载高时定时器可能在 qWait 结束、控件销毁之后才触发（悬空指针）；
+    // 销毁第二个 QApplication 会置空 qApp，破坏后续所有测试。
 }
 
 TEST(UT_CoverageGap_EditorApp, Notify_QComboBox)
@@ -374,9 +374,8 @@ TEST(UT_CoverageGap_EditorApp, Notify_QComboBox)
     EXPECT_TRUE(ret);
     QTest::qWait(100);
 
-    delete combo;
     delete e;
-    // Intentionally leak app (see above).
+    // Intentionally leak combo AND app (see Notify_QCheckBox).
 }
 
 // Stub functions for triggering catch blocks in saveToFile

--- a/tests/src/ut_editorapplication.cpp
+++ b/tests/src/ut_editorapplication.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -61,7 +61,10 @@ TEST(UT_EditorApplication_pressSpace, notify_001)
     bool bRet = app->notify(btn, e);
     ASSERT_TRUE(bRet == true);
 
-    btn->deleteLater();
+    // Intentionally leak btn: pressSpace() 会调度 80ms 定时器并裸捕获 btn，
+    // 若在此销毁会使延迟 lambda 悬空（heap-use-after-free）。
+    // 不能用 qWait 等待定时器触发：二次 QApplication 实例处理事件会导致
+    // QSocketNotifier 无效套接字刷屏。泄漏对象可安全存活至定时器触发。
     delete e;
     e = nullptr;
     app->deleteLater();
@@ -81,7 +84,7 @@ TEST(UT_EditorApplication_pressSpace, notify_002)
     bool bRet = app->notify(btn, e);
     ASSERT_TRUE(bRet == true);
 
-    btn->deleteLater();
+    // 同 notify_001：故意泄漏 btn，避免 pressSpace 延迟 lambda 悬空
     delete e;
     e = nullptr;
     app->deleteLater();
@@ -141,7 +144,7 @@ TEST(UT_EditorApplication_pressSpace, pressSpace)
     QString strRetAppName = app->applicationName();
     ASSERT_TRUE(!strRetOrNmae.compare(QString("deepin")) && !strRetAppName.compare(QString("deepin-editor")));
 
-    btn->deleteLater();
+    // 同 notify_001：故意泄漏 btn，避免 pressSpace 延迟 lambda 悬空
     app->deleteLater();
 }
 

--- a/tests/src/ut_main.cpp
+++ b/tests/src/ut_main.cpp
@@ -53,11 +53,13 @@ int main(int argc, char *argv[])
     quitStub.set(ADDR(QCoreApplication, quit), quitNoop);
 
     // Install SIGALRM handler so coverage data is preserved if the test suite hangs.
-    // The alarm fires after 240s, dumps gcov data, and exits.
+    // The alarm fires after 3600s, dumps gcov data, and exits. The full suite
+    // (1291+ tests) needs ~300s; 3600s keeps hang protection without killing
+    // a normal run (CI total timeout is 7200s).
     signal(SIGALRM, alarmHandler);
     signal(SIGABRT, crashHandler);
     signal(SIGSEGV, crashHandler);
-    alarm(150);
+    alarm(3600);
 
     testing::InitGoogleTest(&argc, argv);
 

--- a/tests/src/ut_zz_editorapplication_extra.cpp
+++ b/tests/src/ut_zz_editorapplication_extra.cpp
@@ -37,7 +37,10 @@ TEST(UT_EditorApplication_pressSpace, pressSpace_Lambda)
         }
     }
 
-    delete btn;
+    // Intentionally leak btn: pressSpace() 的 80ms singleShot lambda 裸捕获 btn，
+    // 若在此销毁会使延迟 lambda 悬空（heap-use-after-free）；上面通过 findChildren
+    // 触发 timeout 的手法对 Qt 6.9 的 QDeferredInvokeEvent 实现无效，真正的
+    // lambda 仍处于挂起状态，会在后续测试的事件循环中触发。
     app->deleteLater();
     SUCCEED();
 }

--- a/tests/src/zz_ut_exit_destructor.cpp
+++ b/tests/src/zz_ut_exit_destructor.cpp
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// 覆盖 EditorApplication::~EditorApplication() (D0/D2 析构变体).
+//
+// 文件名以 "zz_" 前缀使 GLOB 排序在 widgets/ 之后，确保析构测试在整个
+// 测试套件最末尾执行。delete 触发 D0→D2，虽然会销毁 qApp，但此时所有
+// 其它测试已执行完毕。
+
+#include "../../src/editorapplication.h"
+#include "../../src/startmanager.h"
+#include "src/stub.h"
+#include <gtest/gtest.h>
+
+namespace exit_destructor_stub {
+StartManager *startManagerInstanceStub() { return nullptr; }
+} // namespace exit_destructor_stub
+
+using namespace exit_destructor_stub;
+
+// delete triggers D0 (deleting destructor) which internally calls D2 (complete destructor).
+// StartManager::instance() is stubbed to nullptr so the else branch runs.
+// This test intentionally runs last — deleting qApp makes subsequent QWidget usage unsafe.
+TEST(UT_EditorApplication_Destructor, Destructor_Delete)
+{
+    int argc = 1;
+    char *argv[] = {"test"};
+    EditorApplication *app = new EditorApplication(argc, argv);
+
+    Stub s;
+    s.set(ADDR(StartManager, instance), startManagerInstanceStub);
+
+    delete app; // triggers D0 -> D2
+    SUCCEED();
+}


### PR DESCRIPTION
Deliver pending singleShot lambdas before deleting captured objects; leak buttons captured by the 80ms pressSpace timer inside tests. Stop leftover 0ms tween timers and pass valid callbacks to avoid bad_function_call thrown into later tests' event loops. Raise SIGALRM from 150s to 3600s so the full suite is not killed mid-run; guard the color-mark menu Tab lambda with QPointer.

在删除被捕获对象前先执行挂起的 singleShot lambda；测试中泄漏
被 pressSpace 80ms 定时器捕获的按钮。停止残留的 0ms 补间定时器
并传入有效回调，避免 bad_function_call 抛入后续测试事件循环。
SIGALRM 由 150s 调整为 3600s，避免全量测试中途被杀；TextEdit
颜色标记菜单 Tab lambda 增加 QPointer 守卫。

Log: 修复单元测试崩溃与流水线超时
Influence: 全量 1292 个单元测试连续两次全部通过（exit=0），流水线不再中途静默退出；测试进程因故意泄漏少量控件内存略有增加，进程经 _Exit 退出。

## Summary by Sourcery

Stabilize the unit-test suite against deferred-event crashes and premature timeout termination.

Bug Fixes:
- Prevent deferred test callbacks and timers from accessing deleted Qt objects or invoking empty callbacks during later tests.
- Protect deferred color-mark menu handling from menu destruction.
- Prevent the test suite from being terminated during normal full-suite execution by extending the alarm timeout.

Enhancements:
- Add a final destructor test to cover EditorApplication cleanup after the rest of the suite has completed.

Tests:
- Stabilize editor and application unit tests by delivering deferred events before cleanup and retaining objects required by pending test timers.
- Add coverage for EditorApplication destruction.