### PR TITLE
fix(tabbar): disable scroll buttons in tab bar

### DIFF
--- a/src/controls/tabbar.cpp
+++ b/src/controls/tabbar.cpp
@@ -67,6 +67,7 @@ Tabbar::Tabbar(QWidget *parent)
     setMovable(true);
     setTabsClosable(true);
     setVisibleAddButton(true);
+    setUsesScrollButtons(false);
     setDragable(true);
     setAcceptDrops(true);
     // setStartDragDistance(40);


### PR DESCRIPTION
The tab bar currently shows the built-in left/right scroll buttons when tabs overflow. This introduces extra navigation controls that are not needed for the editor UI.

Disable the DTabBar scroll buttons while keeping the add-tab action available, so the tab strip keeps a cleaner and more consistent layout.

Log: fix issue
Bug: https://pms.uniontech.com/bug-view-375693.html

## Summary by Sourcery

Bug Fixes:
- Disable the tab bar’s built-in scroll buttons to remove unnecessary overflow navigation controls while preserving tab addition.