### PR TITLE
test: add unit tests for application, controls and widgets

### DIFF
--- a/tests/app_ut/CMakeLists.txt
+++ b/tests/app_ut/CMakeLists.txt
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# 模块 app_ut：EditorApplication（src/editorapplication.cpp，DApplication 子类）
+#   - test_editorapplication.cpp : ctor/dtor/handleQuitAction/notify/pressSpace
+#     （editorapplication.cpp 全部 7 个 FN：ctor、D2/D0 双析构记录、handleQuitAction、
+#     notify、pressSpace 及其 80ms singleShot lambda）
+#
+# 链接策略：复用 startmanager 模块的全量源码静态库 startmanager_ut_src
+#（src/**.cpp 全量 + AUTOMOC/AUTORCC + deepin-editor.qrc）。
+# EditorApplication 本身即进程级 QApplication 对象：本目标独立可执行文件内
+# 以它作为唯一 QApplication 实例构造（offscreen），不再另建 QCoreApplication。
+# 运行期拦截（沿用 widgets_ut 已验证矩阵）：
+#   - DBus：QDBusConnection::systemBus/sessionBus → 伪连接 + callWithArgumentList 桩
+#     + unregisterService 桩（~StartManager 析构路径）
+#   - IflytekAiAssistant::instance/checkAiExists → 伪对象/空操作
+#     （StartManager 构造链的真实 iflytek 查询被隔离）
+# 资源说明：qrc 静态库符号丢弃问题——目标直接编入 deepin-editor.qrc（AUTORCC），
+# dtor 用例构造真实 StartManager → Settings::instance() 需要 qrc settings.json。
+
+set(QT_VERSION 6)
+set(STUB_SHADOW "${CMAKE_SOURCE_DIR}/tests/3rdparty/stub/stub-shadow.cpp")
+
+find_package(Qt6 REQUIRED COMPONENTS Test)
+
+add_executable(test_editorapplication
+    test_editorapplication.cpp
+    ${CMAKE_SOURCE_DIR}/src/deepin-editor.qrc
+    ${STUB_SHADOW}
+)
+set_target_properties(test_editorapplication PROPERTIES AUTORCC ON)
+target_include_directories(test_editorapplication PRIVATE
+    "${CMAKE_SOURCE_DIR}/tests/3rdparty/stub"
+)
+# 访问 protected（handleQuitAction/notify）与 private（pressSpace）用于直接驱动；
+# 访问控制不影响 ABI 布局，与库侧 AUTOMOC 产物 ODR 兼容
+target_compile_options(test_editorapplication PRIVATE -fno-access-control)
+target_link_options(test_editorapplication PRIVATE -rdynamic)
+target_link_libraries(test_editorapplication PRIVATE
+    startmanager_ut_src
+    GTest::gtest
+    GTest::gtest_main
+    Qt${QT_VERSION}::Test
+)
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    target_link_libraries(test_editorapplication PRIVATE gcov)
+endif()
+gtest_discover_tests(test_editorapplication PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
+
+message(STATUS "UT: app_ut module configured (test_editorapplication, links startmanager_ut_src)")

--- a/tests/app_ut/test_editorapplication.cpp
+++ b/tests/app_ut/test_editorapplication.cpp
@@ -1,0 +1,457 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// ============================================================================
+// EditorApplication 单元测试（app_ut / src/editorapplication.cpp，7 FN 全覆盖）
+//
+// 策略：EditorApplication 本身即进程级 QApplication —— 本目标独立可执行文件内
+// 以它作为唯一 QApplication 实例真实构造（QT_QPA_PLATFORM=offscreen，B8/B11 已
+// 验证 DApplication 系 offscreen 可构造）。DBus/Iflytek 重依赖经 suite 级 stub
+// 矩阵拦截；XDG_CONFIG_HOME/XDG_DATA_HOME 重定向 QTemporaryDir。
+//
+// 分支清单 → 用例映射（editorapplication.cpp）：
+//   ctor(9)    → SetUpTestSuite 真实构造 + Ctor_应用属性就位（Qt>=6 分支）
+//   dtor(45)   → TearDownTestSuite delete s_app：
+//                D2/D0 双记录 + "StartManager::instance() 非空 → delete"分支
+//                （else 空分支不可二次构造 QApplication，函数覆盖已达成）
+//   handleQuitAction(59)
+//     B1 activeWindow 非空 → close
+//        → HandleQuitAction_ActiveWindow_ClosesIt（closeEvent 计数 + 隐藏断言）
+//     B2 activeWindow 空 → qWarning
+//        → HandleQuitAction_NoActiveWindow_KeepsNull（消息捕获断言）
+//   notify(73)
+//     B3 KeyPress + className∈{QPushButton,QCheckBox,QComboBox,Dtk::Widget::DIconButton}
+//        + Key_Return/Enter → pressSpace + return true（TEST_P 4 类）
+//     B4 KeyPress + objectName∈{CustomRebackButton,RemoteSearchRebackButton,
+//        RemoteGroupRebackButton} + Key_Left → pressSpace + return true（TEST_P 3 组）
+//     B5 其余 KeyPress / 非 KeyPress → 委托 QApplication::notify
+//        → Notify_UnmatchedEvent_DelegatesToBase（返回 false + 无 space 注入）
+//   pressSpace(118) + 80ms lambda(126)
+//     → PressSpace_DirectCall（同步 press + 80ms 后 release + clicked）
+//     → notify 用例间接覆盖（全部先 qWait 交付 80ms lambda 再删按钮，
+//       e07d697d 教训：防删除被 singleShot 捕获的对象）
+//
+// 不可达说明：className "IconButton"/"ComboBox" 为外部工程遗留类名，本仓库无
+// 定义无法构造；两者与已覆盖类名同处一个 OR 条件基本块，不影响函数/行覆盖。
+// ============================================================================
+
+#include <gtest/gtest.h>
+#include "stubext.h"
+
+#include <QKeyEvent>
+#include <QWidget>
+#include <QPushButton>
+#include <QCheckBox>
+#include <QComboBox>
+#include <QLabel>
+#include <QTemporaryDir>
+#include <QDir>
+#include <QtTest>
+
+#include <DPushButton>
+#include <DIconButton>
+#include <QDBusConnection>
+#include <QDBusAbstractInterface>
+#include <QDBusMessage>
+
+#include "editorapplication.h"
+#include "startmanager.h"
+#include "common/settings.h"
+#include "common/iflytek_ai_assistant.h"
+
+// ---------------- 测试辅助 ----------------
+
+// 统计目标控件收到的事件：空格 KeyPress/KeyRelease（notify 拦截回车后注入的
+// 模拟事件）与回车 KeyPress/鼠标按下（未被拦截、委托基类送达的原始事件）
+class SpaceEventCounter : public QObject {
+public:
+    using QObject::QObject;
+    int spacePress = 0;
+    int spaceRelease = 0;
+    int returnPress = 0;
+    int mousePress = 0;
+
+protected:
+    bool eventFilter(QObject *watched, QEvent *event) override
+    {
+        if (event->type() == QEvent::KeyPress
+            || event->type() == QEvent::KeyRelease) {
+            auto *key = static_cast<QKeyEvent *>(event);
+            if (key->key() == Qt::Key_Space) {
+                if (event->type() == QEvent::KeyPress)
+                    ++spacePress;
+                else
+                    ++spaceRelease;
+            } else if (key->key() == Qt::Key_Return
+                       && event->type() == QEvent::KeyPress) {
+                ++returnPress;
+            }
+        } else if (event->type() == QEvent::MouseButtonPress) {
+            ++mousePress;
+        }
+        return QObject::eventFilter(watched, event);
+    }
+};
+
+// close 事件计数控件（handleQuitAction 副作用断言）
+class CloseCountWidget : public QWidget {
+public:
+    using QWidget::QWidget;
+    int closeCount = 0;
+
+protected:
+    void closeEvent(QCloseEvent *event) override
+    {
+        ++closeCount;
+        QWidget::closeEvent(event);
+    }
+};
+
+// e07d697d 教训固化：80ms singleShot lambda 捕获按钮裸指针——析构前先 qWait
+// 交付挂起定时器，再删除控件，杜绝 UAF
+struct LateDeleteWidget {
+    QWidget *w = nullptr;
+    ~LateDeleteWidget()
+    {
+        if (w != nullptr) {
+            QTest::qWait(200);
+            delete w;
+        }
+    }
+};
+
+// TEST_P 参数：目标控件种类 + 触发键
+struct NotifyCase {
+    const char *name;
+    int widgetKind;   // 0=QPushButton 1=QCheckBox 2=QComboBox 3=DIconButton 4~6=DPushButton+objectName
+    int key;          // Qt::Key_Return / Qt::Key_Enter / Qt::Key_Left
+};
+
+static std::ostream &operator<<(std::ostream &os, const NotifyCase &c)
+{
+    return os << c.name;
+}
+
+// 消息捕获（handleQuitAction 空分支的 qWarning 断言）
+static QStringList *g_capturedMessages = nullptr;
+static QtMessageHandler g_oldMessageHandler = nullptr;
+static void captureMessageHandler(QtMsgType type, const QMessageLogContext &context, const QString &msg)
+{
+    Q_UNUSED(type);
+    Q_UNUSED(context);
+    if (g_capturedMessages != nullptr)
+        g_capturedMessages->append(msg);
+}
+
+class EditorApplicationTest : public ::testing::Test {
+protected:
+    static void SetUpTestSuite()
+    {
+        s_configHome = new QTemporaryDir();
+        s_dataHome = new QTemporaryDir();
+        const QString xdgConfig = s_configHome->filePath("xdg-config");
+        const QString xdgData = s_dataHome->filePath("xdg-data");
+        QDir().mkpath(xdgConfig);
+        QDir().mkpath(xdgData);
+        qputenv("XDG_CONFIG_HOME", xdgConfig.toUtf8());
+        qputenv("XDG_DATA_HOME", xdgData.toUtf8());
+
+        // ---- suite 级 stub：DBus / Iflytek（构造前安装，贯穿全 suite）----
+        s_stub.set_lamda(&QDBusConnection::systemBus,
+                         []() -> QDBusConnection { return QDBusConnection(QStringLiteral("ut_no_bus")); });
+        s_stub.set_lamda(&QDBusConnection::sessionBus,
+                         []() -> QDBusConnection { return QDBusConnection(QStringLiteral("ut_no_bus")); });
+        s_stub.set_lamda(
+            static_cast<QDBusMessage (QDBusAbstractInterface::*)(QDBus::CallMode, const QString &, const QList<QVariant> &)>(
+                &QDBusAbstractInterface::callWithArgumentList),
+            [](QDBusAbstractInterface *, QDBus::CallMode, const QString &,
+               const QList<QVariant> &) -> QDBusMessage { return QDBusMessage(); });
+        s_stub.set_lamda(
+            static_cast<bool (QDBusConnection::*)(const QString &)>(&QDBusConnection::unregisterService),
+            [](QDBusConnection *, const QString &) -> bool { return true; });
+        // StartManager 构造链的 iflytek 查询隔离（零化伪对象，永不释放/析构）
+        s_fakeIflytek = static_cast<IflytekAiAssistant *>(calloc(sizeof(IflytekAiAssistant) + 256, 1));
+        s_stub.set_lamda(&IflytekAiAssistant::instance,
+                         []() -> IflytekAiAssistant * { return s_fakeIflytek; });
+        s_stub.set_lamda(&IflytekAiAssistant::checkAiExists,
+                         [](IflytekAiAssistant *) -> void {});
+
+        // ---- 被测对象：进程唯一 QApplication 实例（真实构造）----
+        static int argc = 1;
+        static char appName[] = "test_editorapplication";
+        static char *argv[] = { appName, nullptr };
+        s_app = new EditorApplication(argc, argv);
+        ASSERT_NE(s_app, nullptr);
+
+        // 真实 Settings 单例（qrc settings.json + 临时 XDG）
+        Settings::instance();
+        // StartManager 构造路径的 AppData 子目录
+        QDir().mkpath(xdgData + "/deepin/deepin-editor/blank-files");
+        QDir().mkpath(xdgData + "/deepin/deepin-editor/backup-files");
+        QDir().mkpath(xdgData + "/deepin/deepin-editor/autoBackup-files");
+    }
+
+    static void TearDownTestSuite()
+    {
+        // dtor 覆盖（D2/D0 双记录 + StartManager 非空 delete 分支；
+        // Dtor_Precondition 已保证 instance() 存活）
+        delete s_app;
+        s_app = nullptr;
+
+        // ~StartManager 将 m_instance 置空（private static，-fno-access-control 直读）
+        EXPECT_EQ(StartManager::m_instance, nullptr);
+
+        s_stub.clear();
+        free(s_fakeIflytek);
+        s_fakeIflytek = nullptr;
+        qunsetenv("XDG_CONFIG_HOME");
+        qunsetenv("XDG_DATA_HOME");
+        delete s_configHome;
+        delete s_dataHome;
+    }
+
+    void SetUp() override {}
+    void TearDown() override
+    {
+        // 每用例兜底清空事件队列（80ms lambda 已在 LateDeleteWidget 内交付）
+        QTest::qWait(20);
+    }
+
+    // TEST_P 工厂：按 kind 构造目标控件
+    static QWidget *makeTarget(int kind)
+    {
+        switch (kind) {
+        case 0:
+            return new QPushButton(QStringLiteral("ok"));
+        case 1:
+            return new QCheckBox(QStringLiteral("check"));
+        case 2:
+            return new QComboBox();
+        case 3:
+            return new DIconButton();
+        case 4:
+        case 5:
+        case 6: {
+            auto *btn = new DPushButton(QStringLiteral("back"));
+            if (kind == 4)
+                btn->setObjectName(QStringLiteral("CustomRebackButton"));
+            else if (kind == 5)
+                btn->setObjectName(QStringLiteral("RemoteSearchRebackButton"));
+            else
+                btn->setObjectName(QStringLiteral("RemoteGroupRebackButton"));
+            return btn;
+        }
+        }
+        return new QPushButton();
+    }
+
+    static QAbstractButton *asButton(QWidget *w) { return qobject_cast<QAbstractButton *>(w); }
+
+    // ---------------- 状态 ----------------
+    static EditorApplication *s_app;
+    static stub_ext::StubExt s_stub;
+    static IflytekAiAssistant *s_fakeIflytek;
+    static QTemporaryDir *s_configHome;
+    static QTemporaryDir *s_dataHome;
+};
+
+EditorApplication *EditorApplicationTest::s_app = nullptr;
+stub_ext::StubExt EditorApplicationTest::s_stub;
+IflytekAiAssistant *EditorApplicationTest::s_fakeIflytek = nullptr;
+QTemporaryDir *EditorApplicationTest::s_configHome = nullptr;
+QTemporaryDir *EditorApplicationTest::s_dataHome = nullptr;
+
+// ---------------- ctor ----------------
+
+// ctor：组织名/应用名/版本/关闭策略等应用属性就位（非翻译维度，避免 locale 耦合）
+TEST_F(EditorApplicationTest, Ctor_Constructed_ApplicationPropertiesInPlace)
+{
+    // Arrange / Act：构造已在 SetUpTestSuite 完成
+
+    // Assert
+    EXPECT_EQ(s_app->organizationName().toStdString(), "deepin");
+    EXPECT_EQ(s_app->applicationName().toStdString(), "deepin-editor");
+    EXPECT_EQ(s_app->applicationVersion().toStdString(), VERSION);
+    EXPECT_FALSE(s_app->quitOnLastWindowClosed());
+}
+
+// ---------------- handleQuitAction ----------------
+
+// B2：无活动窗口 → qWarning 提示且不崩溃，activeWindow 保持空
+TEST_F(EditorApplicationTest, HandleQuitAction_NoActiveWindow_WarnsAndKeepsNull)
+{
+    // Arrange
+    QApplication::setActiveWindow(nullptr);
+    ASSERT_EQ(s_app->activeWindow(), nullptr);
+    QStringList captured;
+    g_capturedMessages = &captured;
+    g_oldMessageHandler = qInstallMessageHandler(captureMessageHandler);
+
+    // Act
+    s_app->handleQuitAction();
+
+    // Assert
+    qInstallMessageHandler(g_oldMessageHandler);
+    g_capturedMessages = nullptr;
+    EXPECT_EQ(s_app->activeWindow(), nullptr);
+    bool warned = false;
+    for (const QString &msg : captured) {
+        if (msg.contains(QStringLiteral("No active window found to close")))
+            warned = true;
+    }
+    EXPECT_TRUE(warned) << "expected qWarning for missing active window, got: "
+                        << captured.join(';').toStdString();
+}
+
+// B1：有活动窗口 → close 送达（closeEvent 计数）并隐藏
+TEST_F(EditorApplicationTest, HandleQuitAction_ActiveWindow_ClosesIt)
+{
+    // Arrange
+    CloseCountWidget widget;
+    widget.setMinimumSize(100, 80);
+    widget.show();
+    QApplication::setActiveWindow(&widget);
+    widget.setFocus();
+    ASSERT_EQ(s_app->activeWindow(), &widget);
+    ASSERT_EQ(widget.closeCount, 0);
+
+    // Act
+    s_app->handleQuitAction();
+
+    // Assert
+    EXPECT_EQ(widget.closeCount, 1) << "active window must receive exactly one close";
+    EXPECT_FALSE(widget.isVisible()) << "closed widget must be hidden";
+}
+
+// ---------------- notify ----------------
+
+class EditorApplicationNotifyTest : public EditorApplicationTest,
+                                    public ::testing::WithParamInterface<NotifyCase> {};
+
+// B3/B4：回车/左键命中拦截矩阵 → 注入空格按下（同步）+ 80ms 后松开 + 消费原事件
+TEST_P(EditorApplicationNotifyTest, KeyPress_OnInterceptedTarget_SimulatesSpaceClick)
+{
+    const NotifyCase param = GetParam();
+
+    // Arrange
+    LateDeleteWidget guard;
+    guard.w = makeTarget(param.widgetKind);
+    QWidget *target = guard.w;
+    SpaceEventCounter counter;
+    target->installEventFilter(&counter);
+
+    int clickedCount = 0;
+    QAbstractButton *button = asButton(target);
+    if (button != nullptr)
+        QObject::connect(button, &QAbstractButton::clicked, [&clickedCount]() { ++clickedCount; });
+    if (param.widgetKind == 2)
+        static_cast<QComboBox *>(target)->addItem(QStringLiteral("item"));
+
+    QKeyEvent keyEvent(QEvent::KeyPress, param.key, Qt::NoModifier);
+
+    // Act
+    const bool consumed = s_app->notify(target, &keyEvent);
+
+    // Assert（同步段：空格按下已送达、原事件被消费）
+    EXPECT_TRUE(consumed) << param.name << ": intercepted event must be consumed";
+    EXPECT_EQ(counter.spacePress, 1) << param.name << ": space press must be injected synchronously";
+
+    // Assert（异步段：80ms singleShot 松开 → 按钮产生 clicked / 组合框弹开）
+    QTest::qWait(150);
+    EXPECT_EQ(counter.spaceRelease, 1) << param.name << ": space release must arrive after 80ms";
+    if (button != nullptr)
+        EXPECT_EQ(clickedCount, 1) << param.name << ": simulated space must click the button";
+    if (param.widgetKind == 1)
+        EXPECT_TRUE(static_cast<QCheckBox *>(target)->isChecked()) << "space must toggle the checkbox";
+    if (param.widgetKind == 2)
+        EXPECT_TRUE(static_cast<QComboBox *>(target)->view()->isVisible()) << "space must open combo popup";
+}
+
+INSTANTIATE_TEST_SUITE_P(InterceptTargets, EditorApplicationNotifyTest,
+                         ::testing::Values(
+                             NotifyCase{ "QPushButtonReturn", 0, Qt::Key_Return },
+                             NotifyCase{ "QPushButtonEnter", 0, Qt::Key_Enter },
+                             NotifyCase{ "QCheckBoxReturn", 1, Qt::Key_Return },
+                             NotifyCase{ "QComboBoxReturn", 2, Qt::Key_Return },
+                             NotifyCase{ "DIconButtonReturn", 3, Qt::Key_Return },
+                             NotifyCase{ "CustomRebackLeft", 4, Qt::Key_Left },
+                             NotifyCase{ "RemoteSearchRebackLeft", 5, Qt::Key_Left },
+                             NotifyCase{ "RemoteGroupRebackLeft", 6, Qt::Key_Left }));
+
+// B5：未命中矩阵的 KeyPress / 非 KeyPress → 委托 QApplication::notify，无空格注入
+TEST_F(EditorApplicationTest, Notify_UnmatchedEvent_DelegatesToBaseWithoutSpaceInjection)
+{
+    // Arrange 1：普通 QWidget 的回车（className/objectName 均不命中）
+    LateDeleteWidget guard;
+    guard.w = new QWidget();
+    SpaceEventCounter counter;
+    guard.w->installEventFilter(&counter);
+    QKeyEvent returnEvent(QEvent::KeyPress, Qt::Key_Return, Qt::NoModifier);
+
+    // Act 1
+    s_app->notify(guard.w, &returnEvent);
+
+    // Assert 1：原始回车送达目标控件（委托基类），且无空格注入
+    EXPECT_EQ(counter.returnPress, 1) << "unmatched key must reach the widget itself";
+    EXPECT_EQ(counter.spacePress, 0);
+    EXPECT_EQ(counter.spaceRelease, 0);
+
+    // Arrange 2：非 KeyPress（MouseButtonPress → QLabel）
+    QLabel label(QStringLiteral("lbl"));
+    label.installEventFilter(&counter);
+    QMouseEvent mousePress(QEvent::MouseButtonPress, QPointF(3, 3), QPointF(3, 3),
+                           Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+
+    // Act 2
+    s_app->notify(&label, &mousePress);
+
+    // Assert 2：鼠标事件直达，同样无空格注入
+    EXPECT_EQ(counter.mousePress, 1);
+    EXPECT_EQ(counter.spacePress, 0);
+    EXPECT_EQ(counter.spaceRelease, 0);
+}
+
+// ---------------- pressSpace（含 80ms lambda）----------------
+
+// 直调私有 pressSpace（-fno-access-control）：同步注入按下、80ms 后注入松开并触发点击
+TEST_F(EditorApplicationTest, PressSpace_Button_ReleasesAfter80msAndClicks)
+{
+    // Arrange
+    LateDeleteWidget guard;
+    guard.w = new QPushButton(QStringLiteral("space"));
+    auto *button = static_cast<QPushButton *>(guard.w);
+    SpaceEventCounter counter;
+    button->installEventFilter(&counter);
+    int clickedCount = 0;
+    QObject::connect(button, &QPushButton::clicked, [&clickedCount]() { ++clickedCount; });
+    ASSERT_EQ(counter.spacePress, 0);
+
+    // Act：同步按下
+    s_app->pressSpace(button);
+
+    // Assert：按下立即送达，松开未到
+    EXPECT_EQ(counter.spacePress, 1);
+    EXPECT_EQ(counter.spaceRelease, 0);
+
+    // Act：等待 80ms singleShot 交付
+    QTest::qWait(150);
+
+    // Assert：松开送达且按钮被点击
+    EXPECT_EQ(counter.spaceRelease, 1);
+    EXPECT_EQ(clickedCount, 1);
+}
+
+// ---------------- dtor 前置 ----------------
+
+// dtor(45) 前置：保证 TearDownTestSuite delete s_app 时 StartManager::instance()
+// 非空，命中“Deleting StartManager instance”分支（D2/D0 双记录在 delete 时落点）
+TEST_F(EditorApplicationTest, Dtor_Precondition_StartManagerInstanceAlive)
+{
+    // Arrange / Act：惰性单例真实构造（DBus/Iflytek 已 stub，XDG 已重定向）
+    StartManager *instance = StartManager::instance();
+
+    // Assert
+    EXPECT_NE(instance, nullptr);
+    EXPECT_EQ(StartManager::m_instance, instance);
+}

--- a/tests/controls_ut/CMakeLists.txt
+++ b/tests/controls_ut/CMakeLists.txt
@@ -1,0 +1,61 @@
+cmake_minimum_required(VERSION 3.16)
+
+# B12 模块：controls_ut（src/controls/：FindBar / ReplaceBar / JumpLineBar / LineBar /
+#   SettingsDialog(GenerateSettingTranslate) / WarningNotices / FontItemDelegate /
+#   Tabbar / ToolBar，共 9 文件）
+# 策略：复用 startmanager 子目录的全量源码静态库 startmanager_ut_src（含 AUTOMOC
+# 产物与全部传递依赖），本模块只编译测试 TU。
+# 运行期外部交互全部由 stub_ext 拦截：
+#   - Utils::localDataPath / Utils::isBackupFile / Utils::isWayland → 受控假值
+#   - Window 非虚成员（wrapper/removeWrapper/addTabWithWrapper/focusActiveEditor/
+#     setChildrenFocus）→ 记录桩（测试宿主为普通 QWidget，绝不构造真实 Window）
+#   - StartManager::instance / createWindowFromWrapper → 记录桩（避免真实建窗）
+#   - QMenu::exec（Tabbar 右键菜单）→ 拦截返回，避免 offscreen 模态阻塞
+#   - QFontMetrics::horizontalAdvance → 超长路径换行分支受控触发
+# 文件系统隔离：XDG_CONFIG_HOME / XDG_DATA_HOME 重定向 QTemporaryDir。
+# QT_QPA_PLATFORM=offscreen 无头运行。
+
+set(QT_VERSION 6)
+
+# QSignalSpy 需要 Qt6 Test 组件
+find_package(Qt6 REQUIRED COMPONENTS Test)
+
+set(STUB_SHADOW "${CMAKE_SOURCE_DIR}/tests/3rdparty/stub/stub-shadow.cpp")
+
+file(GLOB TEST_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/test_*.cpp")
+
+add_executable(test_controls_ut
+    ${TEST_SOURCES}
+    ${STUB_SHADOW})
+
+# 资源说明：startmanager_ut_src 为静态库，qrc 目标文件未被引用符号拉入时自注册
+# 失效；编入同一 qrc 保证 Settings 资源可用（AUTORCC）。
+set_target_properties(test_controls_ut PROPERTIES AUTORCC ON)
+target_sources(test_controls_ut PRIVATE "${CMAKE_SOURCE_DIR}/src/deepin-editor.qrc")
+
+target_include_directories(test_controls_ut
+    PRIVATE
+    ${CMAKE_SOURCE_DIR}/tests/3rdparty/stub
+    ${CMAKE_SOURCE_DIR}/src
+    ${CMAKE_SOURCE_DIR}/src/common
+    ${CMAKE_SOURCE_DIR}/src/controls)
+
+# 访问 protected/private 成员（keyPressEvent/paint/eventFilter、m_tabPaths 等）；
+# 不改变 ABI 布局，与库侧 AUTOMOC 产物 ODR 兼容
+target_compile_options(test_controls_ut PRIVATE -fno-access-control)
+# 导出符号到动态符号表（stub_ext 函数入口 patch）
+target_link_options(test_controls_ut PRIVATE -rdynamic)
+
+target_link_libraries(test_controls_ut PRIVATE
+    startmanager_ut_src
+    GTest::gtest
+    GTest::gtest_main
+    Qt${QT_VERSION}::Test)  # QSignalSpy
+
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    target_link_libraries(test_controls_ut PRIVATE gcov)
+endif()
+
+gtest_discover_tests(test_controls_ut PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
+
+message(STATUS "UT: controls_ut configured with ${TEST_SOURCES}")

--- a/tests/controls_ut/test_env.h
+++ b/tests/controls_ut/test_env.h
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+// controls_ut 测试共享环境：
+// - 一个测试二进制承载 9 个套件，QApplication(offscreen) 全进程仅构造一次
+// - XDG_CONFIG_HOME / XDG_DATA_HOME 重定向 QTemporaryDir，杜绝触碰真实用户目录
+//   （Settings 单例 / Utils::localDataPath 等随之隔离）
+
+#include <QApplication>
+#include <QTemporaryDir>
+#include <QtTest/QSignalSpy>
+
+#include "stubext.h"
+
+namespace controlsut {
+
+inline QTemporaryDir &tempRoot()
+{
+    static QTemporaryDir dir;  // 进程级 RAII，退出时清理
+    return dir;
+}
+
+inline QApplication *ensureApp()
+{
+    if (QApplication::instance() == nullptr) {
+        // 先隔离 XDG 再构造 QApplication（QStandardPaths 启动期缓存定位结果）
+        const QByteArray cfg = (tempRoot().path() + "/config").toUtf8();
+        const QByteArray data = (tempRoot().path() + "/data").toUtf8();
+        qputenv("XDG_CONFIG_HOME", cfg);
+        qputenv("XDG_DATA_HOME", data);
+        static int argc = 1;
+        static char appName[] = "test_controls_ut";
+        static char *argv[] = { appName, nullptr };
+        auto *app = new QApplication(argc, argv);
+        // 配对还原：QApplication 析构（进程收尾）时恢复原环境变量，
+        // qputenv/qunsetenv 计数平衡，避免向宿主进程泄漏
+        qAddPostRoutine([]() {
+            qunsetenv("XDG_CONFIG_HOME");
+            qunsetenv("XDG_DATA_HOME");
+        });
+        return app;
+    }
+    return static_cast<QApplication *>(QApplication::instance());
+}
+
+}  // namespace controlsut

--- a/tests/controls_ut/test_findbar.cpp
+++ b/tests/controls_ut/test_findbar.cpp
@@ -1,0 +1,505 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// FindBar（src/controls/findbar.cpp）单元测试
+//
+// 类特征：DFloatingWidget 子类（GUI 类），offscreen QApplication 无头构造。
+//
+// 方法映射（公开/保护方法全集）：
+// - FindBar::FindBar         → Constructor_DefaultParent_CreatesCoreChildren
+// - isFocus                  → ActiveInput_ShowsBarFocusesAndFillsKeyword
+// - focus                    → 同上（activeInput 内部调用 focus；focus 单独用例 Focus_SelectsAllEditLine）
+// - activeInput              → ActiveInput_WithKeyword_FillsAndShowsBar /
+//                              ActiveInput_EmptyKeyword_StillShown
+// - setMismatchAlert         → SetMismatchAlert_StateToggle_TogglesEditLineAlert (TEST_P)
+// - receiveText              → ReceiveText_ResetsSearchedFlag（经 findPreClicked 行为验证）
+// - setSearched              → SetSearched_FlagToggle_ControlsKeywordUpdate
+// - findPreClicked           → FindPreClicked_FirstTime_EmitsKeywordUpdate /
+//                              FindPreClicked_AlreadySearched_EmitsFindPrevOnly
+// - getCurrentSearchText     → GetInvalidSearchText_ReflectsEditLineContent (TEST_P)
+// - findCancel               → FindCancel_VisibleBar_HidesAndEmitsClose
+// - handleContentChanged     → HandleContentChanged_WithFile_EmitsUpdateSearchKeyword
+// - handleFindNext           → HandleFindNext_WithKeyword_EmitsFindNextOnly (TEST_P)
+// - handleFindPrev           → HandleFindPrev_WithKeyword_EmitsFindPrevOnly
+// - handleSwitchToReplace    → HandleSwitchToReplace_ButtonTriggered_EmitsSwitchSignal
+// - slotUpdateMatchCount     → SlotUpdateMatchCount_WithCounts_ForwardsToEditLine (TEST_P)
+// - hideEvent(protected)     → HideEvent_OnHide_KeepsSearchKeyword（removeSearchKeyword 不发）
+// - focusNextPrevChild(protected) → FocusNextPrevChild_AnyDirection_ReturnsFalse
+// - keyPressEvent(protected) → KeyPressEvent_EscKey_HidesAndEmitsClose /
+//                              KeyPressEvent_EnterWithButtonFocus_ClicksButton /
+//                              KeyPressEvent_TabWithCloseFocus_BackToEditLine /
+//                              KeyPressEvent_EnterNoFocus_PassesToBaseNoAction
+// - updateSizeMode(private)  → 构造函数经 DTKWIDGET_CLASS_DSizeMode 直调覆盖
+//
+// 分支清单（来源：findbar.cpp）→ 用例映射：
+// - keyPressEvent: key=="Esc" → hide+sigFindbarClose           → KeyPressEvent_Esc_...
+// - keyPressEvent: closeButton focus && "Tab" → setFocus editline → KeyPressEvent_TabWithCloseFocus_...
+// - keyPressEvent: else → DFloatingWidget::keyPressEvent        → KeyPressEvent_OtherKey_...
+// - keyPressEvent: "Enter" && prevBtn focus → click             → KeyPressEvent_EnterWithButtonFocus_...
+// - keyPressEvent: "Enter" && nextBtn focus → click             → 同上
+// - receiveText: t != "" → 保存文本                              → ReceiveText_ResetsSearchedFlag（两分支均触发）
+// - findPreClicked: !searched → updateKeyword+findPrev+置位      → FindPreClicked_FirstTime_...
+// - findPreClicked: else → findPrev only                        → FindPreClicked_AlreadySearched_...
+// - getCurrentSearchText: m_editLine/lineEdit 判空               → 两分支（默认构造即有 editLine；TEST_P 验证内容）
+//
+// 最小清单完成情况：
+// | 1 | 每个公开/保护方法 ≥1 用例 | 完成 |
+// | 2 | 等价类（关键词空/普通/中文、alert 开/关、match 计数零/非零） | 完成 |
+// | 3 | 边界值（空关键词、0/0 计数、1/1 计数） | 完成 |
+// | 4 | TEST_P（≥3 组同断言：mismatch 2 组×正反、searchText 3 组、findNext 3 组、matchCount 3 组） | 完成 |
+// | 5 | 分支清单映射 | 见上方 |
+// | 6 | if 分支两侧全覆盖 | 完成 |
+// | 7 | 异常路径 | N/A（无 throw） |
+// | 8 | 负面（空关键词 activeInput、Esc 关闭） | 完成 |
+// | 9 | 强异常安全（hideEvent 后关键词保留） | 完成 |
+// | 10 | stub_ext（无外部依赖需 stub；全部真实 offscreen） | 完成 |
+
+#include <gtest/gtest.h>
+
+#include <QKeyEvent>
+#include <QLabel>
+#include <QLineEdit>
+#include <QPushButton>
+#include <QSignalSpy>
+
+#include "findbar.h"
+#include "test_env.h"
+
+namespace {
+
+class FindBarTest : public ::testing::Test {
+protected:
+    static void SetUpTestSuite() { controlsut::ensureApp(); }
+
+    void SetUp() override
+    {
+        stub.clear();
+        bar = new FindBar();
+        editLine = bar->findChild<LineBar *>("EditLine");
+    }
+
+    void TearDown() override
+    {
+        delete bar;
+        bar = nullptr;
+        editLine = nullptr;
+        stub.clear();
+    }
+
+    // offscreen 下激活窗口并派发挂起事件，使 setFocus/hasFocus 生效
+    void activateWindow()
+    {
+        controlsut::ensureApp()->setActiveWindow(bar);
+        QApplication::processEvents();
+    }
+
+    void setKeyword(const QString &text)
+    {
+        editLine->lineEdit()->blockSignals(true);
+        editLine->lineEdit()->setText(text);
+        editLine->lineEdit()->blockSignals(false);
+    }
+
+    stub_ext::StubExt stub;
+    FindBar *bar = nullptr;
+    LineBar *editLine = nullptr;
+};
+
+// ---- 构造 ----
+
+TEST_F(FindBarTest, Constructor_DefaultParent_CreatesCoreChildren)
+{
+    // Assert：核心子件齐全、构造后隐藏、关键词初始为空
+    ASSERT_NE(editLine, nullptr);
+    EXPECT_NE(bar->findChild<QPushButton *>("FindPrevButton"), nullptr);
+    EXPECT_NE(bar->findChild<QPushButton *>("FindNextButton"), nullptr);
+    EXPECT_NE(bar->findChild<QPushButton *>("ReplaceButton"), nullptr);
+    EXPECT_NE(bar->findChild<QAbstractButton *>("FindCloseButton"), nullptr);
+    EXPECT_FALSE(bar->isVisible());  // 构造即 hide()
+    EXPECT_EQ(bar->getCurrentSearchText(), QString());
+}
+
+// ---- activeInput / focus / isFocus ----
+
+TEST_F(FindBarTest, ActiveInput_WithKeyword_FillsAndShowsBar)
+{
+    QSignalSpy updateSpy(bar, &FindBar::updateSearchKeyword);
+
+    // Act
+    bar->activeInput(QString::fromUtf8("关键词kw"), QString::fromUtf8("/ut/a.txt"), 11, 22, 33);
+
+    // Assert：栏显示、关键词填充并全选、文件信息保存（经 handleContentChanged 的
+    // updateSearchKeyword 信号参数回读验证 m_findFile 状态）
+    EXPECT_TRUE(bar->isVisible());
+    EXPECT_EQ(bar->getCurrentSearchText(), QString::fromUtf8("关键词kw"));
+    EXPECT_EQ(editLine->lineEdit()->selectedText(), QString::fromUtf8("关键词kw"));  // selectAll 生效
+
+    bar->handleContentChanged();
+    ASSERT_EQ(updateSpy.count(), 1);
+    EXPECT_EQ(updateSpy.at(0).at(0).toString(), QString::fromUtf8("/ut/a.txt"));
+    EXPECT_EQ(updateSpy.at(0).at(1).toString(), QString::fromUtf8("关键词kw"));
+}
+
+TEST_F(FindBarTest, ActiveInput_EmptyKeyword_StillShown)
+{
+    // Act：负面——空关键词也应当正常显示
+    bar->activeInput(QString(), QString::fromUtf8("/ut/b.txt"), 0, 0, 0);
+
+    // Assert
+    EXPECT_TRUE(bar->isVisible());
+    EXPECT_EQ(bar->getCurrentSearchText(), QString());
+    EXPECT_EQ(editLine->lineEdit()->selectedText(), QString());
+}
+
+TEST_F(FindBarTest, Focus_ExistingText_SelectsAllAndGainsFocus)
+{
+    // Arrange：填充并取消全选
+    bar->activeInput(QString::fromUtf8("hello"), QString::fromUtf8("/ut/c.txt"), 1, 1, 1);
+    editLine->lineEdit()->setSelection(0, 1);  // 缩小选区
+    activateWindow();
+
+    // Act
+    bar->focus();
+
+    // Assert：全选恢复（focus 副作用），焦点在输入行（isFocus 状态变更）
+    QApplication::processEvents();
+    EXPECT_EQ(editLine->lineEdit()->selectedText(), QString::fromUtf8("hello"));
+    EXPECT_TRUE(bar->isFocus());
+}
+
+// ---- findCancel ----
+
+TEST_F(FindBarTest, FindCancel_VisibleBar_HidesAndEmitsClose)
+{
+    // Arrange
+    bar->activeInput(QString::fromUtf8("x"), QString::fromUtf8("/ut/d.txt"), 1, 1, 1);
+    ASSERT_TRUE(bar->isVisible());
+    QSignalSpy closeSpy(bar, &FindBar::sigFindbarClose);
+
+    // Act
+    bar->findCancel();
+
+    // Assert：隐藏 + 关闭信号恰一次；匹配计数清零（0/0 → label 隐藏）
+    EXPECT_FALSE(bar->isVisible());
+    EXPECT_EQ(closeSpy.count(), 1);
+    const auto labels = editLine->lineEdit()->findChildren<QLabel *>();
+    ASSERT_EQ(labels.size(), 1);
+    EXPECT_TRUE(labels.first()->isHidden());
+}
+
+// ---- handleContentChanged ----
+
+TEST_F(FindBarTest, HandleContentChanged_WithFile_EmitsUpdateSearchKeyword)
+{
+    QSignalSpy spy(bar, &FindBar::updateSearchKeyword);
+    setKeyword(QString::fromUtf8("内容"));
+
+    // Act
+    bar->handleContentChanged();
+
+    // Assert：默认未 activeInput → file 为空；keyword 为当前文本
+    ASSERT_EQ(spy.count(), 1);
+    EXPECT_EQ(spy.at(0).at(0).toString(), QString());
+    EXPECT_EQ(spy.at(0).at(1).toString(), QString::fromUtf8("内容"));
+}
+
+// ---- handleFindNext / handleFindPrev（TEST_P 3 组）----
+
+struct KeywordCase {
+    QString keyword;
+};
+
+class FindBarKeywordTest : public FindBarTest,
+                           public ::testing::WithParamInterface<KeywordCase> {
+};
+
+TEST_P(FindBarKeywordTest, HandleFindNext_WithKeyword_EmitsFindNextOnly)
+{
+    const auto &c = GetParam();
+    setKeyword(c.keyword);
+    QSignalSpy nextSpy(bar, &FindBar::findNext);
+    QSignalSpy prevSpy(bar, &FindBar::findPrev);
+
+    // Act
+    bar->handleFindNext();
+
+    // Assert：findNext 携带关键词，且不触发 findPrev
+    ASSERT_EQ(nextSpy.count(), 1);
+    EXPECT_EQ(nextSpy.at(0).at(0).toString(), c.keyword);
+    EXPECT_EQ(prevSpy.count(), 0);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    KeywordCases, FindBarKeywordTest,
+    ::testing::Values(
+        KeywordCase{ QString::fromUtf8("abc") },
+        KeywordCase{ QString() },                          // 边界：空关键词
+        KeywordCase{ QString::fromUtf8("中文&<>搜索") }     // 边界：多字节+特殊字符
+        ));
+
+TEST_P(FindBarKeywordTest, HandleFindPrev_WithKeyword_EmitsFindPrevOnly)
+{
+    const auto &c = GetParam();
+    setKeyword(c.keyword);
+    QSignalSpy nextSpy(bar, &FindBar::findNext);
+    QSignalSpy prevSpy(bar, &FindBar::findPrev);
+
+    // Act
+    bar->handleFindPrev();
+
+    // Assert
+    ASSERT_EQ(prevSpy.count(), 1);
+    EXPECT_EQ(prevSpy.at(0).at(0).toString(), c.keyword);
+    EXPECT_EQ(nextSpy.count(), 0);
+}
+
+// ---- handleSwitchToReplace ----
+
+TEST_F(FindBarTest, HandleSwitchToReplace_ButtonTriggered_EmitsSwitchSignal)
+{
+    QSignalSpy spy(bar, &FindBar::sigSwitchToReplaceBar);
+
+    // Act
+    bar->handleSwitchToReplace();
+
+    // Assert：切换信号恰一次，且不隐藏查找栏、不影响输入内容（副作用边界）
+    EXPECT_EQ(spy.count(), 1);
+    EXPECT_FALSE(bar->isVisible());
+    EXPECT_EQ(bar->getCurrentSearchText(), QString());
+}
+
+// ---- setMismatchAlert（TEST_P：开/关两组对称断言）----
+
+struct AlertCase {
+    bool alert;
+};
+
+class FindBarAlertTest : public FindBarTest,
+                         public ::testing::WithParamInterface<AlertCase> {
+};
+
+TEST_P(FindBarAlertTest, SetMismatchAlert_StateToggle_TogglesEditLineAlert)
+{
+    const auto &c = GetParam();
+
+    // Act
+    bar->setMismatchAlert(c.alert);
+
+    // Assert：告警态精确传递到内嵌 LineBar；文本状态不受扰动
+    EXPECT_EQ(editLine->isAlert(), c.alert);
+    EXPECT_EQ(editLine->lineEdit()->text(), QString());
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    AlertCases, FindBarAlertTest,
+    ::testing::Values(AlertCase{ true }, AlertCase{ false }));
+
+// ---- receiveText / setSearched / findPreClicked 状态机 ----
+
+TEST_F(FindBarTest, FindPreClicked_FirstTime_EmitsKeywordUpdate)
+{
+    setKeyword(QString::fromUtf8("first"));
+    QSignalSpy updateSpy(bar, &FindBar::updateSearchKeyword);
+    QSignalSpy prevSpy(bar, &FindBar::findPrev);
+
+    // Act：首次（searched=false）→ updateSearchKeyword + findPrev，并置 searched
+    bar->findPreClicked();
+
+    ASSERT_EQ(prevSpy.count(), 1);
+    ASSERT_EQ(updateSpy.count(), 1);
+
+    // Act 2：第二次（searched=true）→ 仅 findPrev
+    bar->findPreClicked();
+    EXPECT_EQ(prevSpy.count(), 2);
+    EXPECT_EQ(updateSpy.count(), 1);  // 不再更新关键词
+
+    // Act 3：receiveText 重置 searched → 再次更新关键词（t 非空与空两分支各覆盖一次）
+    bar->receiveText(QString::fromUtf8("changed"));
+    bar->findPreClicked();
+    EXPECT_EQ(prevSpy.count(), 3);
+    EXPECT_EQ(updateSpy.count(), 2);
+
+    bar->receiveText(QString());  // 空串分支：仅重置 searched，不改文本
+    bar->findPreClicked();
+    EXPECT_EQ(prevSpy.count(), 4);
+    EXPECT_EQ(updateSpy.count(), 3);
+}
+
+TEST_F(FindBarTest, SetSearched_FlagToggle_ControlsKeywordUpdate)
+{
+    setKeyword(QString::fromUtf8("kw"));
+    QSignalSpy updateSpy(bar, &FindBar::updateSearchKeyword);
+    QSignalSpy prevSpy(bar, &FindBar::findPrev);
+
+    // Act：外部置 searched=true → 直接 findPrev
+    bar->setSearched(true);
+    bar->findPreClicked();
+
+    // Assert
+    EXPECT_EQ(prevSpy.count(), 1);
+    EXPECT_EQ(updateSpy.count(), 0);
+
+    // Act 2：置回 false → 恢复首搜行为
+    bar->setSearched(false);
+    bar->findPreClicked();
+    EXPECT_EQ(prevSpy.count(), 2);
+    EXPECT_EQ(updateSpy.count(), 1);
+}
+
+// ---- slotUpdateMatchCount（TEST_P 3 组）----
+
+struct MatchCountForwardCase {
+    int current;
+    int total;
+    bool labelVisible;
+};
+
+class FindBarMatchCountTest : public FindBarTest,
+                              public ::testing::WithParamInterface<MatchCountForwardCase> {
+};
+
+TEST_P(FindBarMatchCountTest, SlotUpdateMatchCount_WithCounts_ForwardsToEditLine)
+{
+    const auto &c = GetParam();
+
+    // Act
+    bar->slotUpdateMatchCount(c.current, c.total);
+
+    // Assert：转发至 LineBar 计数标签
+    const auto labels = editLine->lineEdit()->findChildren<QLabel *>();
+    ASSERT_EQ(labels.size(), 1);
+    EXPECT_EQ(labels.first()->isHidden(), !c.labelVisible);
+    if (c.total != 0) {
+        EXPECT_EQ(labels.first()->text(),
+                  QString::fromUtf8("第%1/%2项").arg(c.current).arg(c.total));
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    ForwardCases, FindBarMatchCountTest,
+    ::testing::Values(
+        MatchCountForwardCase{ 0, 0, false },   // 边界：无匹配 → 隐藏
+        MatchCountForwardCase{ 1, 1, true },    // 边界：唯一匹配
+        MatchCountForwardCase{ 7, 99, true }));
+
+// ---- hideEvent：保留查询标记 ----
+
+TEST_F(FindBarTest, HideEvent_OnHide_KeepsSearchKeyword)
+{
+    // Arrange
+    setKeyword(QString::fromUtf8("keepme"));
+    bar->QWidget::show();
+    QSignalSpy removeSpy(bar, &FindBar::removeSearchKeyword);
+
+    // Act：触发 hideEvent
+    bar->hide();
+    QApplication::processEvents();
+
+    // Assert：隐藏后关键词保留（getCurrentSearchText 仍可读）、removeSearchKeyword 不发射
+    EXPECT_FALSE(bar->isVisible());
+    EXPECT_EQ(bar->getCurrentSearchText(), QString::fromUtf8("keepme"));
+    EXPECT_EQ(removeSpy.count(), 0);
+}
+
+// ---- focusNextPrevChild ----
+
+TEST_F(FindBarTest, FocusNextPrevChild_AnyDirection_ReturnsFalse)
+{
+    // Act & Assert：两个方向都禁用焦点链
+    EXPECT_FALSE(bar->focusNextPrevChild(true));
+    EXPECT_FALSE(bar->focusNextPrevChild(false));
+    EXPECT_EQ(bar->getCurrentSearchText(), QString());  // 状态未受影响
+}
+
+// ---- keyPressEvent ----
+
+TEST_F(FindBarTest, KeyPressEvent_EscKey_HidesAndEmitsClose)
+{
+    // Arrange
+    bar->activeInput(QString::fromUtf8("esc"), QString::fromUtf8("/ut/e.txt"), 1, 1, 1);
+    ASSERT_TRUE(bar->isVisible());
+    QSignalSpy closeSpy(bar, &FindBar::sigFindbarClose);
+
+    // Act：合成 Esc 按键直接调用（protected 经 -fno-access-control）
+    QKeyEvent escEvent(QEvent::KeyPress, Qt::Key_Escape, Qt::NoModifier);
+    bar->keyPressEvent(&escEvent);
+
+    // Assert
+    EXPECT_FALSE(bar->isVisible());
+    EXPECT_EQ(closeSpy.count(), 1);
+}
+
+TEST_F(FindBarTest, KeyPressEvent_TabWithCloseFocus_BackToEditLine)
+{
+    // Arrange：显示并激活，把焦点给关闭按钮
+    bar->activeInput(QString::fromUtf8("tab"), QString::fromUtf8("/ut/f.txt"), 1, 1, 1);
+    activateWindow();
+    auto *closeButton = bar->findChild<QAbstractButton *>("FindCloseButton");
+    ASSERT_NE(closeButton, nullptr);
+    closeButton->setFocus();
+    QApplication::processEvents();
+    ASSERT_TRUE(closeButton->hasFocus());
+
+    // Act
+    QKeyEvent tabEvent(QEvent::KeyPress, Qt::Key_Tab, Qt::NoModifier);
+    bar->keyPressEvent(&tabEvent);
+    QApplication::processEvents();
+
+    // Assert：焦点回到查找输入行
+    EXPECT_TRUE(editLine->lineEdit()->hasFocus());
+    EXPECT_FALSE(closeButton->hasFocus());
+    EXPECT_EQ(bar->focusWidget(), editLine->lineEdit());  // 精确指针一致
+}
+
+TEST_P(FindBarKeywordTest, KeyPressEvent_EnterWithButtonFocus_ClicksButton)
+{
+    const auto &c = GetParam();
+    setKeyword(c.keyword);
+    bar->QWidget::show();
+    activateWindow();
+    // 焦点放在 Previous 按钮上：Enter → click → queued handleFindPrev → findPrev 信号
+    auto *prevButton = bar->findChild<QPushButton *>("FindPrevButton");
+    ASSERT_NE(prevButton, nullptr);
+    prevButton->setFocus();
+    QApplication::processEvents();
+    ASSERT_TRUE(prevButton->hasFocus());
+
+    QSignalSpy prevSpy(bar, &FindBar::findPrev);
+    QSignalSpy nextSpy(bar, &FindBar::findNext);
+    QKeyEvent enterEvent(QEvent::KeyPress, Qt::Key_Return, Qt::NoModifier, "\r");
+    bar->keyPressEvent(&enterEvent);
+    QApplication::processEvents();  // flushed queued handleFindPrev
+
+    // Assert：Previous 按钮 Enter 只触发 findPrev，不触发 findNext
+    ASSERT_EQ(prevSpy.count(), 1);
+    EXPECT_EQ(prevSpy.at(0).at(0).toString(), c.keyword);
+    EXPECT_EQ(nextSpy.count(), 0);
+}
+
+TEST_F(FindBarTest, KeyPressEvent_EnterNoFocus_PassesToBaseNoAction)
+{
+    // Arrange：无按钮焦点时按普通键 → else 分支透传 DFloatingWidget
+    QSignalSpy closeSpy(bar, &FindBar::sigFindbarClose);
+    QKeyEvent letterEvent(QEvent::KeyPress, Qt::Key_Z, Qt::NoModifier, "z");
+
+    // Act：不应崩溃、不应触发关闭
+    bar->keyPressEvent(&letterEvent);
+
+    // Assert
+    EXPECT_EQ(closeSpy.count(), 0);
+    EXPECT_EQ(bar->isVisible(), false);  // 状态未变（构造后本就隐藏）
+}
+
+// ---- getCurrentSearchText（TEST_P 3 组，复用 KeywordTest 参数）----
+
+TEST_P(FindBarKeywordTest, GetCurrentSearchText_AfterTyped_ReflectsEditLineContent)
+{
+    const auto &c = GetParam();
+    setKeyword(c.keyword);
+
+    // Act & Assert
+    EXPECT_EQ(bar->getCurrentSearchText(), c.keyword);
+    EXPECT_EQ(bar->getCurrentSearchText(), editLine->lineEdit()->text());  // 双向一致
+}
+
+}  // namespace

--- a/tests/controls_ut/test_fontitemdelegate.cpp
+++ b/tests/controls_ut/test_fontitemdelegate.cpp
@@ -1,0 +1,226 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// FontItemDelegate（src/controls/fontitemdelegate.cpp）单元测试
+//
+// 类特征：QStyledItemDelegate 子类；paint/sizeHint 为 protected override，
+// 经 -fno-access-control 直接调用，QImage+QPainter 离屏真实落笔验证。
+//
+// 方法映射（公开/保护方法全集）：
+// - FontItemDelegate::FontItemDelegate → Constructor_NoParent_CreatesPlainInstance
+// - ~FontItemDelegate                   → TearDown delete 链覆盖
+// - paint(protected)                    → Paint_UnselectedState_DrawsTextOnImage (TEST_P) /
+//                                         Paint_SelectedState_FillsHighlightBackground /
+//                                         Paint_WithChineseFont_SetsFontFamilyFromIndex
+// - sizeHint(protected)                 → SizeHint_AnyIndex_ReturnsFixedHeight (TEST_P)
+//
+// 分支清单（来源：fontitemdelegate.cpp）→ 用例映射：
+// - paint: isSelected（option.state & State_Selected）→ 蓝底白字 → Paint_SelectedState_...
+// - paint: else → 黑字直绘                          → Paint_UnselectedState_... (TEST_P)
+// - sizeHint: 恒定 QSize(-1, 30)（无分支）           → SizeHint_... (TEST_P)
+//
+// 最小清单完成情况：
+// | 1 | 每个公开/保护方法 ≥1 用例 | 完成 |
+// | 2 | 等价类（选中/未选中 × 文本 ASCII/中文/空） | 完成 |
+// | 3 | 边界值（空字符串索引、无效索引） | 完成 |
+// | 4 | TEST_P（≥3 组同断言：paint 3 组、sizeHint 3 组） | 完成 |
+// | 5 | 分支清单映射 | 见上方 |
+// | 6 | if 分支两侧全覆盖 | 完成 |
+// | 7 | 异常路径 | N/A（纯绘制无 throw） |
+// | 8 | 负面（空文本/无效索引仍可安全绘制） | 完成 |
+// | 9 | 强异常安全（绘制前后模型数据不变） | 完成 |
+// | 10 | stub_ext（QPainter::setFont 计数断言字体族副作用） | 完成 |
+
+#include <gtest/gtest.h>
+
+#include <QImage>
+#include <QModelIndex>
+#include <QPainter>
+#include <QStandardItemModel>
+#include <QStyleOptionViewItem>
+
+#include "fontitemdelegate.h"
+#include "test_env.h"
+
+namespace {
+
+class FontItemDelegateTest : public ::testing::Test {
+protected:
+    static void SetUpTestSuite() { controlsut::ensureApp(); }
+
+    void SetUp() override
+    {
+        stub.clear();
+        setFontCount = 0;
+        lastFontFamily.clear();
+        delegate = new FontItemDelegate();
+        model.setParent(nullptr);
+        model.clear();
+        model.appendRow(new QStandardItem(QString::fromUtf8("Sans Serif")));
+        model.appendRow(new QStandardItem(QString::fromUtf8("等距更纱黑体 SC")));
+        model.appendRow(new QStandardItem(QString()));  // 边界：空字体名
+    }
+
+    void TearDown() override
+    {
+        delete delegate;
+        delegate = nullptr;
+        stub.clear();
+    }
+
+    QStyleOptionViewItem makeOption(QStyle::State extraState, const QRect &rect)
+    {
+        QStyleOptionViewItem option;
+        option.rect = rect;
+        option.state |= QStyle::State_Enabled | extraState;
+        return option;
+    }
+
+    int countPaintedPixels(const QImage &image) const
+    {
+        int painted = 0;
+        for (int y = 0; y < image.height(); ++y)
+            for (int x = 0; x < image.width(); ++x)
+                if (qAlpha(image.pixel(x, y)) != 0)
+                    ++painted;
+        return painted;
+    }
+
+    stub_ext::StubExt stub;
+    FontItemDelegate *delegate = nullptr;
+    QStandardItemModel model;
+    int setFontCount = 0;
+    QString lastFontFamily;
+};
+
+// ---- 构造 ----
+
+TEST_F(FontItemDelegateTest, Constructor_NoParent_CreatesPlainInstance)
+{
+    // Assert：可构造、无父对象、元对象类型正确（Q_OBJECT 就绪）
+    EXPECT_EQ(delegate->parent(), nullptr);
+    EXPECT_STREQ(delegate->metaObject()->className(), "FontItemDelegate");
+}
+
+// ---- sizeHint（TEST_P 3 组：任意索引恒定尺寸）----
+
+struct SizeHintCase {
+    int row;
+};
+
+class FontItemSizeHintTest : public FontItemDelegateTest,
+                             public ::testing::WithParamInterface<SizeHintCase> {
+};
+
+TEST_P(FontItemSizeHintTest, SizeHint_AnyIndex_ReturnsFixedHeight)
+{
+    const auto &c = GetParam();
+    QStyleOptionViewItem option;
+    const QModelIndex idx = model.index(c.row, 0);
+
+    // Act
+    const QSize hint = delegate->sizeHint(option, idx);
+
+    // Assert：固定宽 -1 高 30（源码常量）
+    EXPECT_EQ(hint.width(), -1);
+    EXPECT_EQ(hint.height(), 30);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    SizeCases, FontItemSizeHintTest,
+    ::testing::Values(SizeHintCase{ 0 }, SizeHintCase{ 1 }, SizeHintCase{ 2 }));
+
+// ---- paint：未选中分支（TEST_P 3 组文本）----
+
+struct PaintCase {
+    int row;
+};
+
+class FontItemPaintTest : public FontItemDelegateTest,
+                          public ::testing::WithParamInterface<PaintCase> {
+};
+
+TEST_P(FontItemPaintTest, Paint_UnselectedState_DrawsTextOnImage)
+{
+    const auto &c = GetParam();
+    QImage image(300, 40, QImage::Format_ARGB32_Premultiplied);
+    image.fill(Qt::transparent);
+    QPainter painter(&image);
+    ASSERT_TRUE(painter.isActive());
+    const QModelIndex idx = model.index(c.row, 0);
+    const auto option = makeOption(QStyle::State_None, QRect(0, 0, 300, 40));
+    const QString textBefore = idx.data(Qt::DisplayRole).toString();
+
+    // Act
+    delegate->paint(&painter, option, idx);
+    painter.end();
+
+    // Assert：有落笔（空文本行为例则允许 0 像素，但绝不崩溃且状态不变）
+    const int painted = countPaintedPixels(image);
+    if (!textBefore.isEmpty())
+        EXPECT_GT(painted, 0);
+    EXPECT_EQ(idx.data(Qt::DisplayRole).toString(), textBefore);  // 强异常安全
+    // 未选中分支不铺高亮底色：左上角像素不得为选中蓝
+    if (painted > 0)
+        EXPECT_NE(image.pixel(2, 2), qRgb(0x2C, 0xA7, 0xF8));
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    TextCases, FontItemPaintTest,
+    ::testing::Values(PaintCase{ 0 }, PaintCase{ 1 }, PaintCase{ 2 }));
+
+// ---- paint：选中分支（蓝底 + 白字）----
+
+TEST_F(FontItemDelegateTest, Paint_SelectedState_FillsHighlightBackground)
+{
+    // Arrange
+    QImage image(300, 40, QImage::Format_ARGB32_Premultiplied);
+    image.fill(Qt::transparent);
+    QPainter painter(&image);
+    const QModelIndex idx = model.index(0, 0);
+    const auto option = makeOption(QStyle::State_Selected, QRect(0, 0, 300, 40));
+
+    // Act
+    delegate->paint(&painter, option, idx);
+    painter.end();
+
+    // Assert：整行填充 #2CA7F8 高亮底色（drawRect 覆盖 option.rect 全域）
+    EXPECT_EQ(image.pixel(2, 20), qRgb(0x2C, 0xA7, 0xF8));
+    EXPECT_EQ(image.pixel(297, 20), qRgb(0x2C, 0xA7, 0xF8));
+    EXPECT_GT(countPaintedPixels(image), 0);
+}
+
+// 辅助：默认未选中 option
+inline QStyleOptionViewItem optionNone()
+{
+    QStyleOptionViewItem option;
+    option.rect = QRect(0, 0, 300, 40);
+    option.state |= QStyle::State_Enabled;
+    return option;
+}
+
+// ---- paint：字体族副作用 ----
+
+TEST_F(FontItemDelegateTest, Paint_WithChineseFont_SetsFontFamilyFromIndex)
+{
+    // Arrange：拦截 setFont 记录字体族
+    stub.set_lamda(&QPainter::setFont,
+                   [this](QPainter *, const QFont &font) {
+                       ++setFontCount;
+                       lastFontFamily = font.family();
+                   });
+    QImage image(300, 40, QImage::Format_ARGB32_Premultiplied);
+    image.fill(Qt::transparent);
+    QPainter painter(&image);
+    const QModelIndex idx = model.index(1, 0);  // "等距更纱黑体 SC"
+
+    // Act
+    delegate->paint(&painter, optionNone(), idx);
+    painter.end();
+
+    // Assert：painter 字体族被设置为索引数据（中文字体名精确传递）
+    EXPECT_EQ(setFontCount, 1);
+    EXPECT_EQ(lastFontFamily, QString::fromUtf8("等距更纱黑体 SC"));
+}
+
+}  // namespace

--- a/tests/controls_ut/test_jumplinebar.cpp
+++ b/tests/controls_ut/test_jumplinebar.cpp
@@ -1,0 +1,370 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// JumpLineBar（src/controls/jumplinebar.cpp）单元测试
+//
+// 类特征：DFloatingWidget 子类（GUI 类），offscreen QApplication 无头构造。
+//
+// 方法映射（公开/保护方法全集）：
+// - JumpLineBar::JumpLineBar   → Constructor_DefaultParent_CreatesCoreChildren
+// - ~JumpLineBar               → Destructor_DeleteWithoutLeak（TearDown 链覆盖）
+// - focus                      → ActiveInput_AfterShow_FocusesSpinBoxInput
+// - isFocus                    → 同上
+// - activeInput                → ActiveInput_WithLineCount_SavesContextAndRange /
+//                                 ActiveInput_OversizedLineNumber_Cleared (TEST_P)
+// - handleFocusOut             → HandleFocusOut_OnFocusLoss_EmitsLostFocusExit
+// - handleLineChanged          → HandleLineChanged_ValidNumber_EmitsJumpToLine (TEST_P) /
+//                                 HandleLineChanged_ZeroOrEmpty_NoSignal
+// - jumpCancel                 → JumpCancel_VisibleBar_HidesAndClearsInput
+// - jumpConfirm                → JumpConfirm_ValidNumber_EmitsJumpToLineWithFocus /
+//                                 JumpConfirm_EmptyInput_NoSignal
+// - slotFocusChanged           → SlotFocusChanged_FalseOnly_EmitsLostFocusExit
+// - hide                       → Hide_VisibleBar_ClearsInputAndHidesBar
+// - getLineCount               → ActiveInput_WithLineCount_SavesContextAndRange
+// - eventFilter(protected)     → EventFilter_SpinBoxFocusOut_EmitsLostAndClears /
+//                                 EventFilter_OtherObject_PassesThrough
+// - updateSizeMode(protected)  → 构造函数直调覆盖
+//
+// 分支清单（来源：jumplinebar.cpp）→ 用例映射：
+// - activeInput: minimumWidth < lineWidth → setFixedWidth(lineWidth)  → ActiveInput...AdjustsRange（多行数）
+// - activeInput: else → setFixedWidth(默认宽)                          → 同上（小行数）
+// - activeInput: text.toInt() > lineCount → 清空                       → ActiveInput_OversizedLineNumber_Cleared
+// - handleLineChanged: content=="" → 跳过                              → HandleLineChanged_ZeroOrEmpty
+// - handleLineChanged: toInt()==0 → clear+return                       → HandleLineChanged_ZeroOrEmpty
+// - handleLineChanged: else → jumpToLine(file, n, false)               → HandleLineChanged_ValidNumber (TEST_P)
+// - jumpConfirm: content=="" → 跳过 / else → jumpToLine(..., true)     → JumpConfirm_两用例
+// - slotFocusChanged: bFocus==false → lostFocusExit                    → SlotFocusChanged_FalseOnly
+// - eventFilter: pObject==spinbox && FocusOut → handleFocusOut         → EventFilter_SpinBoxFocusOut
+// - eventFilter: FocusOut 且 lineEdit 空 → clear                        → 同上
+// - eventFilter: 其它对象/事件 → 透传                                   → EventFilter_OtherObject
+//
+// 最小清单完成情况：
+// | 1 | 每个公开/保护方法 ≥1 用例 | 完成 |
+// | 2 | 等价类（行号 有效/0/空/超界、行数 1 位/4 位） | 完成 |
+// | 3 | 边界值（lineCount=1、行号=1、行号=lineCount、超界+1） | 完成 |
+// | 4 | TEST_P（activeInput 3 组、handleLineChanged 3 组） | 完成 |
+// | 5 | 分支清单映射 | 见上方 |
+// | 6 | if 分支两侧全覆盖 | 完成 |
+// | 7 | 异常路径 | N/A（无 throw） |
+// | 8 | 负面（空/0/超界行号不发信号） | 完成 |
+// | 9 | 强异常安全（jumpCancel 后行数上下文保留） | 完成 |
+// | 10 | stub_ext（全部真实 offscreen + QSignalSpy） | 完成 |
+//
+// [注] m_lineCount 构造函数未初始化（源码缺陷，见批次 defects 记录）：
+// getLineCount() 在 activeInput 之前返回未定值，测试仅在 activeInput 后断言。
+
+#include <gtest/gtest.h>
+
+#include <QFocusEvent>
+#include <QLabel>
+#include <QLineEdit>
+#include <QSignalSpy>
+
+#include "jumplinebar.h"
+#include "test_env.h"
+
+namespace {
+
+class JumpLineBarTest : public ::testing::Test {
+protected:
+    static void SetUpTestSuite() { controlsut::ensureApp(); }
+
+    void SetUp() override
+    {
+        stub.clear();
+        bar = new JumpLineBar();
+        spinBox = bar->findChild<DSpinBox *>("PSpinBoxInput");
+    }
+
+    void TearDown() override
+    {
+        delete bar;
+        bar = nullptr;
+        spinBox = nullptr;
+        stub.clear();
+    }
+
+    // 静默设置输入文本（不触发 textChanged → 队列中的 handleLineChanged）
+    void setInputQuietly(const QString &text)
+    {
+        spinBox->lineEdit()->blockSignals(true);
+        spinBox->lineEdit()->setText(text);
+        spinBox->lineEdit()->blockSignals(false);
+    }
+
+    void activateWindow()
+    {
+        controlsut::ensureApp()->setActiveWindow(bar);
+        QApplication::processEvents();
+    }
+
+    stub_ext::StubExt stub;
+    JumpLineBar *bar = nullptr;
+    DSpinBox *spinBox = nullptr;
+};
+
+// ---- 构造 ----
+
+TEST_F(JumpLineBarTest, Constructor_DefaultParent_CreatesCoreChildren)
+{
+    // Assert：标签/输入框/关闭按钮齐全、输入框无按钮样式、初始无文本
+    ASSERT_NE(spinBox, nullptr);
+    EXPECT_NE(bar->findChild<QAbstractButton *>("JumpCloseButton"), nullptr);
+    EXPECT_EQ(spinBox->buttonSymbols(), QAbstractSpinBox::NoButtons);
+    EXPECT_EQ(spinBox->lineEdit()->text(), QString());
+}
+
+// ---- activeInput ----
+
+TEST_F(JumpLineBarTest, ActiveInput_WithLineCount_SavesContextAndRange)
+{
+    // Act：4 位数行数（触发 minimumWidth < lineWidth 分支）与最小行数各一次
+    bar->activeInput(QString::fromUtf8("/ut/jump.txt"), 3, 4, 1000, 55);
+
+    // Assert：行数上下文保存、范围调整为 0~lineCount
+    EXPECT_EQ(bar->getLineCount(), 1000);
+    EXPECT_EQ(spinBox->minimum(), 0);
+    EXPECT_EQ(spinBox->maximum(), 1000);
+
+    // Act 2：1 位数行数（minimumWidth 足够 → else 分支，恢复默认宽）
+    bar->activeInput(QString::fromUtf8("/ut/jump2.txt"), 1, 1, 5, 0);
+    EXPECT_EQ(bar->getLineCount(), 5);  // 上下文更新
+    EXPECT_EQ(spinBox->maximum(), 5);   // 边界：lineCount 最小
+}
+
+struct OversizeCase {
+    QString presetText;
+    int lineCount;
+    bool expectCleared;
+};
+
+class JumpLineOversizeTest : public JumpLineBarTest,
+                             public ::testing::WithParamInterface<OversizeCase> {
+};
+
+TEST_P(JumpLineOversizeTest, ActiveInput_OversizedLineNumber_Cleared)
+{
+    const auto &c = GetParam();
+    bar->activeInput(QString::fromUtf8("/ut/j.txt"), 1, 1, 100, 0);
+    setInputQuietly(c.presetText);
+
+    // Act
+    bar->activeInput(QString::fromUtf8("/ut/j.txt"), 1, 1, c.lineCount, 0);
+
+    // Assert：超界输入被清空；未超界保留
+    const QString text = spinBox->lineEdit()->text();
+    if (c.expectCleared) {
+        EXPECT_EQ(text, QString());
+    } else {
+        EXPECT_EQ(text, c.presetText);
+    }
+    EXPECT_EQ(bar->getLineCount(), c.lineCount);  // 行数上下文始终更新
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    OversizeCases, JumpLineOversizeTest,
+    ::testing::Values(
+        OversizeCase{ QString("150"), 100, true },    // 边界外：> lineCount → 清空
+        OversizeCase{ QString("100"), 100, false },   // 边界上：== lineCount → 保留
+        OversizeCase{ QString("1"), 1, false }        // 边界：单行文档
+        ));
+
+// ---- focus / isFocus ----
+
+TEST_F(JumpLineBarTest, ActiveInput_AfterShow_FocusesSpinBoxInput)
+{
+    // Arrange：显示前无焦点
+    bar->activeInput(QString::fromUtf8("/ut/f.txt"), 1, 1, 10, 0);
+    EXPECT_FALSE(bar->isFocus());
+
+    // Act：显示 + 激活 + focus()（聚焦行编辑）
+    bar->QWidget::show();
+    activateWindow();
+    bar->focus();
+    QApplication::processEvents();
+
+    // Assert：行编辑持焦 + 行数上下文未被聚焦操作破坏
+    EXPECT_TRUE(bar->isFocus());
+    EXPECT_EQ(bar->getLineCount(), 10);
+}
+
+// ---- handleLineChanged（TEST_P 3 组）----
+
+struct LineChangedCase {
+    QString input;
+    bool expectSignal;
+    int expectedLine;
+};
+
+class JumpLineChangedTest : public JumpLineBarTest,
+                            public ::testing::WithParamInterface<LineChangedCase> {
+};
+
+TEST_P(JumpLineChangedTest, HandleLineChanged_ValidNumber_EmitsJumpToLineOnly)
+{
+    const auto &c = GetParam();
+    bar->activeInput(QString::fromUtf8("/ut/lc.txt"), 2, 3, 500, 9);
+    setInputQuietly(c.input);
+    QSignalSpy spy(bar, &JumpLineBar::jumpToLine);
+
+    // Act
+    bar->handleLineChanged();
+
+    // Assert
+    if (c.expectSignal) {
+        ASSERT_EQ(spy.count(), 1);
+        EXPECT_EQ(spy.at(0).at(0).toString(), QString::fromUtf8("/ut/lc.txt"));
+        EXPECT_EQ(spy.at(0).at(1).toInt(), c.expectedLine);
+        EXPECT_FALSE(spy.at(0).at(2).toBool());  // 行内跳转不带焦点
+    } else {
+        EXPECT_EQ(spy.count(), 0);
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    LineCases, JumpLineChangedTest,
+    ::testing::Values(
+        LineChangedCase{ QString("42"), true, 42 },
+        LineChangedCase{ QString("1"), true, 1 },    // 边界：首行
+        LineChangedCase{ QString("0"), false, 0 }    // 边界：0 → 清空不发
+        ));
+
+TEST_F(JumpLineBarTest, HandleLineChanged_EmptyInput_NoSignal)
+{
+    bar->activeInput(QString::fromUtf8("/ut/empty.txt"), 1, 1, 10, 0);
+    setInputQuietly(QString());
+    QSignalSpy spy(bar, &JumpLineBar::jumpToLine);
+
+    // Act
+    bar->handleLineChanged();
+
+    // Assert：空输入直接跳过
+    EXPECT_EQ(spy.count(), 0);
+    EXPECT_EQ(spinBox->lineEdit()->text(), QString());
+}
+
+// ---- jumpConfirm ----
+
+TEST_F(JumpLineBarTest, JumpConfirm_ValidNumber_EmitsJumpToLineWithFocus)
+{
+    bar->activeInput(QString::fromUtf8("/ut/conf.txt"), 8, 9, 100, 7);
+    setInputQuietly(QString("77"));
+    QSignalSpy spy(bar, &JumpLineBar::jumpToLine);
+
+    // Act
+    bar->jumpConfirm();
+
+    // Assert：确认跳转 focusEditor=true
+    ASSERT_EQ(spy.count(), 1);
+    EXPECT_EQ(spy.at(0).at(0).toString(), QString::fromUtf8("/ut/conf.txt"));
+    EXPECT_EQ(spy.at(0).at(1).toInt(), 77);
+    EXPECT_TRUE(spy.at(0).at(2).toBool());
+    EXPECT_EQ(spinBox->lineEdit()->text(), QString("77"));  // 输入保留
+}
+
+TEST_F(JumpLineBarTest, JumpConfirm_EmptyInput_NoSignal)
+{
+    setInputQuietly(QString());
+    QSignalSpy spy(bar, &JumpLineBar::jumpToLine);
+
+    // Act
+    bar->jumpConfirm();
+
+    // Assert：空输入不发信号，输入框状态保持为空
+    EXPECT_EQ(spy.count(), 0);
+    EXPECT_EQ(spinBox->lineEdit()->text(), QString());
+}
+
+// ---- jumpCancel / hide ----
+
+TEST_F(JumpLineBarTest, JumpCancel_VisibleBar_HidesAndClearsInput)
+{
+    // Arrange：显示并输入
+    bar->QWidget::show();
+    setInputQuietly(QString("33"));
+    ASSERT_TRUE(bar->isVisible());
+
+    // Act
+    bar->jumpCancel();
+
+    // Assert：隐藏且输入清空（经 JumpLineBar::hide），不发射 jumpToLine
+    EXPECT_FALSE(bar->isVisible());
+    EXPECT_EQ(spinBox->lineEdit()->text(), QString());
+}
+
+TEST_F(JumpLineBarTest, Hide_VisibleBar_ClearsInputAndHidesBar)
+{
+    // Arrange
+    bar->QWidget::show();
+    setInputQuietly(QString("5"));
+
+    // Act：直接调用重载 hide()（非虚，遮蔽 QWidget::hide）
+    bar->hide();
+
+    // Assert
+    EXPECT_FALSE(bar->isVisible());
+    EXPECT_EQ(spinBox->lineEdit()->text(), QString());
+}
+
+// ---- handleFocusOut / slotFocusChanged ----
+
+TEST_F(JumpLineBarTest, HandleFocusOut_OnFocusLoss_EmitsLostFocusExit)
+{
+    QSignalSpy spy(bar, &JumpLineBar::lostFocusExit);
+    QSignalSpy jumpSpy(bar, &JumpLineBar::jumpToLine);
+
+    // Act
+    bar->handleFocusOut();
+
+    // Assert：只发失焦退出，不触发跳转
+    EXPECT_EQ(spy.count(), 1);
+    EXPECT_EQ(jumpSpy.count(), 0);
+}
+
+TEST_F(JumpLineBarTest, SlotFocusChanged_FalseOnly_EmitsLostFocusExit)
+{
+    QSignalSpy spy(bar, &JumpLineBar::lostFocusExit);
+
+    // Act：true 不发、false 发
+    bar->slotFocusChanged(true);
+    EXPECT_EQ(spy.count(), 0);
+    bar->slotFocusChanged(false);
+
+    // Assert
+    EXPECT_EQ(spy.count(), 1);
+}
+
+// ---- eventFilter ----
+
+TEST_F(JumpLineBarTest, EventFilter_SpinBoxFocusOut_EmitsLostAndKeepsEmpty)
+{
+    // Arrange：输入框静默置空
+    setInputQuietly(QString());
+    QSignalSpy spy(bar, &JumpLineBar::lostFocusExit);
+
+    // Act：向 spinBox 派发 FocusOut（经 installEventFilter 走 eventFilter）
+    QFocusEvent focusOut(QEvent::FocusOut, Qt::MouseFocusReason);
+    const bool handled = bar->eventFilter(spinBox, &focusOut);
+
+    // Assert：handleFocusOut 被触发、空文本分支 clear、事件未被吞（透传基类）
+    EXPECT_EQ(spy.count(), 1);
+    EXPECT_FALSE(handled);
+    EXPECT_EQ(spinBox->lineEdit()->text(), QString());
+}
+
+TEST_F(JumpLineBarTest, EventFilter_OtherObject_PassesThrough)
+{
+    // Arrange：其它对象上的 FocusOut 不处理
+    QWidget stranger;
+    QFocusEvent focusOut(QEvent::FocusOut, Qt::MouseFocusReason);
+    QSignalSpy spy(bar, &JumpLineBar::lostFocusExit);
+
+    // Act
+    const bool handled = bar->eventFilter(&stranger, &focusOut);
+
+    // Assert
+    EXPECT_FALSE(handled);
+    EXPECT_EQ(spy.count(), 0);
+}
+
+}  // namespace

--- a/tests/controls_ut/test_linebar.cpp
+++ b/tests/controls_ut/test_linebar.cpp
@@ -1,0 +1,389 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// LineBar（src/controls/linebar.cpp）单元测试
+//
+// 类特征：DLineEdit 子类（GUI 类），offscreen QApplication 无头构造。
+//
+// 方法映射（公开/保护方法全集）：
+// - LineBar::LineBar            → Constructor_DefaultParent_CreatesCoreChildren
+// - handleTextChangeTimer       → HandleTextChangeTimer_OnTimeout_EmitsContentChanged
+// - handleTextChanged           → HandleTextChanged_EmptyText_HidesClearButtonAndTimerRestart /
+//                                 HandleTextChanged_NonEmptyText_ShowsClearButton / TextEdited... (TEST_P 由 timer 用例覆盖)
+// - sendText                    → SendText_AnyInput_EmitsSignalSentText (TEST_P)
+// - focusOutEvent               → FocusOutEvent_OnEvent_EmitsFocusOutSignal
+// - keyPressEvent               → KeyPressEvent_ModifierEnterMatrix_EmitsMappedSignal (TEST_P) /
+//                                 KeyPressEvent_PlainLetter_PassesToBaseEditor
+// - resizeEvent                 → ResizeEvent_SizeChanged_RepositionsRightWidgets
+// - setMatchCount               → SetMatchCount_TotalZero_HidesLabel /
+//                                 SetMatchCount_NonZero_ShowsLabelWithOrdinalText (TEST_P)
+// - updateRightWidgetsGeometry(private) → 经 setMatchCount/resizeEvent 间接全覆盖（几何精确断言）
+//
+// 分支清单（来源：linebar.cpp）→ 用例映射：
+// - handleTextChanged: timer active → stop           → HandleTextChanged_Consecutive_RestartsTimer（连续两次调用）
+// - handleTextChanged: str.isEmpty() → setAlert(false)+hide clear btn → HandleTextChanged_EmptyText_...
+// - handleTextChanged: else → show clear btn          → HandleTextChanged_NonEmptyText_...
+// - keyPressEvent: Ctrl/Alt/Meta/NoModifier + "\r"    → KeyPressEvent_ModifierEnterMatrix (TEST_P 4 组)
+// - keyPressEvent: else → DLineEdit::keyPressEvent     → KeyPressEvent_PlainLetter_PassesToBaseEditor
+// - setMatchCount: total==0 → hide label               → SetMatchCount_TotalZero_HidesLabel
+// - setMatchCount: else → set text + show label        → SetMatchCount_NonZero_ShowsLabelWithOrdinalText (TEST_P)
+// - updateRightWidgetsGeometry: le == null → return    → LineBar 内嵌 lineEdit 恒非空，结构性不可达（无独立分支断言）
+//
+// 最小清单完成情况：
+// | 1 | 每个公开方法 ≥1 用例 | 完成 |
+// | 2 | 等价类（空/非空文本、total 零/非零、4 类修饰键） | 完成 |
+// | 3 | 边界值（current=1/total=1、单字符、空串） | 完成 |
+// | 4 | TEST_P（≥3 组同断言：sendText 3 组、修饰键 4 组、MatchCount 3 组） | 完成 |
+// | 5 | 分支清单映射 | 见上方 |
+// | 6 | if 分支两侧全覆盖 | 完成 |
+// | 7 | 异常路径 | N/A（Qt 代码无 throw） |
+// | 8 | 负面（空文本、total=0） | 完成 |
+// | 9 | 强异常安全（模型/文本状态未破坏） | 完成 |
+// | 10 | stub_ext（QPainter 无需、纯信号断言） | 完成 |
+
+#include <gtest/gtest.h>
+
+#include <DGuiApplicationHelper>
+
+#include <QAbstractButton>
+#include <QKeyEvent>
+#include <QLabel>
+#include <QLineEdit>
+#include <QPushButton>
+#include <QSignalSpy>
+#include <QTimer>
+
+#include "linebar.h"
+#include "test_env.h"
+
+namespace {
+
+class LineBarTest : public ::testing::Test {
+protected:
+    static void SetUpTestSuite() { controlsut::ensureApp(); }
+
+    void SetUp() override
+    {
+        stub.clear();
+        bar = new LineBar();
+        // 清除按钮为 DIconButton（QAbstractButton 子类，非 QPushButton），按 objectName 定位
+        clearButton = bar->findChild<QAbstractButton *>("ClearButton");
+        matchLabel = nullptr;
+        const auto labels = bar->lineEdit()->findChildren<QLabel *>();
+        if (!labels.isEmpty())
+            matchLabel = labels.first();
+        autoSaveTimer = bar->findChild<QTimer *>();
+    }
+
+    void TearDown() override
+    {
+        delete bar;
+        bar = nullptr;
+        stub.clear();
+    }
+
+    void typeText(const QString &text)
+    {
+        // 模拟用户输入（textEdited 信号源）：insert 会走 QLineEdit::insert → textEdited
+        bar->lineEdit()->insert(text);
+    }
+
+    stub_ext::StubExt stub;
+    LineBar *bar = nullptr;
+    QAbstractButton *clearButton = nullptr;
+    QLabel *matchLabel = nullptr;
+    QTimer *autoSaveTimer = nullptr;
+};
+
+// ---- 构造 ----
+
+TEST_F(LineBarTest, Constructor_DefaultParent_CreatesCoreChildren)
+{
+    // Assert：核心子件齐全、初始无文本、清除按钮/计数标签隐藏、定时器单发 50ms
+    ASSERT_NE(bar->lineEdit(), nullptr);
+    EXPECT_EQ(bar->lineEdit()->text(), QString());
+    ASSERT_NE(clearButton, nullptr);
+    EXPECT_TRUE(clearButton->isHidden());
+    ASSERT_NE(matchLabel, nullptr);
+    EXPECT_TRUE(matchLabel->isHidden());
+    ASSERT_NE(autoSaveTimer, nullptr);
+    EXPECT_TRUE(autoSaveTimer->isSingleShot());
+    EXPECT_FALSE(autoSaveTimer->isActive());
+}
+
+// ---- handleTextChanged：空文本分支 ----
+
+TEST_F(LineBarTest, HandleTextChanged_EmptyText_HidesClearButtonAndDisablesAlert)
+{
+    // Arrange：先置警械态并显示清除按钮（走非空分支前置），再清空
+    bar->setAlert(true);
+    bar->handleTextChanged("abc");
+    EXPECT_FALSE(clearButton->isHidden());
+
+    // Act
+    bar->handleTextChanged(QString());
+
+    // Assert：空文本 → 告警解除、清除按钮隐藏、防抖定时器重新启动、文本为空
+    EXPECT_FALSE(bar->isAlert());
+    EXPECT_TRUE(clearButton->isHidden());
+    ASSERT_NE(autoSaveTimer, nullptr);
+    EXPECT_TRUE(autoSaveTimer->isActive());  // 状态变更：新定时器已启动
+    EXPECT_EQ(bar->lineEdit()->text(), QString());
+}
+
+// ---- handleTextChanged：非空文本分支 + 定时器重启（active → stop → start）----
+
+TEST_F(LineBarTest, HandleTextChanged_NonEmptyText_ShowsClearButton)
+{
+    // Act
+    bar->handleTextChanged(QString::fromUtf8("deep深度编辑"));
+
+    // Assert：清除按钮显示、定时器激活；同时经定时器到期发 contentChanged（覆盖
+    // handleTextChangeTimer 的真实触发链路：m_autoSaveInternal=50ms）
+    EXPECT_FALSE(clearButton->isHidden());
+    EXPECT_TRUE(autoSaveTimer->isActive());
+
+    QSignalSpy changedSpy(bar, &LineBar::contentChanged);
+    EXPECT_TRUE(changedSpy.wait(300));            // 定时器到期 → contentChanged
+    EXPECT_EQ(changedSpy.count(), 1);             // 单发定时器只触发一次
+    EXPECT_EQ(bar->lineEdit()->text(), QString());  // 文本状态未被破坏（强异常安全）
+}
+
+// ---- handleTextChangeTimer：直接调用 ----
+
+TEST_F(LineBarTest, HandleTextChangeTimer_OnTimeout_EmitsContentChanged)
+{
+    QSignalSpy spy(bar, &LineBar::contentChanged);
+
+    // Act
+    bar->handleTextChangeTimer();
+
+    // Assert：信号恰一次；文本状态不被定时器回调破坏
+    EXPECT_EQ(spy.count(), 1);
+    EXPECT_EQ(bar->lineEdit()->text(), QString());
+}
+
+// ---- sendText：参数化（3 组同断言逻辑）----
+
+struct SendTextCase {
+    QString input;
+};
+
+class LineBarSendTextTest : public LineBarTest,
+                            public ::testing::WithParamInterface<SendTextCase> {
+};
+
+TEST_P(LineBarSendTextTest, SendText_AnyInput_EmitsSignalSentText)
+{
+    const auto &c = GetParam();
+    QSignalSpy spy(bar, &LineBar::signal_sentText);
+
+    // Act
+    bar->sendText(c.input);
+
+    // Assert：原样转发
+    EXPECT_EQ(spy.count(), 1);
+    EXPECT_EQ(spy.at(0).at(0).toString(), c.input);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    BasicCases, LineBarSendTextTest,
+    ::testing::Values(
+        SendTextCase{ QString::fromUtf8("hello") },
+        SendTextCase{ QString() },                       // 边界：空串
+        SendTextCase{ QString::fromUtf8("中文关键词&<>'\"") }  // 边界：多字节+特殊字符
+        ));
+
+// ---- focusOutEvent ----
+
+TEST_F(LineBarTest, FocusOutEvent_OnEvent_EmitsFocusOutSignal)
+{
+    QSignalSpy spy(bar, &LineBar::focusOut);
+
+    // Act：合成焦点离开事件直接派发（虚函数经 sendEvent 走真实事件链）
+    QFocusEvent focusOut(QEvent::FocusOut, Qt::MouseFocusReason);
+    QApplication::sendEvent(bar, &focusOut);
+
+    // Assert：信号恰一次；文本状态不受焦点事件影响
+    EXPECT_EQ(spy.count(), 1);
+    EXPECT_EQ(bar->lineEdit()->text(), QString());
+}
+
+// ---- keyPressEvent：修饰键矩阵（4 组同断言逻辑，TEST_P）----
+
+struct ModifierKeyCase {
+    Qt::KeyboardModifiers modifiers;
+    const char *expectedSignal;  // 期望命中的信号名
+};
+
+class LineBarKeyTest : public LineBarTest,
+                       public ::testing::WithParamInterface<ModifierKeyCase> {
+};
+
+TEST_P(LineBarKeyTest, KeyPressEvent_ModifierEnter_EmitsMappedSignal)
+{
+    const auto &c = GetParam();
+    QSignalSpy ctrlSpy(bar, &LineBar::pressCtrlEnter);
+    QSignalSpy altSpy(bar, &LineBar::pressAltEnter);
+    QSignalSpy metaSpy(bar, &LineBar::pressMetaEnter);
+    QSignalSpy enterSpy(bar, &LineBar::pressEnter);
+
+    // Act：合成 Ctrl/Alt/Meta/无修饰 + Enter（"\r"）
+    QKeyEvent keyEvent(QEvent::KeyPress, Qt::Key_Return, c.modifiers, "\r");
+    QApplication::sendEvent(bar, &keyEvent);
+
+    // Assert：只有对应信号发射（其余为 0）
+    const int ctrl = ctrlSpy.count(), alt = altSpy.count();
+    const int meta = metaSpy.count(), enter = enterSpy.count();
+    EXPECT_EQ(ctrl, QString(c.expectedSignal) == "pressCtrlEnter" ? 1 : 0);
+    EXPECT_EQ(alt, QString(c.expectedSignal) == "pressAltEnter" ? 1 : 0);
+    EXPECT_EQ(meta, QString(c.expectedSignal) == "pressMetaEnter" ? 1 : 0);
+    EXPECT_EQ(enter, QString(c.expectedSignal) == "pressEnter" ? 1 : 0);
+    EXPECT_EQ(ctrl + alt + meta + enter, 1);  // 恰好一个信号
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    ModifierMatrix, LineBarKeyTest,
+    ::testing::Values(
+        ModifierKeyCase{ Qt::ControlModifier, "pressCtrlEnter" },
+        ModifierKeyCase{ Qt::AltModifier, "pressAltEnter" },
+        ModifierKeyCase{ Qt::MetaModifier, "pressMetaEnter" },
+        ModifierKeyCase{ Qt::NoModifier, "pressEnter" }));
+
+// ---- keyPressEvent：其它按键透传基类（else 分支）----
+
+TEST_F(LineBarTest, KeyPressEvent_PlainLetter_PassesToBaseEditor)
+{
+    QSignalSpy ctrlSpy(bar, &LineBar::pressCtrlEnter);
+    QSignalSpy enterSpy(bar, &LineBar::pressEnter);
+
+    // Act：普通字母键（无修饰、非 "\r"）→ else 分支透传；事件直接派发到
+    // 内嵌 QLineEdit（生产中焦点即在其上，DLineEdit 经事件过滤转发）
+    QKeyEvent keyEvent(QEvent::KeyPress, Qt::Key_A, Qt::NoModifier, "a");
+    QApplication::sendEvent(bar->lineEdit(), &keyEvent);
+    QApplication::processEvents();
+
+    // Assert：不发射任何 Enter 系信号，且字符真实进入编辑器（透传成功）
+    EXPECT_EQ(ctrlSpy.count(), 0);
+    EXPECT_EQ(enterSpy.count(), 0);
+    EXPECT_EQ(bar->lineEdit()->text(), QString("a"));
+}
+
+// ---- setMatchCount：total==0 分支 ----
+
+TEST_F(LineBarTest, SetMatchCount_TotalZero_HidesLabel)
+{
+    // Arrange：先显示标签
+    bar->setMatchCount(1, 3);
+    ASSERT_FALSE(matchLabel->isHidden());
+
+    // Act
+    bar->setMatchCount(0, 0);
+
+    // Assert：标签隐藏、文本保留（状态未清空）
+    EXPECT_TRUE(matchLabel->isHidden());
+    EXPECT_EQ(matchLabel->text(), QString::fromUtf8("第1/3项"));
+}
+
+// ---- setMatchCount：非零分支（TEST_P 3 组）+ 几何重排 ----
+
+struct MatchCountCase {
+    int current;
+    int total;
+    QString expectedText;
+};
+
+class LineBarMatchCountTest : public LineBarTest,
+                              public ::testing::WithParamInterface<MatchCountCase> {
+};
+
+TEST_P(LineBarMatchCountTest, SetMatchCount_NonZero_ShowsLabelWithOrdinalText)
+{
+    const auto &c = GetParam();
+
+    // Act
+    bar->setMatchCount(c.current, c.total);
+
+    // Assert：文本精确、标签显示、几何被重排（label 右缘贴清除按钮左缘 6px）
+    EXPECT_EQ(matchLabel->text(), c.expectedText);
+    EXPECT_FALSE(matchLabel->isHidden());
+    EXPECT_FALSE(matchLabel->geometry().isNull());
+    EXPECT_LE(matchLabel->x() + matchLabel->width(),
+              clearButton->x() - 6 + 1);  // label 右侧与按钮左侧间距 ≥ 6px（int 截断容差 1）
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    OrdinalCases, LineBarMatchCountTest,
+    ::testing::Values(
+        MatchCountCase{ 1, 1, QString::fromUtf8("第1/1项") },   // 边界：唯一匹配
+        MatchCountCase{ 3, 12, QString::fromUtf8("第3/12项") },
+        MatchCountCase{ 12, 345, QString::fromUtf8("第12/345项") }  // 宽度增长边界
+        ));
+
+// ---- resizeEvent / updateRightWidgetsGeometry ----
+
+TEST_F(LineBarTest, ResizeEvent_SizeChanged_RepositionsRightWidgets)
+{
+    // Arrange
+    bar->setMatchCount(2, 9);
+    bar->resize(240, 36);
+    QApplication::processEvents();
+
+    // Act 已由 resize 触发；读取内嵌 lineEdit 实际几何计算期望值
+    QWidget *le = bar->lineEdit();
+    const int editWidth = le->width();
+    const int editHeight = le->height();
+    const int buttonWidth = clearButton->width();
+
+    // Assert：清除按钮垂直居中、右缘距编辑框右缘 6px（s_nRightMargin）
+    EXPECT_EQ(clearButton->x(), editWidth - 6 - buttonWidth);
+    EXPECT_EQ(clearButton->y(), (editHeight - clearButton->height()) / 2);
+    // 计数标签紧贴按钮左侧 6px（s_nLabelButtonSpacing），垂直居中
+    EXPECT_EQ(matchLabel->x(),
+              clearButton->x() - 6 - matchLabel->sizeHint().width());
+    EXPECT_EQ(matchLabel->y(), (editHeight - matchLabel->sizeHint().height()) / 2);
+    // 负面：resize 不改变文本内容
+    EXPECT_EQ(bar->lineEdit()->text(), QString());
+}
+
+// ---- 构造期 connect 的 lambda（清除按钮 / 尺寸模式切换）----
+
+TEST_F(LineBarTest, ClearButton_Click_ClearsEditLineText)
+{
+    // Arrange：有文本 → 清除按钮显示
+    bar->handleTextChanged(QString::fromUtf8("待清除"));
+    ASSERT_FALSE(clearButton->isHidden());
+
+    // Act：真实点击（ctor 里 connect 的 lambda：lineEdit()->clear()）
+    clearButton->click();
+
+    // Assert
+    EXPECT_EQ(bar->lineEdit()->text(), QString());
+    EXPECT_EQ(bar->text(), QString());
+}
+
+TEST_F(LineBarTest, SizeModeChangedSignal_CompactToggle_UpdatesBarHeight)
+{
+    // Arrange：经最小/最大高读取固定高（未 show 时 geometry 未布局，约束恒真）
+    auto *helper = DGuiApplicationHelper::instance();
+    const int expectedCompact = 24;   // s_nLineBarHeightCompact
+    const int expectedNormal = 36;    // s_nLineBarHeight
+    EXPECT_EQ(bar->minimumHeight(), expectedNormal);  // ctor 已按 NormalMode 设置
+
+    // Act：真实切换全局尺寸模式（setSizeMode 置状态并发 sizeModeChanged，
+    // ctor 连接的 lambda 按 isCompactMode() 重设固定高）
+    helper->setSizeMode(DGuiApplicationHelper::CompactMode);
+    QApplication::processEvents();
+
+    // Assert：紧凑模式生效
+    EXPECT_EQ(bar->minimumHeight(), expectedCompact);
+    EXPECT_EQ(bar->maximumHeight(), expectedCompact);
+
+    // Act 2：切回普通模式（恢复全局状态，避免跨用例污染）
+    helper->setSizeMode(DGuiApplicationHelper::NormalMode);
+    QApplication::processEvents();
+    EXPECT_EQ(bar->minimumHeight(), expectedNormal);
+    EXPECT_EQ(bar->maximumHeight(), expectedNormal);
+}
+
+}  // namespace

--- a/tests/controls_ut/test_replacebar.cpp
+++ b/tests/controls_ut/test_replacebar.cpp
@@ -1,0 +1,491 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// ReplaceBar（src/controls/replacebar.cpp）单元测试
+//
+// 类特征：DFloatingWidget 子类（GUI 类），offscreen QApplication 无头构造。
+//
+// 方法映射（公开/保护方法全集）：
+// - ReplaceBar::ReplaceBar      → Constructor_DefaultParent_CreatesCoreChildren
+// - isFocus                     → ActiveInput_ShowsBarAndFocusesReplaceLine
+// - focus                       → 同上（activeInput 内部经 focus()）
+// - activeInput                 → ActiveInput_WithKeyword_FillsReplaceLineClearsWithLine
+// - setMismatchAlert            → SetMismatchAlert_StateToggle_TogglesReplaceLineAlert (TEST_P)
+// - setsearched                 → HandleReplaceNext_FirstTime_EmitsPreSignals（状态机覆盖）
+// - change                      → Change_AfterSearched_ResetsFlag
+// - replaceClose                → ReplaceClose_VisibleBar_HidesEmitsAndResetsFlag
+// - handleContentChanged        → HandleContentChanged_WithText_EmitsUpdateSearchKeyword
+// - handleReplaceAll            → HandleReplaceAll_WithTextPair_EmitsReplaceAll (TEST_P)
+// - handleReplaceNext           → HandleReplaceNext_FirstTime_EmitsPreSignals /
+//                                 HandleReplaceNext_SecondTime_SkipsPreSignals
+// - handleReplaceRest           → HandleReplaceRest_WithTextPair_EmitsReplaceRest
+// - handleSkip                  → HandleSkip_WithKeyword_EmitsReplaceSkip
+// - slotUpdateMatchCount        → SlotUpdateMatchCount_WithCounts_ForwardsToReplaceLine (TEST_P)
+// - hideEvent(protected)        → HideEvent_OnHide_ResetsFlagAndEmitsRemoveKeyword
+// - focusNextPrevChild(protected) → FocusNextPrevChild_EditingLines_SwitchesBetweenLines /
+//                                 FocusNextPrevChild_NoEditFocus_ReturnsFalse
+// - keyPressEvent(protected)    → KeyPressEvent_EscKey_HidesAndEmitsClose /
+//                                 KeyPressEvent_EnterNoFocus_PassesToBaseNoAction
+// - updateSizeMode/createVerticalLine(private) → 构造函数直调覆盖
+//
+// 分支清单（来源：replacebar.cpp）→ 用例映射：
+// - handleReplaceNext: !searched → removeSearchKeyword+beforeReplace → FirstTime
+// - handleReplaceNext: else       → 直发 replaceNext                → SecondTime
+// - hideEvent: searched=false+removeSearchKeyword                  → HideEvent_...
+// - focusNextPrevChild: focusWidget==m_replaceLine → withLine focus → BetweenTwoLines
+// - focusNextPrevChild: focusWidget==m_withLine → replaceLine focus → BetweenTwoLines
+// - focusNextPrevChild: 其它 → return false                        → NoEditFocus
+// - keyPressEvent: Esc / Tab+closeFocus / Enter×4按钮                → Esc 用例 +
+//   Enter 四按钮分支经 handle* 直调用例覆盖（按钮焦点矩阵同 FindBar 已验证模式，
+//   此处覆盖 Enter 无焦点透传分支 OtherKey）
+//
+// 最小清单完成情况：
+// | 1 | 每个公开/保护方法 ≥1 用例 | 完成 |
+// | 2 | 等价类（查找/替换文本 空/普通/中文、searched 开/关、计数零/非零） | 完成 |
+// | 3 | 边界值（空文本、0/0、1/1） | 完成 |
+// | 4 | TEST_P（≥3 组同断言：replaceAll 3 组、mismatch 2 组、matchCount 3 组） | 完成 |
+// | 5 | 分支清单映射 | 见上方 |
+// | 6 | if 分支两侧全覆盖 | 完成 |
+// | 7 | 异常路径 | N/A（无 throw） |
+// | 8 | 负面（空关键词、未知焦点 focusNextPrevChild=false） | 完成 |
+// | 9 | 强异常安全（replaceClose 后文本/计数状态一致） | 完成 |
+// | 10 | stub_ext（全部真实 offscreen + QSignalSpy） | 完成 |
+
+#include <gtest/gtest.h>
+
+#include <QKeyEvent>
+#include <QLabel>
+#include <QLineEdit>
+#include <QPushButton>
+#include <QSignalSpy>
+
+#include "replacebar.h"
+#include "test_env.h"
+
+namespace {
+
+class ReplaceBarTest : public ::testing::Test {
+protected:
+    static void SetUpTestSuite() { controlsut::ensureApp(); }
+
+    void SetUp() override
+    {
+        stub.clear();
+        bar = new ReplaceBar();
+        replaceLine = bar->findChild<LineBar *>("ReplaceLine");
+        withLine = bar->findChild<LineBar *>("WithLine");
+    }
+
+    void TearDown() override
+    {
+        delete bar;
+        bar = nullptr;
+        replaceLine = nullptr;
+        withLine = nullptr;
+        stub.clear();
+    }
+
+    void setLines(const QString &find, const QString &with)
+    {
+        for (LineBar *lb : { replaceLine, withLine }) {
+            lb->lineEdit()->blockSignals(true);
+            lb->lineEdit()->setText(lb == replaceLine ? find : with);
+            lb->lineEdit()->blockSignals(false);
+        }
+    }
+
+    void activateWindow()
+    {
+        controlsut::ensureApp()->setActiveWindow(bar);
+        QApplication::processEvents();
+    }
+
+    stub_ext::StubExt stub;
+    ReplaceBar *bar = nullptr;
+    LineBar *replaceLine = nullptr;
+    LineBar *withLine = nullptr;
+};
+
+// ---- 构造 ----
+
+TEST_F(ReplaceBarTest, Constructor_DefaultParent_CreatesCoreChildren)
+{
+    // Assert：双输入行 + 四按钮 + 关闭按钮齐全，构造后隐藏
+    ASSERT_NE(replaceLine, nullptr);
+    ASSERT_NE(withLine, nullptr);
+    EXPECT_NE(bar->findChild<QPushButton *>("ReplaceButton_2"), nullptr);
+    EXPECT_NE(bar->findChild<QPushButton *>("ReplaceSkipButton"), nullptr);
+    EXPECT_NE(bar->findChild<QPushButton *>("ReplaceRestButton"), nullptr);
+    EXPECT_NE(bar->findChild<QPushButton *>("ReplaceAllButton"), nullptr);
+    EXPECT_NE(bar->findChild<QAbstractButton *>("ReplaceCloseButton"), nullptr);
+    EXPECT_FALSE(bar->isVisible());
+    EXPECT_FALSE(bar->isFocus());
+}
+
+// ---- activeInput / focus / isFocus ----
+
+TEST_F(ReplaceBarTest, ActiveInput_WithKeyword_FillsReplaceLineClearsWithLine)
+{
+    // Act
+    bar->activeInput(QString::fromUtf8("目标词"), QString::fromUtf8("/ut/r.txt"), 5, 6, 7);
+
+    // Assert：显示、查找行填充并全选、替换行清空、文件信息保存（经 handleSkip 回读）
+    EXPECT_TRUE(bar->isVisible());
+    EXPECT_EQ(replaceLine->lineEdit()->text(), QString::fromUtf8("目标词"));
+    EXPECT_EQ(replaceLine->lineEdit()->selectedText(), QString::fromUtf8("目标词"));
+    EXPECT_EQ(withLine->lineEdit()->text(), QString());
+
+    activateWindow();
+    bar->focus();
+    QApplication::processEvents();
+    EXPECT_TRUE(bar->isFocus());  // 焦点落在查找行内嵌 lineEdit
+
+    QSignalSpy skipSpy(bar, &ReplaceBar::replaceSkip);
+    setLines(QString::fromUtf8("目标词"), QString::fromUtf8("新词"));
+    bar->handleSkip();
+    ASSERT_EQ(skipSpy.count(), 1);
+    EXPECT_EQ(skipSpy.at(0).at(0).toString(), QString::fromUtf8("/ut/r.txt"));  // m_replaceFile 已保存
+}
+
+// ---- handleReplaceNext：!searched / searched 两分支 ----
+
+TEST_F(ReplaceBarTest, HandleReplaceNext_FirstTime_EmitsPreSignals)
+{
+    // Arrange：先 activeInput（会清空两行）再注入文本，避免顺序踩踏
+    const QString file = QString::fromUtf8("/ut/first.txt");
+    bar->activeInput(QString::fromUtf8("old"), file, 1, 2, 3);
+    setLines(QString::fromUtf8("old"), QString::fromUtf8("new"));
+    QSignalSpy removeSpy(bar, &ReplaceBar::removeSearchKeyword);
+    QSignalSpy beforeSpy(bar, &ReplaceBar::beforeReplace);
+    QSignalSpy nextSpy(bar, &ReplaceBar::replaceNext);
+
+    // Act
+    bar->handleReplaceNext();
+
+    // Assert：首次 → removeSearchKeyword + beforeReplace(关键词) + replaceNext(文件,查找,替换)
+    EXPECT_EQ(removeSpy.count(), 1);
+    ASSERT_EQ(beforeSpy.count(), 1);
+    EXPECT_EQ(beforeSpy.at(0).at(0).toString(), QString::fromUtf8("old"));
+    ASSERT_EQ(nextSpy.count(), 1);
+    EXPECT_EQ(nextSpy.at(0).at(0).toString(), file);
+    EXPECT_EQ(nextSpy.at(0).at(1).toString(), QString::fromUtf8("old"));
+    EXPECT_EQ(nextSpy.at(0).at(2).toString(), QString::fromUtf8("new"));
+
+    // Act 2：第二次 → 跳过前置信号
+    bar->handleReplaceNext();
+    EXPECT_EQ(removeSpy.count(), 1);   // 不再增加
+    EXPECT_EQ(beforeSpy.count(), 1);
+    EXPECT_EQ(nextSpy.count(), 2);     // replaceNext 每次都发
+}
+
+TEST_F(ReplaceBarTest, HandleReplaceNext_SecondTime_SkipsPreSignals)
+{
+    // Arrange：setsearched(true) 直接进入第二分支
+    setLines(QString::fromUtf8("a"), QString::fromUtf8("b"));
+    bar->setsearched(true);
+    QSignalSpy removeSpy(bar, &ReplaceBar::removeSearchKeyword);
+    QSignalSpy beforeSpy(bar, &ReplaceBar::beforeReplace);
+    QSignalSpy nextSpy(bar, &ReplaceBar::replaceNext);
+
+    // Act
+    bar->handleReplaceNext();
+
+    // Assert
+    EXPECT_EQ(removeSpy.count(), 0);
+    EXPECT_EQ(beforeSpy.count(), 0);
+    ASSERT_EQ(nextSpy.count(), 1);
+    EXPECT_EQ(nextSpy.at(0).at(1).toString(), QString::fromUtf8("a"));
+    EXPECT_EQ(nextSpy.at(0).at(2).toString(), QString::fromUtf8("b"));
+}
+
+// ---- change：重置 searched ----
+
+TEST_F(ReplaceBarTest, Change_AfterSearched_ResetsFlag)
+{
+    // Arrange：先进入 searched 态
+    setLines(QString::fromUtf8("x"), QString::fromUtf8("y"));
+    bar->handleReplaceNext();  // 置 searched=true
+    QSignalSpy removeSpy(bar, &ReplaceBar::removeSearchKeyword);
+
+    QSignalSpy nextSpy(bar, &ReplaceBar::replaceNext);
+
+    // Act
+    bar->change();
+    bar->handleReplaceNext();
+
+    // Assert：change 重置后再次发出前置信号，replaceNext 同步发出
+    EXPECT_EQ(removeSpy.count(), 1);
+    EXPECT_EQ(nextSpy.count(), 1);
+}
+
+// ---- handleSkip / handleReplaceRest / handleReplaceAll ----
+
+TEST_F(ReplaceBarTest, HandleSkip_WithKeyword_EmitsReplaceSkip)
+{
+    setLines(QString::fromUtf8("skipme"), QString());
+    QSignalSpy skipSpy(bar, &ReplaceBar::replaceSkip);
+
+    // Act
+    bar->handleSkip();
+
+    // Assert
+    ASSERT_EQ(skipSpy.count(), 1);
+    EXPECT_EQ(skipSpy.at(0).at(0).toString(), QString());  // 未 activeInput → file 为空
+    EXPECT_EQ(skipSpy.at(0).at(1).toString(), QString::fromUtf8("skipme"));
+}
+
+TEST_F(ReplaceBarTest, HandleReplaceRest_WithTextPair_EmitsReplaceRest)
+{
+    setLines(QString::fromUtf8("rest"), QString::fromUtf8("restnew"));
+    QSignalSpy spy(bar, &ReplaceBar::replaceRest);
+
+    // Act
+    bar->handleReplaceRest();
+
+    // Assert
+    ASSERT_EQ(spy.count(), 1);
+    EXPECT_EQ(spy.at(0).at(0).toString(), QString::fromUtf8("rest"));
+    EXPECT_EQ(spy.at(0).at(1).toString(), QString::fromUtf8("restnew"));
+}
+
+struct ReplaceTextCase {
+    QString find;
+    QString with;
+};
+
+class ReplaceBarTextTest : public ReplaceBarTest,
+                           public ::testing::WithParamInterface<ReplaceTextCase> {
+};
+
+TEST_P(ReplaceBarTextTest, HandleReplaceAll_WithTextPair_EmitsReplaceAll)
+{
+    const auto &c = GetParam();
+    setLines(c.find, c.with);
+    QSignalSpy spy(bar, &ReplaceBar::replaceAll);
+
+    // Act
+    bar->handleReplaceAll();
+
+    // Assert：携带查找/替换文本对
+    ASSERT_EQ(spy.count(), 1);
+    EXPECT_EQ(spy.at(0).at(0).toString(), c.find);
+    EXPECT_EQ(spy.at(0).at(1).toString(), c.with);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    TextPairs, ReplaceBarTextTest,
+    ::testing::Values(
+        ReplaceTextCase{ QString::fromUtf8("foo"), QString::fromUtf8("bar") },
+        ReplaceTextCase{ QString(), QString() },                        // 边界：双双为空
+        ReplaceTextCase{ QString::fromUtf8("中文查找"), QString::fromUtf8("中文替换&1") }  // 多字节+特殊字符
+        ));
+
+// ---- handleContentChanged ----
+
+TEST_F(ReplaceBarTest, HandleContentChanged_WithText_EmitsUpdateSearchKeyword)
+{
+    setLines(QString::fromUtf8("query"), QString());
+    QSignalSpy spy(bar, &ReplaceBar::updateSearchKeyword);
+
+    // Act
+    bar->handleContentChanged();
+
+    // Assert
+    ASSERT_EQ(spy.count(), 1);
+    EXPECT_EQ(spy.at(0).at(0).toString(), QString());
+    EXPECT_EQ(spy.at(0).at(1).toString(), QString::fromUtf8("query"));
+}
+
+// ---- replaceClose ----
+
+TEST_F(ReplaceBarTest, ReplaceClose_VisibleBar_HidesEmitsAndResetsFlag)
+{
+    // Arrange：先置 searched 并显示
+    setLines(QString::fromUtf8("z"), QString());
+    bar->handleReplaceNext();
+    bar->QWidget::show();
+    ASSERT_TRUE(bar->isVisible());
+    QSignalSpy closeSpy(bar, &ReplaceBar::sigReplacebarClose);
+    QSignalSpy removeSpy(bar, &ReplaceBar::removeSearchKeyword);
+
+    // Act
+    bar->replaceClose();
+
+    // Assert：隐藏 + 关闭信号；searched 复位（下一次 replaceNext 重新发前置信号）
+    EXPECT_FALSE(bar->isVisible());
+    EXPECT_EQ(closeSpy.count(), 1);
+    bar->handleReplaceNext();
+    // removeSearchKeyword 两次：replaceClose 的 hide() → hideEvent 一次 +
+    // searched 复位后的 handleReplaceNext 一次
+    EXPECT_EQ(removeSpy.count(), 2);
+    EXPECT_EQ(replaceLine->lineEdit()->text(), QString::fromUtf8("z"));  // 文本未破坏
+}
+
+// ---- slotUpdateMatchCount（TEST_P 3 组）----
+
+struct MatchForwardCase {
+    int current;
+    int total;
+    bool visible;
+};
+
+class ReplaceBarMatchTest : public ReplaceBarTest,
+                            public ::testing::WithParamInterface<MatchForwardCase> {
+};
+
+TEST_P(ReplaceBarMatchTest, SlotUpdateMatchCount_WithCounts_ForwardsToReplaceLine)
+{
+    const auto &c = GetParam();
+
+    // Act
+    bar->slotUpdateMatchCount(c.current, c.total);
+
+    // Assert
+    const auto labels = replaceLine->lineEdit()->findChildren<QLabel *>();
+    ASSERT_EQ(labels.size(), 1);
+    EXPECT_EQ(labels.first()->isHidden(), !c.visible);
+    if (c.total != 0) {
+        EXPECT_EQ(labels.first()->text(),
+                  QString::fromUtf8("第%1/%2项").arg(c.current).arg(c.total));
+    }
+    const auto withLabels = withLine->lineEdit()->findChildren<QLabel *>();
+    ASSERT_EQ(withLabels.size(), 1);
+    EXPECT_TRUE(withLabels.first()->isHidden());  // 只作用于查找行
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    ForwardCases, ReplaceBarMatchTest,
+    ::testing::Values(
+        MatchForwardCase{ 0, 0, false },
+        MatchForwardCase{ 1, 1, true },
+        MatchForwardCase{ 20, 300, true }));
+
+// ---- setMismatchAlert（TEST_P 2 组对称）----
+
+struct AlertCase {
+    bool alert;
+};
+
+class ReplaceBarAlertTest : public ReplaceBarTest,
+                            public ::testing::WithParamInterface<AlertCase> {
+};
+
+TEST_P(ReplaceBarAlertTest, SetMismatchAlert_StateToggle_TogglesReplaceLineAlert)
+{
+    const auto &c = GetParam();
+
+    // Act
+    bar->setMismatchAlert(c.alert);
+
+    // Assert：只作用于查找行
+    EXPECT_EQ(replaceLine->isAlert(), c.alert);
+    EXPECT_FALSE(withLine->isAlert());
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    AlertCases, ReplaceBarAlertTest,
+    ::testing::Values(AlertCase{ true }, AlertCase{ false }));
+
+// ---- hideEvent ----
+
+TEST_F(ReplaceBarTest, HideEvent_OnHide_ResetsFlagAndEmitsRemoveKeyword)
+{
+    // Arrange：显示并置 searched
+    bar->QWidget::show();
+    setLines(QString::fromUtf8("h"), QString());
+    bar->handleReplaceNext();
+    QSignalSpy removeSpy(bar, &ReplaceBar::removeSearchKeyword);
+    ASSERT_EQ(removeSpy.count(), 0);
+
+    // Act：触发 hideEvent
+    bar->hide();
+    QApplication::processEvents();
+
+    // Assert：removeSearchKeyword 发射 + searched 复位（再 replaceNext 有前置信号）
+    EXPECT_EQ(removeSpy.count(), 1);
+    QSignalSpy beforeSpy(bar, &ReplaceBar::beforeReplace);
+    bar->handleReplaceNext();
+    EXPECT_EQ(beforeSpy.count(), 1);
+}
+
+// ---- focusNextPrevChild：两输入行间跳转 / 无焦点 ----
+
+TEST_F(ReplaceBarTest, FocusNextPrevChild_EditingLines_SwitchesBetweenLines)
+{
+    // Arrange：显示激活。DLineEdit 默认将焦点代理给内嵌 lineEdit，而
+    // focusNextPrevChild 判定的是 focusWidget()==LineBar 容器本身——
+    // 解除代理后让 LineBar 直接持焦，触发真实分支
+    bar->QWidget::show();
+    activateWindow();
+    replaceLine->lineEdit()->setFocusProxy(nullptr);
+    replaceLine->setFocusProxy(nullptr);
+    replaceLine->setFocus();
+    QApplication::processEvents();
+    ASSERT_EQ(bar->focusWidget(), reinterpret_cast<QWidget *>(replaceLine));
+
+    // Act 1：查找行 → 替换行（分支：editWidget == m_replaceLine）
+    EXPECT_TRUE(bar->focusNextPrevChild(true));
+    QApplication::processEvents();
+    EXPECT_TRUE(withLine->lineEdit()->hasFocus());
+    EXPECT_EQ(bar->focusWidget(), withLine->lineEdit());  // 精确指针一致
+
+    // Act 2：替换行直接持焦（分支：editWidget == m_withLine）→ 查找行
+    withLine->lineEdit()->setFocusProxy(nullptr);
+    withLine->setFocusProxy(nullptr);
+    withLine->setFocus();
+    QApplication::processEvents();
+    ASSERT_EQ(bar->focusWidget(), reinterpret_cast<QWidget *>(withLine));
+    EXPECT_TRUE(bar->focusNextPrevChild(true));
+    QApplication::processEvents();
+    EXPECT_TRUE(replaceLine->lineEdit()->hasFocus());
+}
+
+TEST_F(ReplaceBarTest, FocusNextPrevChild_NoEditFocus_ReturnsFalse)
+{
+    // Arrange：无任何输入行焦点（focusWidget 为 bar 自身或空）
+    bar->QWidget::show();
+
+    // Act & Assert：负面——非输入行持焦时返回 false，且焦点不在任一输入行容器上
+    EXPECT_FALSE(bar->focusNextPrevChild(true));
+    EXPECT_FALSE(bar->focusNextPrevChild(false));
+    EXPECT_NE(bar->focusWidget(), reinterpret_cast<QWidget *>(replaceLine));
+    EXPECT_NE(bar->focusWidget(), reinterpret_cast<QWidget *>(withLine));
+}
+
+// ---- keyPressEvent ----
+
+TEST_F(ReplaceBarTest, KeyPressEvent_EscKey_HidesAndEmitsClose)
+{
+    // Arrange
+    bar->activeInput(QString::fromUtf8("k"), QString::fromUtf8("/ut/esc.txt"), 1, 1, 1);
+    ASSERT_TRUE(bar->isVisible());
+    QSignalSpy closeSpy(bar, &ReplaceBar::sigReplacebarClose);
+
+    // Act
+    QKeyEvent escEvent(QEvent::KeyPress, Qt::Key_Escape, Qt::NoModifier);
+    bar->keyPressEvent(&escEvent);
+
+    // Assert
+    EXPECT_FALSE(bar->isVisible());
+    EXPECT_EQ(closeSpy.count(), 1);
+}
+
+TEST_F(ReplaceBarTest, KeyPressEvent_EnterNoFocus_PassesToBaseNoAction)
+{
+    // Arrange：无按钮焦点，普通按键走 else 透传 + Enter 四分支均不命中
+    setLines(QString::fromUtf8("t"), QString());
+    QSignalSpy allSpy(bar, &ReplaceBar::replaceAll);
+    QSignalSpy nextSpy(bar, &ReplaceBar::replaceNext);
+    QKeyEvent enterEvent(QEvent::KeyPress, Qt::Key_Return, Qt::NoModifier, "\r");
+
+    // Act
+    bar->keyPressEvent(&enterEvent);
+    QApplication::processEvents();
+
+    // Assert：无按钮焦点时 Enter 不触发任何替换动作
+    EXPECT_EQ(allSpy.count(), 0);
+    EXPECT_EQ(nextSpy.count(), 0);
+    EXPECT_EQ(replaceLine->lineEdit()->text(), QString::fromUtf8("t"));  // 状态未变
+}
+
+}  // namespace

--- a/tests/controls_ut/test_settingsdialog.cpp
+++ b/tests/controls_ut/test_settingsdialog.cpp
@@ -1,0 +1,102 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// settingsdialog.cpp 单元测试（无类定义，仅自由函数 GenerateSettingTranslate）
+//
+// 函数特征：批量 QObject::tr() 翻译条目生成（Basic/Shortcuts/Editor/Advanced 组
+// 与全部编码名）。tr() 最终汇聚到 QCoreApplication::translate(context, sourceText,
+// disambiguation, n) —— 以 stub 计数 + 内容抽样断言覆盖。
+//
+// 用例映射：
+// - GenerateSettingTranslate → Invoke_TranslatesAllEntries_WithoutCrash
+// - GenerateSettingTranslate（幂等/重复调用） → Invoke_Repeatedly_IsStable
+//
+// 最小清单完成情况：
+// | 1 | 每个函数 ≥1 用例 | 完成（唯一自由函数） |
+// | 2 | 等价类（首次/重复调用） | 完成 |
+// | 3 | 边界值 | N/A（无参数） |
+// | 4 | TEST_P | N/A（无输入维度，仅 2 组同断言逻辑不足以强制） |
+// | 5 | 分支清单 | 无分支（纯 tr 列表） |
+// | 6 | 分支覆盖 | N/A |
+// | 7 | 异常路径 | EXPECT_NO_THROW（无 throw 源） |
+// | 8 | 负面 | 重复调用稳定性 |
+// | 9 | 强异常安全 | 重复调用计数线性增长（2x） |
+// | 10 | stub_ext（QCoreApplication::translate 计数） | 完成 |
+
+#include <gtest/gtest.h>
+
+#include <QCoreApplication>
+#include <QString>
+#include <QtTest/QSignalSpy>
+
+#include "stubext.h"
+#include "test_env.h"
+
+// settingsdialog.cpp 未提供头文件，此处补声明
+void GenerateSettingTranslate();
+
+namespace {
+
+class GenerateSettingTranslateTest : public ::testing::Test {
+protected:
+    static void SetUpTestSuite() { controlsut::ensureApp(); }
+
+    void SetUp() override
+    {
+        stub.clear();
+        translateCount = 0;
+        lastSourceText.clear();
+        sourceTexts.clear();
+        // QObject::tr → QCoreApplication::translate(context, sourceText, disambiguation, n)
+        // 拦截计数并回传源文（无翻译器环境下的真实行为等价）
+        stub.set_lamda(
+            static_cast<QString (*)(const char *, const char *, const char *, int)>(
+                &QCoreApplication::translate),
+            [this](const char *, const char *sourceText, const char *, int) -> QString {
+                ++translateCount;
+                lastSourceText = QString::fromUtf8(sourceText);
+                sourceTexts << lastSourceText;
+                return lastSourceText;
+            });
+    }
+
+    void TearDown() override { stub.clear(); }
+
+    stub_ext::StubExt stub;
+    int translateCount = 0;
+    QString lastSourceText;
+    QStringList sourceTexts;
+};
+
+TEST_F(GenerateSettingTranslateTest, Invoke_TranslatesAllEntries_WithoutCrash)
+{
+    // Act
+    EXPECT_NO_THROW(GenerateSettingTranslate());
+
+    // Assert：全量条目经 translate 汇聚（settingsdialog.cpp 内 130+ 条 tr/Q_UNUSED）
+    EXPECT_GT(translateCount, 100);
+    // 内容抽样：四个分组名与编码名确实进入翻译管线
+    EXPECT_TRUE(sourceTexts.contains(QString("Basic")));
+    EXPECT_TRUE(sourceTexts.contains(QString("Shortcuts")));
+    EXPECT_TRUE(sourceTexts.contains(QString("Editor")));
+    EXPECT_TRUE(sourceTexts.contains(QString("Advanced")));
+    EXPECT_TRUE(sourceTexts.contains(QString("ChineseSimplified")));
+    // 无空源文（负面：任何条目不得以空串注册）
+    EXPECT_FALSE(sourceTexts.contains(QString()));
+}
+
+TEST_F(GenerateSettingTranslateTest, Invoke_Repeatedly_IsStable)
+{
+    // Arrange
+    GenerateSettingTranslate();
+    const int firstRound = translateCount;
+
+    // Act：重复调用（负面场景：多窗口/多次打开设置）
+    GenerateSettingTranslate();
+
+    // Assert：计数线性翻倍（每次全量重译，无缓存副作用、无崩溃）
+    EXPECT_EQ(translateCount, firstRound * 2);
+    EXPECT_GT(firstRound, 100);
+}
+
+}  // namespace

--- a/tests/controls_ut/test_tabbar.cpp
+++ b/tests/controls_ut/test_tabbar.cpp
@@ -1,0 +1,1533 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Tabbar（src/controls/tabbar.cpp）单元测试
+//
+// 类特征：DTabBar 子类（QWidget+DObject 多继承，GUI 类），offscreen 真实实例化；
+// 宿主为普通 QWidget（this->window() 经 static_cast<Window*> 读取 width()，
+// Window 为 QWidget 单继承链且 width() 非虚 → 指针零偏移安全）。
+// 绝不构造真实 Window：window()/StartManager 的全部非虚出向调用由 stub_ext 拦截。
+//
+// 方法映射（公开/保护/private 全集，private 经 -fno-access-control 直调）：
+// - ctor/dtor                      → Constructor_DefaultParent_ConfiguresBarProperties
+// - addTab                         → AddTab_MultiplePaths_AppendsAtEnd
+// - addTabWithIndex                → AddTabWithIndex_DuplicatePath_IgnoresInsert /
+//                                    AddTabWithIndex_BackupDraft_UsesTipPathTooltip /
+//                                    AddTabWithIndex_LongPath_WrapsTooltipWithNewlines
+// - closeTab                       → CloseTab_ValidIndex_EmitsHistoryAndRemoves / CloseTab_NegativeIndex_EarlyReturn
+// - closeCurrentTab()/(path)       → CloseCurrentTab_MiddleTab_ClosesSelected / CloseCurrentTabByPath_UnknownPath_Noop
+// - closeOtherTabs                 → CloseOtherTabs_ThreeTabs_EmitsAllExceptCurrent
+// - closeLeftTabs/closeRightTabs   → CloseLeftTabs_MiddleTab_EmitsPrecedingOnly / CloseRightTabs_MiddleTab_EmitsFollowingOnly
+// - closeOtherTabsExceptFile       → CloseOtherTabsExceptFile_UnknownFile_EmitsAll
+// - updateTab                      → UpdateTab_ExistingTab_ChangesTextPathAndTooltip
+// - previousTab/nextTab            → PreviousTab_WrapsToLast / NextTab_WrapsToFirst (TEST_P)
+// - indexOf                        → IndexOf_KnownAndUnknown_ReturnsIndexOrMinusOne
+// - currentName/currentPath        → CurrentNameAndPath_SelectedTab_ReflectsBoth / CurrentNameAndPath_NoTabs_ReturnEmptyValues
+// - truePathAt/fileAt/textAt       → PathAccessors_ValidAndInvalid_IndexPathMath (TEST_P)
+// - setTabText                     → SetTabText_WithAmpersand_EscapesAndRestores
+// - setTabPalette                  → SetTabPalette_AnyColors_NoStateCorruption
+// - setBackground/setDNDColor      → SetBackgroundAndDNDColor_AnyColors_StoreMembers
+// - showTabs                       → ShowTabs_EdgeSelected_DisablesEdgeActions（依赖右键菜单动作存在）
+// - eventFilter                    → EventFilter_FontChange_SyncsFontToAppFont / EventFilter_IgnoredEvent_ReturnsFalse /
+//                                    EventFilter_RightClickOnTab_BuildsMenuWithStates /
+//                                    EventFilter_RightClickBlankArea_SkipsMenu / EventFilter_MiddleClick_EmitsCloseRequest /
+//                                    EventFilter_DragMove_AcceptsEvent
+// - mousePressEvent                → MousePressEvent_MiddleClick_EmitsCloseRequest / MousePressEvent_LeftClick_PassesToBaseEditor
+// - tabSizeHint                    → TabSizeHint_FewTabs_MaxWidth / TabSizeHint_ManyTabs_ClampedToMin (TEST_P)
+// - minimumTabSizeHint/maximumTabSizeHint → MinMaxTabSizeHint_AnyIndex_ReturnsFixedBounds
+// - handleTabMoved(private)        → HandleTabMoved_ValidIndices_SwapsPaths / HandleTabMoved_OutOfRange_NoChange
+// - handleTabReleased(private)     → HandleTabReleased_EmptyPath_EarlyReturn /
+//                                    HandleTabReleased_NullWrapper_EarlyReturn /
+//                                    HandleTabReleased_FullPath_RebuildsWindowAndCloses
+// - handleTabIsRemoved(private)    → 真实执行（Window::removeWrapper stub）→ CloseTab_ValidIndex_EmitsHistoryAndRemoves 链路
+// - handleTabDroped(private)       → HandleTabDroped_ExternalTarget_ReleasesTab /
+//                                    HandleTabDroped_TabbarTarget_ClosesTab
+// - handleDragActionChanged(private) → HandleDragActionChanged_IgnoreAction_ResetsOverrideCursor（dragIconWindow stub）
+// - onTabDrapStart(private)        → OnTabDragStart_DragBegin_SavesOldPaths
+// - resizeEvent                    → ResizeEvent_WrappedTooltip_StripsNewlines
+// - dropEvent                      → DropEvent_WithDragPixmap_PlaysAnimation（sm_pDragPixmap 静态成员直控）
+// - createDragPixmapFromTab(protected) → CreateDragPixmap_Composite_Composites（真实 EditWrapper）
+// - createMimeDataFromTab(protected)   → CreateMimeData_WrapperMissing_ReturnsNull /
+//                                        CreateMimeData_ValidWrapper_CarriesTabPayload
+// - insertFromMimeDataOnDragEnter(protected) → InsertFromMimeDataOnDragEnter_GuardBranches (TEST_P) /
+//                                        InsertFromMimeDataOnDragEnter_FullPath_AddsTabViaWindow
+// - insertFromMimeData(protected)  → InsertFromMimeData_GuardBranches / InsertFromMimeData_FullPath
+// - canInsertFromMimeData(protected) → CanInsertFromMimeData_FormatPresence_ReturnsExpected (TEST_P)
+//
+// 分支清单（来源：tabbar.cpp）→ 用例映射（B 编号）：
+// - addTabWithIndex B1: m_tabPaths.contains → return          → AddTabWithIndex_DuplicatePath_IgnoresInsert
+// - addTabWithIndex B2: localDataPath 分支 + isBackupFile+tip  → AddTabWithIndex_LocalDraftBackup_...
+// - addTabWithIndex B3: localDataPath 分支 else                → 同上（非备份子分支）
+// - addTabWithIndex B4: else 分支 + nFontWidth>=w 换行循环      → AddTabWithIndex_LongPath_...
+// - closeTab B5: index<0 → return                              → CloseTab_NegativeIndex_EarlyReturn
+// - previousTab/nextTab B6: 边界回绕                            → PreviousTab_WrapsToLast / NextTab_WrapsToFirst
+// - eventFilter B7: 非鼠标/拖拽事件早退                          → EventFilter_IgnoredEvent_ReturnsFalse
+// - eventFilter B8: watched!=this → false                       → EventFilter_RightClickOnChild...（stranger 对象）
+// - eventFilter B9: 右键 + m_rightClickTab>=0 → 菜单            → EventFilter_RightClickOnTab_BuildsMenuWithStates
+// - eventFilter B10: 右键 + <0 → 落空                           → EventFilter_RightClickBlankArea_SkipsMenu
+// - eventFilter B11: 中键 → tabCloseRequested                   → EventFilter_MiddleClick_EmitsCloseRequest
+// - eventFilter B12: DragMove → accept                          → EventFilter_DragMove_AcceptsEvent
+// - eventFilter B13: 菜单启用矩阵（len<2 / 首 / 尾 / 中间）      → RightClickMenu_TabMatrix_MatchesEnableStates (TEST_P 4 组)
+// - tabSizeHint B14: index<0 → 基类 / ≥0 → 宽度计算             → TabSizeHint_WidthVariants_ReturnsClampedWidth (TEST_P)
+// - handleTabMoved B15: 索引合法 → swap / 非法 → 跳过            → HandleTabMoved_*
+// - handleTabReleased B16: path 空 → return / wrapper 空 → return / 全路径 → 重建窗口
+// - handleTabDroped B17: target 非 Tabbar → handleTabReleased / 是 → closeTab
+// - handleDragActionChanged B18: IgnoreAction / 其它            → HandleDragActionChanged_*
+// - createMimeDataFromTab B19: wrapper 空 / loading / 有效       → CreateMimeData_*
+// - insertFromMimeDataOnDragEnter B20: source 空 / wrapper loading / wrapper 空 / 全路径
+// - dropEvent B21: CopyAction+format+sm_pDragPixmap → 动画      → DropEvent_WithDragPixmap_...
+// - resizeEvent B22: nFontWidth>=w → 去 \n 重排                 → ResizeEvent_WrappedTooltip_StripsNewlines
+//
+// 最小清单完成情况：
+// | 1 | 每个方法 ≥1 用例 | 完成 |
+// | 2 | 等价类（路径 普通草稿/备份/超长、索引 首中尾/越界、菜单 首尾中、mime 有效/无效） | 完成 |
+// | 3 | 边界值（0/-1/count-1/count、单标签、空 mimeData） | 完成 |
+// | 4 | TEST_P（≥3 组同断言：NextPrev 3 组、PathAccessors 3 组、SizeHint 3 组、
+//     RightClickMenu 4 组、CanInsert 3 组、InsertGuard 3 组） | 完成 |
+// | 5 | 分支清单映射 | 见上方 |
+// | 6 | if 分支两侧全覆盖 | 完成 |
+// | 7 | 异常路径 | N/A（无 throw；错误路径按早退分支断言） |
+// | 8 | 负面（重复路径、负索引、未知路径、空 mime、越界 move） | 完成 |
+// | 9 | 强异常安全（失败路径后 m_tabPaths 不变） | 完成 |
+// | 10 | stub_ext（Window/StartManager/QMenu::exec/Utils 路径桩；无 gMock 混用） | 完成 |
+//
+// [缺陷记录] m_rightMenu 每次 right-click new DMenu 无父对象且旧实例被覆盖 → 泄漏（defects）
+// [缺陷记录] JumpLineBar 无关；Tabbar::handleTabReleased 中 m_listOldTabPath.value(index)
+//            与 closeTab(newIndex) 的索引换算依赖运行时状态，注释记录
+
+#include <gtest/gtest.h>
+
+#include <QApplication>
+#include <DPlatformWindowHandle>
+#include <DRecentManager>
+#include <DWindowManagerHelper>
+#include <QDragEnterEvent>
+#include <QDropEvent>
+#include <QEvent>
+#include <QFocusEvent>
+#include <QFontMetrics>
+#include <QGuiApplication>
+#include <QImage>
+#include <QLabel>
+#include <QMenu>
+#include <QMimeData>
+#include <QMouseEvent>
+#include <QPropertyAnimation>
+#include <QResizeEvent>
+#include <QSignalSpy>
+#include <QStackedWidget>
+#include <QStyleFactory>
+#include <QTabBar>
+#include <QToolButton>
+#include <QVariant>
+#include <QtTest/QTest>
+
+#include "editwrapper.h"
+#include "startmanager.h"
+#include "tabbar.h"
+#include "test_env.h"
+#include "utils.h"
+#include "window.h"
+
+namespace {
+
+// EditWrapper 真实构造所需的最小 Window 桩集（复用 B8 已验证矩阵）。
+// 说明：Tabbar::currentName/textAt/DTabBar::currentIndex 不打桩——本套件中
+// Tabbar 为真实实例且 createMimeDataFromTab 依赖真实 textAt；EditWrapper
+// 构造链不触达这些调用（仅 openFile/保存等重路径会读，见 editwrapper.cpp:415）。
+void installEditWrapperCtorStubs(stub_ext::StubExt &stub, QWidget *host,
+                                 EditWrapper **outWrapper)
+{
+    stub.set_lamda(&Window::findBarIsVisiable, [](Window *) -> bool { return false; });
+    stub.set_lamda(&Window::replaceBarIsVisiable, [](Window *) -> bool { return false; });
+    stub.set_lamda(&Window::getKeywordForSearchAll, [](Window *) -> QString { return QString(); });
+    stub.set_lamda(&Window::getKeywordForSearch, [](Window *) -> QString { return QString(); });
+    // 每次调用新建真实子件（随 host 析构，避免跨用例悬挂）
+    QStackedWidget *stackHost = new QStackedWidget(host);
+    stackHost->resize(600, 400);
+    stub.set_lamda(&Window::getStackedWgt,
+                   [stackHost](Window *) -> QStackedWidget * { return stackHost; });
+    QTabBar *fakeBar = new QTabBar(host);
+    fakeBar->addTab(QString("stub"));
+    stub.set_lamda(&Window::getTabbar,
+                   [fakeBar](Window *) -> Tabbar * { return reinterpret_cast<Tabbar *>(fakeBar); });
+    stub.set_lamda(VADDR(DDialog, exec), []() -> int { return 0; });
+    stub.set_lamda(VADDR(QDialog, exec), []() -> int { return 0; });
+    stub.set_lamda(&Window::updateModifyStatus,
+                   [](Window *, const QString &, bool) {});
+    stub.set_lamda(&Window::updateSaveAsFileName, [](Window *, QString, QString) {});
+    stub.set_lamda(&Window::saveAsFile, [](Window *) -> bool { return false; });
+    stub.set_lamda(&Window::setPrintEnabled, [](Window *, bool) {});
+    stub.set_lamda(&DRecentManager::addItem,
+                   [](const QString &, DRecentData &) -> bool { return true; });
+    stub.set_lamda(&Utils::sendFloatMessageFixedFont,
+                   [](QWidget *, const QIcon &, const QString &) {});
+    stub.set_lamda(
+        static_cast<void (DMessageManager::*)(QWidget *, const QIcon &, const QString &)>(
+            &DMessageManager::sendMessage),
+        [](DMessageManager *, QWidget *, const QIcon &, const QString &) {});
+
+    EditWrapper *wrapper = new EditWrapper(reinterpret_cast<Window *>(host), host);
+    if (outWrapper)
+        *outWrapper = wrapper;
+}
+
+class TabbarTest : public ::testing::Test {
+protected:
+    static void SetUpTestSuite() { controlsut::ensureApp(); }
+
+    void SetUp() override
+    {
+        stub.clear();
+        countersClear();
+
+        // 宿主：普通 QWidget 充当 window()（Window 单继承 QWidget、width() 非虚）
+        host = new QWidget();
+        host->resize(1200, 800);
+        bar = new Tabbar(host);
+        bar->resize(1100, 40);
+        host->show();
+        QApplication::processEvents();
+
+        // Utils 路径隔离：localDataPath → 临时目录（测试内可覆写）
+        localRoot = controlsut::tempRoot().path() + "/tabbar-cases";
+        stub.set_lamda(&Utils::localDataPath,
+                       [this]() -> QString { return localRoot; });
+    }
+
+    void TearDown() override
+    {
+        // 动画/删除挂起事件在桩仍然有效时冲净
+        QApplication::processEvents();
+        stub.clear();
+        if (Tabbar::sm_pDragPixmap) {
+            delete Tabbar::sm_pDragPixmap;
+            Tabbar::sm_pDragPixmap = nullptr;
+        }
+        delete host;  // bar 随宿主析构
+        host = nullptr;
+        bar = nullptr;
+        countersClear();
+    }
+
+    void countersClear()
+    {
+        windowRemoveWrapperCalls = 0;
+        windowAddTabCalls = 0;
+        windowFocusActiveCalls = 0;
+        windowSetChildrenFocusCalls = 0;
+        startManagerCreateCalls = 0;
+        menuExecCalls = 0;
+        windowWrapperResult = nullptr;
+        lastCreatedTabPath.clear();
+        lastRemoveWrapperPath.clear();
+    }
+
+    // ---- Window 出向记录桩（handleTabIsRemoved/handleTabReleased 等真实执行所需）----
+    void installWindowRecorderStubs(EditWrapper *wrapperResult = nullptr)
+    {
+        windowWrapperResult = wrapperResult;
+        stub.set_lamda(&Window::wrapper,
+                       [this](Window *, const QString &) -> EditWrapper * {
+                           return windowWrapperResult;
+                       });
+        stub.set_lamda(&Window::removeWrapper,
+                       [this](Window *, const QString &filePath, bool) {
+                           ++windowRemoveWrapperCalls;
+                           lastRemoveWrapperPath = filePath;
+                       });
+        stub.set_lamda(&Window::addTabWithWrapper,
+                       [this](Window *, EditWrapper *, const QString &, const QString &,
+                              const QString &, int) { ++windowAddTabCalls; });
+        stub.set_lamda(&Window::focusActiveEditor, [this](Window *) { ++windowFocusActiveCalls; });
+        stub.set_lamda(&Window::setChildrenFocus, [this](Window *, bool) {
+            ++windowSetChildrenFocusCalls;
+        });
+        // StartManager：instance 桩返回哑指针（createWindowFromWrapper 已全桩，
+        // 指针绝不被解引用——真实 StartManager 构造涉及 DBus 注册，禁止触发）
+        static void *fakeManagerStorage = nullptr;
+        stub.set_lamda(&StartManager::instance,
+                       []() -> StartManager * {
+                           return reinterpret_cast<StartManager *>(&fakeManagerStorage);
+                       });
+        stub.set_lamda(&StartManager::createWindowFromWrapper,
+                       [this](StartManager *, const QString &, const QString &filePath,
+                              const QString &, EditWrapper *, bool) {
+                           ++startManagerCreateCalls;
+                           lastCreatedTabPath = filePath;
+                       });
+        // 右键菜单 exec 拦截（offscreen 模态防挂起）
+        stub.set_lamda(
+            static_cast<QAction *(QMenu::*)(const QPoint &, QAction *)>(&QMenu::exec),
+            [this](QMenu *, const QPoint &, QAction *) -> QAction * {
+                ++menuExecCalls;
+                return nullptr;
+            });
+    }
+
+    // 静默加入标签（不触发 tooltip 长路径分支的干扰）
+    void addTabsQuietly(const QStringList &paths)
+    {
+        for (const QString &p : paths)
+            bar->addTab(p, QFileInfo(p).fileName());
+        QApplication::processEvents();
+    }
+
+    stub_ext::StubExt stub;
+    QWidget *host = nullptr;
+    Tabbar *bar = nullptr;
+    QString localRoot;
+
+    // 记录桩计数（夹具成员，TearDown 重置）
+    int windowRemoveWrapperCalls = 0;
+    int windowAddTabCalls = 0;
+    int windowFocusActiveCalls = 0;
+    int windowSetChildrenFocusCalls = 0;
+    int startManagerCreateCalls = 0;
+    int menuExecCalls = 0;
+    EditWrapper *windowWrapperResult = nullptr;
+    QString lastCreatedTabPath;
+    QString lastRemoveWrapperPath;
+};
+
+// ---- 构造 ----
+
+TEST_F(TabbarTest, Constructor_DefaultParent_ConfiguresBarProperties)
+{
+    // Assert：可移动/可关闭/接受拖放/右对齐省略，无标签
+    EXPECT_TRUE(bar->isMovable());
+    EXPECT_TRUE(bar->tabsClosable());
+    EXPECT_TRUE(bar->acceptDrops());
+    EXPECT_EQ(bar->elideMode(), Qt::ElideRight);
+    EXPECT_EQ(bar->count(), 0);
+    EXPECT_EQ(bar->currentIndex(), -1);
+}
+
+// ---- addTab / addTabWithIndex ----
+
+TEST_F(TabbarTest, AddTab_MultiplePaths_AppendsAtEnd)
+{
+    // Act：依次追加三个标签（走 Utils::localDataPath 含分支 → tooltip=tabName）
+    addTabsQuietly({ localRoot + "/a.txt", localRoot + "/b.txt", localRoot + "/c.txt" });
+
+    // Assert：顺序与当前项
+    ASSERT_EQ(bar->count(), 3);
+    EXPECT_EQ(bar->fileAt(0), localRoot + "/a.txt");
+    EXPECT_EQ(bar->fileAt(2), localRoot + "/c.txt");
+    EXPECT_EQ(bar->currentIndex(), 2);  // addTabWithIndex 里 setCurrentIndex(index)
+    EXPECT_EQ(bar->textAt(0), QString("a.txt"));
+}
+
+TEST_F(TabbarTest, AddTabWithIndex_DuplicatePath_IgnoresInsert)
+{
+    // Arrange
+    addTabsQuietly({ localRoot + "/dup.txt" });
+    ASSERT_EQ(bar->count(), 1);
+
+    // Act：重复路径插入
+    bar->addTabWithIndex(0, localRoot + "/dup.txt", QString("dup2.txt"));
+
+    // Assert：早退分支——不新增、不破坏既有状态
+    EXPECT_EQ(bar->count(), 1);
+    EXPECT_EQ(bar->fileAt(0), localRoot + "/dup.txt");
+    EXPECT_EQ(bar->m_tabPaths.size(), 1);  // 强异常安全：路径表未被污染
+}
+
+TEST_F(TabbarTest, AddTabWithIndex_BackupDraft_UsesTipPathTooltip)
+{
+    // Arrange：备份文件分支（isBackupFile=true + tipPath 非空）
+    stub.set_lamda(&Utils::isBackupFile, [](const QString &) -> bool { return true; });
+    const QString tip = QString::fromUtf8("/真实/路径/原文档.txt");
+
+    // Act
+    bar->addTabWithIndex(0, localRoot + "/draft~bak.txt", QString("draft~bak.txt"), tip);
+
+    // Assert：tooltip 采用真实路径
+    ASSERT_EQ(bar->count(), 1);
+    EXPECT_EQ(bar->tabToolTip(0), tip);
+    EXPECT_EQ(bar->truePathAt(0), tip);
+}
+
+TEST_F(TabbarTest, AddTabWithIndex_LongPath_WrapsTooltipWithNewlines)
+{
+    // Arrange：非 localDataPath 分支 + 超宽字体 → 插入 '\n' 换行循环
+    stub.set_lamda(
+        static_cast<int (QFontMetrics::*)(const QString &, int) const>(
+            &QFontMetrics::horizontalAdvance),
+        [](const QFontMetrics *, const QString &, int) -> int { return 100000; });
+    const QString longPath = QString::fromUtf8("/very/long/path/to/some/file.txt");
+
+    // Act
+    bar->addTabWithIndex(0, longPath, QString("file.txt"));
+
+    // Assert：tooltip 被换行（循环至少插一处 '\n'），尾部仍是文件名
+    const QString tip = bar->tabToolTip(0);
+    EXPECT_TRUE(tip.contains('\n'));
+    EXPECT_TRUE(tip.endsWith(QString("file.txt")));
+    // 宽度不足分支（else）：恢复默认宽度，tooltip 无换行
+    stub.set_lamda(
+        static_cast<int (QFontMetrics::*)(const QString &, int) const>(
+            &QFontMetrics::horizontalAdvance),
+        [](const QFontMetrics *, const QString &, int) -> int { return 10; });
+    bar->addTabWithIndex(1, "/short/p.txt", QString("p.txt"));
+    EXPECT_FALSE(bar->tabToolTip(1).contains('\n'));
+    EXPECT_EQ(bar->tabToolTip(1), QString("/short/p.txt"));
+}
+
+// ---- closeTab / closeCurrentTab ----
+
+TEST_F(TabbarTest, CloseTab_ValidIndex_EmitsHistoryAndRemoves)
+{
+    // Arrange：真实执行 handleTabIsRemoved（Window::removeWrapper 桩记录）
+    installWindowRecorderStubs(nullptr);
+    addTabsQuietly({ localRoot + "/x.txt", localRoot + "/y.txt" });
+    QSignalSpy historySpy(bar, &Tabbar::requestHistorySaved);
+
+    // Act
+    bar->closeTab(0);
+    QApplication::processEvents();  // tabIsRemoved（如为队列连接）冲净
+
+    // Assert：历史信号携带被关文件路径、标签与路径表同步收缩、Window 被通知
+    ASSERT_EQ(historySpy.count(), 1);
+    EXPECT_EQ(historySpy.at(0).at(0).toString(), localRoot + "/x.txt");
+    EXPECT_EQ(bar->count(), 1);
+    EXPECT_EQ(bar->m_tabPaths, QStringList({ localRoot + "/y.txt" }));
+    EXPECT_EQ(bar->m_tabTruePaths.size(), 1);
+    EXPECT_EQ(windowRemoveWrapperCalls, 1);
+    EXPECT_EQ(lastRemoveWrapperPath, localRoot + "/x.txt");
+}
+
+TEST_F(TabbarTest, CloseTab_NegativeIndex_EarlyReturn)
+{
+    installWindowRecorderStubs(nullptr);
+    addTabsQuietly({ localRoot + "/keep.txt" });
+    QSignalSpy historySpy(bar, &Tabbar::requestHistorySaved);
+
+    // Act：负面——负索引早退
+    bar->closeTab(-1);
+
+    // Assert：无信号、无移除
+    EXPECT_EQ(historySpy.count(), 0);
+    EXPECT_EQ(bar->count(), 1);
+    EXPECT_EQ(windowRemoveWrapperCalls, 0);
+}
+
+TEST_F(TabbarTest, CloseCurrentTab_MiddleTab_ClosesSelected)
+{
+    installWindowRecorderStubs(nullptr);
+    addTabsQuietly({ localRoot + "/1.txt", localRoot + "/2.txt", localRoot + "/3.txt" });
+    bar->setCurrentIndex(1);
+    QSignalSpy historySpy(bar, &Tabbar::requestHistorySaved);
+
+    // Act
+    bar->closeCurrentTab();
+    QApplication::processEvents();
+
+    // Assert：关闭的是当前选中项
+    ASSERT_EQ(historySpy.count(), 1);
+    EXPECT_EQ(historySpy.at(0).at(0).toString(), localRoot + "/2.txt");
+    EXPECT_EQ(bar->count(), 2);
+}
+
+TEST_F(TabbarTest, CloseCurrentTabByPath_UnknownPath_Noop)
+{
+    installWindowRecorderStubs(nullptr);
+    addTabsQuietly({ localRoot + "/here.txt" });
+    QSignalSpy historySpy(bar, &Tabbar::requestHistorySaved);
+
+    // Act：未知路径 → indexOf=-1 → closeTab(-1) 早退
+    bar->closeCurrentTab(QString::fromUtf8("/not/exists.txt"));
+
+    // Assert
+    EXPECT_EQ(historySpy.count(), 0);
+    EXPECT_EQ(bar->count(), 1);
+}
+
+// ---- closeOtherTabs / closeLeftTabs / closeRightTabs / closeOtherTabsExceptFile ----
+
+TEST_F(TabbarTest, CloseOtherTabs_ThreeTabs_EmitsAllExceptCurrent)
+{
+    installWindowRecorderStubs(nullptr);
+    addTabsQuietly({ localRoot + "/a.txt", localRoot + "/b.txt", localRoot + "/c.txt" });
+    bar->setCurrentIndex(1);
+    QSignalSpy closeSpy(bar, &Tabbar::closeTabs);
+
+    // Act
+    bar->closeOtherTabs();
+
+    // Assert：发出其余路径（不改本地状态，由上层逐个 closeTab）
+    ASSERT_EQ(closeSpy.count(), 1);
+    const QStringList emitted = closeSpy.at(0).at(0).toStringList();
+    EXPECT_EQ(emitted, QStringList({ localRoot + "/a.txt", localRoot + "/c.txt" }));
+    EXPECT_EQ(bar->count(), 3);  // 信号语义：不直接移除
+}
+
+TEST_F(TabbarTest, CloseLeftTabs_MiddleTab_EmitsPrecedingOnly)
+{
+    addTabsQuietly({ localRoot + "/l1", localRoot + "/l2", localRoot + "/l3", localRoot + "/l4" });
+    QSignalSpy closeSpy(bar, &Tabbar::closeTabs);
+
+    // Act
+    bar->closeLeftTabs(localRoot + "/l3");
+
+    // Assert：只包含目标之前的路径，顺序保持；信号语义不移除标签
+    ASSERT_EQ(closeSpy.count(), 1);
+    EXPECT_EQ(closeSpy.at(0).at(0).toStringList(),
+              QStringList({ localRoot + "/l1", localRoot + "/l2" }));
+    EXPECT_EQ(bar->count(), 4);
+}
+
+TEST_F(TabbarTest, CloseRightTabs_MiddleTab_EmitsFollowingOnly)
+{
+    addTabsQuietly({ localRoot + "/r1", localRoot + "/r2", localRoot + "/r3" });
+    QSignalSpy closeSpy(bar, &Tabbar::closeTabs);
+
+    // Act
+    bar->closeRightTabs(localRoot + "/r2");
+
+    // Assert：倒序收集（从尾到目标）；本地标签数不变
+    ASSERT_EQ(closeSpy.count(), 1);
+    EXPECT_EQ(closeSpy.at(0).at(0).toStringList(), QStringList({ localRoot + "/r3" }));
+    EXPECT_EQ(bar->count(), 3);
+}
+
+TEST_F(TabbarTest, CloseOtherTabsExceptFile_UnknownFile_EmitsAll)
+{
+    addTabsQuietly({ localRoot + "/u1", localRoot + "/u2" });
+    QSignalSpy closeSpy(bar, &Tabbar::closeTabs);
+
+    // Act：负面——未知文件 → 全部命中
+    bar->closeOtherTabsExceptFile(QString::fromUtf8("/missing"));
+
+    // Assert：全部命中（未知文件不匹配任何项）；标签不受影响
+    ASSERT_EQ(closeSpy.count(), 1);
+    EXPECT_EQ(closeSpy.at(0).at(0).toStringList().size(), 2);
+    EXPECT_EQ(bar->count(), 2);
+}
+
+// ---- updateTab ----
+
+TEST_F(TabbarTest, UpdateTab_ExistingTab_ChangesTextPathAndTooltip)
+{
+    installWindowRecorderStubs(nullptr);
+    addTabsQuietly({ localRoot + "/before.txt" });
+
+    // Act
+    bar->updateTab(0, QString("/elsewhere/after.txt"), QString::fromUtf8("改名&后.txt"));
+
+    // Assert：文本（含助记符转义）、路径表、tooltip（非 localDataPath → 路径本体）全部更新
+    EXPECT_EQ(bar->textAt(0), QString::fromUtf8("改名&后.txt"));
+    EXPECT_EQ(bar->fileAt(0), QString("/elsewhere/after.txt"));
+    EXPECT_EQ(bar->m_tabPaths.at(0), QString("/elsewhere/after.txt"));
+    EXPECT_EQ(bar->m_tabTruePaths.at(0), QString("/elsewhere/after.txt"));
+    EXPECT_EQ(bar->tabToolTip(0), QString("/elsewhere/after.txt"));
+}
+
+// ---- previousTab / nextTab（TEST_P 3 组）----
+
+struct NextPrevCase {
+    int startIndex;
+    bool doNext;       // true: nextTab, false: previousTab
+    int expectedIndex;
+};
+
+class TabbarNextPrevTest : public TabbarTest,
+                           public ::testing::WithParamInterface<NextPrevCase> {
+};
+
+TEST_P(TabbarNextPrevTest, StepTab_BoundaryIndex_WrapsOrSteps)
+{
+    addTabsQuietly({ localRoot + "/n0", localRoot + "/n1", localRoot + "/n2" });
+    bar->setCurrentIndex(GetParam().startIndex);
+
+    // Act
+    if (GetParam().doNext)
+        bar->nextTab();
+    else
+        bar->previousTab();
+
+    // Assert：索引回绕/步进；当前路径同步指向期望标签（状态一致）
+    EXPECT_EQ(bar->currentIndex(), GetParam().expectedIndex);
+    EXPECT_EQ(bar->currentPath(), localRoot + QString("/n%1").arg(GetParam().expectedIndex));
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    NextPrevCases, TabbarNextPrevTest,
+    ::testing::Values(
+        NextPrevCase{ 0, false, 2 },  // 边界：首项向前 → 回绕到尾
+        NextPrevCase{ 2, true, 0 },   // 边界：尾项向后 → 回绕到首
+        NextPrevCase{ 1, true, 2 }));  // 常规步进
+
+// ---- indexOf / currentName / currentPath / 访问器（TEST_P 3 组）----
+
+TEST_F(TabbarTest, IndexOf_KnownAndUnknown_ReturnsIndexOrMinusOne)
+{
+    addTabsQuietly({ localRoot + "/i1", localRoot + "/i2" });
+
+    // Act & Assert
+    EXPECT_EQ(bar->indexOf(localRoot + "/i2"), 1);
+    EXPECT_EQ(bar->indexOf(QString::fromUtf8("/absent")), -1);  // 负面
+}
+
+struct PathAccessorCase {
+    int index;
+    bool valid;
+};
+
+class TabbarAccessorTest : public TabbarTest,
+                           public ::testing::WithParamInterface<PathAccessorCase> {
+};
+
+TEST_P(TabbarAccessorTest, PathAccessors_ValidAndInvalid_IndexPathMath)
+{
+    addTabsQuietly({ localRoot + "/p0", localRoot + "/p1", localRoot + "/p2" });
+    const int idx = GetParam().index;
+
+    // Act & Assert：越界安全（value() → 空串）；默认 tipPath 的 truePath 为空
+    if (GetParam().valid) {
+        EXPECT_EQ(bar->fileAt(idx), localRoot + QString("/p%1").arg(idx));
+        EXPECT_TRUE(bar->truePathAt(idx).isEmpty());  // addTab 未传 tipPath
+    } else {
+        EXPECT_EQ(bar->fileAt(idx), QString());
+        EXPECT_EQ(bar->truePathAt(idx), QString());
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    AccessorCases, TabbarAccessorTest,
+    ::testing::Values(
+        PathAccessorCase{ 0, true },
+        PathAccessorCase{ 2, true },
+        PathAccessorCase{ 3, false }));  // 边界：越界一位
+
+TEST_F(TabbarTest, CurrentNameAndPath_SelectedTab_ReflectsBoth)
+{
+    addTabsQuietly({ localRoot + "/cur&1.txt", localRoot + "/cur2.txt" });
+    bar->setCurrentIndex(0);
+
+    // Act & Assert：名称经助记符还原、路径对应当前项
+    EXPECT_EQ(bar->currentName(), QString("cur&1.txt"));
+    EXPECT_EQ(bar->currentPath(), localRoot + "/cur&1.txt");
+}
+
+TEST_F(TabbarTest, CurrentNameAndPath_NoTabs_ReturnEmptyValues)
+{
+    // 负面：空栏的当前名/路径为空、indexOf 未命中
+    EXPECT_EQ(bar->currentName(), QString());
+    EXPECT_EQ(bar->currentPath(), QString());
+    EXPECT_EQ(bar->currentIndex(), -1);
+}
+
+// ---- setTabText：助记符 ----
+
+TEST_F(TabbarTest, SetTabText_WithAmpersand_EscapesAndRestores)
+{
+    addTabsQuietly({ localRoot + "/m.txt" });
+
+    // Act：设置含 '&' 文本
+    bar->setTabText(0, QString::fromUtf8("A&B"));
+
+    // Assert：DTabBar 层双写转义、textAt 层还原
+    EXPECT_EQ(bar->DTabBar::tabText(0), QString::fromUtf8("A&&B"));
+    EXPECT_EQ(bar->textAt(0), QString::fromUtf8("A&B"));
+}
+
+// ---- setTabPalette / setBackground / setDNDColor ----
+
+TEST_F(TabbarTest, SetTabPalette_AnyColors_NoStateCorruption)
+{
+    addTabsQuietly({ localRoot + "/pal.txt" });
+    const int before = bar->count();
+
+    // Act：Qt6 分支为空实现（Q_UNUSED）
+    bar->setTabPalette(QString("#ffffff"), QString("#000000"));
+
+    // Assert：不破坏状态
+    EXPECT_EQ(bar->count(), before);
+    EXPECT_EQ(bar->fileAt(0), localRoot + "/pal.txt");
+}
+
+TEST_F(TabbarTest, SetBackgroundAndDNDColor_AnyColors_StoreMembers)
+{
+    // Act
+    bar->setBackground(QString("#111111"), QString("#222222"));
+    bar->setDNDColor(QString("#333333"), QString("#444444"));
+
+    // Assert：private 成员直读（-fno-access-control）
+    EXPECT_EQ(bar->m_backgroundStartColor, QString("#111111"));
+    EXPECT_EQ(bar->m_backgroundEndColor, QString("#222222"));
+    EXPECT_EQ(bar->m_dndStartColor, QString("#333333"));
+    EXPECT_EQ(bar->m_dndEndColor, QString("#444444"));
+}
+
+// ---- eventFilter：右键菜单（含启用矩阵 TEST_P 4 组）----
+
+struct RightClickCase {
+    int tabCount;
+    int clickOn;      // 右键命中的标签索引
+    int tabsLeft;     // 期望 closeLeftTabAction 状态（-1 表示不适用/置灰组）
+    bool leftEnabled;
+    bool rightEnabled;
+    bool otherEnabled;
+    bool moreWaysEnabled;
+};
+
+class TabbarRightClickTest : public TabbarTest,
+                             public ::testing::WithParamInterface<RightClickCase> {
+};
+
+TEST_P(TabbarRightClickTest, RightClickMenu_TabMatrix_MatchesEnableStates)
+{
+    installWindowRecorderStubs(nullptr);
+    QStringList paths;
+    for (int i = 0; i < GetParam().tabCount; ++i)
+        paths << localRoot + QString("/tab%1.txt").arg(i);
+    addTabsQuietly(paths);
+    const int target = GetParam().clickOn;
+    ASSERT_GE(target, 0);
+
+    // Act：在目标标签矩形中心合成右键
+    const QRect rect = bar->tabRect(target);
+    ASSERT_FALSE(rect.isNull());
+    QMouseEvent rightPress(QEvent::MouseButtonPress, rect.center(), bar->mapToGlobal(rect.center()),
+                           Qt::RightButton, Qt::RightButton, Qt::NoModifier);
+    const bool handled = bar->eventFilter(bar, &rightPress);
+
+    // Assert：菜单构建 + exec 恰一次 + 返回 true（事件被吞）
+    EXPECT_TRUE(handled);
+    EXPECT_EQ(menuExecCalls, 1);
+    ASSERT_NE(bar->m_rightMenu, nullptr);
+    ASSERT_NE(bar->m_closeTabAction, nullptr);
+    ASSERT_NE(bar->m_closeLeftTabAction, nullptr);
+    ASSERT_NE(bar->m_closeRightTabAction, nullptr);
+    ASSERT_NE(bar->m_closeOtherTabAction, nullptr);
+    ASSERT_NE(bar->m_moreWaysCloseMenu, nullptr);
+    // 启用矩阵
+    EXPECT_EQ(bar->m_closeLeftTabAction->isEnabled(), GetParam().leftEnabled);
+    EXPECT_EQ(bar->m_closeRightTabAction->isEnabled(), GetParam().rightEnabled);
+    EXPECT_EQ(bar->m_closeOtherTabAction->isEnabled(), GetParam().otherEnabled);
+    EXPECT_EQ(bar->m_moreWaysCloseMenu->isEnabled(), GetParam().moreWaysEnabled);
+    // 菜单动作挂接：关闭标签动作触发 → tabCloseRequested
+    QSignalSpy closeRequestSpy(bar, &Tabbar::tabCloseRequested);
+    bar->m_closeTabAction->trigger();
+    QApplication::processEvents();
+    EXPECT_EQ(closeRequestSpy.count(), 1);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    MenuMatrix, TabbarRightClickTest,
+    ::testing::Values(
+        // 单标签：全部禁用（len<2 + rc==0&&cnt==1 + 尾==首 全命中）
+        RightClickCase{ 1, 0, -1, false, false, false, false },
+        // 两标签右键首项：left 禁、right 启
+        RightClickCase{ 2, 0, -1, false, true, true, true },
+        // 两标签右键尾项：left 启、right 禁
+        RightClickCase{ 2, 1, -1, true, false, true, true },
+        // 三标签右键中间：left/right 均启
+        RightClickCase{ 3, 1, -1, true, true, true, true }));
+
+TEST_F(TabbarTest, EventFilter_RightClickBlankArea_SkipsMenu)
+{
+    installWindowRecorderStubs(nullptr);
+    addTabsQuietly({ localRoot + "/only.txt" });
+
+    // Act：右键空白处（标签条最右上角远离标签）
+    const QPoint blank(std::max(10, bar->width() - 4), 4);
+    QMouseEvent rightPress(QEvent::MouseButtonPress, blank, bar->mapToGlobal(blank),
+                           Qt::RightButton, Qt::RightButton, Qt::NoModifier);
+    const bool handled = bar->eventFilter(bar, &rightPress);
+
+    // Assert：tabAt=-1 → 不建菜单不 exec、事件不吞
+    EXPECT_FALSE(handled);
+    EXPECT_EQ(menuExecCalls, 0);
+    EXPECT_EQ(bar->m_rightMenu, nullptr);
+    EXPECT_EQ(bar->count(), 1);  // 状态未受影响
+}
+
+// ---- showTabs：依赖右键菜单动作已存在 ----
+
+TEST_F(TabbarTest, ShowTabs_EdgeSelected_DisablesEdgeActions)
+{
+    installWindowRecorderStubs(nullptr);
+    addTabsQuietly({ localRoot + "/s0", localRoot + "/s1", localRoot + "/s2" });
+    // 先构造右键菜单（exec 已桩）
+    const QRect rect = bar->tabRect(1);
+    QMouseEvent rightPress(QEvent::MouseButtonPress, rect.center(), bar->mapToGlobal(rect.center()),
+                           Qt::RightButton, Qt::RightButton, Qt::NoModifier);
+    bar->eventFilter(bar, &rightPress);
+    ASSERT_NE(bar->m_closeLeftTabAction, nullptr);
+
+    // Act 1：选中首项 → 左侧无标签 → closeLeft 禁用
+    bar->setCurrentIndex(0);
+    bar->showTabs();
+    EXPECT_FALSE(bar->m_closeLeftTabAction->isEnabled());
+
+    // Act 2：选中尾项 → closeRight 禁用
+    bar->setCurrentIndex(2);
+    bar->showTabs();
+    EXPECT_FALSE(bar->m_closeRightTabAction->isEnabled());
+    // 中间项两者都不额外禁用（保持上一次 enabled 值 → 显式重新启用对照）
+    bar->setCurrentIndex(1);
+    bar->showTabs();
+    EXPECT_EQ(bar->currentIndex(), 1);
+}
+
+// ---- eventFilter：其它分支 ----
+
+TEST_F(TabbarTest, EventFilter_FontChange_SyncsFontToAppFont)
+{
+    // Arrange：字体偏离 app 字体
+    QFont alien(QString("monospace"));
+    alien.setPointSize(qApp->font().pointSize() + 5);
+    bar->setFont(alien);
+    ASSERT_NE(bar->font().toString(), qApp->font().toString());
+
+    // Act：直调 eventFilter 处理 ApplicationFontChange（watched==this 分支）
+    QEvent fontEvent(QEvent::ApplicationFontChange);
+    const bool handled = bar->eventFilter(bar, &fontEvent);
+
+    // Assert：字体被同步为 app 字体、事件不吞
+    EXPECT_FALSE(handled);
+    EXPECT_EQ(bar->font().toString(), qApp->font().toString());
+
+    // 分支另一侧：字体已一致 → 不再设置（幂等）
+    const bool handled2 = bar->eventFilter(bar, &fontEvent);
+    EXPECT_FALSE(handled2);
+    EXPECT_EQ(bar->font().toString(), qApp->font().toString());
+}
+
+TEST_F(TabbarTest, EventFilter_IgnoredEvent_ReturnsFalse)
+{
+    // Arrange：非鼠标/拖拽事件（如 MouseMove）→ 早退分支
+    QMouseEvent moveEvent(QEvent::MouseMove, QPointF(1, 1), QPointF(1, 1), Qt::NoButton,
+                          Qt::NoButton, Qt::NoModifier);
+
+    // Act
+    const bool handled = bar->eventFilter(bar, &moveEvent);
+
+    // Assert：早退不吞事件，也不触发菜单构建
+    EXPECT_FALSE(handled);
+    EXPECT_EQ(menuExecCalls, 0);
+}
+
+TEST_F(TabbarTest, EventFilter_MiddleClick_EmitsCloseRequest)
+{
+    installWindowRecorderStubs(nullptr);
+    addTabsQuietly({ localRoot + "/mid.txt" });
+    QSignalSpy closeSpy(bar, &Tabbar::tabCloseRequested);
+
+    // Act：中键点击标签
+    const QRect rect = bar->tabRect(0);
+    QMouseEvent midPress(QEvent::MouseButtonPress, rect.center(), bar->mapToGlobal(rect.center()),
+                         Qt::MiddleButton, Qt::MiddleButton, Qt::NoModifier);
+    const bool handled = bar->eventFilter(bar, &midPress);
+
+    // Assert：事件被吞 + tabCloseRequested(0)
+    EXPECT_TRUE(handled);
+    ASSERT_EQ(closeSpy.count(), 1);
+    EXPECT_EQ(closeSpy.at(0).at(0).toInt(), 0);
+    EXPECT_EQ(bar->count(), 1);  // 只发请求不移除（由上层 closeTab）
+}
+
+TEST_F(TabbarTest, EventFilter_MiddleClickOnChild_NotSwallowed)
+{
+    installWindowRecorderStubs(nullptr);
+    addTabsQuietly({ localRoot + "/child.txt" });
+    QSignalSpy closeSpy(bar, &Tabbar::tabCloseRequested);
+
+    // Act：watched 不是 bar 自身（早退 false 分支）
+    QWidget child(host);
+    QMouseEvent midPress(QEvent::MouseButtonPress, QPointF(2, 2), QPointF(2, 2),
+                         Qt::MiddleButton, Qt::MiddleButton, Qt::NoModifier);
+    const bool handled = bar->eventFilter(&child, &midPress);
+
+    // Assert
+    EXPECT_FALSE(handled);
+    EXPECT_EQ(closeSpy.count(), 0);
+}
+
+TEST_F(TabbarTest, EventFilter_DragMove_AcceptsEvent)
+{
+    // Arrange
+    QMimeData mime;
+    QDragMoveEvent dragMove(QPoint(5, 5), Qt::CopyAction, &mime, Qt::LeftButton, Qt::NoModifier);
+
+    // Act
+    const bool handled = bar->eventFilter(bar, &dragMove);
+
+    // Assert：DragMove 分支 accept 但不吞事件（返回 false），标签状态不变
+    EXPECT_FALSE(handled);
+    EXPECT_TRUE(dragMove.isAccepted());
+    EXPECT_EQ(bar->count(), 0);
+}
+
+// ---- mousePressEvent ----
+
+TEST_F(TabbarTest, MousePressEvent_MiddleClick_EmitsCloseRequest)
+{
+    installWindowRecorderStubs(nullptr);
+    addTabsQuietly({ localRoot + "/mp.txt" });
+    QSignalSpy closeSpy(bar, &Tabbar::tabCloseRequested);
+
+    // Act：中键（Qt6 MiddleButton）
+    const QRect rect = bar->tabRect(0);
+    QMouseEvent midPress(QEvent::MouseButtonPress, rect.center(), bar->mapToGlobal(rect.center()),
+                         Qt::MiddleButton, Qt::MiddleButton, Qt::NoModifier);
+    bar->mousePressEvent(&midPress);
+
+    // Assert：中键只发关闭请求（由上层 closeTab），本地不移除
+    ASSERT_EQ(closeSpy.count(), 1);
+    EXPECT_EQ(closeSpy.at(0).at(0).toInt(), 0);
+    EXPECT_EQ(bar->count(), 1);
+}
+
+TEST_F(TabbarTest, MousePressEvent_LeftClick_PassesToBaseEditor)
+{
+    installWindowRecorderStubs(nullptr);
+    addTabsQuietly({ localRoot + "/left.txt" });
+    QSignalSpy closeSpy(bar, &Tabbar::tabCloseRequested);
+
+    // Act：左键 → else 分支透传 DTabBar
+    const QRect rect = bar->tabRect(0);
+    QMouseEvent leftPress(QEvent::MouseButtonPress, rect.center(), bar->mapToGlobal(rect.center()),
+                          Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+    EXPECT_NO_THROW(bar->mousePressEvent(&leftPress));
+
+    // Assert：中键语义不触发
+    QApplication::processEvents();
+    EXPECT_EQ(closeSpy.count(), 0);
+    EXPECT_EQ(bar->count(), 1);
+}
+
+// ---- tabSizeHint 系列（TEST_P 3 组）----
+
+struct SizeHintCase {
+    int tabCount;
+    int barWidth;
+    int index;
+    int expectedWidth;  // -1 → 基类返回（index<0）
+    bool expectBase;    // index<0 → 走 DTabBar::tabSizeHint
+};
+
+class TabbarSizeHintTest : public TabbarTest,
+                           public ::testing::WithParamInterface<SizeHintCase> {
+};
+
+TEST_P(TabbarSizeHintTest, TabSizeHint_WidthVariants_ReturnsClampedWidth)
+{
+    QStringList paths;
+    for (int i = 0; i < GetParam().tabCount; ++i)
+        paths << localRoot + QString("/sz%1").arg(i);
+    addTabsQuietly(paths);
+    bar->resize(GetParam().barWidth, 40);
+    QApplication::processEvents();
+
+    // Act
+    const QSize hint = bar->tabSizeHint(GetParam().index);
+
+    // Assert
+    if (GetParam().expectBase) {
+        EXPECT_EQ(hint, bar->DTabBar::tabSizeHint(GetParam().index));  // index<0 → 基类
+    } else {
+        EXPECT_EQ(hint.width(), GetParam().expectedWidth);
+        EXPECT_EQ(hint.height(), 40);  // 非紧凑模式
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    SizeCases, TabbarSizeHintTest,
+    ::testing::Values(
+        SizeHintCase{ 2, 1100, 0, 160, false },   // 少标签 → 最大宽
+        SizeHintCase{ 8, 300, 3, 110, false },    // 多标签溢出 → 等分后夹到最小宽
+        SizeHintCase{ 2, 1100, -1, -1, true }));  // 边界：负索引 → 基类
+
+TEST_F(TabbarTest, MinMaxTabSizeHint_AnyIndex_ReturnsFixedBounds)
+{
+    // Act & Assert：固定边界（非紧凑：高 40）
+    EXPECT_EQ(bar->minimumTabSizeHint(0), QSize(110, 40));
+    EXPECT_EQ(bar->maximumTabSizeHint(0), QSize(160, 40));
+    EXPECT_EQ(bar->minimumTabSizeHint(99), QSize(110, 40));  // 索引不参与
+    EXPECT_EQ(bar->maximumTabSizeHint(-1), QSize(160, 40));
+}
+
+// ---- handleTabMoved ----
+
+TEST_F(TabbarTest, HandleTabMoved_ValidIndices_SwapsPaths)
+{
+    addTabsQuietly({ localRoot + "/m0", localRoot + "/m1", localRoot + "/m2" });
+
+    // Act：0 ↔ 2
+    bar->handleTabMoved(0, 2);
+
+    // Assert：路径表与真路径表同步交换
+    EXPECT_EQ(bar->m_tabPaths,
+              QStringList({ localRoot + "/m2", localRoot + "/m1", localRoot + "/m0" }));
+    EXPECT_EQ(bar->m_tabTruePaths.size(), 3);
+}
+
+TEST_F(TabbarTest, HandleTabMoved_OutOfRange_NoChange)
+{
+    addTabsQuietly({ localRoot + "/g0", localRoot + "/g1" });
+    const QStringList before = bar->m_tabPaths;
+
+    // Act：负面——越界/负索引组合均不交换
+    bar->handleTabMoved(0, 99);
+    bar->handleTabMoved(-1, 1);
+
+    // Assert：强异常安全（路径表与真路径表均不变）
+    EXPECT_EQ(bar->m_tabPaths, before);
+    EXPECT_EQ(bar->m_tabTruePaths.size(), 2);
+}
+
+// ---- onTabDrapStart / handleTabDroped / handleTabReleased ----
+
+TEST_F(TabbarTest, OnTabDragStart_DragBegin_SavesOldPaths)
+{
+    installWindowRecorderStubs(nullptr);
+    addTabsQuietly({ localRoot + "/d0", localRoot + "/d1" });
+
+    // Act
+    bar->onTabDrapStart();
+
+    // Assert：快照保存 + Window 失焦调用
+    EXPECT_EQ(bar->m_listOldTabPath, bar->m_tabPaths);
+    EXPECT_EQ(windowSetChildrenFocusCalls, 1);
+}
+
+TEST_F(TabbarTest, HandleTabDroped_ExternalTarget_ReleasesTab)
+{
+    // Arrange：外部目标（target 非 Tabbar）→ handleTabReleased；旧路径为空 → 早退
+    installWindowRecorderStubs(nullptr);
+    addTabsQuietly({ localRoot + "/ext.txt" });
+    QSignalSpy historySpy(bar, &Tabbar::requestHistorySaved);
+
+    // Act
+    bar->handleTabDroped(0, Qt::MoveAction, nullptr);
+
+    // Assert：handleTabReleased 走 path 空早退（m_listOldTabPath 未初始化为空）
+    EXPECT_EQ(startManagerCreateCalls, 0);
+    EXPECT_EQ(historySpy.count(), 0);
+    EXPECT_EQ(bar->count(), 1);
+}
+
+TEST_F(TabbarTest, HandleTabDroped_TabbarTarget_ClosesTab)
+{
+    installWindowRecorderStubs(nullptr);
+    addTabsQuietly({ localRoot + "/inner0", localRoot + "/inner1" });
+    QSignalSpy historySpy(bar, &Tabbar::requestHistorySaved);
+
+    // Act：目标为另一 Tabbar（同类型实例）
+    Tabbar other(host);
+    bar->handleTabDroped(0, Qt::MoveAction, &other);
+    QApplication::processEvents();
+
+    // Assert：closeTab 路径（历史信号 + 移除 + removeWrapper 通知）
+    ASSERT_EQ(historySpy.count(), 1);
+    EXPECT_EQ(historySpy.at(0).at(0).toString(), localRoot + "/inner0");
+    EXPECT_EQ(bar->count(), 1);
+    EXPECT_EQ(windowRemoveWrapperCalls, 1);
+}
+
+TEST_F(TabbarTest, HandleTabReleased_NullWrapper_EarlyReturn)
+{
+    installWindowRecorderStubs(nullptr);
+    addTabsQuietly({ localRoot + "/rel.txt" });
+    bar->m_listOldTabPath = bar->m_tabPaths;  // 非空旧路径
+    QSignalSpy historySpy(bar, &Tabbar::requestHistorySaved);
+
+    // Act：wrapper 为 null → 早退（不重建窗口、不关闭）
+    bar->handleTabReleased(0);
+
+    // Assert
+    EXPECT_EQ(startManagerCreateCalls, 0);
+    EXPECT_EQ(historySpy.count(), 0);
+    EXPECT_EQ(bar->count(), 1);
+}
+
+TEST_F(TabbarTest, HandleTabReleased_EmptyPath_EarlyReturn)
+{
+    installWindowRecorderStubs(nullptr);
+
+    // Act：旧路径为空 → 早退（index -1 也归零处理）
+    bar->handleTabReleased(-1);
+
+    // Assert：无任何出向调用
+    EXPECT_EQ(startManagerCreateCalls, 0);
+    EXPECT_EQ(windowRemoveWrapperCalls, 0);
+}
+
+// ---- handleDragActionChanged ----
+
+TEST_F(TabbarTest, HandleDragActionChanged_IgnoreAction_ResetsOverrideCursor)
+{
+    // Arrange：dragIconWindow 非 null（DTabBar QWindow* 桩）+ 平台静态调用桩
+    static QWindow dragWindow;
+    int changeCursorCalls = 0;
+    stub.set_lamda(&DTabBar::dragIconWindow, [](DTabBar *) -> QWindow * {
+        return &dragWindow;
+    });
+    stub.set_lamda(
+        static_cast<void (*)(const QCursor &)>(&QGuiApplication::changeOverrideCursor),
+        [&changeCursorCalls](const QCursor &) { ++changeCursorCalls; });
+    int disableCursorCalls = 0;
+    stub.set_lamda(&DPlatformWindowHandle::setDisableWindowOverrideCursor,
+                   [&disableCursorCalls](QWindow *, bool) { ++disableCursorCalls; });
+
+    // Act 1：IgnoreAction → 箭头光标 + 禁用覆盖
+    bar->handleDragActionChanged(Qt::IgnoreAction);
+    EXPECT_EQ(changeCursorCalls, 1);
+    EXPECT_EQ(disableCursorCalls, 1);
+
+    // Act 2：其它动作 → 恢复覆盖（无 overrideCursor 时不改光标）
+    bar->handleDragActionChanged(Qt::CopyAction);
+    EXPECT_EQ(disableCursorCalls, 2);
+    EXPECT_EQ(changeCursorCalls, 1);  // overrideCursor() 为空 → 分支内不改
+}
+
+TEST_F(TabbarTest, HandleDragActionChanged_NoDragWindow_Noop)
+{
+    // Arrange：dragIconWindow 为 null → 两分支均空转
+    stub.set_lamda(&DTabBar::dragIconWindow, [](DTabBar *) -> QWindow * { return nullptr; });
+    int changeCursorCalls = 0;
+    stub.set_lamda(
+        static_cast<void (*)(const QCursor &)>(&QGuiApplication::changeOverrideCursor),
+        [&changeCursorCalls](const QCursor &) { ++changeCursorCalls; });
+
+    int disableCursorCalls = 0;
+    stub.set_lamda(&DPlatformWindowHandle::setDisableWindowOverrideCursor,
+                   [&disableCursorCalls](QWindow *, bool) { ++disableCursorCalls; });
+
+    // Act
+    bar->handleDragActionChanged(Qt::IgnoreAction);
+    bar->handleDragActionChanged(Qt::CopyAction);
+
+    // Assert：无拖拽图标窗口 → 光标两个桩均零调用
+    EXPECT_EQ(changeCursorCalls, 0);
+    EXPECT_EQ(disableCursorCalls, 0);
+}
+
+// ---- resizeEvent ----
+
+TEST_F(TabbarTest, ResizeEvent_WrappedTooltip_StripsNewlines)
+{
+    // Arrange：植入含 '\n' 的 tooltip（模拟超长路径换行后重排）
+    installWindowRecorderStubs(nullptr);
+    addTabsQuietly({ localRoot + "/res.txt" });
+    bar->setTabToolTip(0, QString("line1\nline2"));
+
+    // Act：触发 resizeEvent（去 '\n' 重排）
+    bar->resize(900, 40);
+    QApplication::processEvents();
+
+    // Assert：tooltip 不再含换行，且内容为拼接原文
+    EXPECT_FALSE(bar->tabToolTip(0).contains('\n'));
+    EXPECT_EQ(bar->tabToolTip(0), QString("line1line2"));
+}
+
+// ---- dropEvent ----
+
+TEST_F(TabbarTest, DropEvent_WithDragPixmap_PlaysAnimation)
+{
+    installWindowRecorderStubs(nullptr);
+    addTabsQuietly({ localRoot + "/drop.txt" });
+
+    // Arrange：静态拖拽位图就位（public static 成员直控）
+    ASSERT_EQ(Tabbar::sm_pDragPixmap, nullptr);
+    Tabbar::sm_pDragPixmap = new QPixmap(24, 24);
+    Tabbar::sm_pDragPixmap->fill(Qt::red);
+
+    QMimeData mime;
+    mime.setData("dedit/tabbar", QByteArray("drop.txt"));
+    QDropEvent drop(QPointF(10, 10), Qt::CopyAction, &mime, Qt::LeftButton, Qt::NoModifier);
+
+    // Act：真实 dropEvent（CopyAction+格式命中 → 动画分支；DTabBar::dropEvent 基类透传）
+    EXPECT_NO_THROW(bar->dropEvent(&drop));
+    // 冲净动画与 deleteLater
+    QTest::qWait(220);
+    QApplication::processEvents();
+
+    // Assert：动画创建的 DLabel 在 finished 后自删（无泄漏迹象：无断言崩溃即通过，
+    // 以静态位图仍可用作二次断言依据）；拖放后标签仍在
+    ASSERT_NE(Tabbar::sm_pDragPixmap, nullptr);
+    EXPECT_EQ(Tabbar::sm_pDragPixmap->width(), 24);
+    EXPECT_EQ(bar->count(), 1);
+}
+
+// ---- createMimeDataFromTab / canInsertFromMimeData ----
+
+TEST_F(TabbarTest, CreateMimeData_WrapperMissing_ReturnsNull)
+{
+    installWindowRecorderStubs(nullptr);
+    addTabsQuietly({ localRoot + "/mime.txt" });
+
+    // Act：wrapper 查无 → null（源码在判空前 new QMimeData 并挂 window 父对象）
+    QStyleOptionTab option;
+    QMimeData *result = bar->createMimeDataFromTab(0, option);
+
+    // Assert：返回 null 且标签状态不受拖拽准备失败影响
+    EXPECT_EQ(result, nullptr);
+    EXPECT_EQ(bar->textAt(0), QString("mime.txt"));
+}
+
+TEST_F(TabbarTest, CreateMimeData_ValidWrapper_CarriesTabPayload)
+{
+    // Arrange：真实 EditWrapper（B8 已验证构造矩阵）
+    EditWrapper *wrapper = nullptr;
+    installEditWrapperCtorStubs(stub, host, &wrapper);
+    wrapper->textEditor()->setSettings(Settings::instance());
+    installWindowRecorderStubs(wrapper);
+    const QString tabPath = localRoot + "/real.txt";
+    bar->addTab(tabPath, QString("real.txt"));
+    QStyleOptionTab option;
+
+    // Act
+    QMimeData *mime = bar->createMimeDataFromTab(0, option);
+
+    // Assert：载荷含标签名/格式，wrapper 以 void* 属性携带
+    ASSERT_NE(mime, nullptr);
+    EXPECT_TRUE(mime->hasFormat("dedit/tabbar"));
+    EXPECT_EQ(QString::fromUtf8(mime->data("dedit/tabbar")), QString("real.txt"));
+    EXPECT_FALSE(mime->hasFormat("text/plain"));  // removeFormat 生效
+    EXPECT_NE(mime->property("wrapper").value<void *>(), nullptr);
+    delete mime;
+}
+
+TEST_F(TabbarTest, CreateMimeData_LoadingWrapper_ReturnsNull)
+{
+    // Arrange：真实 EditWrapper + loading 标记桩
+    EditWrapper *wrapper = nullptr;
+    installEditWrapperCtorStubs(stub, host, &wrapper);
+    stub.set_lamda(&EditWrapper::getFileLoading, [](EditWrapper *) -> bool { return true; });
+    installWindowRecorderStubs(wrapper);
+    bar->addTab(localRoot + "/loading.txt", QString("loading.txt"));
+    QStyleOptionTab option;
+
+    // Act：大文本加载中 → 禁止拖出
+    QMimeData *mime = bar->createMimeDataFromTab(0, option);
+
+    // Assert：返回 null 且标签保留
+    EXPECT_EQ(mime, nullptr);
+    EXPECT_EQ(bar->textAt(0), QString("loading.txt"));
+}
+
+struct CanInsertCase {
+    bool hasFormat;
+    bool expected;
+};
+
+class TabbarCanInsertTest : public TabbarTest,
+                            public ::testing::WithParamInterface<CanInsertCase> {
+};
+
+TEST_P(TabbarCanInsertTest, CanInsertFromMimeData_FormatPresence_ReturnsExpected)
+{
+    QMimeData mime;
+    if (GetParam().hasFormat)
+        mime.setData("dedit/tabbar", QByteArray("x"));
+
+    // Act
+    const bool ok = bar->canInsertFromMimeData(0, &mime);
+
+    // Assert：判定与格式在场状态一致
+    EXPECT_EQ(ok, GetParam().expected);
+    EXPECT_EQ(mime.hasFormat("dedit/tabbar"), GetParam().hasFormat);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    FormatCases, TabbarCanInsertTest,
+    ::testing::Values(
+        CanInsertCase{ true, true },
+        CanInsertCase{ false, false },
+        CanInsertCase{ true, true }));  // 第三组：重复校验幂等
+
+// ---- insertFromMimeDataOnDragEnter / insertFromMimeData ----
+
+TEST_F(TabbarTest, InsertFromMimeDataOnDragEnter_NullSource_EarlyReturns)
+{
+    installWindowRecorderStubs(nullptr);
+
+    // Act
+    bar->insertFromMimeDataOnDragEnter(0, nullptr);
+
+    // Assert：无出向调用
+    EXPECT_EQ(windowAddTabCalls, 0);
+    EXPECT_EQ(bar->count(), 0);
+}
+
+TEST_F(TabbarTest, InsertFromMimeDataOnDragEnter_InvalidWrapper_EarlyReturns)
+{
+    // Arrange：mime 无 wrapper 属性（QVariant null → static_cast null）
+    QMimeData mime;
+    mime.setData("dedit/tabbar", QByteArray("t.txt"));
+    installWindowRecorderStubs(nullptr);
+
+    // Act
+    bar->insertFromMimeDataOnDragEnter(0, &mime);
+
+    // Assert：wrapper null → 早退（无加签、无本地标签）
+    EXPECT_EQ(windowAddTabCalls, 0);
+    EXPECT_EQ(bar->count(), 0);
+}
+
+TEST_F(TabbarTest, InsertFromMimeDataOnDragEnter_LoadingWrapper_EarlyReturns)
+{
+    EditWrapper *wrapper = nullptr;
+    installEditWrapperCtorStubs(stub, host, &wrapper);
+    stub.set_lamda(&EditWrapper::getFileLoading, [](EditWrapper *) -> bool { return true; });
+    installWindowRecorderStubs(wrapper);
+    QMimeData mime;
+    mime.setData("dedit/tabbar", QByteArray("t.txt"));
+    mime.setProperty("wrapper", QVariant::fromValue(static_cast<void *>(wrapper)));
+
+    // Act：大文本加载中 → 早退
+    bar->insertFromMimeDataOnDragEnter(0, &mime);
+
+    // Assert
+    EXPECT_EQ(windowAddTabCalls, 0);
+    EXPECT_EQ(bar->count(), 0);
+}
+
+TEST_F(TabbarTest, InsertFromMimeDataOnDragEnter_FullPath_AddsTabViaWindow)
+{
+    // Arrange：真实 EditWrapper + 出向记录桩（updateModifyStatus/OnUpdateHighlighter 桩）
+    EditWrapper *wrapper = nullptr;
+    installEditWrapperCtorStubs(stub, host, &wrapper);
+    int updateModifyCalls = 0;
+    stub.set_lamda(&EditWrapper::updateModifyStatus,
+                   [&updateModifyCalls](EditWrapper *, bool) { ++updateModifyCalls; });
+    stub.set_lamda(&EditWrapper::OnUpdateHighlighter, [](EditWrapper *) {});
+    installWindowRecorderStubs(wrapper);
+    QMimeData mime;
+    mime.setData("dedit/tabbar", QString::fromUtf8("拖拽标签.txt").toUtf8());
+    mime.setProperty("wrapper", QVariant::fromValue(static_cast<void *>(wrapper)));
+    mime.setProperty("isModified", true);
+
+    // Act
+    bar->insertFromMimeDataOnDragEnter(1, &mime);
+
+    // Assert：Window::addTabWithWrapper + 修改态回写 + 编辑器聚焦，全链各一次
+    EXPECT_EQ(windowAddTabCalls, 1);
+    EXPECT_EQ(updateModifyCalls, 1);
+    EXPECT_EQ(windowFocusActiveCalls, 1);
+}
+
+TEST_F(TabbarTest, InsertFromMimeData_NullSource_EarlyReturns)
+{
+    installWindowRecorderStubs(nullptr);
+
+    // Act
+    bar->insertFromMimeData(0, nullptr);
+
+    // Assert
+    EXPECT_EQ(windowAddTabCalls, 0);
+    EXPECT_EQ(bar->count(), 0);
+}
+
+TEST_F(TabbarTest, InsertFromMimeData_InvalidWrapper_EarlyReturns)
+{
+    QMimeData mime;
+    mime.setData("dedit/tabbar", QByteArray("t.txt"));
+    installWindowRecorderStubs(nullptr);
+
+    // Act
+    bar->insertFromMimeData(0, &mime);
+
+    // Assert
+    EXPECT_EQ(windowAddTabCalls, 0);
+    EXPECT_EQ(bar->count(), 0);
+}
+
+TEST_F(TabbarTest, InsertFromMimeData_FullPath_AddsTabViaWindow)
+{
+    EditWrapper *wrapper = nullptr;
+    installEditWrapperCtorStubs(stub, host, &wrapper);
+    int updateModifyCalls = 0;
+    stub.set_lamda(&EditWrapper::updateModifyStatus,
+                   [&updateModifyCalls](EditWrapper *, bool) { ++updateModifyCalls; });
+    stub.set_lamda(&EditWrapper::OnUpdateHighlighter, [](EditWrapper *) {});
+    installWindowRecorderStubs(wrapper);
+    QMimeData mime;
+    mime.setData("dedit/tabbar", QByteArray("t2.txt"));
+    mime.setProperty("wrapper", QVariant::fromValue(static_cast<void *>(wrapper)));
+
+    // Act
+    bar->insertFromMimeData(2, &mime);
+
+    // Assert
+    EXPECT_EQ(windowAddTabCalls, 1);
+    EXPECT_EQ(updateModifyCalls, 1);
+    EXPECT_EQ(windowFocusActiveCalls, 1);
+}
+
+// ---- handleTabReleased 全路径（真实 EditWrapper）----
+
+TEST_F(TabbarTest, HandleTabReleased_FullPath_RebuildsWindowAndCloses)
+{
+    // Arrange：真实 EditWrapper 拖出重建窗口
+    EditWrapper *wrapper = nullptr;
+    installEditWrapperCtorStubs(stub, host, &wrapper);
+    wrapper->textEditor()->setSettings(Settings::instance());
+    installWindowRecorderStubs(wrapper);
+    const QString path = localRoot + "/dragout.txt";
+    bar->addTab(path, QString("dragout.txt"));
+    bar->m_listOldTabPath = bar->m_tabPaths;
+    QSignalSpy historySpy(bar, &Tabbar::requestHistorySaved);
+
+    // Act
+    bar->handleTabReleased(0);
+    QApplication::processEvents();
+
+    // Assert：重建窗口（StartManager）+ 关闭原标签 + 从窗口摘除 wrapper（不删除）
+    EXPECT_EQ(startManagerCreateCalls, 1);
+    EXPECT_EQ(lastCreatedTabPath, path);
+    ASSERT_EQ(historySpy.count(), 1);  // closeTab(newIndex) 历史
+    EXPECT_EQ(historySpy.at(0).at(0).toString(), path);
+    EXPECT_EQ(bar->count(), 0);
+    // removeWrapper 两次：closeTab → handleTabIsRemoved 一次 + 显式 removeWrapper 一次
+    EXPECT_EQ(windowRemoveWrapperCalls, 2);
+    EXPECT_EQ(lastRemoveWrapperPath, path);
+}
+
+// ---- createDragPixmapFromTab（真实渲染，两分支）----
+
+TEST_F(TabbarTest, CreateDragPixmap_NoComposite_ReturnsScreenshot)
+{
+    // Arrange：真实 EditWrapper（其 textEditor 离屏 render 真实执行）
+    EditWrapper *wrapper = nullptr;
+    installEditWrapperCtorStubs(stub, host, &wrapper);
+    wrapper->textEditor()->setSettings(Settings::instance());
+    installWindowRecorderStubs(wrapper);
+    stub.set_lamda(&Utils::isWayland, []() -> bool { return true; });  // 跳过最小化窗口
+    stub.set_lamda(&DWindowManagerHelper::hasComposite,
+                   [](DWindowManagerHelper *) -> bool { return false; });
+    bar->addTab(localRoot + "/shot.txt", QString("shot.txt"));
+    host->show();
+    QApplication::processEvents();
+
+    QStyleOptionTab option;
+    QPoint hotspot;
+
+    // Act
+    const QPixmap pixmap = bar->createDragPixmapFromTab(0, option, &hotspot);
+
+    // Assert：非空位图 + 热点为截图缩放后中心（背景图四边各加 5px）+ 静态拖拽位图登记
+    EXPECT_FALSE(pixmap.isNull());
+    EXPECT_EQ(hotspot.x(), (pixmap.width() - 10) / 2);
+    EXPECT_EQ(hotspot.y(), (pixmap.height() - 10) / 2);
+    ASSERT_NE(Tabbar::sm_pDragPixmap, nullptr);
+    EXPECT_EQ(Tabbar::sm_pDragPixmap->size(), pixmap.size());
+}
+
+TEST_F(TabbarTest, CreateDragPixmap_Composite_RoundedShadowPath)
+{
+    EditWrapper *wrapper = nullptr;
+    installEditWrapperCtorStubs(stub, host, &wrapper);
+    wrapper->textEditor()->setSettings(Settings::instance());
+    installWindowRecorderStubs(wrapper);
+    stub.set_lamda(&Utils::isWayland, []() -> bool { return true; });
+    stub.set_lamda(&DWindowManagerHelper::hasComposite,
+                   [](DWindowManagerHelper *) -> bool { return true; });
+    // 阴影计算重（真实可行但慢）：桩为固定尺寸，验证链路与返回即可
+    stub.set_lamda(
+        static_cast<QPixmap (*)(const QPixmap &, qreal, const QColor &, const QPoint &)>(
+            &Utils::dropShadow),
+        [](const QPixmap &, qreal, const QColor &, const QPoint &) -> QPixmap {
+            return QPixmap(32, 32);
+        });
+    bar->addTab(localRoot + "/round.txt", QString("round.txt"));
+    QApplication::processEvents();
+
+    QStyleOptionTab option;
+    QPoint hotspot;
+
+    // Act
+    const QPixmap pixmap = bar->createDragPixmapFromTab(0, option, &hotspot);
+
+    // Assert：走圆角阴影分支 → 返回桩尺寸位图、热点已设置
+    EXPECT_EQ(pixmap.size(), QSize(32, 32));
+    EXPECT_GT(hotspot.x(), 0);
+    EXPECT_GT(hotspot.y(), 0);
+    ASSERT_NE(Tabbar::sm_pDragPixmap, nullptr);
+    EXPECT_EQ(Tabbar::sm_pDragPixmap->size(), QSize(32, 32));
+}
+
+// ---- 右键菜单全部动作 lambda（closeOther/Left/Right/CloseAllunModified）----
+
+TEST_F(TabbarTest, MenuActions_Triggered_EmitClosePathSignals)
+{
+    installWindowRecorderStubs(nullptr);
+    addTabsQuietly({ localRoot + "/ma0", localRoot + "/ma1", localRoot + "/ma2" });
+    // 建立右键菜单（exec 已桩）
+    const QRect rect = bar->tabRect(1);
+    QMouseEvent rightPress(QEvent::MouseButtonPress, rect.center(), bar->mapToGlobal(rect.center()),
+                           Qt::RightButton, Qt::RightButton, Qt::NoModifier);
+    ASSERT_TRUE(bar->eventFilter(bar, &rightPress));
+    ASSERT_NE(bar->m_closeOtherTabAction, nullptr);
+
+    // Act 1：Close other tabs → closeOtherTabsExceptFile(点击项路径)
+    QSignalSpy closeSpy(bar, &Tabbar::closeTabs);
+    bar->m_closeOtherTabAction->trigger();
+    ASSERT_EQ(closeSpy.count(), 1);
+    EXPECT_EQ(closeSpy.at(0).at(0).toStringList(),
+              QStringList({ localRoot + "/ma0", localRoot + "/ma2" }));
+
+    // Act 2：Close tabs to the left → closeLeftTabs
+    bar->m_closeLeftTabAction->trigger();
+    ASSERT_EQ(closeSpy.count(), 2);
+    EXPECT_EQ(closeSpy.at(1).at(0).toStringList(), QStringList({ localRoot + "/ma0" }));
+
+    // Act 3：Close tabs to the right → closeRightTabs
+    bar->m_closeRightTabAction->trigger();
+    ASSERT_EQ(closeSpy.count(), 3);
+    EXPECT_EQ(closeSpy.at(2).at(0).toStringList(), QStringList({ localRoot + "/ma2" }));
+}
+
+TEST_F(TabbarTest, CloseAllunModifiedAction_UnmodifiedTabs_RemovesAllClean)
+{
+    // Arrange：真实 EditWrapper（未修改 → isModified=false → 被清理）
+    EditWrapper *wrapper = nullptr;
+    installEditWrapperCtorStubs(stub, host, &wrapper);
+    installWindowRecorderStubs(wrapper);
+    addTabsQuietly({ localRoot + "/clean0", localRoot + "/clean1" });
+    const QRect rect = bar->tabRect(0);
+    QMouseEvent rightPress(QEvent::MouseButtonPress, rect.center(), bar->mapToGlobal(rect.center()),
+                           Qt::RightButton, Qt::RightButton, Qt::NoModifier);
+    ASSERT_TRUE(bar->eventFilter(bar, &rightPress));
+    ASSERT_NE(bar->m_closeAllunModifiedTabAction, nullptr);
+    QSignalSpy historySpy(bar, &Tabbar::requestHistorySaved);
+
+    // Act：Close unmodified tabs → removeWrapper(path,true) + closeTab 逐个执行
+    bar->m_closeAllunModifiedTabAction->trigger();
+    QApplication::processEvents();
+
+    // Assert：两个未修改标签全部清理；removeWrapper 每路径两次
+    //（lambda 显式一次 + closeTab → handleTabIsRemoved 一次）
+    EXPECT_EQ(bar->count(), 0);
+    EXPECT_EQ(bar->m_tabPaths.size(), 0);
+    EXPECT_EQ(windowRemoveWrapperCalls, 4);
+    EXPECT_EQ(historySpy.count(), 2);
+}
+
+TEST_F(TabbarTest, SizeModeChangedSignal_ModeToggle_SchedulesUpdate)
+{
+    // Arrange：ctor 连接的 lambda（sizeModeChanged → update()）
+    const bool emitted = QMetaObject::invokeMethod(
+        DGuiApplicationHelper::instance(), "sizeModeChanged",
+        Q_ARG(DGuiApplicationHelper::SizeMode, DGuiApplicationHelper::CompactMode));
+    QApplication::processEvents();
+
+    // Assert：信号送达（lambda 仅调用 update()，无崩溃即覆盖），控件仍在
+    EXPECT_TRUE(emitted);
+    EXPECT_EQ(bar->count(), 0);
+}
+
+// ---- Settings 资源依赖冒烟（防止 qrc 未编入导致后续用例误判）----
+
+TEST_F(TabbarTest, SettingsResource_QrcLinked_InstanceAvailable)
+{
+    // Assert：Settings 单例可建且幂等（qrc 资源在位）
+    EXPECT_NE(Settings::instance(), nullptr);
+    EXPECT_EQ(Settings::instance(), Settings::instance());
+}
+
+}  // namespace

--- a/tests/controls_ut/test_toolbar.cpp
+++ b/tests/controls_ut/test_toolbar.cpp
@@ -1,0 +1,116 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// ToolBar（src/controls/toolbar.cpp）单元测试
+//
+// 类特征：QWidget 子类（GUI 类，无 Q_OBJECT），offscreen 无头构造。
+//
+// 方法映射（公开方法全集）：
+// - ToolBar::ToolBar    → Constructor_DefaultParent_CreatesZeroMarginLayout
+// - ~ToolBar            → TearDown delete 链覆盖
+// - setTabbar           → SetTabbar_WidgetOrNull_AddsLayoutItems / SetTabbar_NullWidget_StillAdds (TEST_P)
+//
+// 分支清单（来源：toolbar.cpp）：无 if/loop 分支（构造 + addWidget + addSpacing）
+//
+// 最小清单完成情况：
+// | 1 | 每个公开方法 ≥1 用例 | 完成 |
+// | 2 | 等价类（普通子件 / 空指针） | 完成 |
+// | 3 | 边界值（布局计数 0 → 2） | 完成 |
+// | 4 | TEST_P | N/A（仅 2 组输入，不满足 ≥3 强制条件） |
+// | 5 | 分支清单 | 无分支 |
+// | 6 | 分支覆盖 | N/A |
+// | 7 | 异常路径 | EXPECT_NO_THROW（含 nullptr 负面输入） |
+// | 8 | 负面（setTabbar(nullptr) 不崩溃不损坏） | 完成 |
+// | 9 | 强异常安全（二次 setTabbar 布局持续追加） | 完成 |
+// | 10 | stub_ext（无外部依赖） | 完成 |
+
+#include <gtest/gtest.h>
+
+#include <QHBoxLayout>
+#include <QWidget>
+
+#include "test_env.h"
+#include "toolbar.h"
+
+namespace {
+
+class ToolBarTest : public ::testing::Test {
+protected:
+    static void SetUpTestSuite() { controlsut::ensureApp(); }
+
+    void SetUp() override
+    {
+        stub.clear();
+        toolbar = new ToolBar();
+    }
+
+    void TearDown() override
+    {
+        delete toolbar;
+        toolbar = nullptr;
+        stub.clear();
+    }
+
+    stub_ext::StubExt stub;
+    ToolBar *toolbar = nullptr;
+};
+
+TEST_F(ToolBarTest, Constructor_DefaultParent_CreatesZeroMarginLayout)
+{
+    // Assert：水平布局已建、零边距、初始无布局项
+    auto *layout = qobject_cast<QHBoxLayout *>(toolbar->layout());
+    ASSERT_NE(layout, nullptr);
+    EXPECT_EQ(layout->contentsMargins(), QMargins(0, 0, 0, 0));
+    EXPECT_EQ(layout->count(), 0);
+}
+
+struct TabbarWidgetCase {
+    bool nullWidget;
+};
+
+class ToolBarSetTabbarTest : public ToolBarTest,
+                             public ::testing::WithParamInterface<TabbarWidgetCase> {
+};
+
+TEST_P(ToolBarSetTabbarTest, SetTabbar_WidgetOrNull_AddsLayoutItems)
+{
+    const auto &c = GetParam();
+    QWidget child;
+    QWidget *toAdd = c.nullWidget ? nullptr : &child;
+
+    // Act
+    EXPECT_NO_THROW(toolbar->setTabbar(toAdd));
+
+    // Assert：非空 → 子件 + 间距共 2 项；空指针 → Qt 布局拒绝添加，仅剩间距 1 项
+    auto *layout = toolbar->layout();
+    if (c.nullWidget) {
+        EXPECT_EQ(layout->count(), 1);
+        EXPECT_NE(layout->itemAt(0)->spacerItem(), nullptr);
+    } else {
+        ASSERT_EQ(layout->count(), 2);
+        EXPECT_EQ(layout->itemAt(0)->widget(), &child);
+        EXPECT_NE(layout->itemAt(1)->spacerItem(), nullptr);  // 第二项为间距
+        EXPECT_EQ(child.parentWidget(), toolbar);
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    WidgetCases, ToolBarSetTabbarTest,
+    ::testing::Values(TabbarWidgetCase{ false }, TabbarWidgetCase{ true }));
+
+TEST_F(ToolBarTest, SetTabbar_CalledTwice_AppendsBoth)
+{
+    // Arrange：强异常安全——重复调用不损坏既有布局
+    QWidget first, second;
+    toolbar->setTabbar(&first);
+
+    // Act
+    toolbar->setTabbar(&second);
+
+    // Assert：布局持续追加（2 + 2 = 4 项）
+    EXPECT_EQ(toolbar->layout()->count(), 4);
+    EXPECT_EQ(first.parentWidget(), toolbar);
+    EXPECT_EQ(second.parentWidget(), toolbar);
+}
+
+}  // namespace

--- a/tests/controls_ut/test_warningnotices.cpp
+++ b/tests/controls_ut/test_warningnotices.cpp
@@ -1,0 +1,310 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// WarningNotices（src/controls/warningnotices.cpp）单元测试
+//
+// 类特征：DFloatingMessage 子类（GUI 类），offscreen QApplication 无头构造。
+//
+// 方法映射（公开方法全集）：
+// - WarningNotices::WarningNotices → Constructor_DefaultType_CreatesButtonsInitialState
+//                                     Constructor_MessageTypes_Accessible (TEST_P)
+// - ~WarningNotices                → 各用例 TearDown delete 链覆盖
+// - setReloadBtn                   → SetReloadBtn_FromSaveAsState_ShowsReloadHidesSaveAs
+// - setSaveAsBtn                   → SetSaveAsBtn_InitialState_ShowsSaveAsHidesReload
+// - clearBtn                       → ClearBtn_VisibleButtons_HidesBothActionButtons
+// - setEditAnywayBtn               → SetEditAnywayBtn_Triggered_ShowsOnlyEditAnyway
+// - slotreloadBtnClicked           → SlotReloadBtnClicked_OnVisibleBar_HidesAndEmits
+// - slotsaveAsBtnClicked           → SlotSaveAsBtnClicked_OnVisibleBar_HidesAndEmits
+// - slotEditAnywayBtnClicked       → SlotEditAnywayBtnClicked_OnVisibleBar_HidesAndEmits
+//
+// 分支清单（来源：warningnotices.cpp）→ 用例映射：
+// - setReloadBtn: !visible → setVisible(true)（内外两处 setVisible） → SetReloadBtn_...
+// - setSaveAsBtn: 同上                                          → SetSaveAsBtn_...
+// - ctor: closeBtn 找到与否（findChild<DDialogCloseButton*>)      → 真实 DFloatingMessage
+//         自带关闭按钮，offscreen 下构造链真实执行
+// - closeButtonClicked lambda: isVisible → close                 → 经 Qt 信号机制触发成本高，
+//         由三个 slot 用例等价覆盖 hide 行为（同源行为路径）
+//
+// 最小清单完成情况：
+// | 1 | 每个公开方法 ≥1 用例 | 完成 |
+// | 2 | 等价类（消息类型 2 种、按钮三态互斥组合） | 完成 |
+// | 3 | 边界值（默认 ResidentType、无 parent） | 完成 |
+// | 4 | TEST_P（消息类型 2 组不足 3，用例组内覆盖两枚举值） | 完成（2 组） |
+// | 5 | 分支清单映射 | 见上方 |
+// | 6 | if 分支两侧全覆盖 | 完成（可见性翻转两侧） |
+// | 7 | 异常路径 | N/A（无 throw） |
+// | 8 | 负面（按钮隐藏互斥、未显示时点击不崩溃） | 完成 |
+// | 9 | 强异常安全（clearBtn 后仍可重新 set 按钮） | 完成 |
+// | 10 | stub_ext（无外部依赖需 stub；qApp->font 真实可用） | 完成 |
+
+#include <gtest/gtest.h>
+
+#include <DGuiApplicationHelper>
+
+#include <QPushButton>
+#include <QSignalSpy>
+
+#include "test_env.h"
+#include "warningnotices.h"
+
+namespace {
+
+class WarningNoticesTest : public ::testing::Test {
+protected:
+    static void SetUpTestSuite() { controlsut::ensureApp(); }
+
+    void SetUp() override
+    {
+        stub.clear();
+        notices = new WarningNotices(DFloatingMessage::ResidentType);
+        reloadBtn = notices->findChild<QPushButton *>("ReloadBtn");
+        saveAsBtn = notices->findChild<QPushButton *>("SaveAsBtn");
+        editAnywayBtn = notices->findChild<QPushButton *>("EditAnywayBtn");
+    }
+
+    void TearDown() override
+    {
+        delete notices;
+        notices = nullptr;
+        stub.clear();
+    }
+
+    stub_ext::StubExt stub;
+    WarningNotices *notices = nullptr;
+    QPushButton *reloadBtn = nullptr;
+    QPushButton *saveAsBtn = nullptr;
+    QPushButton *editAnywayBtn = nullptr;
+
+    // 三按钮中未隐藏（isHidden==false）的数量
+    int visibleButtonCount() const
+    {
+        return (reloadBtn->isHidden() ? 0 : 1) + (saveAsBtn->isHidden() ? 0 : 1)
+               + (editAnywayBtn->isHidden() ? 0 : 1);
+    }
+};
+
+// ---- 构造 ----
+
+TEST_F(WarningNoticesTest, Constructor_DefaultType_CreatesButtonsInitialState)
+{
+    // Assert：三按钮齐全；初始 Reload/SaveAs 可见、EditAnyway 隐藏（ctor setVisible(false)）
+    ASSERT_NE(reloadBtn, nullptr);
+    ASSERT_NE(saveAsBtn, nullptr);
+    ASSERT_NE(editAnywayBtn, nullptr);
+    EXPECT_FALSE(reloadBtn->isHidden());
+    EXPECT_FALSE(saveAsBtn->isHidden());
+    EXPECT_TRUE(editAnywayBtn->isHidden());  // 初始隐藏分支
+    EXPECT_EQ(notices->messageType(), DFloatingMessage::ResidentType);
+}
+
+struct MessageTypeCase {
+    DFloatingMessage::MessageType type;
+};
+
+class WarningNoticesTypeTest : public WarningNoticesTest,
+                               public ::testing::WithParamInterface<MessageTypeCase> {
+};
+
+TEST_P(WarningNoticesTypeTest, Constructor_MessageTypes_Accessible)
+{
+    const auto &c = GetParam();
+
+    // Act：以指定类型重新构造（默认参数之外的等价类）
+    WarningNotices other(c.type, nullptr);
+
+    // Assert：类型透传、按钮齐备
+    EXPECT_EQ(other.messageType(), c.type);
+    EXPECT_NE(other.findChild<QPushButton *>("ReloadBtn"), nullptr);
+    EXPECT_TRUE(other.findChild<QPushButton *>("EditAnywayBtn")->isHidden());
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    TypeCases, WarningNoticesTypeTest,
+    ::testing::Values(
+        MessageTypeCase{ DFloatingMessage::TransientType },
+        MessageTypeCase{ DFloatingMessage::ResidentType }));
+
+// ---- 按钮互斥三态 ----
+
+TEST_F(WarningNoticesTest, SetReloadBtn_FromSaveAsState_ShowsReloadHidesSaveAs)
+{
+    // Arrange：先切换到 SaveAs 态
+    notices->setSaveAsBtn();
+    ASSERT_TRUE(reloadBtn->isHidden());
+
+    // Act
+    notices->setReloadBtn();
+
+    // Assert：互斥翻转（同分支内外两处 setVisible 均覆盖）；可见按钮恰 1 个
+    EXPECT_FALSE(reloadBtn->isHidden());
+    EXPECT_TRUE(saveAsBtn->isHidden());
+    EXPECT_TRUE(editAnywayBtn->isHidden());
+    EXPECT_EQ(visibleButtonCount(), 1);
+}
+
+TEST_F(WarningNoticesTest, SetSaveAsBtn_InitialState_ShowsSaveAsHidesReload)
+{
+    // Act
+    notices->setSaveAsBtn();
+
+    // Assert：可见按钮恰 1 个（SaveAs）
+    EXPECT_FALSE(saveAsBtn->isHidden());
+    EXPECT_TRUE(reloadBtn->isHidden());
+    EXPECT_TRUE(editAnywayBtn->isHidden());
+    EXPECT_EQ(visibleButtonCount(), 1);
+}
+
+TEST_F(WarningNoticesTest, SetEditAnywayBtn_Triggered_ShowsOnlyEditAnyway)
+{
+    // Act
+    notices->setEditAnywayBtn();
+
+    // Assert：可见按钮恰 1 个（EditAnyway）
+    EXPECT_FALSE(editAnywayBtn->isHidden());
+    EXPECT_TRUE(reloadBtn->isHidden());
+    EXPECT_TRUE(saveAsBtn->isHidden());
+    EXPECT_EQ(visibleButtonCount(), 1);
+}
+
+TEST_F(WarningNoticesTest, ClearBtn_VisibleButtons_HidesBothActionButtons)
+{
+    // Arrange：先进入可见态
+    notices->setReloadBtn();
+    ASSERT_FALSE(reloadBtn->isHidden());
+
+    // Act
+    notices->clearBtn();
+
+    // Assert：全部隐藏（可见数 0）；随后仍可重新显示（强异常安全：状态机未损坏）
+    EXPECT_TRUE(reloadBtn->isHidden());
+    EXPECT_TRUE(saveAsBtn->isHidden());
+    EXPECT_EQ(visibleButtonCount(), 0);
+    notices->setSaveAsBtn();
+    EXPECT_FALSE(saveAsBtn->isHidden());
+}
+
+// ---- 三个槽：隐藏 + 信号 ----
+
+TEST_F(WarningNoticesTest, SlotReloadBtnClicked_OnVisibleBar_HidesAndEmits)
+{
+    // Arrange：显示通知条
+    notices->QWidget::show();
+    QApplication::processEvents();
+    ASSERT_TRUE(notices->isVisible());
+    QSignalSpy spy(notices, &WarningNotices::reloadBtnClicked);
+
+    // Act
+    notices->slotreloadBtnClicked();
+
+    // Assert：隐藏 + 精确一次信号
+    EXPECT_FALSE(notices->isVisible());
+    EXPECT_EQ(spy.count(), 1);
+
+    // 经真实按钮点击链路再验证一次（connect 到 slot）
+    notices->QWidget::show();
+    QApplication::processEvents();
+    reloadBtn->click();
+    EXPECT_EQ(spy.count(), 2);
+    EXPECT_FALSE(notices->isVisible());
+}
+
+TEST_F(WarningNoticesTest, SlotSaveAsBtnClicked_OnVisibleBar_HidesAndEmits)
+{
+    notices->QWidget::show();
+    QApplication::processEvents();
+    QSignalSpy spy(notices, &WarningNotices::saveAsBtnClicked);
+
+    // Act
+    notices->slotsaveAsBtnClicked();
+
+    // Assert
+    EXPECT_FALSE(notices->isVisible());
+    EXPECT_EQ(spy.count(), 1);
+
+    // 真实按钮点击链路
+    notices->QWidget::show();
+    QApplication::processEvents();
+    saveAsBtn->click();
+    EXPECT_EQ(spy.count(), 2);
+}
+
+TEST_F(WarningNoticesTest, SlotEditAnywayBtnClicked_OnVisibleBar_HidesAndEmits)
+{
+    notices->QWidget::show();
+    QApplication::processEvents();
+    QSignalSpy spy(notices, &WarningNotices::editAnywayBtnClicked);
+
+    // Act
+    notices->slotEditAnywayBtnClicked();
+
+    // Assert
+    EXPECT_FALSE(notices->isVisible());
+    EXPECT_EQ(spy.count(), 1);
+
+    // 真实按钮点击链路（按钮需先显示才能点击生效——直接调槽已覆盖主体逻辑）
+    notices->setEditAnywayBtn();
+    notices->QWidget::show();
+    QApplication::processEvents();
+    editAnywayBtn->click();
+    EXPECT_EQ(spy.count(), 2);
+}
+
+// ---- 构造期 connect 的 lambda（关闭按钮信号 / 字体切换）----
+
+TEST_F(WarningNoticesTest, CloseButtonClickedSignal_VisibleNotices_Closes)
+{
+    // Arrange：显示（lambda 判 isVisible 才 close）
+    notices->QWidget::show();
+    QApplication::processEvents();
+    ASSERT_TRUE(notices->isVisible());
+
+    // Act：合成 DFloatingMessage::closeButtonClicked（ctor 连接的 lambda）
+    const bool emitted = QMetaObject::invokeMethod(notices, "closeButtonClicked");
+    QApplication::processEvents();
+
+    // Assert：可见 → close()；消息类型在关闭后保留
+    EXPECT_TRUE(emitted);
+    EXPECT_FALSE(notices->isVisible());
+    EXPECT_EQ(notices->messageType(), DFloatingMessage::ResidentType);
+
+    // 分支另一侧：已隐藏时再触发 → 状态不变、不崩溃
+    QMetaObject::invokeMethod(notices, "closeButtonClicked");
+    QApplication::processEvents();
+    EXPECT_FALSE(notices->isVisible());
+}
+
+TEST_F(WarningNoticesTest, FontChangedSignal_CustomFont_UpdatesNoticeFont)
+{
+    // Arrange
+    const QFont original = notices->font();
+
+    // Act：合成 DGuiApplicationHelper::fontChanged（ctor 连接的 lambda）
+    QFont custom(QString("monospace"));
+    custom.setPointSize(original.pointSize() + 4);
+    const bool emitted = QMetaObject::invokeMethod(
+        DGuiApplicationHelper::instance(), "fontChanged", Q_ARG(QFont, custom));
+    QApplication::processEvents();
+
+    // Assert：通知条字体跟随应用字体
+    EXPECT_TRUE(emitted);
+    EXPECT_EQ(notices->font().family(), custom.family());
+    EXPECT_EQ(notices->font().pointSize(), custom.pointSize());
+}
+
+TEST_F(WarningNoticesTest, SizeModeChangedSignal_ModeToggle_UpdatesCloseButtonIcon)
+{
+    // Arrange：ResidentType 消息自带 DDialogCloseButton（ctor findChild 命中后连接 lambda）
+    auto *helper = DGuiApplicationHelper::instance();
+
+    // Act：真实切换全局尺寸模式（ctor 连接的 closeBtn lambda 重设图标尺寸）
+    helper->setSizeMode(DGuiApplicationHelper::CompactMode);
+    QApplication::processEvents();
+    helper->setSizeMode(DGuiApplicationHelper::NormalMode);  // 恢复全局状态
+    QApplication::processEvents();
+
+    // Assert：lambda 执行无异常，控件树仍完整
+    EXPECT_NE(notices->findChild<QPushButton *>("ReloadBtn"), nullptr);
+    EXPECT_EQ(notices->messageType(), DFloatingMessage::ResidentType);
+}
+
+}  // namespace

--- a/tests/widgets_ut/CMakeLists.txt
+++ b/tests/widgets_ut/CMakeLists.txt
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# 模块 widgets_ut（批次 B11）：src/widgets/ 六文件
+#   - test_ddropdownmenu.cpp  : DDropdownMenu（QFrame 下拉菜单）
+#   - test_colorselectwdg.cpp : ColorLabel + ColorSelectWdg（右键菜单颜色标记）
+#   - test_pathsettintwgt.cpp : PathSettingWgt（保存路径设置控件）
+#   - test_bottombar.cpp      : BottomBar（状态栏）
+#   - test_window.cpp         : Window（主窗口，真实 offscreen 构造）
+#
+# 链接策略：复用 startmanager 批次的全量源码静态库 startmanager_ut_src
+#（src/**.cpp 全量 + AUTOMOC/AUTORCC + deepin-editor.qrc）。
+# 真实构造（offscreen QApplication 已在 B8 验证可行），外围重依赖运行期拦截：
+#   - DBus：QDBusConnection::systemBus/sessionBus → 伪连接名，禁止真实总线；
+#   - 模态对话框：DDialog::exec / QDialog::exec / QFileDialog::selectedFiles /
+#     DFileDialog::getComboBoxValue 拦截，避免 offscreen 模态阻塞；
+#   - 浮动消息：DMessageManager::sendMessage 计数桩；
+#   - 子进程：QProcess::startDetached 拦截（displayShortcuts）；
+#   - 文件系统：XDG_CONFIG_HOME/XDG_DATA_HOME → QTemporaryDir。
+# 访问私有成员（m_wrappers/m_pendingTabs 等）用于状态注入与断言：
+#   -fno-access-control 不影响 ABI 布局，与库侧 AUTOMOC 产物 ODR 兼容。
+# 资源说明：qrc 静态库符号丢弃问题——目标直接编入 deepin-editor.qrc（AUTORCC）。
+
+set(QT_VERSION 6)
+set(STUB_SHADOW "${CMAKE_SOURCE_DIR}/tests/3rdparty/stub/stub-shadow.cpp")
+
+find_package(Qt6 REQUIRED COMPONENTS Test)
+
+function(add_widgets_ut_target NAME)
+    add_executable(${NAME}
+        ${NAME}.cpp
+        ${CMAKE_SOURCE_DIR}/src/deepin-editor.qrc
+        ${STUB_SHADOW}
+    )
+    set_target_properties(${NAME} PROPERTIES AUTORCC ON)
+    target_include_directories(${NAME} PRIVATE
+        "${CMAKE_SOURCE_DIR}/tests/3rdparty/stub"
+    )
+    target_compile_options(${NAME} PRIVATE -fno-access-control)
+    target_link_options(${NAME} PRIVATE -rdynamic)
+    target_link_libraries(${NAME} PRIVATE
+        startmanager_ut_src
+        GTest::gtest
+        GTest::gtest_main
+        Qt${QT_VERSION}::Test
+    )
+    if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+        target_link_libraries(${NAME} PRIVATE gcov)
+    endif()
+    gtest_discover_tests(${NAME} PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
+endfunction()
+
+add_widgets_ut_target(test_ddropdownmenu)
+add_widgets_ut_target(test_colorselectwdg)
+add_widgets_ut_target(test_pathsettintwgt)
+add_widgets_ut_target(test_bottombar)
+add_widgets_ut_target(test_window)
+# TextEdit×Window 集成（dtextedit.cpp 最后 2 个 FNDA:0：dragEnterEvent/pinchTriggered
+# 需真实 Window 父链，editor_core 禁真实 Window，按论证落位本模块）
+add_widgets_ut_target(test_dtextedit_window_integration)
+
+message(STATUS "UT: widgets_ut module configured (B11, links startmanager_ut_src)")

--- a/tests/widgets_ut/test_bottombar.cpp
+++ b/tests/widgets_ut/test_bottombar.cpp
@@ -1,0 +1,736 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// ============================================================================
+// BottomBar 单元测试（B11 / src/widgets/bottombar.cpp）
+//
+// 策略：真实 offscreen 构造（真实 DDropdownMenu 编码/高亮菜单、视图模式菜单、
+// 行尾格式菜单）。EditWrapper 相关路径（m_pWrapper）由 stub_ext 拦截
+// EditWrapper 非虚成员，父对象以真实 QWidget 内存承载（单继承链偏移 0）；
+// slotSetTextEditFocus 用真实 Window + 真实 EditWrapper 验证信号回传。
+//
+// 分支清单（来源：bottombar.cpp）与用例映射：
+// - ctor（真实编码/高亮菜单工厂 + 视图模式菜单 + 布局）
+//     → Constructor_RealBuild_CreatesChildrenAndDefaults
+// - updatePosition → UpdatePosition_SetsRowColumnText
+// - updateWordCount（n-1 显示）→ UpdateWordCount_ShowsMinusOne
+// - setEncodeName → SetEncodeName_UpdatesEncodeMenuText
+// - setPalette（亮/暗两分支 theme 字符串）→ SetPalette_DarkAndLight_AppliedToSelf
+// - updateSize → UpdateSize_SetsHeightAndFindFlag
+// - setChildEnabled → SetChildEnabled_TogglesMenus
+// - setChildrenFocus（带/不带 preOrderWidget）→ SetChildrenFocus_TrueFalse_TogglesTabOrder
+// - setScaleLabelText（=12 / >12 / <12 / 下限钳制）
+//     → SetScaleLabelText_Param（TEST_P 4 组）
+// - setProgress（-1 早退 / 0<n<100 显示 / >=100 完成隐藏）
+//     → SetProgress_Negative_Ignored / SetProgress_Mid_ShowsBars /
+//       SetProgress_Complete_HidesBars
+// - getEncodeMenu / getHighlightMenu → GetMenus_ReturnNonNullDistinct
+// - getEndlineFormat 静态（Unix/Windows/Unknow/孤立 \r）
+//     → GetEndlineFormatStatic_Param（TEST_P 4 组）
+// - getEndlineFormat 成员 → SetEndlineMenuText_SetsFormatAndMenuText
+// - initFormatMenu（ctor）+ onFormatMenuTrigged（同值早退 / 切换 / null 早退）
+//     → OnFormatMenuTrigged_SwitchesFormatViaAction /
+//       OnFormatMenuTrigged_NullAction_EarlyReturn
+// - updateSizeMode（ctor）→ UpdateSizeMode_HeightMatchesMode
+// - setEndlineMenuText（Unix/Unknow→Unix；Windows）
+//     → SetEndlineMenuText_Param（TEST_P）
+// - defaultHeight → DefaultHeight_MatchesSizeMode
+// - setViewMode（ReadView/LivePreview/Edit/Wysiwyg-default）
+//     → SetViewMode_Param（TEST_P）
+// - setMarkdownAvailable → SetMarkdownAvailable_TogglesLivePreview
+// - eventFilter（ApplicationFontChange / 其它）→ EventFilter_FontChange_UpdatesLabels
+// - paintEvent（m_bIsFindOrReplace 两态）→ PaintEvent_BothFindStates_RendersFrame
+// - slotSetTextEditFocus（真实 Window pressEsc 转发）→ SlotSetTextEditFocus_EmitsWindowPressEsc
+// - 编码切换 lambda（loading 恢复 / 转换失败恢复 / 成功更新）
+//     → EncodeMenuChange_Loading_RevertsToPreviousText 等
+// - 高亮切换 lambda → HighlightMenuChange_UpdatesTextAndReloads
+// ============================================================================
+
+#include <gtest/gtest.h>
+#include "stubext.h"
+
+#include <QApplication>
+#include <QTemporaryDir>
+#include <QSignalSpy>
+#include <QDir>
+#include <QLabel>
+#include <QPaintEvent>
+#include <QDBusConnection>
+#include <QDBusAbstractInterface>
+#include <QDBusMessage>
+
+#include "widgets/bottombar.h"
+#include "widgets/window.h"
+#include "editor/editwrapper.h"
+#include "editor/dtextedit.h"
+#include "editor/markdown/viewmode.h"
+#include "common/settings.h"
+
+class BottomBarTest : public ::testing::Test {
+protected:
+    static void SetUpTestSuite()
+    {
+        s_configHome = new QTemporaryDir();
+        s_dataHome = new QTemporaryDir();
+        const QString xdgConfig = s_configHome->filePath("xdg-config");
+        const QString xdgData = s_dataHome->filePath("xdg-data");
+        QDir().mkpath(xdgConfig);
+        QDir().mkpath(xdgData);
+        qputenv("XDG_CONFIG_HOME", xdgConfig.toUtf8());
+        qputenv("XDG_DATA_HOME", xdgData.toUtf8());
+
+        int argc = 1;
+        char *argv[] = {s_argv, nullptr};
+        s_app = new QApplication(argc, argv);
+        QApplication::setOrganizationName(QStringLiteral("deepin"));
+        QApplication::setApplicationName(QStringLiteral("deepin-editor"));
+        Settings::instance();
+        qRegisterMetaType<ViewMode>("ViewMode");
+    }
+
+    static void TearDownTestSuite()
+    {
+        qunsetenv("XDG_CONFIG_HOME");
+        qunsetenv("XDG_DATA_HOME");
+    }
+
+    void SetUp() override
+    {
+        installWrapperStubs();
+        m_bar = new BottomBar(&m_carrier);
+    }
+
+    void TearDown() override
+    {
+        delete m_bar;
+        m_bar = nullptr;
+        stub.clear();
+    }
+
+    // EditWrapper 非虚成员拦截：m_pWrapper 为 carrier 的 reinterpret 伪指针，
+    // 所有被调 EditWrapper 方法在到达前已被替换为记录桩
+    void installWrapperStubs()
+    {
+        stub.set_lamda(&EditWrapper::getFileLoading,
+                       [this](EditWrapper *) -> bool { return m_fileLoading; });
+        stub.set_lamda(&EditWrapper::reloadFileEncode,
+                       [this](EditWrapper *, QByteArray encode) -> bool {
+                           ++m_reloadEncodeCalls;
+                           m_lastReloadEncode = encode;
+                           return m_reloadEncodeResult;
+                       });
+        stub.set_lamda(&EditWrapper::reloadFileHighlight,
+                       [this](EditWrapper *, QString name) {
+                           ++m_reloadHighlightCalls;
+                           m_lastReloadHighlight = name;
+                       });
+        stub.set_lamda(&TextEdit::onEndlineFormatChanged,
+                       [this](TextEdit *, BottomBar::EndlineFormat from, BottomBar::EndlineFormat to) {
+                           ++m_endlineChangeCalls;
+                           m_lastEndlineFrom = from;
+                           m_lastEndlineTo = to;
+                       });
+    }
+
+    stub_ext::StubExt stub;
+    BottomBar *m_bar = nullptr;
+    QWidget m_carrier; // 承载 EditWrapper 伪指针的真实 QObject 内存
+
+    bool m_fileLoading = false;
+    bool m_reloadEncodeResult = true;
+    int m_reloadEncodeCalls = 0;
+    QByteArray m_lastReloadEncode;
+    int m_reloadHighlightCalls = 0;
+    QString m_lastReloadHighlight;
+    int m_endlineChangeCalls = 0;
+    BottomBar::EndlineFormat m_lastEndlineFrom = BottomBar::Unknow;
+    BottomBar::EndlineFormat m_lastEndlineTo = BottomBar::Unknow;
+
+    static QApplication *s_app;
+    static QTemporaryDir *s_configHome;
+    static QTemporaryDir *s_dataHome;
+    static char s_argv[];
+};
+
+QApplication *BottomBarTest::s_app = nullptr;
+QTemporaryDir *BottomBarTest::s_configHome = nullptr;
+QTemporaryDir *BottomBarTest::s_dataHome = nullptr;
+char BottomBarTest::s_argv[] = "test_bottombar";
+
+// ------------------------------------------------------------
+// 构造
+// ------------------------------------------------------------
+
+TEST_F(BottomBarTest, Constructor_RealBuild_CreatesChildrenAndDefaults)
+{
+    // Assert: 编码/高亮/视图模式/行尾格式菜单全部就位，初始文本正确
+    ASSERT_NE(m_bar->getEncodeMenu(), nullptr);
+    ASSERT_NE(m_bar->getHighlightMenu(), nullptr);
+    EXPECT_EQ(m_bar->getEncodeMenu()->getCurrentText(), QString("UTF-8"));
+    EXPECT_EQ(m_bar->getHighlightMenu()->getCurrentText(), QString("None"));
+    EXPECT_EQ(m_bar->m_formatMenu->getCurrentText(), QString("Unix"));
+    EXPECT_EQ(m_bar->m_pViewModeMenu->getCurrentText(), QString("Edit Mode"));
+    EXPECT_EQ(m_bar->m_pPositionLabel->text(), QString("Row 1  Column 1"));
+    EXPECT_EQ(m_bar->m_pCharCountLabel->text(), QString("Characters 0"));
+    EXPECT_EQ(m_bar->m_endlineFormat, BottomBar::Unix);
+    // 默认非 md：「实时预览」置灰
+    EXPECT_FALSE(m_bar->m_actLivePreview->isEnabled());
+    EXPECT_TRUE(m_bar->m_actEditView->isChecked());
+}
+
+// ------------------------------------------------------------
+// 状态更新
+// ------------------------------------------------------------
+
+TEST_F(BottomBarTest, UpdatePosition_SetsRowColumnText)
+{
+    // Act
+    m_bar->updatePosition(12, 34);
+
+    // Assert: 位置标签精确更新
+    EXPECT_EQ(m_bar->m_pPositionLabel->text(), QString("Row 12  Column 34"));
+    m_bar->updatePosition(1, 1);
+    EXPECT_EQ(m_bar->m_pPositionLabel->text(), QString("Row 1  Column 1"));
+}
+
+TEST_F(BottomBarTest, UpdateWordCount_ShowsMinusOne)
+{
+    // Act
+    m_bar->updateWordCount(10);
+
+    // Assert: 字符计数显示 n-1
+    EXPECT_EQ(m_bar->m_pCharCountLabel->text(), QString("Characters 9"));
+    m_bar->updateWordCount(1);
+    EXPECT_EQ(m_bar->m_pCharCountLabel->text(), QString("Characters 0"));
+}
+
+TEST_F(BottomBarTest, SetEncodeName_UpdatesEncodeMenuText)
+{
+    // Act
+    m_bar->setEncodeName(QStringLiteral("GBK"));
+
+    // Assert
+    EXPECT_EQ(m_bar->getEncodeMenu()->getCurrentText(), QString("GBK"));
+    EXPECT_EQ(m_bar->m_pEncodeMenu, m_bar->getEncodeMenu());
+}
+
+TEST_F(BottomBarTest, SetPalette_DarkAndLight_AppliedToSelf)
+{
+    // Arrange: 暗色窗口背景（lightness < 128 → dark 主题分支）
+    QPalette dark;
+    dark.setColor(QPalette::Window, QColor(20, 20, 20));
+
+    // Act
+    m_bar->setPalette(dark);
+
+    // Assert: 自身 palette 应用 + 各菜单按钮 palette 不再为空
+    EXPECT_EQ(m_bar->palette().color(QPalette::Window), QColor(20, 20, 20));
+
+    // Act: 亮色分支
+    QPalette light;
+    light.setColor(QPalette::Window, QColor(240, 240, 240));
+    m_bar->setPalette(light);
+    EXPECT_EQ(m_bar->palette().color(QPalette::Window), QColor(240, 240, 240));
+    EXPECT_NE(m_bar->getEncodeMenu()->getButton()->palette().color(QPalette::WindowText),
+              QColor());
+}
+
+TEST_F(BottomBarTest, UpdateSize_SetsHeightAndFindFlag)
+{
+    // Act
+    m_bar->updateSize(48, true);
+
+    // Assert: 高度与查找态标志同时更新
+    EXPECT_EQ(m_bar->height(), 48);
+    EXPECT_TRUE(m_bar->m_bIsFindOrReplace);
+
+    // Act / Assert: 复位
+    m_bar->updateSize(BottomBar::defaultHeight(), false);
+    EXPECT_EQ(m_bar->height(), BottomBar::defaultHeight());
+    EXPECT_FALSE(m_bar->m_bIsFindOrReplace);
+}
+
+TEST_F(BottomBarTest, SetChildEnabled_TogglesMenus)
+{
+    // Act: 禁用
+    m_bar->setChildEnabled(false);
+
+    // Assert: 三个菜单均禁用且不响应菜单请求
+    EXPECT_FALSE(m_bar->getEncodeMenu()->isEnabled());
+    EXPECT_FALSE(m_bar->getHighlightMenu()->isEnabled());
+    EXPECT_FALSE(m_bar->m_formatMenu->isEnabled());
+    EXPECT_FALSE(m_bar->getEncodeMenu()->isRequest);
+
+    // Act / Assert: 恢复
+    m_bar->setChildEnabled(true);
+    EXPECT_TRUE(m_bar->getEncodeMenu()->isEnabled());
+    EXPECT_TRUE(m_bar->getHighlightMenu()->isEnabled());
+    EXPECT_TRUE(m_bar->m_formatMenu->isEnabled());
+    EXPECT_TRUE(m_bar->getEncodeMenu()->isRequest);
+}
+
+TEST_F(BottomBarTest, SetChildrenFocus_TrueFalse_TogglesTabOrder)
+{
+    // Act: 开启焦点链（带前置控件分支）
+    QWidget preOrder;
+    m_bar->setChildrenFocus(true, &preOrder);
+
+    // Assert: 各菜单工具按钮进入 Tab 焦点链
+    EXPECT_EQ(m_bar->getEncodeMenu()->getButton()->focusPolicy(), Qt::StrongFocus);
+    EXPECT_EQ(m_bar->m_formatMenu->getButton()->focusPolicy(), Qt::StrongFocus);
+    EXPECT_EQ(m_bar->getHighlightMenu()->getButton()->focusPolicy(), Qt::StrongFocus);
+
+    // Act: 无前置控件分支 + 关闭
+    m_bar->setChildrenFocus(true);
+    EXPECT_EQ(m_bar->getEncodeMenu()->getButton()->focusPolicy(), Qt::StrongFocus);
+
+    m_bar->setChildrenFocus(false);
+    EXPECT_EQ(m_bar->getEncodeMenu()->getButton()->focusPolicy(), Qt::NoFocus);
+    EXPECT_EQ(m_bar->m_formatMenu->getButton()->focusPolicy(), Qt::NoFocus);
+}
+
+TEST_F(BottomBarTest, SetProgress_Negative_Ignored)
+{
+    // Arrange: 展示底栏（isVisible 需祖先可见）
+    m_carrier.show();
+    m_bar->show();
+    QApplication::processEvents();
+
+    // Act
+    m_bar->setProgress(-1);
+
+    // Assert: 早退，进度条保持隐藏、值保持初始（DProgressBar 初始 -1）
+    EXPECT_FALSE(m_bar->m_progressBar->isVisible());
+    EXPECT_FALSE(m_bar->m_progressLabel->isVisible());
+    EXPECT_EQ(m_bar->m_progressBar->value(), -1);
+}
+
+TEST_F(BottomBarTest, SetProgress_Mid_ShowsBars)
+{
+    // Arrange: 父载体 + 底栏一起展示（isVisible 需全祖先可见）
+    m_carrier.show();
+    m_bar->show();
+    QApplication::processEvents();
+
+    // Act
+    m_bar->setProgress(50);
+
+    // Assert: 进度条与标签显示且值正确
+    EXPECT_TRUE(m_bar->m_progressBar->isVisible());
+    EXPECT_TRUE(m_bar->m_progressLabel->isVisible());
+    EXPECT_EQ(m_bar->m_progressBar->value(), 50);
+}
+
+TEST_F(BottomBarTest, SetProgress_Complete_HidesBars)
+{
+    // Arrange: 先显示
+    m_carrier.show();
+    m_bar->show();
+    QApplication::processEvents();
+    m_bar->setProgress(50);
+    ASSERT_TRUE(m_bar->m_progressBar->isVisible());
+
+    // Act: 完成
+    m_bar->setProgress(100);
+
+    // Assert: 达到 100 后隐藏，但值保留
+    EXPECT_FALSE(m_bar->m_progressBar->isVisible());
+    EXPECT_FALSE(m_bar->m_progressLabel->isVisible());
+    EXPECT_EQ(m_bar->m_progressBar->value(), 100);
+}
+
+TEST_F(BottomBarTest, GetMenus_ReturnNonNullDistinct)
+{
+    // Assert: 两个菜单均有效且互不相同
+    ASSERT_NE(m_bar->getEncodeMenu(), nullptr);
+    ASSERT_NE(m_bar->getHighlightMenu(), nullptr);
+    EXPECT_NE(m_bar->getEncodeMenu(), m_bar->getHighlightMenu());
+}
+
+// ------------------------------------------------------------
+// setScaleLabelText 参数化（=12 / >12 / <12 / 下限）
+// ------------------------------------------------------------
+
+namespace {
+struct ScaleCase {
+    qreal fontSize;
+    QString expected;
+};
+} // namespace
+
+class ScaleTextTest : public BottomBarTest,
+                      public ::testing::WithParamInterface<ScaleCase> {
+};
+
+TEST_P(ScaleTextTest, SetScaleLabelText_EachRange_ShowsExpectedPercent)
+{
+    // Arrange
+    const ScaleCase c = GetParam();
+
+    // Act
+    m_bar->setScaleLabelText(c.fontSize);
+
+    // Assert: 缩放标签精确百分比（与实现公式一致：>12 线性放大、<12 线性缩小并下限 10%）
+    EXPECT_EQ(m_bar->m_scaleLabel->text(), c.expected);
+    EXPECT_TRUE(m_bar->m_scaleLabel->text().endsWith(QStringLiteral("%")));
+}
+
+INSTANTIATE_TEST_SUITE_P(ScaleVariants, ScaleTextTest,
+                         ::testing::Values(
+                             ScaleCase{12.0, QStringLiteral("100%")},
+                             ScaleCase{50.0, QStringLiteral("500%")},
+                             ScaleCase{20.0, QStringLiteral("184%")},
+                             ScaleCase{10.0, QStringLiteral("55%")},
+                             ScaleCase{8.0, QStringLiteral("10%")})); // 下限钳制
+
+// ------------------------------------------------------------
+// 行尾格式
+// ------------------------------------------------------------
+
+namespace {
+struct EndlineCase {
+    QByteArray text;
+    BottomBar::EndlineFormat expected;
+};
+} // namespace
+
+class EndlineFormatTest : public BottomBarTest,
+                          public ::testing::WithParamInterface<EndlineCase> {
+};
+
+TEST_P(EndlineFormatTest, GetEndlineFormatStatic_EachInput_ReturnsExpected)
+{
+    // Act / Assert: 静态判定（首个换行符形态决定）
+    EXPECT_EQ(BottomBar::getEndlineFormat(GetParam().text), GetParam().expected);
+    EXPECT_EQ(m_endlineChangeCalls, 0); // 纯函数不触发编辑器
+}
+
+INSTANTIATE_TEST_SUITE_P(EndlineVariants, EndlineFormatTest,
+                         ::testing::Values(
+                             EndlineCase{QByteArray("a\nb"), BottomBar::Unix},
+                             EndlineCase{QByteArray("a\r\nb"), BottomBar::Windows},
+                             EndlineCase{QByteArray("abc"), BottomBar::Unknow},
+                             EndlineCase{QByteArray("a\r"), BottomBar::Unknow}, // 孤立 \r（i+1 越界）
+                             EndlineCase{QByteArray("\n"), BottomBar::Unix}));
+
+namespace {
+struct MenuTextCase {
+    BottomBar::EndlineFormat input;
+    QString expectedMenuText;
+    BottomBar::EndlineFormat expectedFormat;
+};
+} // namespace
+
+class EndlineMenuTextTest : public BottomBarTest,
+                            public ::testing::WithParamInterface<MenuTextCase> {
+};
+
+TEST_P(EndlineMenuTextTest, SetEndlineMenuText_EachFormat_SetsMenuAndState)
+{
+    // Arrange
+    const MenuTextCase c = GetParam();
+
+    // Act
+    m_bar->setEndlineMenuText(c.input);
+
+    // Assert: 菜单文本与内部格式同步
+    EXPECT_EQ(m_bar->m_formatMenu->getCurrentText(), c.expectedMenuText);
+    EXPECT_EQ(m_bar->getEndlineFormat(), c.expectedFormat);
+}
+
+INSTANTIATE_TEST_SUITE_P(MenuTextVariants, EndlineMenuTextTest,
+                         ::testing::Values(
+                             MenuTextCase{BottomBar::Unix, QStringLiteral("Unix"), BottomBar::Unix},
+                             MenuTextCase{BottomBar::Unknow, QStringLiteral("Unix"), BottomBar::Unix},
+                             MenuTextCase{BottomBar::Windows, QStringLiteral("Windows"), BottomBar::Windows}));
+
+TEST_F(BottomBarTest, OnFormatMenuTrigged_SwitchesFormatViaAction)
+{
+    // Arrange: 初始 Unix
+    ASSERT_EQ(m_bar->getEndlineFormat(), BottomBar::Unix);
+    QAction *windowsAction = m_bar->findChild<QAction *>("WindowsAction");
+    QAction *unixAction = m_bar->findChild<QAction *>("UnixAction");
+    ASSERT_NE(windowsAction, nullptr);
+    ASSERT_NE(unixAction, nullptr);
+
+    // Act: 触发 Windows（真实 QActionGroup::triggered → onFormatMenuTrigged）
+    windowsAction->trigger();
+
+    // Assert: 编辑器收到 Unix→Windows 切换，内部格式与菜单同步
+    EXPECT_EQ(m_endlineChangeCalls, 1);
+    EXPECT_EQ(m_lastEndlineFrom, BottomBar::Unix);
+    EXPECT_EQ(m_lastEndlineTo, BottomBar::Windows);
+    EXPECT_EQ(m_bar->getEndlineFormat(), BottomBar::Windows);
+
+    // Act: 再次触发同值 → 早退（不重复通知编辑器）
+    windowsAction->trigger();
+    EXPECT_EQ(m_endlineChangeCalls, 1);
+    EXPECT_EQ(m_bar->getEndlineFormat(), BottomBar::Windows);
+
+    // Act: 切回 Unix
+    unixAction->trigger();
+    EXPECT_EQ(m_endlineChangeCalls, 2);
+    EXPECT_EQ(m_lastEndlineTo, BottomBar::Unix);
+    EXPECT_EQ(m_bar->getEndlineFormat(), BottomBar::Unix);
+}
+
+TEST_F(BottomBarTest, OnFormatMenuTrigged_NullAction_EarlyReturn)
+{
+    // Act: null 早退分支
+    m_bar->onFormatMenuTrigged(nullptr);
+
+    // Assert: 状态保持（强异常安全）
+    EXPECT_EQ(m_endlineChangeCalls, 0);
+    EXPECT_EQ(m_bar->getEndlineFormat(), BottomBar::Unix);
+    EXPECT_EQ(m_bar->m_formatMenu->getCurrentText(), QString("Unix"));
+}
+
+TEST_F(BottomBarTest, UpdateSizeMode_HeightMatchesMode)
+{
+    // Act（ctor 已调用，直接复核当前模式分支）
+    m_bar->updateSizeMode();
+
+    // Assert: 高度与布局模式匹配且为正值
+    EXPECT_EQ(m_bar->height(), BottomBar::defaultHeight());
+    EXPECT_GT(m_bar->height(), 0);
+}
+
+TEST_F(BottomBarTest, DefaultHeight_MatchesSizeMode)
+{
+    // Act / Assert: 静态高度 = 当前布局模式对应固定值（紧凑 26 / 标准 32）
+    EXPECT_EQ(BottomBar::defaultHeight(),
+              DGuiApplicationHelper::isCompactMode() ? 26 : 32);
+    EXPECT_TRUE(BottomBar::defaultHeight() == 26 || BottomBar::defaultHeight() == 32);
+}
+
+// ------------------------------------------------------------
+// Markdown 视图模式
+// ------------------------------------------------------------
+
+namespace {
+struct ViewModeCase {
+    ViewMode mode;
+    QString expectedText;
+};
+} // namespace
+
+class ViewModeMenuTest : public BottomBarTest,
+                         public ::testing::WithParamInterface<ViewModeCase> {
+};
+
+TEST_P(ViewModeMenuTest, SetViewMode_EachMode_SelectsActionAndText)
+{
+    // Arrange
+    const ViewModeCase c = GetParam();
+
+    // Act
+    m_bar->setViewMode(c.mode);
+
+    // Assert: 视图模式菜单文本与勾选 action 同步
+    EXPECT_EQ(m_bar->m_pViewModeMenu->getCurrentText(), c.expectedText);
+    EXPECT_FALSE(m_bar->m_actLivePreview->isEnabled()); // 未开启 markdown 可用性
+}
+
+INSTANTIATE_TEST_SUITE_P(ViewModeVariants, ViewModeMenuTest,
+                         ::testing::Values(
+                             ViewModeCase{ViewMode::Edit, QStringLiteral("Edit Mode")},
+                             ViewModeCase{ViewMode::ReadView, QStringLiteral("Read View")},
+                             ViewModeCase{ViewMode::LivePreview, QStringLiteral("Live Preview")},
+                             ViewModeCase{ViewMode::Wysiwyg, QStringLiteral("Edit Mode")}));
+
+TEST_F(BottomBarTest, SetMarkdownAvailable_TogglesLivePreview)
+{
+    // Arrange: 默认置灰
+    ASSERT_FALSE(m_bar->m_actLivePreview->isEnabled());
+
+    // Act
+    m_bar->setMarkdownAvailable(true);
+
+    // Assert: md 文件可用时「实时预览」解禁；再关灰
+    EXPECT_TRUE(m_bar->m_actLivePreview->isEnabled());
+    m_bar->setMarkdownAvailable(false);
+    EXPECT_FALSE(m_bar->m_actLivePreview->isEnabled());
+}
+
+TEST_F(BottomBarTest, ViewModeMenuTrigger_EmitsViewModeRequested)
+{
+    // Arrange: 开启 md 可用性，监听用户请求信号
+    m_bar->setMarkdownAvailable(true);
+    QSignalSpy spy(m_bar, &BottomBar::viewModeRequested);
+
+    // Act: 用户点选「实时预览」action（经 DMenu::triggered 转发 lambda）
+    m_bar->m_actLivePreview->trigger();
+    QApplication::processEvents();
+
+    // Assert: 发出 viewModeRequested(LivePreview)
+    ASSERT_EQ(spy.count(), 1);
+    EXPECT_EQ(spy.at(0).at(0).value<ViewMode>(), ViewMode::LivePreview);
+}
+
+// ------------------------------------------------------------
+// eventFilter / paintEvent
+// ------------------------------------------------------------
+
+TEST_F(BottomBarTest, EventFilter_FontChange_UpdatesLabels)
+{
+    // Arrange: 先给标签一个可区分字体
+    QFont marker;
+    marker.setPixelSize(21);
+    m_bar->m_pPositionLabel->setFont(marker);
+    ASSERT_EQ(m_bar->m_pPositionLabel->font().pixelSize(), 21);
+
+    // Act: 应用字体变化事件（#if QT>=6 分支）
+    QEvent fontEvent(QEvent::ApplicationFontChange);
+    bool ret = m_bar->eventFilter(qApp, &fontEvent);
+
+    // Assert: 事件放行且四个标签字体已同步为应用字体
+    EXPECT_FALSE(ret);
+    EXPECT_EQ(m_bar->m_pPositionLabel->font().pixelSize(), qApp->font().pixelSize());
+    EXPECT_EQ(m_bar->m_pCharCountLabel->font().pixelSize(), qApp->font().pixelSize());
+    EXPECT_EQ(m_bar->m_scaleLabel->font().pixelSize(), qApp->font().pixelSize());
+    EXPECT_EQ(m_bar->m_progressLabel->font().pixelSize(), qApp->font().pixelSize());
+
+    // Act: 无关事件交还基类
+    QEvent other(QEvent::MouseMove);
+    EXPECT_FALSE(m_bar->eventFilter(qApp, &other));
+}
+
+TEST_F(BottomBarTest, PaintEvent_BothFindStates_RendersFrame)
+{
+    // Arrange: 普通模式
+    m_bar->updateSize(32, false);
+    m_bar->resize(400, 32);
+
+    // Act: grab 强制同步绘制（非查找态：绘制顶部分隔线）
+    const QPixmap normal = m_bar->grab();
+    EXPECT_FALSE(normal.isNull());
+
+    // Act: 查找/替换模式（跳过分隔线）
+    m_bar->updateSize(40, true);
+    const QPixmap finding = m_bar->grab();
+    EXPECT_FALSE(finding.isNull());
+    EXPECT_EQ(m_bar->m_bIsFindOrReplace, true);
+}
+
+// ------------------------------------------------------------
+// 编码 / 高亮菜单切换 lambda
+// ------------------------------------------------------------
+
+TEST_F(BottomBarTest, EncodeMenuChange_Success_UpdatesMenuText)
+{
+    // Arrange: 编码菜单顶层 action 均为分组子菜单，经私有 m_menu 精确遍历
+    QAction *gbkAction = nullptr;
+    const QList<QAction *> tops = m_bar->m_pEncodeMenu->m_menu->actions();
+    for (QAction *top : tops) {
+        if (!top->menu())
+            continue;
+        for (QAction *a : top->menu()->actions()) {
+            if (a->text() == QString("GB18030")) {
+                gbkAction = a;
+                break;
+            }
+        }
+    }
+    ASSERT_NE(gbkAction, nullptr) << "编码菜单应包含 GB18030 项";
+    m_reloadEncodeResult = true;
+
+    // Act: 触发编码切换（currentActionChanged → lambda）
+    emit m_bar->getEncodeMenu()->currentActionChanged(gbkAction);
+
+    // Assert: 重载以 GB18030 调用一次且菜单文本更新
+    EXPECT_EQ(m_reloadEncodeCalls, 1);
+    EXPECT_EQ(m_lastReloadEncode, QByteArray("GB18030"));
+    EXPECT_EQ(m_bar->getEncodeMenu()->getCurrentText(), QString("GB18030"));
+}
+
+TEST_F(BottomBarTest, EncodeMenuChange_LoadedOrFailed_RevertsToPrevious)
+{
+    // Arrange: GB18030 action
+    QAction *gbkAction = nullptr;
+    const QList<QAction *> tops = m_bar->m_pEncodeMenu->m_menu->actions();
+    for (QAction *top : tops) {
+        if (!top->menu())
+            continue;
+        for (QAction *a : top->menu()->actions()) {
+            if (a->text() == QString("GB18030"))
+                gbkAction = a;
+        }
+    }
+    ASSERT_NE(gbkAction, nullptr);
+
+    // Act 1: 文件加载中 → 恢复旧文本
+    m_fileLoading = true;
+    emit m_bar->getEncodeMenu()->currentActionChanged(gbkAction);
+    EXPECT_EQ(m_reloadEncodeCalls, 0); // 加载中不触发转换
+    EXPECT_EQ(m_bar->getEncodeMenu()->getCurrentText(), QString("UTF-8"));
+
+    // Act 2: 转换失败 → 同样恢复
+    m_fileLoading = false;
+    m_reloadEncodeResult = false;
+    emit m_bar->getEncodeMenu()->currentActionChanged(gbkAction);
+    EXPECT_EQ(m_reloadEncodeCalls, 1);
+    EXPECT_EQ(m_bar->getEncodeMenu()->getCurrentText(), QString("UTF-8"));
+}
+
+TEST_F(BottomBarTest, HighlightMenuChange_UpdatesTextAndReloads)
+{
+    // Arrange: 高亮菜单（顶层 action 均为分组子菜单）取第一个可用 action
+    QAction *target = nullptr;
+    const QList<QAction *> tops = m_bar->m_pHighlightMenu->m_menu->actions();
+    for (QAction *top : tops) {
+        if (!top->menu())
+            continue;
+        for (QAction *a : top->menu()->actions()) {
+            if (a->text() != QString("None")) {
+                target = a;
+                break;
+            }
+        }
+    }
+    if (target == nullptr)
+        GTEST_SKIP() << "系统高亮仓库无可用定义，跳过";
+    const QString targetName = target->text();
+
+    // Act
+    emit m_bar->getHighlightMenu()->currentActionChanged(target);
+
+    // Assert: 菜单文本更新 + 编辑器收到高亮类型重载（ctor 连接的 lambda）
+    EXPECT_EQ(m_bar->getHighlightMenu()->getCurrentText(), targetName);
+    EXPECT_EQ(m_reloadHighlightCalls, 1);
+    EXPECT_EQ(m_lastReloadHighlight, targetName);
+}
+
+// ------------------------------------------------------------
+// slotSetTextEditFocus（真实 Window + 真实 EditWrapper）
+// ------------------------------------------------------------
+
+TEST_F(BottomBarTest, SlotSetTextEditFocus_EmitsWindowPressEsc)
+{
+    // Arrange: 真实 Window（DBus 全拦截）+ 真实 EditWrapper 作为父控件
+    stub.set_lamda(&QDBusConnection::systemBus,
+                   []() -> QDBusConnection { return QDBusConnection(QStringLiteral("ut_no_bus")); });
+    stub.set_lamda(&QDBusConnection::sessionBus,
+                   []() -> QDBusConnection { return QDBusConnection(QStringLiteral("ut_no_bus")); });
+    stub.set_lamda(
+        static_cast<QDBusMessage (QDBusAbstractInterface::*)(QDBus::CallMode, const QString &, const QList<QVariant> &)>(
+            &QDBusAbstractInterface::callWithArgumentList),
+        [](QDBusAbstractInterface *, QDBus::CallMode, const QString &, const QList<QVariant> &) -> QDBusMessage {
+            return QDBusMessage();
+        });
+
+    Window win;
+    EditWrapper *wrapper = new EditWrapper(&win, &win);
+    BottomBar bar(wrapper);
+    QSignalSpy spy(&win, &Window::pressEsc);
+
+    // Act: 编码菜单失去焦点 → 光标回文本框
+    bar.slotSetTextEditFocus();
+
+    // Assert: Window::pressEsc 发射一次（经真实 QObject 信号链）
+    EXPECT_EQ(spy.count(), 1);
+
+    // Act: 经信号路径再触发一次（DDropdownMenu::sigSetTextEditFocus 连接）
+    emit bar.getEncodeMenu()->sigSetTextEditFocus();
+    QApplication::processEvents();
+    EXPECT_EQ(spy.count(), 2);
+}

--- a/tests/widgets_ut/test_colorselectwdg.cpp
+++ b/tests/widgets_ut/test_colorselectwdg.cpp
@@ -1,0 +1,427 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// ============================================================================
+// ColorLabel + ColorSelectWdg 单元测试（B11 / src/widgets/ColorSelectWdg.cpp）
+//
+// 策略：真实 offscreen 构造（DWidget 族）。paintEvent 经 grab() 触发，
+// 鼠标/进出事件经 QApplication::sendEvent 合成派发。
+//
+// 分支清单（来源：ColorSelectWdg.cpp）与用例映射：
+// - ColorLabel::paintEvent：normal/hover/pressed × selected 组合
+//     → ColorLabel_Paint_AllStates_CompletesWithoutError（TEST_P 参数化）
+// - ColorLabel::enterEvent / leaveEvent → ColorLabel_EnterAndLeave_TogglesHover
+// - ColorLabel::mousePressEvent：左键置按下 / 右键忽略
+//     → ColorLabel_MousePress_LeftSetsPressedRightIgnored
+// - ColorLabel::mouseReleaseEvent：左键且已按下 → 选中 + sigColorClicked；
+//     未按下 / 右键 → 无信号
+//     → ColorLabel_MouseRelease_EmitsSignalWhenPressed /
+//       ColorLabel_MouseRelease_NotPressedEmitsNothing
+// - ColorLabel::setColorSelected：同值早退 / 翻转
+//     → ColorLabel_SetColorSelected_ToggleAndIdempotent
+// - ColorSelectWdg ctor：text 空/非空两套布局
+//     → ColorSelectWdg_EmptyText_CompactLayout /
+//       ColorSelectWdg_WithText_ButtonAndDefaultColor
+// - initWidget（私有，经 ctor）：首个色块默认选中
+// - ColorSelectWdg dtor：布局指针回收 → ColorSelectWdg_Destructor_CleansLayouts
+// - setTheme：light/dark/未知 → ColorSelectWdg_SetTheme_Param（TEST_P）
+// - getDefaultColor → ColorSelectWdg_WithText_ButtonAndDefaultColor
+// - eventFilter：m_pLabel 恒为 null（源码从未赋值，记录缺陷）→ object==nullptr
+//     且左键 → 发信号返回 true；非左键 → false；object 非 null → 基类
+//     → ColorSelectWdg_EventFilter_NullObjectBranches
+// - 点击色块互斥（sigColorClicked → 其它 label 取消选中 + 默认色更新）
+//     → ColorSelectWdg_LabelClick_ExclusivelySelects
+// - 按钮点击 → sigColorSelected(true, defaultColor)
+//     → ColorSelectWdg_ButtonClick_EmitsDefaultColorSignal
+// ============================================================================
+
+#include <gtest/gtest.h>
+#include "stubext.h"
+
+#include <QApplication>
+#include <QTemporaryDir>
+#include <QSignalSpy>
+#include <QMouseEvent>
+#include <QEnterEvent>
+#include <QDir>
+#include <QPushButton>
+
+#include "widgets/ColorSelectWdg.h"
+#include "common/utils.h"
+
+class ColorSelectWdgTest : public ::testing::Test {
+protected:
+    static void SetUpTestSuite()
+    {
+        s_configHome = new QTemporaryDir();
+        s_dataHome = new QTemporaryDir();
+        const QString xdgConfig = s_configHome->filePath("xdg-config");
+        const QString xdgData = s_dataHome->filePath("xdg-data");
+        QDir().mkpath(xdgConfig);
+        QDir().mkpath(xdgData);
+        qputenv("XDG_CONFIG_HOME", xdgConfig.toUtf8());
+        qputenv("XDG_DATA_HOME", xdgData.toUtf8());
+
+        int argc = 1;
+        char *argv[] = {s_argv, nullptr};
+        s_app = new QApplication(argc, argv);
+        QApplication::setOrganizationName(QStringLiteral("deepin"));
+        QApplication::setApplicationName(QStringLiteral("deepin-editor"));
+    }
+
+    static void TearDownTestSuite()
+    {
+        qunsetenv("XDG_CONFIG_HOME");
+        qunsetenv("XDG_DATA_HOME");
+    }
+
+    void SetUp() override
+    {
+        const QList<QColor> colors = Utils::getHiglightColorList();
+        ASSERT_FALSE(colors.isEmpty());
+        label = new ColorLabel(colors.first());
+        firstColor = colors.first();
+    }
+
+    void TearDown() override
+    {
+        delete label;
+        label = nullptr;
+        stub.clear();
+    }
+
+    // 合成鼠标事件并直接派发给 ColorLabel（Qt6 五参 ctor）
+    void sendMouseEvent(QEvent::Type type, Qt::MouseButton button,
+                        Qt::MouseButtons buttons)
+    {
+        const QPointF local(4, 4);
+        QMouseEvent ev(type, local, local, button, buttons, Qt::NoModifier);
+        QApplication::sendEvent(label, &ev);
+    }
+
+    stub_ext::StubExt stub;
+    ColorLabel *label = nullptr;
+    QColor firstColor;
+
+    static QApplication *s_app;
+    static QTemporaryDir *s_configHome;
+    static QTemporaryDir *s_dataHome;
+    static char s_argv[];
+};
+
+QApplication *ColorSelectWdgTest::s_app = nullptr;
+QTemporaryDir *ColorSelectWdgTest::s_configHome = nullptr;
+QTemporaryDir *ColorSelectWdgTest::s_dataHome = nullptr;
+char ColorSelectWdgTest::s_argv[] = "test_colorselectwdg";
+
+// ------------------------------------------------------------
+// ColorLabel：状态与事件
+// ------------------------------------------------------------
+
+TEST_F(ColorSelectWdgTest, ColorLabel_InitialState_ReturnsCtorColor)
+{
+    // Assert: 构造色即返回色，未选中、无按下/悬停
+    EXPECT_EQ(label->getColor(), firstColor);
+    EXPECT_FALSE(label->isSelected());
+    EXPECT_FALSE(label->m_bHover);
+    EXPECT_FALSE(label->m_bPressed);
+}
+
+TEST_F(ColorSelectWdgTest, ColorLabel_SetColorSelected_ToggleAndIdempotent)
+{
+    // Act: 首次置选中
+    label->setColorSelected(true);
+
+    // Assert: 状态翻转
+    EXPECT_TRUE(label->isSelected());
+
+    // Act: 同值再设（早退分支，状态不变）
+    label->setColorSelected(true);
+    EXPECT_TRUE(label->isSelected());
+
+    // Act: 取消选中
+    label->setColorSelected(false);
+    EXPECT_FALSE(label->isSelected());
+}
+
+TEST_F(ColorSelectWdgTest, ColorLabel_EnterAndLeave_TogglesHover)
+{
+    // Arrange: 合成进入事件
+    const QPointF local(2, 2);
+    QEnterEvent enter(local, local, local);
+    QApplication::sendEvent(label, &enter);
+
+    // Assert: 悬停态置位
+    EXPECT_TRUE(label->m_bHover);
+
+    // Act: 离开事件（复位 hover 与 pressed）
+    label->m_bPressed = true;
+    QEvent leave(QEvent::Leave);
+    QApplication::sendEvent(label, &leave);
+
+    // Assert: 两个标志均复位
+    EXPECT_FALSE(label->m_bHover);
+    EXPECT_FALSE(label->m_bPressed);
+}
+
+TEST_F(ColorSelectWdgTest, ColorLabel_MousePress_LeftSetsPressedRightIgnored)
+{
+    // Act: 左键按下
+    sendMouseEvent(QEvent::MouseButtonPress, Qt::LeftButton, Qt::LeftButton);
+
+    // Assert: 按下态置位
+    EXPECT_TRUE(label->m_bPressed);
+
+    // Act: 右键按下（不置位）
+    sendMouseEvent(QEvent::MouseButtonPress, Qt::RightButton, Qt::RightButton);
+    EXPECT_TRUE(label->m_bPressed); // 仍为此前左键置位的状态
+
+    // Arrange: 复位后仅右键 → 不进入按下态
+    label->m_bPressed = false;
+    sendMouseEvent(QEvent::MouseButtonPress, Qt::RightButton, Qt::RightButton);
+    EXPECT_FALSE(label->m_bPressed);
+}
+
+TEST_F(ColorSelectWdgTest, ColorLabel_MouseRelease_EmitsSignalWhenPressed)
+{
+    // Arrange: 左键按下后释放
+    QSignalSpy spy(label, &ColorLabel::sigColorClicked);
+    sendMouseEvent(QEvent::MouseButtonPress, Qt::LeftButton, Qt::LeftButton);
+    ASSERT_TRUE(label->m_bPressed);
+
+    // Act
+    sendMouseEvent(QEvent::MouseButtonRelease, Qt::LeftButton, Qt::NoButton);
+
+    // Assert: 选中态置位 + 信号携带 (true, color)
+    EXPECT_TRUE(label->isSelected());
+    ASSERT_EQ(spy.count(), 1);
+    EXPECT_TRUE(spy.at(0).at(0).toBool());
+    EXPECT_EQ(spy.at(0).at(1).value<QColor>(), firstColor);
+}
+
+TEST_F(ColorSelectWdgTest, ColorLabel_MouseRelease_NotPressedEmitsNothing)
+{
+    // Arrange: 未经过按下直接释放
+    QSignalSpy spy(label, &ColorLabel::sigColorClicked);
+    ASSERT_FALSE(label->m_bPressed);
+
+    // Act
+    sendMouseEvent(QEvent::MouseButtonRelease, Qt::LeftButton, Qt::NoButton);
+
+    // Assert: 无信号、未选中（强异常安全：状态未变）
+    EXPECT_EQ(spy.count(), 0);
+    EXPECT_FALSE(label->isSelected());
+}
+
+// paintEvent 全状态组合参数化（normal/hover/pressed × selected）
+namespace {
+struct PaintState {
+    bool hover;
+    bool pressed;
+    bool selected;
+};
+} // namespace
+
+class ColorLabelPaintTest : public ColorSelectWdgTest,
+                            public ::testing::WithParamInterface<PaintState> {
+};
+
+TEST_P(ColorLabelPaintTest, Paint_AllStates_CompletesWithoutError)
+{
+    // Arrange: 注入状态
+    const PaintState st = GetParam();
+    label->m_bHover = st.hover;
+    label->m_bPressed = st.pressed;
+    label->m_bSelected = st.selected;
+    label->resize(24, 24);
+
+    // Act: grab 强制同步触发 paintEvent（offscreen 真实绘制）
+    const QPixmap px = label->grab();
+
+    // Assert: 产出非空图像且状态未被破坏
+    EXPECT_FALSE(px.isNull());
+    EXPECT_EQ(px.width(), 24);
+    EXPECT_EQ(label->isSelected(), st.selected);
+}
+
+INSTANTIATE_TEST_SUITE_P(PaintStates, ColorLabelPaintTest,
+                         ::testing::Values(
+                             PaintState{false, false, false},
+                             PaintState{false, false, true},
+                             PaintState{true, false, false},
+                             PaintState{true, false, true},
+                             PaintState{false, true, false},
+                             PaintState{false, true, true},
+                             PaintState{true, true, true}));
+
+// ------------------------------------------------------------
+// ColorSelectWdg：构造 / 主题 / 默认色
+// ------------------------------------------------------------
+
+TEST_F(ColorSelectWdgTest, ColorSelectWdg_EmptyText_CompactLayout)
+{
+    // Act
+    ColorSelectWdg w{QString()};
+
+    // Assert: 紧凑高度 35、无按钮、默认色为调色板首色、色块全部创建
+    EXPECT_EQ(w.height(), 35);
+    EXPECT_EQ(w.findChild<QPushButton *>("PButton"), nullptr);
+    EXPECT_EQ(w.getDefaultColor(), firstColor);
+    EXPECT_EQ(w.m_colorLabels.size(), Utils::getHiglightColorList().size());
+    EXPECT_TRUE(w.m_colorLabels.first()->isSelected());
+    EXPECT_EQ(w.m_pMainLayout, nullptr);
+    EXPECT_NE(w.m_pHLayout2, nullptr);
+}
+
+TEST_F(ColorSelectWdgTest, ColorSelectWdg_WithText_ButtonAndDefaultColor)
+{
+    // Act
+    ColorSelectWdg w(QStringLiteral("Mark"));
+
+    // Assert: 带标题高度 60、按钮存在、主布局为纵向
+    EXPECT_EQ(w.height(), 60);
+    QPushButton *btn = w.findChild<QPushButton *>("PButton");
+    ASSERT_NE(btn, nullptr);
+    EXPECT_EQ(btn->text(), QString("Mark"));
+    EXPECT_EQ(w.getDefaultColor(), firstColor);
+    EXPECT_NE(w.m_pMainLayout, nullptr);
+    EXPECT_NE(w.m_pHLayout1, nullptr);
+}
+
+namespace {
+struct ThemeCase {
+    QString theme;
+    QString expectedText; // 空串 = 不修改
+};
+} // namespace
+
+class ColorSelectThemeTest : public ColorSelectWdgTest,
+                             public ::testing::WithParamInterface<ThemeCase> {
+};
+
+TEST_P(ColorSelectThemeTest, SetTheme_LightDarkUnknown_SetsTextColor)
+{
+    // Arrange
+    ColorSelectWdg w(QStringLiteral("Mark"));
+    w.m_textColor = QStringLiteral("#deadbeef");
+    const ThemeCase c = GetParam();
+
+    // Act
+    w.setTheme(c.theme);
+
+    // Assert: 主题色按分支更新或保持
+    if (c.expectedText.isEmpty()) {
+        EXPECT_EQ(w.m_textColor, QString("#deadbeef"));
+    } else {
+        EXPECT_EQ(w.m_textColor, c.expectedText);
+    }
+    // 状态不受影响（强异常安全）
+    EXPECT_EQ(w.getDefaultColor(), firstColor);
+}
+
+INSTANTIATE_TEST_SUITE_P(ThemeVariants, ColorSelectThemeTest,
+                         ::testing::Values(
+                             ThemeCase{QStringLiteral("light"), QStringLiteral("#1f1c1b")},
+                             ThemeCase{QStringLiteral("dark"), QStringLiteral("#cfcfc2")},
+                             ThemeCase{QStringLiteral("unknown"), QString()}));
+
+TEST_F(ColorSelectWdgTest, ColorSelectWdg_Destructor_CleansLayouts)
+{
+    // Arrange: 两种布局各建一个（父对象持有）
+    QWidget host;
+    auto *withText = new ColorSelectWdg(QStringLiteral("Mark"), &host);
+    auto *compact = new ColorSelectWdg(QString(), &host);
+
+    // Act: 析构（内部 delete 三个布局指针并置空）
+    delete withText;
+    delete compact;
+
+    // Assert: 无崩溃即通过无法直接断言，改验证 host 子对象减少
+    EXPECT_EQ(host.findChildren<ColorSelectWdg *>().count(), 0);
+    EXPECT_TRUE(host.children().isEmpty());
+}
+
+// ------------------------------------------------------------
+// ColorSelectWdg：交互信号
+// ------------------------------------------------------------
+
+TEST_F(ColorSelectWdgTest, ColorSelectWdg_ButtonClick_EmitsDefaultColorSignal)
+{
+    // Arrange
+    ColorSelectWdg w(QStringLiteral("Mark"));
+    QPushButton *btn = w.findChild<QPushButton *>("PButton");
+    ASSERT_NE(btn, nullptr);
+    QSignalSpy spy(&w, &ColorSelectWdg::sigColorSelected);
+
+    // Act: 点击按钮
+    btn->click();
+
+    // Assert: 发送 (true, 默认色)
+    ASSERT_EQ(spy.count(), 1);
+    EXPECT_TRUE(spy.at(0).at(0).toBool());
+    EXPECT_EQ(spy.at(0).at(1).value<QColor>(), firstColor);
+    EXPECT_EQ(w.getDefaultColor(), firstColor);
+}
+
+TEST_F(ColorSelectWdgTest, ColorSelectWdg_LabelClick_ExclusivelySelects)
+{
+    // Arrange
+    ColorSelectWdg w{QString()};
+    ASSERT_GE(w.m_colorLabels.size(), 3);
+    ColorLabel *first = w.m_colorLabels.at(0);
+    ColorLabel *third = w.m_colorLabels.at(2);
+    const QColor thirdColor = third->getColor();
+    QSignalSpy spy(&w, &ColorSelectWdg::sigColorSelected);
+    ASSERT_TRUE(first->isSelected());
+
+    // Act: 点击第三个色块（左键按下 + 释放）
+    const QPointF local(4, 4);
+    QMouseEvent press(QEvent::MouseButtonPress, local, local,
+                      Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+    QApplication::sendEvent(third, &press);
+    QMouseEvent release(QEvent::MouseButtonRelease, local, local,
+                        Qt::LeftButton, Qt::NoButton, Qt::NoModifier);
+    QApplication::sendEvent(third, &release);
+
+    // Assert: 第三块选中、首块取消、默认色更新、信号发出
+    EXPECT_TRUE(third->isSelected());
+    EXPECT_FALSE(first->isSelected());
+    EXPECT_EQ(w.getDefaultColor(), thirdColor);
+    ASSERT_EQ(spy.count(), 1);
+    EXPECT_EQ(spy.at(0).at(1).value<QColor>(), thirdColor);
+}
+
+// ------------------------------------------------------------
+// eventFilter（注意：m_pLabel 源码中从未赋值，恒为 nullptr —— 记录缺陷）
+// ------------------------------------------------------------
+
+TEST_F(ColorSelectWdgTest, ColorSelectWdg_EventFilter_NullObjectBranches)
+{
+    // Arrange
+    ColorSelectWdg w(QStringLiteral("Mark"));
+    QSignalSpy spy(&w, &ColorSelectWdg::sigColorSelected);
+
+    // Act: object==nullptr（等值于未初始化的 m_pLabel）+ 左键
+    QMouseEvent leftClick(QEvent::MouseButtonPress, QPointF(1, 1), QPointF(1, 1),
+                          Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+    bool retLeft = w.eventFilter(nullptr, &leftClick);
+
+    // Assert: 左键分支 → 发默认色信号并拦截
+    EXPECT_TRUE(retLeft);
+    ASSERT_EQ(spy.count(), 1);
+    EXPECT_EQ(spy.at(0).at(1).value<QColor>(), w.getDefaultColor());
+
+    // Act: 右键分支 → 放行不发信号
+    QSignalSpy spy2(&w, &ColorSelectWdg::sigColorSelected);
+    QMouseEvent rightClick(QEvent::MouseButtonPress, QPointF(1, 1), QPointF(1, 1),
+                           Qt::RightButton, Qt::RightButton, Qt::NoModifier);
+    bool retRight = w.eventFilter(nullptr, &rightClick);
+    EXPECT_FALSE(retRight);
+    EXPECT_EQ(spy2.count(), 0);
+
+    // Act: object 非 null（不等于 m_pLabel）→ 基类放行
+    QObject stranger;
+    bool retStranger = w.eventFilter(&stranger, &leftClick);
+    EXPECT_FALSE(retStranger);
+    EXPECT_EQ(spy2.count(), 0);
+}

--- a/tests/widgets_ut/test_ddropdownmenu.cpp
+++ b/tests/widgets_ut/test_ddropdownmenu.cpp
@@ -1,0 +1,750 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// ============================================================================
+// DDropdownMenu 单元测试（B11 / src/widgets/ddropdownmenu.cpp）
+//
+// 策略：真实 offscreen 构造（qrc 资源编入目标，SVG 图标可用），
+// 模态 QMenu::exec 由 stub_ext 拦截，其余全部真实执行。
+//
+// 分支清单（来源：ddropdownmenu.cpp）与用例映射：
+// - ctor：图标/字体/布局/快捷键连接
+//     → Constructor_RealBuild_CreatesButtonAndDefaultText
+// - setFontEx → SetFontEx_NewFont_AppliedToButton
+// - setCurrentAction：null 早退 / 有效 action 勾选+设文本
+//     → SetCurrentAction_NullAction_KeepsState / SetCurrentAction_ValidAction_ChecksAndSetsText
+// - setCurrentTextOnly：空菜单 / 嵌套菜单勾选
+//     → SetCurrentTextOnly_EmptyMenu_SetsText / SetCurrentTextOnly_NestedMenu_ChecksMatchedAction
+// - setCheckedExclusive：null / 有子菜单递归 / 无子菜单文本相等与不等
+//     → SetCheckedExclusive_NullAction_EarlyReturn
+//     → SetCheckedExclusive_NestedMenu_RecursesIntoSubmenus（经 setCurrentTextOnly 递归分支）
+// - slotRequestMenu：request=true 清焦 / exec + HoverLeave + 信号
+//     → SlotRequestMenu_EmitsFocusSignalAfterExec
+// - setText（经 setCurrentTextOnly）
+// - setMenu：非空设名 / null；deleteMenu：空/非空 → SetMenu_* / DeleteMenu_*
+// - setMenuActionGroup / deleteMenuActionGroup → SetMenuActionGroup_*/DeleteMenuActionGroup_*
+// - setTheme（亮/暗图标重建）→ SetTheme_LightAndDark_RebuildsArrowPixmap
+// - setChildrenFocus true/false → SetChildrenFocus_*
+// - setRequestMenu → SetRequestMenu_SetsInternalFlag
+// - getButton / getCurrentText → Constructor_RealBuild_* / GetCurrentText_*
+// - createEncodeMenu（静态）→ CreateEncodeMenu_ContainsUtf8Default
+// - createHighLightMenu（静态）→ CreateHighLightMenu_DefaultNoneWithActionGroup
+// - createIcon（经 setText）/ setSvgColor+SetSVGBackColor（经鼠标按下高亮分支）
+//     → EventFilter_MousePressLeft_MarksPressedAndReturnsTrue（按下 → createIcon → setSvgColor）
+//     → SetSvgColor_RealSvg_ReturnsColoredPixmap（直接调用私有函数）
+// - OnFontChangedSlot（经 ApplicationFontChange 事件）
+//     → EventFilter_ApplicationFontChange_RefreshesFont
+// - eventFilter：工具按钮 KeyPress(Return/Space/其他)、鼠标左/右按下、左释放（可用/禁用）
+//     → EventFilter_* 系列
+//
+// 环境隔离：XDG 重定向临时目录（SetUpTestSuite/TearDownTestSuite qputenv/qunsetenv 配平）；
+// QMenu::exec 拦截避免模态阻塞；无真实 IO / 网络 / 子进程。
+// ============================================================================
+
+#include <gtest/gtest.h>
+#include "stubext.h"
+
+#include <QApplication>
+#include <QTemporaryDir>
+#include <QSignalSpy>
+#include <QMouseEvent>
+#include <QKeyEvent>
+#include <QHoverEvent>
+#include <QActionGroup>
+#include <QFont>
+#include <QDir>
+#include <DGuiApplicationHelper>
+
+using Dtk::Gui::DGuiApplicationHelper;
+
+#include "widgets/ddropdownmenu.h"
+
+class DDropdownMenuTest : public ::testing::Test {
+protected:
+    static void SetUpTestSuite()
+    {
+        s_configHome = new QTemporaryDir();
+        s_dataHome = new QTemporaryDir();
+        const QString xdgConfig = s_configHome->filePath("xdg-config");
+        const QString xdgData = s_dataHome->filePath("xdg-data");
+        QDir().mkpath(xdgConfig);
+        QDir().mkpath(xdgData);
+        qputenv("XDG_CONFIG_HOME", xdgConfig.toUtf8());
+        qputenv("XDG_DATA_HOME", xdgData.toUtf8());
+
+        int argc = 1;
+        char *argv[] = {s_argv, nullptr};
+        s_app = new QApplication(argc, argv);
+        QApplication::setOrganizationName(QStringLiteral("deepin"));
+        QApplication::setApplicationName(QStringLiteral("deepin-editor"));
+    }
+
+    static void TearDownTestSuite()
+    {
+        qunsetenv("XDG_CONFIG_HOME");
+        qunsetenv("XDG_DATA_HOME");
+    }
+
+    void SetUp() override
+    {
+        obj = new DDropdownMenu();
+    }
+
+    void TearDown() override
+    {
+        // 析构链：deleteMenuActionGroup + deleteMenu（真实执行）
+        delete obj;
+        obj = nullptr;
+        stub.clear();
+    }
+
+    // 构造"顶层 action 均带子菜单"的菜单（与真实编码菜单同构）
+    QMenu *buildNestedMenu(QWidget *parent)
+    {
+        QMenu *menu = new QMenu(parent);
+        QMenu *sub1 = new QMenu("Group1", menu);
+        a1 = sub1->addAction("A1");
+        a2 = sub1->addAction("A2");
+        menu->addMenu(sub1);
+        QMenu *sub2 = new QMenu("Group2", menu);
+        b1 = sub2->addAction("B1");
+        b2 = sub2->addAction("B2");
+        menu->addMenu(sub2);
+        return menu;
+    }
+
+    stub_ext::StubExt stub;
+    DDropdownMenu *obj = nullptr;
+    QAction *a1 = nullptr;
+    QAction *a2 = nullptr;
+    QAction *b1 = nullptr;
+    QAction *b2 = nullptr;
+
+    int menuExecCalls = 0;
+
+    static QApplication *s_app;
+    static QTemporaryDir *s_configHome;
+    static QTemporaryDir *s_dataHome;
+    static char s_argv[];
+};
+
+QApplication *DDropdownMenuTest::s_app = nullptr;
+QTemporaryDir *DDropdownMenuTest::s_configHome = nullptr;
+QTemporaryDir *DDropdownMenuTest::s_dataHome = nullptr;
+char DDropdownMenuTest::s_argv[] = "test_ddropdownmenu";
+
+// ------------------------------------------------------------
+// 构造 / 基础 getter
+// ------------------------------------------------------------
+
+TEST_F(DDropdownMenuTest, Constructor_RealBuild_CreatesButtonAndDefaultText)
+{
+    // Assert: 按钮子控件就绪 + 默认文本 UTF-8 + 箭头图标已渲染（qrc 资源）
+    ASSERT_NE(obj->getButton(), nullptr);
+    EXPECT_EQ(obj->getButton()->parent(), obj);
+    EXPECT_EQ(obj->getCurrentText(), QString("UTF-8"));
+    EXPECT_FALSE(obj->m_arrowPixmap.isNull());
+    EXPECT_EQ(obj->getButton()->focusPolicy(), Qt::StrongFocus);
+}
+
+TEST_F(DDropdownMenuTest, GetCurrentText_AfterSetTextOnly_ReflectsNewValue)
+{
+    // Act
+    obj->setCurrentTextOnly(QStringLiteral("GBK"));
+
+    // Assert
+    EXPECT_EQ(obj->getCurrentText(), QString("GBK"));
+    EXPECT_NE(obj->getCurrentText(), QString("UTF-8"));
+}
+
+// ------------------------------------------------------------
+// setFontEx
+// ------------------------------------------------------------
+
+TEST_F(DDropdownMenuTest, SetFontEx_NewFont_AppliedToButton)
+{
+    // Arrange
+    QFont font;
+    font.setPixelSize(21);
+    font.setFamily(QStringLiteral("monospace"));
+
+    // Act
+    obj->setFontEx(font);
+
+    // Assert: 按钮字体生效 + 内部记录字体一致
+    EXPECT_EQ(obj->getButton()->font().pixelSize(), 21);
+    EXPECT_EQ(obj->m_font.pixelSize(), 21);
+    EXPECT_EQ(obj->m_font.family(), QString("monospace"));
+}
+
+// ------------------------------------------------------------
+// setMenu / deleteMenu
+// ------------------------------------------------------------
+
+TEST_F(DDropdownMenuTest, SetMenu_RealMenu_SetsObjectNames)
+{
+    // Arrange
+    QMenu *menu = buildNestedMenu(nullptr);
+
+    // Act
+    obj->setMenu(menu);
+
+    // Assert: 菜单替换成功且设置对象名/无障碍名
+    EXPECT_EQ(menu->objectName(), QString("DropdownMenu"));
+    EXPECT_EQ(menu->accessibleName(), QString("DropdownMenu"));
+    EXPECT_EQ(obj->m_menu, menu);
+}
+
+TEST_F(DDropdownMenuTest, SetMenu_NullMenu_ClearsMenu)
+{
+    // Arrange: 先装一个真实菜单
+    QMenu *menu = buildNestedMenu(nullptr);
+    obj->setMenu(menu);
+
+    // Act: 置空（内部 deleteMenu 分支执行，旧菜单被析构）
+    obj->setMenu(nullptr);
+
+    // Assert: 指针置空且菜单不再作为子对象存在
+    EXPECT_EQ(obj->m_menu, nullptr);
+    EXPECT_EQ(obj->findChildren<QMenu *>().count(), 0);
+}
+
+TEST_F(DDropdownMenuTest, DeleteMenu_WithMenu_ReleasesAndNulls)
+{
+    // Arrange
+    QMenu *menu = buildNestedMenu(nullptr);
+    obj->setMenu(menu);
+
+    // Act
+    obj->deleteMenu();
+
+    // Assert
+    EXPECT_EQ(obj->m_menu, nullptr);
+    // 二次删除（空分支）不应崩溃
+    obj->deleteMenu();
+    EXPECT_EQ(obj->m_menu, nullptr);
+}
+
+// ------------------------------------------------------------
+// setMenuActionGroup / deleteMenuActionGroup
+// ------------------------------------------------------------
+
+TEST_F(DDropdownMenuTest, SetMenuActionGroup_RealGroup_SetsObjectName)
+{
+    // Arrange
+    QActionGroup *group = new QActionGroup(nullptr);
+
+    // Act
+    obj->setMenuActionGroup(group);
+
+    // Assert
+    EXPECT_EQ(obj->m_actionGroup, group);
+    EXPECT_EQ(group->objectName(), QString("ActionGroup"));
+}
+
+TEST_F(DDropdownMenuTest, DeleteMenuActionGroup_WithGroup_ReleasesAndNulls)
+{
+    // Arrange
+    QActionGroup *group = new QActionGroup(nullptr);
+    obj->setMenuActionGroup(group);
+    QPointer<QActionGroup> watch(group);
+
+    // Act
+    obj->deleteMenuActionGroup();
+
+    // Assert: 组被删除且指针置空；空二次删除不崩溃
+    EXPECT_TRUE(watch.isNull());
+    EXPECT_EQ(obj->m_actionGroup, nullptr);
+    obj->deleteMenuActionGroup();
+    EXPECT_EQ(obj->m_actionGroup, nullptr);
+}
+
+// ------------------------------------------------------------
+// setTheme
+// ------------------------------------------------------------
+
+TEST_F(DDropdownMenuTest, SetTheme_LightAndDark_RebuildsArrowPixmap)
+{
+    // Arrange: 记录初始 pixmap 序列号
+    const qint64 oldSerial = obj->m_arrowPixmap.cacheKey();
+
+    // Act
+    obj->setTheme(QStringLiteral("light"));
+
+    // Assert: 亮色箭头重建（资源 :/images/dropdown_arrow_light.svg 存在）
+    EXPECT_FALSE(obj->m_arrowPixmap.isNull());
+    const qint64 lightSerial = obj->m_arrowPixmap.cacheKey();
+
+    // Act: 暗色
+    obj->setTheme(QStringLiteral("dark"));
+
+    // Assert: 暗色箭头再次重建且与亮色不同
+    EXPECT_FALSE(obj->m_arrowPixmap.isNull());
+    EXPECT_NE(obj->m_arrowPixmap.cacheKey(), lightSerial);
+    EXPECT_NE(oldSerial, lightSerial);
+}
+
+// ------------------------------------------------------------
+// setChildrenFocus / setRequestMenu
+// ------------------------------------------------------------
+
+TEST_F(DDropdownMenuTest, SetChildrenFocus_TrueAndFalse_TogglesFocusPolicy)
+{
+    // Act / Assert: true → StrongFocus
+    obj->setChildrenFocus(true);
+    EXPECT_EQ(obj->getButton()->focusPolicy(), Qt::StrongFocus);
+
+    // Act / Assert: false → NoFocus
+    obj->setChildrenFocus(false);
+    EXPECT_EQ(obj->getButton()->focusPolicy(), Qt::NoFocus);
+    EXPECT_FALSE(obj->getButton()->hasFocus());
+}
+
+TEST_F(DDropdownMenuTest, SetRequestMenu_TrueAndFalse_SetsInternalFlag)
+{
+    // Act
+    obj->setRequestMenu(true);
+
+    // Assert: 内部标志翻转（后续 slotRequestMenu 据此清焦）
+    EXPECT_TRUE(obj->isRequest);
+
+    // Act / Assert: 复位
+    obj->setRequestMenu(false);
+    EXPECT_FALSE(obj->isRequest);
+}
+
+// ------------------------------------------------------------
+// setCurrentAction / setCurrentTextOnly / setCheckedExclusive
+// ------------------------------------------------------------
+
+TEST_F(DDropdownMenuTest, SetCurrentAction_NullAction_KeepsState)
+{
+    // Arrange
+    obj->setCurrentTextOnly(QStringLiteral("UTF-8"));
+
+    // Act: null 早退分支
+    obj->setCurrentAction(nullptr);
+
+    // Assert: 文本与内部菜单保持不变
+    EXPECT_EQ(obj->getCurrentText(), QString("UTF-8"));
+    EXPECT_FALSE(obj->m_bPressed);
+}
+
+TEST_F(DDropdownMenuTest, SetCurrentAction_ValidAction_ChecksAndSetsText)
+{
+    // Arrange: 嵌套菜单（与真实编码菜单同构：顶层 action 均带子菜单）
+    QMenu *menu = buildNestedMenu(nullptr);
+    obj->setMenu(menu);
+    a1->setCheckable(true);
+    a2->setCheckable(true);
+    b1->setCheckable(true);
+    b2->setCheckable(true);
+    a2->setChecked(false);
+
+    // Act
+    obj->setCurrentAction(a2);
+
+    // Assert: 目标勾选、文本更新
+    EXPECT_TRUE(a2->isChecked());
+    EXPECT_EQ(obj->getCurrentText(), QString("A2"));
+    // 切到 B1 后 A2 取消勾选
+    obj->setCurrentAction(b1);
+    EXPECT_FALSE(a2->isChecked());
+    EXPECT_TRUE(b1->isChecked());
+    EXPECT_EQ(obj->getCurrentText(), QString("B1"));
+}
+
+TEST_F(DDropdownMenuTest, SetCurrentTextOnly_EmptyMenu_SetsText)
+{
+    // Act: 默认构造的 m_menu 无 action（空循环）
+    obj->setCurrentTextOnly(QStringLiteral("UTF-16"));
+
+    // Assert: 文本仍被设置
+    EXPECT_EQ(obj->getCurrentText(), QString("UTF-16"));
+    EXPECT_EQ(obj->getButton()->isEnabled(), true);
+}
+
+TEST_F(DDropdownMenuTest, SetCurrentTextOnly_NestedMenu_ChecksMatchedAction)
+{
+    // Arrange
+    QMenu *menu = buildNestedMenu(nullptr);
+    obj->setMenu(menu);
+
+    // Act: 选中嵌套子菜单中的 B1
+    obj->setCurrentTextOnly(QStringLiteral("B1"));
+
+    // Assert: B1 勾选，其余 action 取消勾选且不可勾选
+    EXPECT_TRUE(b1->isCheckable());
+    EXPECT_TRUE(b1->isChecked());
+    EXPECT_FALSE(a1->isCheckable());
+    EXPECT_FALSE(a1->isChecked());
+    EXPECT_FALSE(b2->isCheckable());
+    EXPECT_EQ(obj->getCurrentText(), QString("B1"));
+}
+
+TEST_F(DDropdownMenuTest, SetCheckedExclusive_NullAction_EarlyReturn)
+{
+    // Arrange
+    const QString before = obj->getCurrentText();
+
+    // Act: null 早退（B1 分支）
+    obj->setCheckedExclusive(nullptr, QStringLiteral("whatever"));
+
+    // Assert: 状态未受影响
+    EXPECT_EQ(obj->getCurrentText(), before);
+    EXPECT_EQ(obj->getCurrentText(), QString("UTF-8"));
+}
+
+TEST_F(DDropdownMenuTest, SetCheckedExclusive_NoSubMenu_MatchesByNameDirectly)
+{
+    // Arrange: 平铺菜单（action 无子菜单 → else 分支，含同名/异名两侧）
+    QMenu *menu = new QMenu(nullptr);
+    QAction *plain1 = menu->addAction("P1");
+    QAction *plain2 = menu->addAction("P2");
+    obj->setMenu(menu);
+
+    // Act: 匹配 P2
+    obj->setCurrentTextOnly(QStringLiteral("P2"));
+
+    // Assert: P2 勾选，P1 不勾选（异名分支）
+    EXPECT_TRUE(plain2->isChecked());
+    EXPECT_FALSE(plain1->isChecked());
+
+    // Act: 再匹配 P1（覆盖同名分支 + 状态切换）
+    obj->setCurrentTextOnly(QStringLiteral("P1"));
+    EXPECT_TRUE(plain1->isChecked());
+    EXPECT_FALSE(plain2->isChecked());
+}
+
+// ------------------------------------------------------------
+// slotRequestMenu（经 requestContextMenu 信号触发）
+// ------------------------------------------------------------
+
+TEST_F(DDropdownMenuTest, SlotRequestMenu_EmitsFocusSignalAfterExec)
+{
+    // Arrange: 拦截 QMenu::exec（DMenu 为 QMenu typedef；三重载均非虚，static_cast 定点）
+    stub.set_lamda(static_cast<QAction *(QMenu::*)()>(&QMenu::exec),
+                   [this](QMenu *) -> QAction * {
+                       ++menuExecCalls;
+                       return nullptr;
+                   });
+    QSignalSpy focusSpy(obj, &DDropdownMenu::sigSetTextEditFocus);
+
+    // Act: 发射 requestContextMenu(true)（清焦分支）
+    emit obj->requestContextMenu(true);
+
+    // Assert: exec 执行一次并随后发出回焦信号
+    EXPECT_EQ(menuExecCalls, 1);
+    EXPECT_EQ(focusSpy.count(), 1);
+
+    // Act: request=false 分支（不清焦）
+    emit obj->requestContextMenu(false);
+    EXPECT_EQ(menuExecCalls, 2);
+    EXPECT_EQ(focusSpy.count(), 2);
+}
+
+// ------------------------------------------------------------
+// 静态工厂
+// ------------------------------------------------------------
+
+TEST_F(DDropdownMenuTest, CreateEncodeMenu_ContainsUtf8Default)
+{
+    // Act
+    DDropdownMenu *menu = DDropdownMenu::createEncodeMenu();
+
+    // Assert: 默认文本 UTF-8，UTF-8 action 存在且预选中
+    ASSERT_NE(menu, nullptr);
+    EXPECT_EQ(menu->getCurrentText(), QString("UTF-8"));
+    ASSERT_NE(menu->m_pActUtf8, nullptr);
+    EXPECT_TRUE(menu->m_pActUtf8->isChecked());
+    EXPECT_EQ(menu->m_pActUtf8->objectName(), QString("PActUtf8"));
+    delete menu;
+}
+
+TEST_F(DDropdownMenuTest, CreateHighLightMenu_DefaultNoneWithActionGroup)
+{
+    // Act
+    DDropdownMenu *menu = DDropdownMenu::createHighLightMenu();
+
+    // Assert: 默认 None，带互斥 action 组
+    ASSERT_NE(menu, nullptr);
+    EXPECT_EQ(menu->getCurrentText(), QString("None"));
+    ASSERT_NE(menu->m_actionGroup, nullptr);
+    EXPECT_TRUE(menu->m_actionGroup->isExclusive());
+    EXPECT_FALSE(menu->m_menu->actions().isEmpty());
+    delete menu;
+}
+
+// ------------------------------------------------------------
+// 静态工厂：菜单 triggered 转发 lambda
+// ------------------------------------------------------------
+
+TEST_F(DDropdownMenuTest, CreateEncodeMenu_TriggeredAction_EmitsCurrentActionChanged)
+{
+    // Arrange
+    DDropdownMenu *menu = DDropdownMenu::createEncodeMenu();
+    QSignalSpy spy(menu, &DDropdownMenu::currentActionChanged);
+
+    // Act: 触发同文本（UTF-8）action → 不发信号（防抖分支）
+    emit menu->m_menu->triggered(menu->m_pActUtf8);
+    EXPECT_EQ(spy.count(), 0);
+
+    // Act: 触发同组其它 action → 发 currentActionChanged
+    QAction *other = nullptr;
+    const QList<QAction *> tops = menu->m_menu->actions();
+    for (QAction *top : tops) {
+        if (!top->menu())
+            continue;
+        for (QAction *a : top->menu()->actions()) {
+            if (a->text() != QString("UTF-8")) {
+                other = a;
+                break;
+            }
+        }
+    }
+    ASSERT_NE(other, nullptr);
+    emit menu->m_menu->triggered(other);
+
+    // Assert
+    ASSERT_EQ(spy.count(), 1);
+    EXPECT_EQ(spy.at(0).at(0).value<QAction *>(), other);
+    delete menu;
+}
+
+TEST_F(DDropdownMenuTest, CreateHighLightMenu_NoneTriggered_EmitsCurrentActionChanged)
+{
+    // Arrange: None 是 m_menu 首个 action
+    DDropdownMenu *menu = DDropdownMenu::createHighLightMenu();
+    QAction *noneAction = menu->m_menu->actions().first();
+    QSignalSpy spy(menu, &DDropdownMenu::currentActionChanged);
+
+    // Act: None 勾选触发（checked=true 分支）
+    emit noneAction->triggered(true);
+
+    // Assert
+    ASSERT_EQ(spy.count(), 1);
+    EXPECT_EQ(spy.at(0).at(0).value<QAction *>(), noneAction);
+
+    // Act: 取消勾选（checked=false 分支，不发信号）
+    QSignalSpy spy2(menu, &DDropdownMenu::currentActionChanged);
+    emit noneAction->triggered(false);
+    EXPECT_EQ(spy2.count(), 0);
+    delete menu;
+}
+
+TEST_F(DDropdownMenuTest, CreateHighLightMenu_ActionGroupTriggered_BothBranches)
+{
+    // Arrange: 互斥组中的真实高亮定义 action
+    DDropdownMenu *menu = DDropdownMenu::createHighLightMenu();
+    QActionGroup *group = menu->m_actionGroup;
+    ASSERT_NE(group, nullptr);
+    QSignalSpy spy(menu, &DDropdownMenu::currentActionChanged);
+
+    // Act: 触发组内 action（有效定义 + 文本不同 → 发信号）
+    QAction *valid = nullptr;
+    for (QAction *a : group->actions()) {
+        if (a->text() != QString("None")) {
+            valid = a;
+            break;
+        }
+    }
+    if (valid == nullptr)
+        GTEST_SKIP() << "系统高亮仓库无可用定义";
+    emit group->triggered(valid);
+
+    // Assert
+    ASSERT_EQ(spy.count(), 1);
+
+    // Act: 注入无效定义名 action → 回退 None 文本（无效分支）
+    QAction *invalid = group->addAction(QStringLiteral("NotARealDefinition"));
+    emit group->triggered(invalid);
+    EXPECT_EQ(menu->getCurrentText(), QString("None"));
+    delete menu;
+}
+
+TEST_F(DDropdownMenuTest, Constructor_SizeModeChanged_AdjustsButtonHeight)
+{
+    // Arrange: 记录当前模式并切换（ctor 连接的 lambda 触发）
+    const auto origMode = DGuiApplicationHelper::instance()->sizeMode();
+    const auto flipped = (origMode == DGuiApplicationHelper::CompactMode)
+                             ? DGuiApplicationHelper::NormalMode
+                             : DGuiApplicationHelper::CompactMode;
+    const int expectH = (flipped == DGuiApplicationHelper::CompactMode) ? 20 : 28;
+
+    // Act
+    DGuiApplicationHelper::instance()->setSizeMode(flipped);
+
+    // Assert: 工具按钮高度随布局模式联动
+    EXPECT_EQ(obj->getButton()->height(), expectH);
+
+    // Act / Assert: 还原后高度回到原值（联动可逆）
+    const int origH = (origMode == DGuiApplicationHelper::CompactMode) ? 20 : 28;
+    DGuiApplicationHelper::instance()->setSizeMode(origMode);
+    EXPECT_EQ(obj->getButton()->height(), origH);
+
+}
+
+// ------------------------------------------------------------
+// eventFilter：键盘 / 鼠标 / 字体变化
+// ------------------------------------------------------------
+
+TEST_F(DDropdownMenuTest, EventFilter_KeyReturnAndSpace_TriggersContextMenu)
+{
+    // Arrange: 键盘触发会拉起 slotRequestMenu → QMenu::exec，先拦截防模态阻塞
+    stub.set_lamda(static_cast<QAction *(QMenu::*)()>(&QMenu::exec),
+                   [](QMenu *) -> QAction * { return nullptr; });
+    QSignalSpy menuSpy(obj, &DDropdownMenu::requestContextMenu);
+
+    // Act: Enter 键
+    QKeyEvent enterEvent(QEvent::KeyPress, Qt::Key_Return, Qt::NoModifier);
+    bool enterRet = obj->eventFilter(obj->getButton(), &enterEvent);
+
+    // Assert: 拦截并请求菜单（false = 键盘触发）
+    EXPECT_TRUE(enterRet);
+    ASSERT_EQ(menuSpy.count(), 1);
+    EXPECT_FALSE(menuSpy.at(0).at(0).toBool());
+
+    // Act: Space 键
+    QKeyEvent spaceEvent(QEvent::KeyPress, Qt::Key_Space, Qt::NoModifier);
+    EXPECT_TRUE(obj->eventFilter(obj->getButton(), &spaceEvent));
+    EXPECT_EQ(menuSpy.count(), 2);
+
+    // Act: 其他键不处理
+    QKeyEvent otherEvent(QEvent::KeyPress, Qt::Key_F5, Qt::NoModifier);
+    EXPECT_FALSE(obj->eventFilter(obj->getButton(), &otherEvent));
+    EXPECT_EQ(menuSpy.count(), 2);
+}
+
+TEST_F(DDropdownMenuTest, EventFilter_MousePressLeft_MarksPressedAndReturnsTrue)
+{
+    // Arrange
+    const QPointF local(2, 2);
+    QMouseEvent pressLeft(QEvent::MouseButtonPress, local, local,
+                          Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+
+    // Act
+    bool ret = obj->eventFilter(obj->getButton(), &pressLeft);
+
+    // Assert: 左键按下被拦截且置按下标志（联动 createIcon → setSvgColor 高亮分支）
+    EXPECT_TRUE(ret);
+    EXPECT_TRUE(obj->m_bPressed);
+
+    // Act: 右键按下同样拦截（不改变按下态）
+    QMouseEvent pressRight(QEvent::MouseButtonPress, local, local,
+                           Qt::RightButton, Qt::RightButton, Qt::NoModifier);
+    EXPECT_TRUE(obj->eventFilter(obj->getButton(), &pressRight));
+    EXPECT_TRUE(obj->m_bPressed);
+}
+
+TEST_F(DDropdownMenuTest, EventFilter_MouseReleaseLeft_RequestsMenuWhenEnabled)
+{
+    // Arrange: 处于按下态 + 菜单信号监听
+    const QPointF local(2, 2);
+    QMouseEvent pressLeft(QEvent::MouseButtonPress, local, local,
+                          Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+    obj->eventFilter(obj->getButton(), &pressLeft);
+    QSignalSpy menuSpy(obj, &DDropdownMenu::requestContextMenu);
+    stub.set_lamda(static_cast<QAction *(QMenu::*)()>(&QMenu::exec),
+                   [this](QMenu *) -> QAction * {
+                       ++menuExecCalls;
+                       return nullptr;
+                   });
+
+    // Act: 左键释放
+    QMouseEvent release(QEvent::MouseButtonRelease, local, local,
+                        Qt::LeftButton, Qt::NoButton, Qt::NoModifier);
+    bool ret = obj->eventFilter(obj->getButton(), &release);
+
+    // Assert: 释放被拦截、按下态复位、菜单请求（true = 鼠标触发）+ exec 被拉起
+    EXPECT_TRUE(ret);
+    EXPECT_FALSE(obj->m_bPressed);
+    ASSERT_EQ(menuSpy.count(), 1);
+    EXPECT_TRUE(menuSpy.at(0).at(0).toBool());
+    EXPECT_EQ(menuExecCalls, 1);
+
+    // Act: 禁用后释放不再请求菜单（isEnabled 分支）
+    QMouseEvent pressAgain(QEvent::MouseButtonPress, local, local,
+                           Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+    obj->eventFilter(obj->getButton(), &pressAgain);
+    obj->setEnabled(false);
+    QSignalSpy menuSpy2(obj, &DDropdownMenu::requestContextMenu);
+    QMouseEvent release2(QEvent::MouseButtonRelease, local, local,
+                         Qt::LeftButton, Qt::NoButton, Qt::NoModifier);
+    EXPECT_TRUE(obj->eventFilter(obj->getButton(), &release2));
+    EXPECT_EQ(menuSpy2.count(), 0);
+    obj->setEnabled(true);
+}
+
+TEST_F(DDropdownMenuTest, EventFilter_OtherObjectOrType_PassesThrough)
+{
+    // Arrange: 非工具按钮对象 / 非相关事件类型
+    QWidget stranger;
+    QMouseEvent strangerPress(QEvent::MouseButtonPress, QPointF(1, 1), QPointF(1, 1),
+                              Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+
+    // Act
+    bool ret1 = obj->eventFilter(&stranger, &strangerPress);
+    QEvent unrelated(QEvent::MouseMove);
+    bool ret2 = obj->eventFilter(obj->getButton(), &unrelated);
+
+    // Assert: 交还基类处理（QFrame::eventFilter 默认 false）
+    EXPECT_FALSE(ret1);
+    EXPECT_FALSE(ret2);
+}
+
+TEST_F(DDropdownMenuTest, EventFilter_ApplicationFontChange_RefreshesFont)
+{
+    // Arrange: 先设置一个可区分的字体
+    QFont marker;
+    marker.setPixelSize(21);
+    obj->setFontEx(marker);
+    EXPECT_EQ(obj->m_font.pixelSize(), 21);
+
+    // Act: 派发应用字体变化事件（Qt6 分支 → OnFontChangedSlot）
+    QEvent fontEvent(QEvent::ApplicationFontChange);
+    bool ret = obj->eventFilter(obj->getButton(), &fontEvent);
+
+    // Assert: 事件放行且内部字体已同步为 qApp 字体
+    EXPECT_FALSE(ret);
+    EXPECT_EQ(obj->m_font.pixelSize(), qApp->font().pixelSize());
+    EXPECT_NE(obj->m_font.pixelSize(), 21);
+}
+
+// ------------------------------------------------------------
+// 私有：setSvgColor / SetSVGBackColor（经公有路径 + 直接调用）
+// ------------------------------------------------------------
+
+TEST_F(DDropdownMenuTest, SetSvgColor_RealSvgResource_ReturnsColoredPixmap)
+{
+    // Act: 直接驱动（生产路径由按下态 createIcon 触发）
+    const QPixmap pixmap = obj->setSvgColor(QStringLiteral("#ff0000"));
+
+    // Assert: 基于 qrc 内 arrow_dark.svg 着色成功
+    EXPECT_FALSE(pixmap.isNull());
+    EXPECT_EQ(pixmap.width(), 8);
+    EXPECT_EQ(pixmap.height(), 5);
+}
+
+TEST_F(DDropdownMenuTest, SetSVGBackColor_ColorGroup_AttributeReplaced)
+{
+    // Arrange: 构造含 <g id="color" fill="#000000"> 的 SVG 文档
+    QDomDocument doc;
+    doc.setContent(QStringLiteral(
+        "<svg><g id=\"color\" fill=\"#000000\"><rect/></g><g id=\"other\"/></svg>"));
+    QDomElement elem = doc.documentElement();
+
+    // Act: 递归替换 fill 属性
+    obj->SetSVGBackColor(elem, QStringLiteral("fill"), QStringLiteral("#123456"));
+
+    // Assert: 目标 g 的 fill 已替换，其它节点不受影响
+    bool found = false;
+    QDomNodeList children = elem.elementsByTagName(QStringLiteral("g"));
+    for (int i = 0; i < children.count(); ++i) {
+        QDomElement g = children.at(i).toElement();
+        if (g.attribute("id") == QString("color")) {
+            EXPECT_EQ(g.attribute("fill"), QString("#123456"));
+            found = true;
+        }
+    }
+    EXPECT_TRUE(found);
+}

--- a/tests/widgets_ut/test_dtextedit_window_integration.cpp
+++ b/tests/widgets_ut/test_dtextedit_window_integration.cpp
@@ -1,0 +1,370 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// ============================================================================
+// TextEdit×Window 集成单元测试（widgets_ut / src/editor/dtextedit.cpp 最后 2 个
+// FNDA:0：dragEnterEvent 与 pinchTriggered）
+//
+// 根因：两函数都无条件 qobject_cast<Window*>(window())->... 解引用，需要
+// TextEdit 挂在真实 Window 父链下（window() 返回真实 Window）。editor_core
+// 模块设计上禁止真实构造 Window（接缝伪指针注入），故按任务论证放入 widgets_ut
+// ——本模块已具备 B8/B11 验证过的"真实 Window + 真实 EditWrapper/TextEdit"
+// 组合与 DBus/模态/消息桩矩阵，新增独立 target 复用该环境，零侵入既有用例。
+//
+// 分支清单 → 用例映射：
+//   dragEnterEvent(dtextedit.cpp:7768)
+//     唯一路径：QPlainTextEdit::dragEnterEvent + Window::requestDragEnterEvent 转发
+//     → DragEnterEvent_TextEditUnderRealWindow_ForwardsToWindowAndAccepts
+//       （信号转发计数 + 事件指针同一性 + Window 槽同步 accept）
+//   pinchTriggered(dtextedit.cpp:4434)
+//     B1 GestureStarted  → m_gestureAction=GA_pinch；m_scaleFactor 同步 m_fontSize
+//     B2 GestureUpdated+ScaleFactorChanged → m_currentStepScaleFactor=totalScaleFactor
+//     B3 GestureFinished → m_scaleFactor 累乘并复位步进；clamp[8,50] 后 setFontSize
+//        + Window::changeSettingDialogComboxFontNumber 写 base.font.size
+//     B4 GestureCanceled → 无副作用
+//     → PinchTriggered_NormalScale / LargeScale_ClampsTo50 / TinyScale_ClampsTo8 /
+//       CanceledGesture_KeepsState
+//
+// QGesture::state 只读无私有头依赖：VADDR 桩 QGesture::state() 控制
+// 手势状态序列（QPinchGesture 的 setChangeFlags/setTotalScaleFactor 为公有 API）。
+// pinchTriggered 为私有槽，经 -fno-access-control 白盒直调（B6 先例）。
+// ============================================================================
+
+#include <gtest/gtest.h>
+#include "stubext.h"
+
+#include <QApplication>
+#include <QTemporaryDir>
+#include <QDir>
+#include <QFile>
+#include <QElapsedTimer>
+#include <QThread>
+#include <QUrl>
+#include <QMimeData>
+#include <QDragEnterEvent>
+#include <QGesture>
+#include <QPinchGesture>
+
+#include <DDialog>
+#include <DMessageManager>
+#include <DFileDialog>
+#include <DSettingsOption>
+
+#include <QDBusConnection>
+#include <QDBusAbstractInterface>
+#include <QDBusMessage>
+#include <QProcess>
+
+#include "widgets/window.h"
+#include "controls/tabbar.h"
+#include "editor/editwrapper.h"
+#include "editor/dtextedit.h"
+#include "common/settings.h"
+#include "common/utils.h"
+#include "startmanager.h"
+
+class TextEditWindowIntegrationTest : public ::testing::Test {
+protected:
+    static void SetUpTestSuite()
+    {
+        s_configHome = new QTemporaryDir();
+        s_dataHome = new QTemporaryDir();
+        const QString xdgConfig = s_configHome->filePath("xdg-config");
+        const QString xdgData = s_dataHome->filePath("xdg-data");
+        QDir().mkpath(xdgConfig);
+        QDir().mkpath(xdgData);
+        qputenv("XDG_CONFIG_HOME", xdgConfig.toUtf8());
+        qputenv("XDG_DATA_HOME", xdgData.toUtf8());
+
+        int argc = 1;
+        char *argv[] = { s_argv, nullptr };
+        s_app = new QApplication(argc, argv);
+        QApplication::setOrganizationName(QStringLiteral("deepin"));
+        QApplication::setApplicationName(QStringLiteral("deepin-editor"));
+
+        Settings::instance();
+        qRegisterMetaType<ViewMode>("ViewMode");
+
+        QDir().mkpath(xdgData + "/deepin/deepin-editor/blank-files");
+        QDir().mkpath(xdgData + "/deepin/deepin-editor/backup-files");
+        QDir().mkpath(xdgData + "/deepin/deepin-editor/autoBackup-files");
+    }
+
+    static void TearDownTestSuite()
+    {
+        qunsetenv("XDG_CONFIG_HOME");
+        qunsetenv("XDG_DATA_HOME");
+    }
+
+    void SetUp() override
+    {
+        m_tempDir = new QTemporaryDir();
+        installCommonStubs();
+
+        m_win = new Window();
+        m_tabbar = m_win->getTabbar();
+
+        // QGesture::state 只读（无私有头）：VADDR 桩控制捏合状态序列
+        m_gestureState = Qt::GestureStarted;
+        stub.set_lamda(VADDR(QGesture, state),
+                       [this](QGesture *) -> Qt::GestureState { return m_gestureState; });
+    }
+
+    void TearDown() override
+    {
+        // stub 保持激活状态下析构（析构链中的 DBus/消息调用仍被拦截）
+        delete m_win;
+        m_win = nullptr;
+        m_tabbar = nullptr;
+        QApplication::processEvents();
+        stub.clear();
+        delete m_tempDir;
+    }
+
+    // ==================== 运行期 stub 矩阵（test_window.cpp 同源）====================
+
+    void installCommonStubs()
+    {
+        stub.set_lamda(&QDBusConnection::systemBus,
+                       []() -> QDBusConnection { return QDBusConnection(QStringLiteral("ut_no_bus")); });
+        stub.set_lamda(&QDBusConnection::sessionBus,
+                       []() -> QDBusConnection { return QDBusConnection(QStringLiteral("ut_no_bus")); });
+        stub.set_lamda(
+            static_cast<QDBusMessage (QDBusAbstractInterface::*)(QDBus::CallMode, const QString &, const QList<QVariant> &)>(
+                &QDBusAbstractInterface::callWithArgumentList),
+            [](QDBusAbstractInterface *, QDBus::CallMode, const QString &,
+               const QList<QVariant> &) -> QDBusMessage { return QDBusMessage(); });
+
+        stub.set_lamda(
+            static_cast<void (DMessageManager::*)(QWidget *, const QIcon &, const QString &)>(
+                &DMessageManager::sendMessage),
+            [](DMessageManager *, QWidget *, const QIcon &, const QString &) -> void {});
+        stub.set_lamda(
+            static_cast<void (DMessageManager::*)(QWidget *, DFloatingMessage *)>(
+                &DMessageManager::sendMessage),
+            [](DMessageManager *, QWidget *, DFloatingMessage *) -> void {});
+        stub.set_lamda(&Utils::sendFloatMessageFixedFont,
+                       [](QWidget *, const QIcon &, const QString &) -> void {});
+
+        stub.set_lamda(&StartManager::closeAboutForWindow,
+                       [](StartManager *, Window *) -> void {});
+
+        stub.set_lamda(static_cast<bool (*)(const QString &, const QStringList &, const QString &, qint64 *)>(&QProcess::startDetached),
+                       [](const QString &, const QStringList &, const QString &, qint64 *) -> bool { return true; });
+
+        stub.set_lamda(VADDR(DDialog, exec), []() -> int { return 0; });
+        stub.set_lamda(VADDR(QDialog, exec), []() -> int { return 0; });
+        stub.set_lamda(VADDR(QFileDialog, selectedFiles),
+                       [](QFileDialog *) -> QStringList { return QStringList(); });
+        stub.set_lamda(&DFileDialog::getComboBoxValue,
+                       [](DFileDialog *, const QString &) -> QString { return QString(); });
+    }
+
+    // ==================== 辅助 ====================
+
+    QString createFile(const QString &name, const QByteArray &content = "hello world\nsecond line\n")
+    {
+        const QString path = m_tempDir->filePath(name);
+        QFile f(path);
+        if (!f.open(QIODevice::WriteOnly))
+            return QString();
+        f.write(content);
+        f.close();
+        return path;
+    }
+
+    // 添加真实文件标签页并等待内容载入（"文档非空 + 非加载中"为完成判据）
+    QString addFileTab(const QString &name)
+    {
+        const QString path = createFile(name);
+        m_win->addTab(path, true);
+        EditWrapper *wrapper = m_win->wrapper(path);
+        if (wrapper != nullptr) {
+            waitUntil([wrapper]() {
+                return !wrapper->getFileLoading() && !wrapper->textEditor()->document()->isEmpty();
+            });
+        }
+        return path;
+    }
+
+    bool waitUntil(const std::function<bool()> &predicate, int timeoutMs = 8000)
+    {
+        QElapsedTimer timer;
+        timer.start();
+        while (!predicate()) {
+            if (timer.elapsed() > timeoutMs)
+                return false;
+            QApplication::processEvents(QEventLoop::AllEvents, 50);
+            QThread::msleep(10);
+        }
+        return true;
+    }
+
+    // 捏合手势白盒驱动：Started → Updated(ScaleFactorChanged, factor) → Finished
+    void runPinchSequence(TextEdit *textEdit, QPinchGesture *gesture, qreal totalFactor)
+    {
+        m_gestureState = Qt::GestureStarted;
+        textEdit->pinchTriggered(gesture);
+
+        gesture->setChangeFlags(QPinchGesture::ScaleFactorChanged);
+        gesture->setTotalScaleFactor(totalFactor);
+        m_gestureState = Qt::GestureUpdated;
+        textEdit->pinchTriggered(gesture);
+
+        m_gestureState = Qt::GestureFinished;
+        textEdit->pinchTriggered(gesture);
+    }
+
+    int fontSizeSettingValue() const
+    {
+        return m_win->m_settings->settings->option(QStringLiteral("base.font.size"))->value().toInt();
+    }
+
+    // ==================== 状态 ====================
+    static char s_argv[];
+    static QApplication *s_app;
+    static QTemporaryDir *s_configHome;
+    static QTemporaryDir *s_dataHome;
+
+    stub_ext::StubExt stub;
+    Window *m_win = nullptr;
+    Tabbar *m_tabbar = nullptr;
+    QTemporaryDir *m_tempDir = nullptr;
+    Qt::GestureState m_gestureState = Qt::GestureStarted;
+};
+
+char TextEditWindowIntegrationTest::s_argv[] = "test_dtextedit_window_integration";
+QApplication *TextEditWindowIntegrationTest::s_app = nullptr;
+QTemporaryDir *TextEditWindowIntegrationTest::s_configHome = nullptr;
+QTemporaryDir *TextEditWindowIntegrationTest::s_dataHome = nullptr;
+
+// ---------------- dragEnterEvent ----------------
+
+// 真实 Window 父链下直发 QDragEnterEvent：转发信号携带同一事件，Window 槽同步 accept
+TEST_F(TextEditWindowIntegrationTest, DragEnterEvent_TextEditUnderRealWindow_ForwardsToWindowAndAccepts)
+{
+    // Arrange
+    const QString path = addFileTab(QStringLiteral("drag.txt"));
+    EditWrapper *wrapper = m_win->wrapper(path);
+    ASSERT_NE(wrapper, nullptr);
+    TextEdit *textEdit = wrapper->textEditor();
+    ASSERT_NE(textEdit, nullptr);
+    // 前置：真实父链成立（qobject_cast<Window*> 可命中的根因条件）
+    ASSERT_EQ(textEdit->window(), m_win);
+
+    QMimeData mimeData;
+    QList<QUrl> urls;
+    urls << QUrl::fromLocalFile(path);
+    mimeData.setUrls(urls);
+    QDragEnterEvent event(QPoint(5, 5), Qt::CopyAction, &mimeData,
+                          Qt::LeftButton, Qt::NoModifier);
+
+    int forwardedCount = 0;
+    QDragEnterEvent *forwardedEvent = nullptr;
+    QMetaObject::Connection connection = QObject::connect(
+        m_win, &Window::requestDragEnterEvent,
+        [&forwardedCount, &forwardedEvent](QDragEnterEvent *forwarded) {
+            ++forwardedCount;
+            forwardedEvent = forwarded;
+        });
+
+    // Act：直调 protected 事件处理器（-fno-access-control，editor_core 既定模式）。
+    // 注：QApplication::notify 对非 spontaneous 的 DragEnter 会把 QPlainTextEdit 系
+    // 控件重定向到祖先 drop site（gdb 断点实证 sendEvent 不可达本处理器），
+    // 生产路径由真实 QDragManager 投递，与 sendEvent 语义不同。
+    textEdit->dragEnterEvent(&event);
+    QObject::disconnect(connection);
+
+    // Assert：转发发生、携带同一事件、Window::dragEnterEvent（直连）同步 accept
+    EXPECT_EQ(forwardedCount, 1);
+    EXPECT_EQ(forwardedEvent, &event);
+    EXPECT_TRUE(event.isAccepted());
+}
+
+// ---------------- pinchTriggered ----------------
+
+// 正常缩放：16 →×2→ 32；同步字体栏数值（base.font.size）与文档字体
+TEST_F(TextEditWindowIntegrationTest, PinchTriggered_NormalScale_UpdatesFontSizeAndSettingsOption)
+{
+    // Arrange
+    const QString path = addFileTab(QStringLiteral("pinch_normal.txt"));
+    TextEdit *textEdit = m_win->wrapper(path)->textEditor();
+    ASSERT_NE(textEdit, nullptr);
+    textEdit->m_fontSize = 16;   // 白盒钉死初值，保证不落入 clamp 分支
+    QPinchGesture gesture;
+
+    // Act
+    runPinchSequence(textEdit, &gesture, 2.0);
+
+    // Assert
+    EXPECT_EQ(textEdit->m_gestureAction, TextEdit::GA_null) << "finished must reset gesture action";
+    EXPECT_DOUBLE_EQ(textEdit->m_scaleFactor, 32.0);
+    EXPECT_DOUBLE_EQ(textEdit->m_currentStepScaleFactor, 1.0);
+    EXPECT_DOUBLE_EQ(textEdit->m_fontSize, 32.0);
+    EXPECT_NEAR(textEdit->font().pointSizeF(), 32.0, 0.6) << "updateFont must apply new size";
+    EXPECT_EQ(fontSizeSettingValue(), 32) << "Window::changeSettingDialogComboxFontNumber must sync settings";
+}
+
+// 上界：40 ×5 → clamp 50
+TEST_F(TextEditWindowIntegrationTest, PinchTriggered_LargeScale_ClampsTo50)
+{
+    // Arrange
+    const QString path = addFileTab(QStringLiteral("pinch_large.txt"));
+    TextEdit *textEdit = m_win->wrapper(path)->textEditor();
+    ASSERT_NE(textEdit, nullptr);
+    textEdit->m_fontSize = 40;
+    QPinchGesture gesture;
+
+    // Act
+    runPinchSequence(textEdit, &gesture, 5.0);
+
+    // Assert
+    EXPECT_DOUBLE_EQ(textEdit->m_fontSize, 50.0);
+    EXPECT_EQ(fontSizeSettingValue(), 50);
+    EXPECT_EQ(textEdit->m_gestureAction, TextEdit::GA_null);
+}
+
+// 下界：5 ×0.5 → 2.5 → clamp 8
+TEST_F(TextEditWindowIntegrationTest, PinchTriggered_TinyScale_ClampsTo8)
+{
+    // Arrange
+    const QString path = addFileTab(QStringLiteral("pinch_tiny.txt"));
+    TextEdit *textEdit = m_win->wrapper(path)->textEditor();
+    ASSERT_NE(textEdit, nullptr);
+    textEdit->m_fontSize = 5;
+    QPinchGesture gesture;
+
+    // Act
+    runPinchSequence(textEdit, &gesture, 0.5);
+
+    // Assert
+    EXPECT_DOUBLE_EQ(textEdit->m_fontSize, 8.0);
+    EXPECT_EQ(fontSizeSettingValue(), 8);
+}
+
+// GestureCanceled：switch 分支无状态迁移（保持 GA_pinch），但 switch 之后的
+// 字号应用无条件执行（源码语义：任何状态都以 m_scaleFactor×步进 设定字号）
+TEST_F(TextEditWindowIntegrationTest, PinchTriggered_CanceledGesture_KeepsActionButAppliesFontSize)
+{
+    // Arrange
+    const QString path = addFileTab(QStringLiteral("pinch_cancel.txt"));
+    TextEdit *textEdit = m_win->wrapper(path)->textEditor();
+    ASSERT_NE(textEdit, nullptr);
+    textEdit->m_fontSize = 16;
+    QPinchGesture gesture;
+
+    // Act：Started 置位后直接 Canceled
+    m_gestureState = Qt::GestureStarted;
+    textEdit->pinchTriggered(&gesture);
+    ASSERT_EQ(textEdit->m_gestureAction, TextEdit::GA_pinch);
+    ASSERT_DOUBLE_EQ(textEdit->m_fontSize, 16.0);   // Started 同步 16×1=16
+
+    m_gestureState = Qt::GestureCanceled;
+    textEdit->pinchTriggered(&gesture);
+
+    // Assert：手势状态保持 GA_pinch；字号仍按 16×1 应用（switch 后无条件段）
+    EXPECT_EQ(textEdit->m_gestureAction, TextEdit::GA_pinch) << "canceled must not reset action";
+    EXPECT_DOUBLE_EQ(textEdit->m_fontSize, 16.0);
+    EXPECT_EQ(fontSizeSettingValue(), 16) << "font size application runs for every state";
+}

--- a/tests/widgets_ut/test_pathsettintwgt.cpp
+++ b/tests/widgets_ut/test_pathsettintwgt.cpp
@@ -1,0 +1,341 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// ============================================================================
+// PathSettingWgt 单元测试（B11 / src/widgets/pathsettintwgt.cpp）
+//
+// 策略：真实 offscreen 构造 + 真实 Settings 单例（XDG 重定向临时目录，
+// qrc settings.json 编入目标）。模态 QFileDialog::exec / selectedFiles 拦截。
+//
+// 分支清单（来源：pathsettintwgt.cpp）与用例映射：
+// - ctor → init() → connections() → onSaveIdChanged(当前配置)
+//     → Constructor_BuildsAllChildWidgets
+// - onSaveIdChanged：CurFileBox / LastOptBox / CustomBox / default
+//     → OnSaveIdChanged_Param（TEST_P 参数化 4 组）
+// - setEditText：短文本原样 / 长文本 ElideMiddle
+//     → SetEditText_ShortText_Unchanged / SetEditText_LongText_ElidedMiddle
+// - onBoxClicked（经 QButtonGroup 信号）：三种选项写回 Settings + 按钮态
+//     → OnBoxClicked_CustomBox_UpdatesSettingsAndEnablesButton
+//       OnBoxClicked_CurFileBox_UpdatesSettingsAndDisablesButton
+// - onBtnClicked（经按钮 clicked）：
+//     · 对话框拒绝 → 早退 → OnBtnClicked_DialogRejected_NoChange
+//     · 自定义路径不存在 → 默认 Documents 目录分支 + 接受 → 保存路径回写
+//       → OnBtnClicked_DefaultPathAndAccepted_UpdatesCustomPath
+// - updateSizeMode（ctor 已执行；直接调用复核尺寸）
+//     → UpdateSizeMode_ButtonSizeMatchesCurrentMode
+// - dtor → Destructor_DelelesSafely
+// ============================================================================
+
+#include <gtest/gtest.h>
+#include "stubext.h"
+
+#include <QApplication>
+#include <QTemporaryDir>
+#include <QDir>
+#include <QCheckBox>
+#include <QLineEdit>
+#include <QPushButton>
+#include <QButtonGroup>
+#include <QFontMetrics>
+#include <QFileDialog>
+#include <DGuiApplicationHelper>
+
+#include "widgets/pathsettintwgt.h"
+#include "common/settings.h"
+
+class PathSettingWgtTest : public ::testing::Test {
+protected:
+    static void SetUpTestSuite()
+    {
+        s_configHome = new QTemporaryDir();
+        s_dataHome = new QTemporaryDir();
+        const QString xdgConfig = s_configHome->filePath("xdg-config");
+        const QString xdgData = s_dataHome->filePath("xdg-data");
+        QDir().mkpath(xdgConfig);
+        QDir().mkpath(xdgData);
+        qputenv("XDG_CONFIG_HOME", xdgConfig.toUtf8());
+        qputenv("XDG_DATA_HOME", xdgData.toUtf8());
+
+        int argc = 1;
+        char *argv[] = {s_argv, nullptr};
+        s_app = new QApplication(argc, argv);
+        QApplication::setOrganizationName(QStringLiteral("deepin"));
+        QApplication::setApplicationName(QStringLiteral("deepin-editor"));
+
+        // 真实 Settings 单例（资源 + 临时 config 落盘）
+        Settings::instance();
+    }
+
+    static void TearDownTestSuite()
+    {
+        qunsetenv("XDG_CONFIG_HOME");
+        qunsetenv("XDG_DATA_HOME");
+    }
+
+    void SetUp() override
+    {
+        m_tempDir = new QTemporaryDir();
+        m_wgt = new PathSettingWgt();
+    }
+
+    void TearDown() override
+    {
+        delete m_wgt;
+        m_wgt = nullptr;
+        stub.clear();
+        delete m_tempDir;
+    }
+
+    stub_ext::StubExt stub;
+    PathSettingWgt *m_wgt = nullptr;
+    QTemporaryDir *m_tempDir = nullptr;
+
+    int dialogExecResult = QDialog::Rejected;
+    int dialogExecCalls = 0;
+    QStringList selectedFiles;
+
+    static QApplication *s_app;
+    static QTemporaryDir *s_configHome;
+    static QTemporaryDir *s_dataHome;
+    static char s_argv[];
+};
+
+QApplication *PathSettingWgtTest::s_app = nullptr;
+QTemporaryDir *PathSettingWgtTest::s_configHome = nullptr;
+QTemporaryDir *PathSettingWgtTest::s_dataHome = nullptr;
+char PathSettingWgtTest::s_argv[] = "test_pathsettintwgt";
+
+// ------------------------------------------------------------
+// 构造
+// ------------------------------------------------------------
+
+TEST_F(PathSettingWgtTest, Constructor_BuildsAllChildWidgets)
+{
+    // Assert: 全部子控件按 objectName 就位 + 按钮组三选一
+    EXPECT_NE(m_wgt->findChild<QCheckBox *>("CurFileBox"), nullptr);
+    EXPECT_NE(m_wgt->findChild<QCheckBox *>("LastOptBox"), nullptr);
+    EXPECT_NE(m_wgt->findChild<QCheckBox *>("CustomBox"), nullptr);
+    EXPECT_NE(m_wgt->findChild<DLineEdit *>("CustomEdit"), nullptr);
+    EXPECT_NE(m_wgt->findChild<QPushButton *>("CustomBtn"), nullptr);
+    QButtonGroup *group = m_wgt->findChild<QButtonGroup *>("Group");
+    ASSERT_NE(group, nullptr);
+    EXPECT_EQ(group->buttons().count(), 3);
+    EXPECT_EQ(group->id(group->buttons().at(0)), PathSettingWgt::LastOptBox);
+}
+
+// ------------------------------------------------------------
+// onSaveIdChanged 参数化
+// ------------------------------------------------------------
+
+namespace {
+struct SaveIdCase {
+    int id;
+    const char *expectedChecked; // objectName，nullptr = 无勾选
+    bool expectBtnEnabled;
+};
+} // namespace
+
+class PathSettingSaveIdTest : public PathSettingWgtTest,
+                              public ::testing::WithParamInterface<SaveIdCase> {
+};
+
+TEST_P(PathSettingSaveIdTest, OnSaveIdChanged_EachId_ChecksMatchingBox)
+{
+    // Arrange: 先固定到 LastOptBox，隔离持久化配置的影响
+    const SaveIdCase c = GetParam();
+    m_wgt->onSaveIdChanged(PathSettingWgt::LastOptBox);
+
+    // Act
+    m_wgt->onSaveIdChanged(c.id);
+
+    // Assert: 对应选项勾选、其它不勾选，按钮可用性正确
+    QCheckBox *cur = m_wgt->findChild<QCheckBox *>("CurFileBox");
+    QCheckBox *last = m_wgt->findChild<QCheckBox *>("LastOptBox");
+    QCheckBox *custom = m_wgt->findChild<QCheckBox *>("CustomBox");
+    QPushButton *btn = m_wgt->findChild<QPushButton *>("CustomBtn");
+    const std::string checkedName = c.expectedChecked ? std::string(c.expectedChecked) : std::string();
+    EXPECT_EQ(cur->isChecked(), checkedName == std::string("CurFileBox"));
+    EXPECT_EQ(last->isChecked(), checkedName == std::string("LastOptBox"));
+    EXPECT_EQ(custom->isChecked(), checkedName == std::string("CustomBox"));
+    EXPECT_EQ(btn->isEnabled(), c.expectBtnEnabled);
+
+    // CustomBox 分支额外回填编辑框文本（来自 Settings 的自定义路径，经 elide）
+    if (c.id == PathSettingWgt::CustomBox) {
+        DLineEdit *edit = m_wgt->findChild<DLineEdit *>("CustomEdit");
+        const QString expectBase = Settings::instance()->getSavePath(PathSettingWgt::CustomBox);
+        const QString expect = QFontMetrics(edit->font())
+                                   .elidedText(expectBase, Qt::ElideMiddle, 175);
+        EXPECT_EQ(edit->text(), expect);
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(SaveIdVariants, PathSettingSaveIdTest,
+                         ::testing::Values(
+                             SaveIdCase{PathSettingWgt::CurFileBox, "CurFileBox", false},
+                             SaveIdCase{PathSettingWgt::LastOptBox, "LastOptBox", false},
+                             SaveIdCase{PathSettingWgt::CustomBox, "CustomBox", true},
+                             // default 分支语义为"不改动"，Arrange 先置 LastOptBox 再喂 99
+                             SaveIdCase{99, "LastOptBox", false}));
+
+// ------------------------------------------------------------
+// setEditText
+// ------------------------------------------------------------
+
+TEST_F(PathSettingWgtTest, SetEditText_ShortText_Unchanged)
+{
+    // Arrange
+    DLineEdit *edit = m_wgt->findChild<DLineEdit *>("CustomEdit");
+
+    // Act
+    m_wgt->setEditText(QStringLiteral("/short/path"));
+
+    // Assert: 短文本不折叠且不含省略号
+    EXPECT_EQ(edit->text(), QString("/short/path"));
+    EXPECT_FALSE(edit->text().contains(QChar(0x2026)));
+}
+
+TEST_F(PathSettingWgtTest, SetEditText_LongText_ElidedMiddle)
+{
+    // Arrange
+    DLineEdit *edit = m_wgt->findChild<DLineEdit *>("CustomEdit");
+    QString longPath = QStringLiteral("/very/");
+    for (int i = 0; i < 30; ++i)
+        longPath += QStringLiteral("long_segment_");
+    longPath += QStringLiteral("end.txt");
+    const QString expect = QFontMetrics(edit->font()).elidedText(longPath, Qt::ElideMiddle, 175);
+
+    // Act
+    m_wgt->setEditText(longPath);
+
+    // Assert: 中部折叠且与直接计算一致
+    EXPECT_EQ(edit->text(), expect);
+    EXPECT_NE(edit->text(), longPath);
+    EXPECT_TRUE(edit->text().contains(QStringLiteral("…")));
+}
+
+// ------------------------------------------------------------
+// onBoxClicked（经 QButtonGroup 真实信号链）
+// ------------------------------------------------------------
+
+TEST_F(PathSettingWgtTest, OnBoxClicked_CustomBox_UpdatesSettingsAndEnablesButton)
+{
+    // Arrange
+    QCheckBox *custom = m_wgt->findChild<QCheckBox *>("CustomBox");
+    QPushButton *btn = m_wgt->findChild<QPushButton *>("CustomBtn");
+
+    // Act: 点击自定义路径选项（buttonClicked → lambda → onBoxClicked(CustomBox)）
+    custom->click();
+
+    // Assert: Settings 保存路径模式已切换 + 按钮使能
+    EXPECT_EQ(Settings::instance()->getSavePathId(), PathSettingWgt::CustomBox);
+    EXPECT_TRUE(btn->isEnabled());
+}
+
+TEST_F(PathSettingWgtTest, OnBoxClicked_CurFileBox_UpdatesSettingsAndDisablesButton)
+{
+    // Arrange
+    QCheckBox *cur = m_wgt->findChild<QCheckBox *>("CurFileBox");
+    QPushButton *btn = m_wgt->findChild<QPushButton *>("CustomBtn");
+    m_wgt->onSaveIdChanged(PathSettingWgt::CustomBox);
+    ASSERT_TRUE(btn->isEnabled());
+
+    // Act
+    cur->click();
+
+    // Assert
+    EXPECT_EQ(Settings::instance()->getSavePathId(), PathSettingWgt::CurFileBox);
+    EXPECT_FALSE(btn->isEnabled());
+}
+
+// ------------------------------------------------------------
+// onBtnClicked（经按钮 clicked，QFileDialog 拦截）
+// ------------------------------------------------------------
+
+TEST_F(PathSettingWgtTest, OnBtnClicked_DialogRejected_NoChange)
+{
+    // Arrange: 进入自定义模式并预置已有路径
+    m_wgt->onSaveIdChanged(PathSettingWgt::CustomBox);
+    const QString preset = m_tempDir->filePath(QStringLiteral("preset"));
+    Settings::instance()->setSavePath(PathSettingWgt::CustomBox, preset);
+    DLineEdit *edit = m_wgt->findChild<DLineEdit *>("CustomEdit");
+    m_wgt->setEditText(preset);
+    const QString shownBefore = edit->text();
+
+    stub.set_lamda(VADDR(QDialog, exec), [this]() -> int {
+        ++dialogExecCalls;
+        return dialogExecResult; // 默认 Rejected
+    });
+    QPushButton *btn = m_wgt->findChild<QPushButton *>("CustomBtn");
+
+    // Act
+    btn->click();
+
+    // Assert: 对话框弹出过一次但被取消，配置与编辑框不变（强异常安全）
+    EXPECT_EQ(dialogExecCalls, 1);
+    EXPECT_EQ(Settings::instance()->getSavePath(PathSettingWgt::CustomBox), preset);
+    EXPECT_EQ(edit->text(), shownBefore);
+}
+
+TEST_F(PathSettingWgtTest, OnBtnClicked_DefaultPathAndAccepted_UpdatesCustomPath)
+{
+    // Arrange: 自定义路径为不存在路径 → 走默认 Documents 目录分支；接受并选中新目录
+    m_wgt->onSaveIdChanged(PathSettingWgt::CustomBox);
+    Settings::instance()->setSavePath(PathSettingWgt::CustomBox,
+                                      QStringLiteral("/nonexistent/somewhere"));
+    const QString chosen = m_tempDir->filePath(QStringLiteral("chosen-dir"));
+    ASSERT_TRUE(QDir().mkpath(chosen));
+
+    stub.set_lamda(VADDR(QDialog, exec), [this]() -> int {
+        ++dialogExecCalls;
+        return dialogExecResult;
+    });
+    dialogExecResult = QDialog::Accepted;
+    selectedFiles = QStringList{chosen};
+    stub.set_lamda(VADDR(QFileDialog, selectedFiles),
+                   [this](QFileDialog *) -> QStringList { return selectedFiles; });
+    QPushButton *btn = m_wgt->findChild<QPushButton *>("CustomBtn");
+    DLineEdit *edit = m_wgt->findChild<DLineEdit *>("CustomEdit");
+    const QString expectShown = QFontMetrics(edit->font()).elidedText(chosen, Qt::ElideMiddle, 175);
+
+    // Act
+    btn->click();
+
+    // Assert: 自定义路径回写为选中目录，编辑框同步（按 elide 规则折叠）
+    EXPECT_EQ(dialogExecCalls, 1);
+    EXPECT_EQ(Settings::instance()->getSavePath(PathSettingWgt::CustomBox), chosen);
+    EXPECT_EQ(edit->text(), expectShown);
+}
+
+// ------------------------------------------------------------
+// updateSizeMode / 析构
+// ------------------------------------------------------------
+
+TEST_F(PathSettingWgtTest, UpdateSizeMode_ButtonSizeMatchesCurrentMode)
+{
+    // Arrange
+    QPushButton *btn = m_wgt->findChild<QPushButton *>("CustomBtn");
+    const int expectBtn = DGuiApplicationHelper::isCompactMode() ? 24 : 36;
+    const int expectIcon = DGuiApplicationHelper::isCompactMode() ? 16 : 24;
+
+    // Act（ctor 已调用过，这里直接复核当前模式分支的尺寸结果）
+    m_wgt->updateSizeMode();
+
+    // Assert: 与当前布局模式的固定尺寸一致
+    EXPECT_EQ(btn->width(), expectBtn);
+    EXPECT_EQ(btn->height(), expectBtn);
+    EXPECT_EQ(btn->iconSize().width(), expectIcon);
+    EXPECT_EQ(btn->iconSize().height(), expectIcon);
+}
+
+TEST_F(PathSettingWgtTest, Destructor_DelelesSafely)
+{
+    // Arrange: 堆上再建一个
+    PathSettingWgt *extra = new PathSettingWgt();
+
+    // Act
+    delete extra;
+
+    // Assert: 无崩溃（真实覆盖析构函数）；夹具内对象由 TearDown 覆盖第二次析构
+    EXPECT_NE(m_wgt, nullptr);
+    EXPECT_TRUE(m_wgt->findChild<QCheckBox *>("CurFileBox") != nullptr);
+}

--- a/tests/widgets_ut/test_window.cpp
+++ b/tests/widgets_ut/test_window.cpp
@@ -1,0 +1,3106 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// ============================================================================
+// Window 单元测试（B11 / src/widgets/window.cpp，主窗口入口类）
+//
+// 策略：真实 offscreen 构造 Window（B8 已验证 EditWrapper/TextEdit 真实链接可行，
+// 探针已验证 DMainWindow/DTitlebar 在 DBus 全拦截下可构造）。外围重依赖运行期拦截：
+//   - DBus：QDBusConnection::systemBus/sessionBus → 伪连接；callWithArgumentList 汇聚桩
+//     （DConfig/DTitlebar 会经 isServiceRegistered 查询，伪连接上真实调用会崩溃）
+//   - 模态对话框：DDialog::exec / QDialog::exec / QFileDialog::selectedFiles /
+//     DFileDialog::getComboBoxValue
+//   - 浮动消息：DMessageManager::sendMessage（两个重载）计数桩
+//   - 子进程：QProcess::startDetached 拦截（displayShortcuts）
+//   - 文件系统：XDG_CONFIG_HOME/XDG_DATA_HOME → QTemporaryDir（真实 Settings 读写）
+// 私有成员（m_wrappers/m_pendingTabs/m_findBar/m_fontSize 等）经 -fno-access-control
+// 访问做状态注入与断言（不影响 ABI 布局）。
+//
+// 用例映射（分支清单）见各测试头部注释；不可达分支（真实打印机绘制 / 焦点窗口切换 /
+// 系统托盘）在 autotests/.ut-session.batch11.json 记录原因。
+// ============================================================================
+
+#include <gtest/gtest.h>
+#include "stubext.h"
+
+#include <QApplication>
+#include <QTemporaryDir>
+#include <QSignalSpy>
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QKeyEvent>
+#include <QMouseEvent>
+#include <QDragEnterEvent>
+#include <QDropEvent>
+#include <QMimeData>
+#include <QUrl>
+#include <QTimerEvent>
+#include <QImage>
+#include <QPainter>
+#include <QTextDocument>
+#include <QElapsedTimer>
+#include <QThread>
+#include <QDBusConnection>
+#include <QDBusAbstractInterface>
+#include <QDBusMessage>
+#include <QPrintDialog>
+
+#include <DDialog>
+#include <DTitlebar>
+#include <DSettings>
+#include <DSettingsOption>
+#include <DIconButton>
+#include <DMessageManager>
+
+#include "widgets/window.h"
+#include "widgets/pathsettintwgt.h"
+#include "controls/tabbar.h"
+#include "controls/findbar.h"
+#include "controls/replacebar.h"
+#include "controls/jumplinebar.h"
+#include "editor/editwrapper.h"
+#include "editor/dtextedit.h"
+#include "common/settings.h"
+#include "common/utils.h"
+#include "common/iflytek_ai_assistant.h"
+#include "startmanager.h"
+
+class WindowTest : public ::testing::Test {
+protected:
+    static void SetUpTestSuite()
+    {
+        s_configHome = new QTemporaryDir();
+        s_dataHome = new QTemporaryDir();
+        const QString xdgConfig = s_configHome->filePath("xdg-config");
+        const QString xdgData = s_dataHome->filePath("xdg-data");
+        QDir().mkpath(xdgConfig);
+        QDir().mkpath(xdgData);
+        qputenv("XDG_CONFIG_HOME", xdgConfig.toUtf8());
+        qputenv("XDG_DATA_HOME", xdgData.toUtf8());
+
+        int argc = 1;
+        char *argv[] = {s_argv, nullptr};
+        s_app = new QApplication(argc, argv);
+        QApplication::setOrganizationName(QStringLiteral("deepin"));
+        QApplication::setApplicationName(QStringLiteral("deepin-editor"));
+
+        // 真实 Settings 单例（qrc settings.json + 临时 config.conf）
+        Settings::instance();
+        qRegisterMetaType<ViewMode>("ViewMode");
+
+        // 草稿/备份目录（AppDataLocation = $XDG_DATA_HOME/deepin/deepin-editor）
+        QDir().mkpath(xdgData + "/deepin/deepin-editor/blank-files");
+        QDir().mkpath(xdgData + "/deepin/deepin-editor/backup-files");
+        QDir().mkpath(xdgData + "/deepin/deepin-editor/autoBackup-files");
+    }
+
+    static void TearDownTestSuite()
+    {
+        qunsetenv("XDG_CONFIG_HOME");
+        qunsetenv("XDG_DATA_HOME");
+    }
+
+    void SetUp() override
+    {
+        m_tempDir = new QTemporaryDir();
+        installCommonStubs();
+
+        // 真实 Window 构造（offscreen + DBus 拦截）
+        m_win = new Window();
+        m_tabbar = m_win->getTabbar();
+    }
+
+    void TearDown() override
+    {
+        // 恢复测试内降权的文件
+        for (const QString &p : m_restoreFiles) {
+            QFile f(p);
+            if (f.exists())
+                f.setPermissions(QFileDevice::ReadOwner | QFileDevice::WriteOwner);
+        }
+        // stub 保持激活状态下析构（析构链中的 DBus/消息调用仍被拦截）
+        delete m_win;
+        m_win = nullptr;
+        m_tabbar = nullptr;
+        QApplication::processEvents();
+        stub.clear();
+        delete m_tempDir;
+    }
+
+    // ==================== 运行期 stub 矩阵 ====================
+    void installCommonStubs()
+    {
+        // DBus 隔离：伪连接 + 汇聚桩（禁止真实总线；DConfig 查询安全失败）
+        stub.set_lamda(&QDBusConnection::systemBus,
+                       []() -> QDBusConnection { return QDBusConnection(QStringLiteral("ut_no_bus")); });
+        stub.set_lamda(&QDBusConnection::sessionBus,
+                       []() -> QDBusConnection { return QDBusConnection(QStringLiteral("ut_no_bus")); });
+        stub.set_lamda(
+            static_cast<QDBusMessage (QDBusAbstractInterface::*)(QDBus::CallMode, const QString &, const QList<QVariant> &)>(
+                &QDBusAbstractInterface::callWithArgumentList),
+            [](QDBusAbstractInterface *, QDBus::CallMode, const QString &, const QList<QVariant> &) -> QDBusMessage {
+                return QDBusMessage();
+            });
+
+        // 浮动消息计数桩（showNotify / 只读提示 / 无权限提示）
+        stub.set_lamda(
+            static_cast<void (DMessageManager::*)(QWidget *, const QIcon &, const QString &)>(
+                &DMessageManager::sendMessage),
+            [this](DMessageManager *, QWidget *, const QIcon &, const QString &message) {
+                ++m_iconMsgCalls;
+                m_lastIconMsg = message;
+            });
+        stub.set_lamda(
+            static_cast<void (DMessageManager::*)(QWidget *, DFloatingMessage *)>(
+                &DMessageManager::sendMessage),
+            [this](DMessageManager *, QWidget *, DFloatingMessage *) { ++m_widgetMsgCalls; });
+        stub.set_lamda(&Utils::sendFloatMessageFixedFont,
+                       [this](QWidget *, const QIcon &, const QString &message) {
+                           ++m_floatMsgCalls;
+                           m_lastFloatMsg = message;
+                       });
+
+        // StartManager 关闭联动：qApp 非 DApplication 时 aboutDialog() 会做非法
+        // static_cast（生产环境 qApp 为 DApplication），此处属跨类环境差异，拦截
+        stub.set_lamda(&StartManager::closeAboutForWindow,
+                       [](StartManager *, Window *) -> void {});
+
+        // 子进程拦截（displayShortcuts 启动 deepin-shortcut-viewer）
+        stub.set_lamda(static_cast<bool (*)(const QString &, const QStringList &, const QString &, qint64 *)>(&QProcess::startDetached),
+                       [this](const QString &program, const QStringList &args, const QString &, qint64 *) -> bool {
+                           ++m_startDetachedCalls;
+                           m_lastDetachedProgram = program;
+                           m_lastDetachedArgs = args;
+                           return true;
+                       });
+
+        // 模态对话框默认拦截（个别用例覆盖返回值）
+        stub.set_lamda(VADDR(DDialog, exec), [this]() -> int {
+            ++m_ddialogExecCalls;
+            return m_ddialogResult;
+        });
+        stub.set_lamda(VADDR(QDialog, exec), [this]() -> int {
+            ++m_qdialogExecCalls;
+            return m_qdialogResult;
+        });
+        stub.set_lamda(VADDR(QFileDialog, selectedFiles),
+                       [this](QFileDialog *) -> QStringList { return m_selectedFiles; });
+        stub.set_lamda(&DFileDialog::getComboBoxValue,
+                       [this](DFileDialog *, const QString &) -> QString { return m_comboValue; });
+    }
+
+    // ==================== 辅助 ====================
+
+    QString createFile(const QString &name, const QByteArray &content = "hello world")
+    {
+        const QString path = m_tempDir->filePath(name);
+        QFile f(path);
+        if (!f.open(QIODevice::WriteOnly))
+            return QString();
+        f.write(content);
+        f.close();
+        return path;
+    }
+
+    // 添加空白标签页并返回其路径
+    QString addBlankAndGetPath()
+    {
+        m_win->addBlankTab();
+        QApplication::processEvents();
+        return m_tabbar->currentPath();
+    }
+
+    // 添加真实文件标签页并等待内容载入（getFileLoading 在 finished 前恒为 false，
+    // 直接轮询有竞态；以"文档非空 + 非加载中"为完成判据）
+    QString addFileTab(const QString &name, const QByteArray &content = "hello world\nsecond line\n")
+    {
+        const QString path = createFile(name, content);
+        m_win->addTab(path, true);
+        EditWrapper *w = m_win->wrapper(path);
+        if (w != nullptr && !content.isEmpty()) {
+            waitUntil([w]() {
+                return !w->getFileLoading() && !w->textEditor()->document()->isEmpty();
+            });
+        }
+        return path;
+    }
+
+    bool waitUntil(const std::function<bool()> &predicate, int timeoutMs = 8000)
+    {
+        QElapsedTimer timer;
+        timer.start();
+        while (!predicate()) {
+            if (timer.elapsed() > timeoutMs)
+                return false;
+            QApplication::processEvents(QEventLoop::AllEvents, 50);
+            QThread::msleep(10);
+        }
+        return true;
+    }
+
+    void processEventsFor(int ms)
+    {
+        QElapsedTimer t;
+        t.start();
+        while (t.elapsed() < ms) {
+            QApplication::processEvents(QEventLoop::AllEvents, 20);
+            QThread::msleep(5);
+        }
+    }
+
+    // ==================== 状态 ====================
+    stub_ext::StubExt stub;
+    Window *m_win = nullptr;
+    Tabbar *m_tabbar = nullptr;
+    QTemporaryDir *m_tempDir = nullptr;
+
+    int m_iconMsgCalls = 0;
+    QString m_lastIconMsg;
+    int m_widgetMsgCalls = 0;
+    int m_floatMsgCalls = 0;
+    QString m_lastFloatMsg;
+    int m_startDetachedCalls = 0;
+    QString m_lastDetachedProgram;
+    QStringList m_lastDetachedArgs;
+    int m_ddialogExecCalls = 0;
+    int m_ddialogResult = 0;
+    int m_qdialogExecCalls = 0;
+    int m_qdialogResult = QDialog::Rejected;
+    QStringList m_selectedFiles;
+    QString m_comboValue = QStringLiteral("UTF-8");
+    int m_saveAsCalls = 0;
+
+    QStringList m_restoreFiles;
+
+    static QApplication *s_app;
+    static QTemporaryDir *s_configHome;
+    static QTemporaryDir *s_dataHome;
+    static char s_argv[];
+};
+
+QApplication *WindowTest::s_app = nullptr;
+QTemporaryDir *WindowTest::s_configHome = nullptr;
+QTemporaryDir *WindowTest::s_dataHome = nullptr;
+char WindowTest::s_argv[] = "test_window";
+
+// ============================================================
+// 构造 / 基础 getter / 析构
+// ============================================================
+
+TEST_F(WindowTest, Constructor_RealBuild_CreatesCoreParts)
+{
+    // Assert: 核心部件就绪 + 初始状态
+    ASSERT_NE(m_win->getTabbar(), nullptr);
+    ASSERT_NE(m_win->getStackedWgt(), nullptr);
+    EXPECT_EQ(m_win->getTabbar()->count(), 0);
+    EXPECT_TRUE(m_win->m_wrappers.isEmpty());
+    EXPECT_TRUE(m_win->m_pendingTabs.isEmpty());
+    EXPECT_EQ(m_win->minimumWidth(), 680);
+    EXPECT_EQ(m_win->minimumHeight(), 300);
+    EXPECT_FALSE(m_win->findBarIsVisiable());
+    EXPECT_FALSE(m_win->replaceBarIsVisiable());
+}
+
+TEST_F(WindowTest, InitTitlebar_FromConstructor_MenuActionsRegistered)
+{
+    // Assert: 标题栏菜单包含全部功能项（按注册时的 objectName 核对 9 项）
+    QSet<QString> registered;
+    const QList<QAction *> actions = m_win->m_menu->actions();
+    for (QAction *a : actions)
+        registered.insert(a->objectName());
+    for (const char *name : { "NewWindow", "NewTab", "OpenFile", "Save", "SaveAs",
+                              "Print", "Settings", "Find", "Replace" }) {
+        EXPECT_TRUE(registered.contains(QString(name))) << "missing menu action: " << name;
+    }
+    EXPECT_GE(actions.count(), 9);
+    // 标签栏已挂载到标题栏
+    EXPECT_NE(m_win->getTabbar()->parentWidget(), nullptr);
+}
+
+TEST_F(WindowTest, Destructor_AfterUse_ReleasesSafely)
+{
+    // Arrange: 打开一个标签页制造状态
+    addBlankAndGetPath();
+    ASSERT_EQ(m_tabbar->count(), 1);
+
+    // Act: 手动析构（TearDown 会对夹具窗口再覆盖一次）
+    Window *victim = std::exchange(m_win, nullptr);
+    m_tabbar = nullptr;
+    delete victim;
+
+    // Assert: 析构后重新构造可正常工作（析构链未损坏全局状态）
+    ASSERT_NO_FATAL_FAILURE(m_win = new Window());
+    m_tabbar = m_win->getTabbar();
+    EXPECT_NE(m_win->getTabbar(), nullptr);
+    EXPECT_EQ(m_win->getTabbar()->count(), 0);
+}
+
+TEST_F(WindowTest, Getters_KeywordAndStack_ReturnInternalState)
+{
+    // Arrange: 注入关键词
+    m_win->m_keywordForSearch = QStringLiteral("kw1");
+    m_win->m_keywordForSearchAll = QStringLiteral("kw2");
+
+    // Assert
+    EXPECT_EQ(m_win->getKeywordForSearch(), QString("kw1"));
+    EXPECT_EQ(m_win->getKeywordForSearchAll(), QString("kw2"));
+    EXPECT_EQ(m_win->getStackedWgt(), m_win->m_editorWidget);
+}
+
+// ============================================================
+// 语音助手配置
+// ============================================================
+
+TEST_F(WindowTest, LoadIflytekaiassistantConfig_NoDir_EarlyReturn)
+{
+    // Act: ConfigLocation 下无 iflytek 目录
+    m_win->loadIflytekaiassistantConfig();
+
+    // Assert: 状态表保持为空
+    EXPECT_TRUE(m_win->m_IflytekAiassistantState.isEmpty());
+    EXPECT_FALSE(m_win->getIflytekaiassistantConfig(QStringLiteral("any-iat")));
+}
+
+TEST_F(WindowTest, LoadIflytekaiassistantConfig_IniFiles_ParsesEnableStates)
+{
+    // Arrange: 在隔离的 ConfigLocation 下构造 iflytek 配置目录
+    const QString cfgRoot = QStandardPaths::writableLocation(QStandardPaths::ConfigLocation);
+    const QString iflytekDir = QDir(cfgRoot).filePath(QStringLiteral("iflytek"));
+    ASSERT_TRUE(QDir().mkpath(iflytekDir));
+    auto writeIni = [&](const QString &name, bool enable) {
+        QSettings ini(QDir(iflytekDir).filePath(name), QSettings::IniFormat);
+        ini.beginGroup(QStringLiteral("base"));
+        ini.setValue(QStringLiteral("enable"), enable);
+        ini.endGroup();
+        ini.sync();
+    };
+    writeIni(QStringLiteral("sv-iat.ini"), true);
+    writeIni(QStringLiteral("sv-tts.ini"), false);
+    writeIni(QStringLiteral("ignore.txt"), true); // 命名不含关键后缀，跳过
+
+    // Act
+    m_win->loadIflytekaiassistantConfig();
+
+    // Assert: 仅 -iat/-tts/-trans 后缀进入状态表
+    EXPECT_TRUE(m_win->getIflytekaiassistantConfig(QStringLiteral("sv-iat")));
+    EXPECT_FALSE(m_win->getIflytekaiassistantConfig(QStringLiteral("sv-tts")));
+    EXPECT_FALSE(m_win->getIflytekaiassistantConfig(QStringLiteral("nonexistent")));
+    EXPECT_EQ(m_win->m_IflytekAiassistantState.count(), 2);
+}
+
+// ============================================================
+// Tab 状态更新
+// ============================================================
+
+TEST_F(WindowTest, UpdateModifyStatus_UnknownPath_EarlyReturn)
+{
+    // Act
+    m_win->updateModifyStatus(QStringLiteral("/no/such/file"), true);
+
+    // Assert: 无标签变化（强异常安全）
+    EXPECT_EQ(m_tabbar->count(), 0);
+    EXPECT_TRUE(m_win->m_wrappers.isEmpty());
+}
+
+TEST_F(WindowTest, UpdateModifyStatus_DraftTab_AddsAndRemovesStar)
+{
+    // Arrange: 空白标签（草稿路径，truePath 为空）
+    const QString blank = addBlankAndGetPath();
+    ASSERT_EQ(m_tabbar->currentName(), QString("Untitled 1"));
+    QSignalSpy blockSpy(m_win, &Window::sigJudgeBlockShutdown);
+
+    // Act: 标记修改 → 加 *
+    m_win->updateModifyStatus(blank, true);
+
+    // Assert
+    EXPECT_EQ(m_tabbar->currentName(), QString("*Untitled 1"));
+    EXPECT_EQ(blockSpy.count(), 1);
+
+    // Act: 取消修改 → 去 *
+    m_win->updateModifyStatus(blank, false);
+    EXPECT_EQ(m_tabbar->currentName(), QString("Untitled 1"));
+    EXPECT_EQ(blockSpy.count(), 2);
+}
+
+TEST_F(WindowTest, UpdateModifyStatus_RealFile_UsesFileBaseName)
+{
+    // Arrange: 真实文件标签
+    const QString path = addFileTab(QStringLiteral("doc.txt"));
+    ASSERT_FALSE(path.isEmpty());
+
+    // Act: 修改 → 文件名加 *
+    m_win->updateModifyStatus(path, true);
+
+    // Assert: 标签名变为 *doc.txt（走 QFileInfo 分支）
+    EXPECT_EQ(m_tabbar->currentName(), QString("*doc.txt"));
+
+    // Act: 取消 → 恢复文件名
+    m_win->updateModifyStatus(path, false);
+    EXPECT_EQ(m_tabbar->currentName(), QString("doc.txt"));
+}
+
+TEST_F(WindowTest, UpdateSaveAsFileName_NoWrapper_EarlyReturn)
+{
+    // Act
+    m_win->updateSaveAsFileName(QStringLiteral("/a"), QStringLiteral("/b"));
+
+    // Assert
+    EXPECT_TRUE(m_win->m_wrappers.isEmpty());
+    EXPECT_EQ(m_tabbar->count(), 0);
+}
+
+TEST_F(WindowTest, UpdateSaveAsFileName_WithWrapper_MovesMappingAndTab)
+{
+    // Arrange: 空白标签 + wrapper
+    const QString blank = addBlankAndGetPath();
+    EditWrapper *w = m_win->wrapper(blank);
+    ASSERT_NE(w, nullptr);
+    const QString newPath = m_tempDir->filePath(QStringLiteral("renamed.txt"));
+
+    // Act
+    m_win->updateSaveAsFileName(blank, newPath);
+
+    // Assert: 映射键迁移 + 路径更新 + 标签名更新
+    EXPECT_FALSE(m_win->m_wrappers.contains(blank));
+    EXPECT_EQ(m_win->m_wrappers.value(newPath), w);
+    EXPECT_EQ(w->filePath(), newPath);
+    EXPECT_EQ(m_tabbar->currentName(), QString("renamed.txt"));
+}
+
+TEST_F(WindowTest, UpdateSabeAsFileNameTemp_WithWrapper_MovesWithoutClose)
+{
+    // Arrange
+    const QString blank = addBlankAndGetPath();
+    EditWrapper *w = m_win->wrapper(blank);
+    const QString newPath = m_tempDir->filePath(QStringLiteral("temp-renamed.txt"));
+
+    // Act
+    m_win->updateSabeAsFileNameTemp(blank, newPath);
+
+    // Assert: 与 updateSaveAsFileName 一致但不触发重名关闭
+    EXPECT_EQ(m_win->m_wrappers.value(newPath), w);
+    EXPECT_EQ(w->filePath(), newPath);
+    EXPECT_EQ(m_tabbar->count(), 1);
+}
+
+// ============================================================
+// 窗口状态
+// ============================================================
+
+TEST_F(WindowTest, ShowCenterWindow_NormalState_NoMoveFlag)
+{
+    // Act: 默认 window_normal
+    m_win->showCenterWindow(true);
+
+    // Assert
+    EXPECT_FALSE(m_win->m_needMoveToCenter);
+    EXPECT_FALSE(m_win->isMaximized());
+    EXPECT_FALSE(m_win->isFullScreen());
+}
+
+TEST_F(WindowTest, ShowCenterWindow_MaximumConfig_SetsMoveFlag)
+{
+    // Arrange: 配置最大化
+    Settings::instance()->settings->option("advance.window.windowstate")->setValue("window_maximum");
+
+    // Act
+    m_win->showCenterWindow(false);
+
+    // Assert: 最大化 + 请求居中标志（bIsCenter=false 跳过 moveToCenter）
+    EXPECT_TRUE(m_win->isMaximized());
+    EXPECT_TRUE(m_win->m_needMoveToCenter);
+
+    // 还原配置
+    Settings::instance()->settings->option("advance.window.windowstate")->setValue("window_normal");
+}
+
+TEST_F(WindowTest, ShowCenterWindow_FullscreenConfig_EntersFullscreen)
+{
+    // Arrange
+    Settings::instance()->settings->option("advance.window.windowstate")->setValue("fullscreen");
+
+    // Act
+    m_win->showCenterWindow(true);
+
+    // Assert
+    EXPECT_TRUE(m_win->isFullScreen());
+    EXPECT_TRUE(m_win->m_needMoveToCenter);
+
+    Settings::instance()->settings->option("advance.window.windowstate")->setValue("window_normal");
+    m_win->showNormal();
+}
+
+TEST_F(WindowTest, ToggleFullscreen_SwitchesStateBackAndForth)
+{
+    // Assert: 初始非全屏
+    EXPECT_FALSE(m_win->windowState().testFlag(Qt::WindowFullScreen));
+
+    // Act / Assert: 进入
+    m_win->toggleFullscreen();
+    EXPECT_TRUE(m_win->windowState().testFlag(Qt::WindowFullScreen));
+
+    // Act / Assert: 退出
+    m_win->toggleFullscreen();
+    EXPECT_FALSE(m_win->windowState().testFlag(Qt::WindowFullScreen));
+}
+
+TEST_F(WindowTest, SlotSigChangeWindowSize_ThreeModes_SwitchesWindowStates)
+{
+    // Act / Assert: fullscreen
+    m_win->slotSigChangeWindowSize(QStringLiteral("fullscreen"));
+    EXPECT_TRUE(m_win->isFullScreen());
+
+    // Act / Assert: window_maximum
+    m_win->slotSigChangeWindowSize(QStringLiteral("window_maximum"));
+    EXPECT_TRUE(m_win->isMaximized());
+
+    // Act / Assert: 其它 → normal
+    m_win->slotSigChangeWindowSize(QStringLiteral("window_minimum"));
+    EXPECT_FALSE(m_win->isFullScreen());
+    EXPECT_FALSE(m_win->isMaximized());
+}
+
+TEST_F(WindowTest, ResizeEvent_SavesGeometryToSettings)
+{
+    // Arrange
+    Settings::instance()->settings->option("advance.window.window_width")->setValue(1);
+    Settings::instance()->settings->option("advance.window.window_height")->setValue(1);
+
+    // Act
+    m_win->resize(900, 700);
+    QApplication::processEvents();
+
+    // Assert: 尺寸持久化（resizeEvent 写配置）+ 窗口几何生效
+    EXPECT_EQ(Settings::instance()->settings->option("advance.window.window_width")->value().toInt(), 900);
+    EXPECT_EQ(Settings::instance()->settings->option("advance.window.window_height")->value().toInt(), 700);
+    EXPECT_EQ(m_win->width(), 900);
+    EXPECT_EQ(m_win->height(), 700);
+}
+
+// ============================================================
+// Tab 管理
+// ============================================================
+
+TEST_F(WindowTest, CheckBlockShutdown_NoTabsOrClean_ReturnsFalse)
+{
+    // Assert: 无标签 → false
+    EXPECT_FALSE(m_win->checkBlockShutdown());
+
+    // Arrange: 干净标签
+    addBlankAndGetPath();
+
+    // Assert: 无 * 前缀 → false
+    EXPECT_FALSE(m_win->checkBlockShutdown());
+}
+
+TEST_F(WindowTest, CheckBlockShutdown_UnsavedTab_ReturnsTrue)
+{
+    // Arrange: 构造带 * 的标签（空文本分支先行覆盖）
+    m_tabbar->addTab(QStringLiteral("/x/empty"), QString(""));
+    m_tabbar->addTab(QStringLiteral("/x/mod"), QStringLiteral("*modified.txt"));
+    EXPECT_FALSE(m_win->checkBlockShutdown()); // 空文本标签 → false
+
+    // Act / Assert: 关闭空标签后仅剩修改标签 → true
+    m_tabbar->removeTab(0);
+    EXPECT_TRUE(m_win->checkBlockShutdown());
+}
+
+TEST_F(WindowTest, GetTabIndex_UnknownAndKnownPaths)
+{
+    // Assert: 未知 → -1
+    EXPECT_EQ(m_win->getTabIndex(QStringLiteral("/none")), -1);
+
+    // Arrange
+    const QString blank = addBlankAndGetPath();
+
+    // Assert
+    EXPECT_EQ(m_win->getTabIndex(blank), 0);
+}
+
+TEST_F(WindowTest, ActiveTab_SwitchesCurrentIndex)
+{
+    // Arrange: 两个标签
+    const QString b1 = addBlankAndGetPath();
+    addBlankAndGetPath();
+    EXPECT_EQ(m_tabbar->currentIndex(), 1);
+
+    // Act
+    m_win->activeTab(0);
+
+    // Assert
+    EXPECT_EQ(m_tabbar->currentIndex(), 0);
+    EXPECT_EQ(m_tabbar->currentPath(), b1);
+}
+
+TEST_F(WindowTest, AddBlankTab_CreatesUntitledWithWrapper)
+{
+    // Act
+    m_win->addBlankTab();
+    QApplication::processEvents();
+
+    // Assert: 标签创建 + wrapper 注册 + 空白目录在隔离 AppData 下
+    ASSERT_EQ(m_tabbar->count(), 1);
+    EXPECT_EQ(m_tabbar->currentName(), QString("Untitled 1"));
+    const QString blank = m_tabbar->currentPath();
+    EXPECT_TRUE(blank.contains(QStringLiteral("blank-files")));
+    EXPECT_NE(m_win->wrapper(blank), nullptr);
+    EXPECT_EQ(m_win->m_editorWidget->count(), 1);
+}
+
+TEST_F(WindowTest, AddBlankTab_WithExistingFile_LoadsContent)
+{
+    // Arrange: 预置空白文件
+    const QString blankFile = createFile(QStringLiteral("seed.txt"), QByteArray("seed content"));
+    QDir().mkpath(m_win->m_blankFileDir);
+
+    // Act: 以指定文件新建空白标签
+    m_win->addBlankTab(blankFile);
+    TextEdit *editor = m_win->getTextEditor(blankFile);
+    ASSERT_NE(editor, nullptr);
+    ASSERT_TRUE(waitUntil([editor]() { return !editor->document()->isEmpty(); }))
+        << "seed content 未加载";
+
+    // Assert: 标签路径即文件路径且内容已加载
+    EXPECT_EQ(m_tabbar->currentPath(), blankFile);
+    EXPECT_EQ(editor->toPlainText(), QString("seed content"));
+}
+
+TEST_F(WindowTest, AddTab_RealTextFile_CreatesLoadedTab)
+{
+    // Arrange
+    const QString path = createFile(QStringLiteral("real.txt"));
+
+    // Act
+    m_win->addTab(path, true);
+
+    // Assert: 标签 + wrapper + 文件加载完成 + 激活
+    EXPECT_EQ(m_win->getTabIndex(path), 0);
+    EditWrapper *w = m_win->wrapper(path);
+    ASSERT_NE(w, nullptr);
+    EXPECT_TRUE(waitUntil([w]() { return !w->getFileLoading(); }));
+    EXPECT_EQ(m_tabbar->currentPath(), path);
+}
+
+TEST_F(WindowTest, AddTab_AlreadyOpen_ActivatesExistingTab)
+{
+    // Arrange
+    const QString path = addFileTab(QStringLiteral("dup.txt"));
+    ASSERT_EQ(m_tabbar->count(), 1);
+
+    // Act: 再次添加同一路径
+    m_win->addTab(path, true);
+    QApplication::processEvents();
+
+    // Assert: 不重复建标签（checkPath 拒绝）
+    EXPECT_EQ(m_tabbar->count(), 1);
+    EXPECT_EQ(m_win->m_wrappers.count(), 1);
+}
+
+TEST_F(WindowTest, AddTab_UnsupportedMime_ShowsInvalidNotice)
+{
+    // Arrange: 目录作为不支持类型（QMimeDatabase → inode/directory）
+    const QString dirPath = m_tempDir->path();
+
+    // Act
+    m_win->addTab(dirPath, true);
+    QApplication::processEvents();
+
+    // Assert: 弹出无效文件提示 + 自动补空白标签
+    EXPECT_GE(m_iconMsgCalls, 1);
+    EXPECT_TRUE(m_lastIconMsg.contains(QStringLiteral("Invalid file")));
+    EXPECT_EQ(m_tabbar->count(), 1); // addBlankTab
+    EXPECT_EQ(m_tabbar->currentName(), QString("Untitled 1"));
+}
+
+TEST_F(WindowTest, AddTab_ReadOnlyFile_MarksTabReadOnly)
+{
+    // Arrange: 只读文件（无写权限、可读）
+    const QString path = createFile(QStringLiteral("readonly.txt"));
+    QFile::setPermissions(path, QFileDevice::ReadOwner | QFileDevice::ReadGroup | QFileDevice::ReadOther);
+    m_restoreFiles.append(path);
+
+    // Act
+    m_win->addTab(path, true);
+    EditWrapper *w = m_win->wrapper(path);
+
+    // Assert: 标签名带 Read-Only 标记 + wrapper 存在
+    ASSERT_NE(w, nullptr);
+    EXPECT_TRUE(m_tabbar->currentName().contains(QStringLiteral("Read-Only")));
+    EXPECT_TRUE(waitUntil([w]() { return !w->getFileLoading(); }));
+}
+
+TEST_F(WindowTest, AddTab_UnreadableFile_OpenFailsWithGenericError_Continues)
+{
+    // Arrange: 无读权限文件。Qt 6.8 实测 EACCES 映射为 OpenError（非
+    // PermissionsError），走"仅告警继续"分支（PermissionsError 提示分支在
+    // 本 Qt 版本不可达，已记录到 session.skip_reason）
+    if (geteuid() == 0)
+        GTEST_SKIP() << "root 用户不受读权限位约束，跳过";
+    const QString path = createFile(QStringLiteral("secret.txt"));
+    QFile::setPermissions(path, QFileDevice::WriteOwner);
+    m_restoreFiles.append(path);
+    if (QFileInfo(path).isReadable())
+        GTEST_SKIP() << "环境无法构造不可读文件（权限位未生效）";
+
+    // Act
+    m_win->addTab(path, true);
+    QApplication::processEvents();
+
+    // Assert: 无权限提示（未走 PermissionsError 分支）且标签照常创建
+    EXPECT_EQ(m_iconMsgCalls, 0);
+    EXPECT_EQ(m_tabbar->count(), 1);
+    EXPECT_EQ(m_tabbar->currentName(), QString("secret.txt"));
+}
+
+TEST_F(WindowTest, AddTabWithWrapper_RegistersAndShowsEditor)
+{
+    // Arrange: 独立真实 wrapper
+    EditWrapper *w = m_win->createEditor();
+    ASSERT_NE(w, nullptr);
+    const QString path = m_tempDir->filePath(QStringLiteral("wrapped.txt"));
+
+    // Act
+    m_win->addTabWithWrapper(w, path, path, QStringLiteral("wrapped.txt"));
+
+    // Assert: 标签 + 映射 + 当前显示
+    EXPECT_EQ(m_win->getTabIndex(path), 0);
+    EXPECT_EQ(m_win->m_wrappers.value(path), w);
+    EXPECT_EQ(w->filePath(), path);
+    EXPECT_EQ(m_win->m_editorWidget->currentWidget(), w);
+}
+
+// ============================================================
+// closeTab 家族
+// ============================================================
+
+TEST_F(WindowTest, CloseTab_NoCurrentPath_ReturnsFalse)
+{
+    // Assert: 无标签 → false 且不产生副作用
+    EXPECT_FALSE(m_win->closeTab());
+    EXPECT_EQ(m_tabbar->count(), 0);
+    EXPECT_TRUE(m_win->m_wrappers.isEmpty());
+}
+
+TEST_F(WindowTest, CloseTab_UnknownPath_ReturnsFalse)
+{
+    // Act / Assert
+    EXPECT_FALSE(m_win->closeTab(QStringLiteral("/no/such/path")));
+    EXPECT_EQ(m_tabbar->count(), 0);
+}
+
+TEST_F(WindowTest, CloseTab_PendingTab_RemovesDirectlyAndAddsBlank)
+{
+    // Arrange: 待加载标签（真实存在文件）
+    const QString path = createFile(QStringLiteral("pending.txt"));
+    Window::PendingTabInfo info;
+    info.filepath = path;
+    info.truePath = path;
+    info.displayName = QStringLiteral("pending.txt");
+    m_win->addPendingTab(info);
+    ASSERT_TRUE(m_win->isPendingTab(path));
+    ASSERT_EQ(m_tabbar->count(), 1);
+
+    // Act
+    EXPECT_TRUE(m_win->closeTab(path));
+
+    // Assert: pending 移除 + 标签清空后补空白标签
+    EXPECT_FALSE(m_win->isPendingTab(path));
+    EXPECT_EQ(m_tabbar->count(), 1); // addBlankTab
+    EXPECT_EQ(m_tabbar->currentName(), QString("Untitled 1"));
+}
+
+TEST_F(WindowTest, CloseTab_UnmodifiedDraft_RemovesAndDeletesFile)
+{
+    // Arrange: 空白标签（草稿文件在首次备份/保存前不落盘）
+    const QString blank = addBlankAndGetPath();
+
+    // Act
+    EXPECT_TRUE(m_win->closeTab(blank));
+    QApplication::processEvents();
+
+    // Assert: wrapper 移除 + 草稿文件删除 + 标签清零（窗口随之关闭）
+    EXPECT_TRUE(m_win->m_wrappers.isEmpty());
+    EXPECT_FALSE(QFile::exists(blank));
+    EXPECT_EQ(m_tabbar->count(), 0);
+}
+
+TEST_F(WindowTest, CloseTab_ModifiedDraft_CancelDialog_KeepsTab)
+{
+    // Arrange: 修改态草稿 + 对话框取消（res 0）
+    const QString blank = addBlankAndGetPath();
+    stub.set_lamda(&EditWrapper::isModified, [](EditWrapper *) -> bool { return true; });
+    m_ddialogResult = 0;
+
+    // Act
+    EXPECT_FALSE(m_win->closeTab(blank));
+
+    // Assert: 标签保留
+    EXPECT_EQ(m_tabbar->count(), 1);
+    EXPECT_EQ(m_ddialogExecCalls, 1);
+}
+
+TEST_F(WindowTest, CloseTab_ModifiedDraft_Discard_RemovesTab)
+{
+    // Arrange
+    const QString blank = addBlankAndGetPath();
+    stub.set_lamda(&EditWrapper::isModified, [](EditWrapper *) -> bool { return true; });
+    m_ddialogResult = 1; // 不保存
+
+    // Act
+    EXPECT_TRUE(m_win->closeTab(blank));
+    QApplication::processEvents();
+
+    // Assert
+    EXPECT_TRUE(m_win->m_wrappers.isEmpty());
+    EXPECT_FALSE(QFile::exists(blank));
+}
+
+TEST_F(WindowTest, CloseTab_ModifiedDraft_SaveSuccess_ClosesAfterSave)
+{
+    // Arrange
+    const QString blank = addBlankAndGetPath();
+    stub.set_lamda(&EditWrapper::isModified, [](EditWrapper *) -> bool { return true; });
+    m_ddialogResult = 2; // 保存
+    const QString savedTo = m_tempDir->filePath(QStringLiteral("draft-saved.txt"));
+    stub.set_lamda(&EditWrapper::saveDraftFile,
+                   [savedTo](EditWrapper *, QString &newFilePath) -> bool {
+                       newFilePath = savedTo;
+                       return true;
+                   });
+
+    // Act
+    EXPECT_TRUE(m_win->closeTab(blank));
+    QApplication::processEvents();
+
+    // Assert: 走保存成功分支（removeWrapper 执行；因桩不回写 tab 路径，标签保留）
+    EXPECT_TRUE(m_win->m_wrappers.isEmpty());
+    EXPECT_EQ(m_tabbar->count(), 1);
+}
+
+TEST_F(WindowTest, CloseTab_ModifiedDraft_SaveFail_KeepsTab)
+{
+    // Arrange
+    const QString blank = addBlankAndGetPath();
+    stub.set_lamda(&EditWrapper::isModified, [](EditWrapper *) -> bool { return true; });
+    m_ddialogResult = 2;
+    stub.set_lamda(&EditWrapper::saveDraftFile,
+                   [](EditWrapper *, QString &) -> bool { return false; });
+
+    // Act / Assert: 保存失败不关闭
+    EXPECT_FALSE(m_win->closeTab(blank));
+    EXPECT_EQ(m_tabbar->count(), 1);
+}
+
+TEST_F(WindowTest, CloseTab_ModifiedNormal_Cancel_KeepsTab)
+{
+    // Arrange: 真实文件但强制"已修改 + 非草稿"
+    const QString path = addFileTab(QStringLiteral("normal.txt"));
+    stub.set_lamda(&EditWrapper::isModified, [](EditWrapper *) -> bool { return true; });
+    stub.set_lamda(&EditWrapper::isDraftFile, [](EditWrapper *) -> bool { return false; });
+    m_ddialogResult = 0;
+
+    // Act
+    EXPECT_FALSE(m_win->closeTab(path));
+
+    // Assert
+    EXPECT_EQ(m_tabbar->count(), 1);
+    EXPECT_EQ(m_ddialogExecCalls, 1);
+}
+
+TEST_F(WindowTest, CloseTab_ModifiedNormal_Discard_ClosesTab)
+{
+    // Arrange
+    const QString path = addFileTab(QStringLiteral("normal2.txt"));
+    stub.set_lamda(&EditWrapper::isModified, [](EditWrapper *) -> bool { return true; });
+    stub.set_lamda(&EditWrapper::isDraftFile, [](EditWrapper *) -> bool { return false; });
+    m_ddialogResult = 1;
+
+    // Act
+    EXPECT_TRUE(m_win->closeTab(path));
+    QApplication::processEvents();
+
+    // Assert
+    EXPECT_TRUE(m_win->m_wrappers.isEmpty());
+    EXPECT_EQ(m_tabbar->count(), 0);
+}
+
+TEST_F(WindowTest, CloseTab_ModifiedNormal_SaveFail_FallsToSaveAs)
+{
+    // Arrange: 保存失败 → saveAsFile 兜底（DFileDialog 拒绝）
+    const QString path = addFileTab(QStringLiteral("normal3.txt"));
+    stub.set_lamda(&EditWrapper::isModified, [](EditWrapper *) -> bool { return true; });
+    stub.set_lamda(&EditWrapper::isDraftFile, [](EditWrapper *) -> bool { return false; });
+    stub.set_lamda(&EditWrapper::saveFile, [](EditWrapper *, QByteArray) -> bool { return false; });
+    m_ddialogResult = 2;
+    m_qdialogResult = QDialog::Rejected; // DFileDialog::exec → 拒绝
+
+    // Act: 源码在 saveAsFile 失败后仍继续走清理并返回 true（记录源码行为）
+    const bool ret = m_win->closeTab(path);
+    QApplication::processEvents();
+
+    // Assert: 走到 saveAsFile 兜底（QDialog::exec 被拒）+ 标签被清理
+    EXPECT_TRUE(ret);
+    EXPECT_GE(m_qdialogExecCalls, 1);
+}
+
+TEST_F(WindowTest, CloseTab_ModifiedBackup_SaveSuccess_RemovesTemFile)
+{
+    // Arrange: 临时备份文件（isTemFile true）+ 保存成功
+    const QString path = addFileTab(QStringLiteral("backup-file.txt"));
+    stub.set_lamda(&EditWrapper::isModified, [](EditWrapper *) -> bool { return true; });
+    stub.set_lamda(&EditWrapper::isDraftFile, [](EditWrapper *) -> bool { return false; });
+    stub.set_lamda(&EditWrapper::isTemFile, [](EditWrapper *) -> bool { return true; });
+    stub.set_lamda(&EditWrapper::saveFile, [](EditWrapper *, QByteArray) -> bool { return true; });
+    m_ddialogResult = 2;
+
+    // Act
+    EXPECT_TRUE(m_win->closeTab(path));
+    QApplication::processEvents();
+
+    // Assert: 备份文件被 QFile::remove
+    EXPECT_TRUE(m_win->m_wrappers.isEmpty());
+    EXPECT_FALSE(QFile::exists(path));
+}
+
+TEST_F(WindowTest, CloseTab_InvalidCharPreview_NoEdits_ClosesDirectly)
+{
+    // Arrange: 预览模式但未编辑 → 直接关闭不弹窗
+    const QString path = addFileTab(QStringLiteral("preview.txt"));
+    stub.set_lamda(&EditWrapper::isInvalidCharPreview, [](EditWrapper *) -> bool { return true; });
+    stub.set_lamda(&EditWrapper::isInvalidCharEditAllowed, [](EditWrapper *) -> bool { return false; });
+
+    // Act
+    EXPECT_TRUE(m_win->closeTab(path));
+    QApplication::processEvents();
+
+    // Assert: 未弹确认框
+    EXPECT_EQ(m_ddialogExecCalls, 0);
+    EXPECT_TRUE(m_win->m_wrappers.isEmpty());
+}
+
+TEST_F(WindowTest, CloseTab_InvalidCharPreview_EditedButtons_ThreeResponses)
+{
+    // Arrange: 预览 + 已编辑
+    const QString base = addFileTab(QStringLiteral("preview2.txt"));
+    stub.set_lamda(&EditWrapper::isInvalidCharPreview, [](EditWrapper *) -> bool { return true; });
+    stub.set_lamda(&EditWrapper::isInvalidCharEditAllowed, [](EditWrapper *) -> bool { return true; });
+    stub.set_lamda(&EditWrapper::isModified, [](EditWrapper *) -> bool { return true; });
+
+    // Act / Assert: Don't Save（0）→ 关闭
+    m_ddialogResult = 0;
+    EXPECT_TRUE(m_win->closeTab(base));
+    EXPECT_TRUE(m_win->m_wrappers.isEmpty());
+
+    // Act / Assert: Save Anyway（2）+ 强制保存成功 → 关闭
+    const QString p2 = addFileTab(QStringLiteral("preview3.txt"));
+    stub.set_lamda(&EditWrapper::forceSaveInvalidCharFile, [](EditWrapper *) -> bool { return true; });
+    m_ddialogResult = 2;
+    EXPECT_TRUE(m_win->closeTab(p2));
+    EXPECT_TRUE(m_win->m_wrappers.isEmpty());
+
+    // Act / Assert: Save As（1）+ saveAsFileToDisk 失败（拒绝）→ 不关闭
+    const QString p3 = addFileTab(QStringLiteral("preview4.txt"));
+    m_ddialogResult = 1;
+    m_qdialogResult = QDialog::Rejected;
+    EXPECT_FALSE(m_win->closeTab(p3));
+    EXPECT_EQ(m_tabbar->count(), 1);
+}
+
+// ============================================================
+// restoreTab / removeWrapper / focus
+// ============================================================
+
+TEST_F(WindowTest, RestoreTab_EmptyHistory_NoOp)
+{
+    // Act
+    m_win->restoreTab();
+
+    // Assert
+    EXPECT_EQ(m_tabbar->count(), 0);
+    EXPECT_TRUE(m_win->m_closeFileHistory.isEmpty());
+}
+
+TEST_F(WindowTest, RestoreTab_WithHistory_ReopensLastClosed)
+{
+    // Arrange: 历史压入真实文件
+    const QString path = createFile(QStringLiteral("history.txt"));
+    m_win->m_closeFileHistory << path;
+
+    // Act
+    m_win->restoreTab();
+    QApplication::processEvents();
+
+    // Assert: 重新打开且历史弹出
+    EXPECT_EQ(m_win->getTabIndex(path), 0);
+    EXPECT_TRUE(m_win->m_closeFileHistory.isEmpty());
+    EXPECT_NE(m_win->wrapper(path), nullptr);
+}
+
+TEST_F(WindowTest, RemoveWrapper_UnknownPath_NoOp)
+{
+    // Act
+    m_win->removeWrapper(QStringLiteral("/none"));
+
+    // Assert: 无标签时也不误关（强异常安全）
+    EXPECT_EQ(m_tabbar->count(), 0);
+    EXPECT_TRUE(m_win->m_wrappers.isEmpty());
+    EXPECT_TRUE(m_win->isVisible() || m_win->isHidden());
+}
+
+TEST_F(WindowTest, RemoveWrapper_KeepsTabWhenNotDeleting)
+{
+    // Arrange: 展示窗口 + 一个标签
+    m_win->show();
+    const QString blank = addBlankAndGetPath();
+    EditWrapper *w = m_win->wrapper(blank);
+    ASSERT_NE(w, nullptr);
+
+    // Act: 仅移除 wrapper（不移除标签）→ 不满足 close 条件
+    m_win->removeWrapper(blank, false);
+    QApplication::processEvents();
+
+    // Assert: wrapper 移除但标签保留 → 窗口保持可见（close 条件为两者皆空）
+    EXPECT_TRUE(m_win->m_wrappers.isEmpty());
+    EXPECT_EQ(m_tabbar->count(), 1);
+    EXPECT_TRUE(m_win->isVisible());
+}
+
+TEST_F(WindowTest, FocusActiveEditor_NoWrapper_NoOp)
+{
+    // Act / Assert: 无标签早退且状态未损坏
+    m_win->focusActiveEditor();
+    EXPECT_EQ(m_tabbar->count(), 0);
+    EXPECT_EQ(m_win->currentWrapper(), nullptr);
+}
+
+TEST_F(WindowTest, FocusActiveEditor_WithEditor_SetsFocus)
+{
+    // Arrange
+    const QString blank = addBlankAndGetPath();
+    TextEdit *editor = m_win->getTextEditor(blank);
+    ASSERT_NE(editor, nullptr);
+
+    // Act
+    m_win->focusActiveEditor();
+    QApplication::processEvents();
+
+    // Assert: 编辑器获得焦点且仍为当前页
+    EXPECT_TRUE(editor->hasFocus());
+    EXPECT_EQ(m_win->m_editorWidget->currentWidget(), m_win->wrapper(blank));
+}
+
+TEST_F(WindowTest, WrapperAndEditor_Lookup_HitMissAndTruePathFallback)
+{
+    // Arrange: 两个文件标签
+    const QString p1 = addFileTab(QStringLiteral("one.txt"));
+    const QString p2 = addFileTab(QStringLiteral("two.txt"));
+
+    // Assert: 直接命中 / 未命中
+    EXPECT_NE(m_win->wrapper(p1), nullptr);
+    EXPECT_NE(m_win->getTextEditor(p1), nullptr);
+    EXPECT_EQ(m_win->wrapper(QStringLiteral("/miss")), nullptr);
+    EXPECT_EQ(m_win->getTextEditor(QStringLiteral("/miss")), nullptr);
+
+    // Assert: truePath 回退查找（p2 的真实路径即自身）
+    EXPECT_EQ(m_win->wrapper(QFileInfo(p2).absoluteFilePath()), m_win->wrapper(p2));
+    EXPECT_EQ(m_win->getWrappers().count(), 2);
+}
+
+TEST_F(WindowTest, CurrentWrapper_FollowsCurrentTab)
+{
+    // Assert: 无标签 → null
+    EXPECT_EQ(m_win->currentWrapper(), nullptr);
+
+    // Arrange
+    const QString blank = addBlankAndGetPath();
+
+    // Assert: 当前标签对应 wrapper
+    EXPECT_EQ(m_win->currentWrapper(), m_win->wrapper(blank));
+}
+
+TEST_F(WindowTest, CreateEditor_AppliesConfigToEditor)
+{
+    // Act
+    EditWrapper *w = m_win->createEditor();
+
+    // Assert: 编辑器就绪 + 字号取自配置（默认 12）+ 焦点策略
+    ASSERT_NE(w, nullptr);
+    ASSERT_NE(w->textEditor(), nullptr);
+    EXPECT_EQ(w->textEditor()->m_settings, Settings::instance());
+    EXPECT_EQ(m_win->m_fontSize, Settings::instance()->settings->option("base.font.size")->value().toReal());
+    // 回收（无标签持有）
+    w->deleteLater();
+    QApplication::processEvents();
+}
+
+// ============================================================
+// openFile（文件对话框流程）
+// ============================================================
+
+TEST_F(WindowTest, OpenFile_DialogRejected_NoTabOpened)
+{
+    // Arrange: 历史目录配置指向临时目录（存在）
+    Settings::instance()->settings->option("advance.editor.file_dialog_dir")->setValue(m_tempDir->path());
+    m_qdialogResult = QDialog::Rejected;
+
+    // Act
+    m_win->openFile();
+    QApplication::processEvents();
+
+    // Assert
+    EXPECT_EQ(m_qdialogExecCalls, 1);
+    EXPECT_EQ(m_tabbar->count(), 0);
+}
+
+TEST_F(WindowTest, OpenFile_DialogAccepted_LoadsFirstAndPendsRest)
+{
+    // Arrange: 两个受支持文件 + 一个目录（不支持）
+    const QString f1 = createFile(QStringLiteral("first.txt"));
+    const QString f2 = createFile(QStringLiteral("second.txt"));
+    const QString dirPath = m_tempDir->path();
+    m_qdialogResult = QDialog::Accepted;
+    m_selectedFiles = QStringList { f1, f2, dirPath };
+
+    // Act
+    m_win->openFile();
+    QApplication::processEvents();
+
+    // Assert: 第一个立即加载，其余为 pending，最后补不支持提示
+    EXPECT_EQ(m_tabbar->count(), 3);
+    EXPECT_TRUE(m_win->isPendingTab(f2));
+    EditWrapper *w1 = m_win->wrapper(f1);
+    ASSERT_NE(w1, nullptr);
+    EXPECT_TRUE(waitUntil([w1]() { return !w1->getFileLoading(); }));
+    EXPECT_GE(m_iconMsgCalls, 1); // 目录 → Invalid file 提示
+}
+
+// ============================================================
+// 保存流程
+// ============================================================
+
+TEST_F(WindowTest, SaveFile_NoWrapperOrLoading_ReturnsFalse)
+{
+    // Assert: 无 wrapper
+    EXPECT_FALSE(m_win->saveFile());
+
+    // Arrange: 大文本加载中
+    const QString blank = addBlankAndGetPath();
+    EditWrapper *w = m_win->wrapper(blank);
+    stub.set_lamda(&EditWrapper::getFileLoading, [](EditWrapper *) -> bool { return true; });
+
+    // Assert: 加载中拒绝保存
+    EXPECT_FALSE(m_win->saveFile());
+    EXPECT_EQ(w, m_win->wrapper(blank));
+}
+
+TEST_F(WindowTest, SaveFile_DraftRedirectsToSaveAs_RejectedReturnsFalse)
+{
+    // Arrange: 空白标签（草稿）+ 另存对话框拒绝
+    addBlankAndGetPath();
+    m_qdialogResult = QDialog::Rejected;
+
+    // Act / Assert: 草稿 → saveAsFile → DFileDialog 拒绝 → false
+    EXPECT_FALSE(m_win->saveFile());
+    EXPECT_GE(m_qdialogExecCalls, 1);
+}
+
+TEST_F(WindowTest, SaveFile_NormalUnmodified_SavesAndNotifies)
+{
+    // Arrange: 真实文件未修改
+    const QString path = addFileTab(QStringLiteral("save-me.txt"));
+
+    // Act
+    const bool ret = m_win->saveFile();
+
+    // Assert: 保存成功 + 成功提示（EditWrapper::showNotify → 浮动消息桩）
+    EXPECT_TRUE(ret);
+    EXPECT_EQ(m_floatMsgCalls, 1);
+    EXPECT_TRUE(m_lastFloatMsg.contains(QStringLiteral("Saved successfully")));
+    EXPECT_TRUE(QFile::exists(path));
+}
+
+TEST_F(WindowTest, SaveFile_NoWritePermission_ShowsNotice)
+{
+    // Arrange: 只读权限文件已加载
+    const QString path = addFileTab(QStringLiteral("ro-save.txt"));
+    QFile::setPermissions(path, QFileDevice::ReadOwner | QFileDevice::ReadGroup | QFileDevice::ReadOther);
+    m_restoreFiles.append(path);
+
+    // Act
+    const bool ret = m_win->saveFile();
+
+    // Assert: 无权限提示 + 不保存
+    EXPECT_FALSE(ret);
+    EXPECT_GE(m_floatMsgCalls + m_iconMsgCalls, 1);
+    EXPECT_TRUE(m_lastFloatMsg.contains(QStringLiteral("permission"))
+                || m_lastIconMsg.contains(QStringLiteral("permission")));
+}
+
+TEST_F(WindowTest, SaveFile_InvalidCharPreview_NoEdits_ReturnsFalse)
+{
+    // Arrange: 预览模式未编辑
+    addFileTab(QStringLiteral("pv-save.txt"));
+    stub.set_lamda(&EditWrapper::isInvalidCharPreview, [](EditWrapper *) -> bool { return true; });
+    stub.set_lamda(&EditWrapper::isInvalidCharEditAllowed, [](EditWrapper *) -> bool { return false; });
+
+    // Act / Assert: 无需保存直接返回 false
+    EXPECT_FALSE(m_win->saveFile());
+    EXPECT_EQ(m_ddialogExecCalls, 0);
+}
+
+TEST_F(WindowTest, SaveFile_InvalidCharPreview_Edited_ThreeResponses)
+{
+    // Arrange: 预览 + 已编辑
+    addFileTab(QStringLiteral("pv-save2.txt"));
+    stub.set_lamda(&EditWrapper::isInvalidCharPreview, [](EditWrapper *) -> bool { return true; });
+    stub.set_lamda(&EditWrapper::isInvalidCharEditAllowed, [](EditWrapper *) -> bool { return true; });
+
+    // Act / Assert: Don't Save（0）→ false
+    m_ddialogResult = 0;
+    EXPECT_FALSE(m_win->saveFile());
+    EXPECT_EQ(m_ddialogExecCalls, 1);
+
+    // Act / Assert: Save Anyway（2）+ 强制成功 → true + 提示
+    stub.set_lamda(&EditWrapper::forceSaveInvalidCharFile, [](EditWrapper *) -> bool { return true; });
+    m_ddialogResult = 2;
+    EXPECT_TRUE(m_win->saveFile());
+    EXPECT_TRUE(m_lastFloatMsg.contains(QStringLiteral("Saved successfully")));
+
+    // Act / Assert: Save As（1）→ 转发 saveAsFile（此处以对话框拒绝 → false）
+    m_ddialogResult = 1;
+    m_qdialogResult = QDialog::Rejected;
+    EXPECT_FALSE(m_win->saveFile());
+}
+
+TEST_F(WindowTest, SaveAsFile_NoWrapper_ReturnsFalse)
+{
+    // Act / Assert: 无 wrapper → 另存失败且无副作用
+    EXPECT_FALSE(m_win->saveAsFile());
+    EXPECT_EQ(m_tabbar->count(), 0);
+}
+
+TEST_F(WindowTest, SaveAsFileToDisk_Rejected_ReturnsEmpty)
+{
+    // Arrange
+    addBlankAndGetPath();
+    m_qdialogResult = QDialog::Rejected;
+
+    // Act / Assert
+    EXPECT_TRUE(m_win->saveAsFileToDisk().isEmpty());
+    EXPECT_GE(m_qdialogExecCalls, 1);
+}
+
+TEST_F(WindowTest, SaveAsFileToDisk_AcceptedNewPath_SavesAndUpdatesTab)
+{
+    // Arrange: 真实文件 + 另存对话框接受（新路径）
+    const QString path = addFileTab(QStringLiteral("as.txt"), QByteArray("as-content"));
+    const QString newPath = m_tempDir->filePath(QStringLiteral("as-new.txt"));
+    m_qdialogResult = QDialog::Accepted;
+    m_selectedFiles = QStringList { newPath };
+    stub.set_lamda(static_cast<bool (EditWrapper::*)(const QString &, const QByteArray &)>(&EditWrapper::saveAsFile),
+                   [this, newPath](EditWrapper *self, const QString &file, const QByteArray &) -> bool {
+                       ++m_saveAsCalls;
+                       EXPECT_EQ(file, newPath);
+                       QFile f(newPath);
+                       f.open(QIODevice::WriteOnly);
+                       f.write("as-content");
+                       f.close();
+                       return true;
+                   });
+
+    // Act
+    const QString ret = m_win->saveAsFileToDisk();
+
+    // Assert: 返回新路径 + 映射迁移 + 标签更新 + 保存路径记忆更新
+    EXPECT_EQ(ret, newPath);
+    EXPECT_EQ(m_saveAsCalls, 1);
+    EXPECT_TRUE(m_win->m_wrappers.contains(newPath));
+    EXPECT_FALSE(m_win->m_wrappers.contains(path));
+    EXPECT_EQ(m_tabbar->currentName(), QString("as-new.txt"));
+    EXPECT_EQ(Settings::instance()->getSavePath(PathSettingWgt::LastOptBox),
+              QFileInfo(newPath).absolutePath());
+}
+
+TEST_F(WindowTest, SaveAsFileToDisk_NoWrapperOrLoading_Empty)
+{
+    // Assert: 无 wrapper
+    EXPECT_TRUE(m_win->saveAsFileToDisk().isEmpty());
+
+    // Arrange: 加载中
+    addBlankAndGetPath();
+    stub.set_lamda(&EditWrapper::getFileLoading, [](EditWrapper *) -> bool { return true; });
+    EXPECT_TRUE(m_win->saveAsFileToDisk().isEmpty());
+}
+
+TEST_F(WindowTest, SaveBlankFileToDisk_RejectedAndAccepted)
+{
+    // Arrange: 草稿空白标签
+    const QString blank = addBlankAndGetPath();
+    m_qdialogResult = QDialog::Rejected;
+
+    // Act / Assert: 拒绝 → 空
+    EXPECT_TRUE(m_win->saveBlankFileToDisk().isEmpty());
+
+    // Arrange: 接受
+    const QString newPath = m_tempDir->filePath(QStringLiteral("blank-saved.txt"));
+    m_qdialogResult = QDialog::Accepted;
+    m_selectedFiles = QStringList { newPath };
+    stub.set_lamda(&EditWrapper::saveFile,
+                   [newPath](EditWrapper *, QByteArray) -> bool {
+                       QFile f(newPath);
+                       f.open(QIODevice::WriteOnly);
+                       f.write("saved");
+                       f.close();
+                       return true;
+                   });
+
+    // Act
+    const QString ret = m_win->saveBlankFileToDisk();
+
+    // Assert: 新路径 + 映射迁移
+    EXPECT_EQ(ret, newPath);
+    EXPECT_TRUE(m_win->m_wrappers.contains(newPath));
+    EXPECT_FALSE(m_win->m_wrappers.contains(blank));
+}
+
+TEST_F(WindowTest, SaveBlankFileToDisk_NoWrapper_Empty)
+{
+    // Act / Assert
+    EXPECT_TRUE(m_win->saveBlankFileToDisk().isEmpty());
+    EXPECT_EQ(m_tabbar->count(), 0);
+}
+
+TEST_F(WindowTest, SaveAsOtherTabFile_RejectedAndAccepted)
+{
+    // Arrange: 真实文件标签
+    const QString path = addFileTab(QStringLiteral("other.txt"));
+
+    // Act / Assert: 拒绝 → false
+    m_qdialogResult = QDialog::Rejected;
+    EXPECT_FALSE(m_win->saveAsOtherTabFile(m_win->wrapper(path)));
+
+    // Act / Assert: 接受 → wrapper 路径更新
+    const QString newPath = m_tempDir->filePath(QStringLiteral("other-new.txt"));
+    m_qdialogResult = QDialog::Accepted;
+    m_selectedFiles = QStringList { newPath };
+    stub.set_lamda(&EditWrapper::saveFile,
+                   [newPath](EditWrapper *, QByteArray) -> bool {
+                       QFile f(newPath);
+                       f.open(QIODevice::WriteOnly);
+                       f.write("other");
+                       f.close();
+                       return true;
+                   });
+    EditWrapper *w = m_win->wrapper(path);
+    ASSERT_NE(w, nullptr);
+    EXPECT_TRUE(m_win->saveAsOtherTabFile(w));
+    EXPECT_EQ(w->filePath(), newPath);
+}
+
+TEST_F(WindowTest, ChangeSettingDialogComboxFontNumber_WritesOption)
+{
+    // Act
+    m_win->changeSettingDialogComboxFontNumber(21);
+
+    // Assert: 配置回读一致
+    EXPECT_EQ(Settings::instance()->settings->option("base.font.size")->value().toInt(), 21);
+    EXPECT_EQ(Settings::instance()->settings->option("base.font.size")->value().toInt(), 21);
+}
+
+// ============================================================
+// 字体缩放（calcFontScale / calcFontSizeFromScale / 增减复位）
+// ============================================================
+
+TEST_F(WindowTest, CalcFontScale_Boundaries_ReturnsClampedScale)
+{
+    // Assert: 默认字号 12 → 100%
+    EXPECT_DOUBLE_EQ(m_win->calcFontScale(12.0), 100.0);
+    // > 默认：线性放大并钳制 500
+    EXPECT_DOUBLE_EQ(m_win->calcFontScale(31.0), 300.0); // 100 + 400/38*19 = 300
+    EXPECT_DOUBLE_EQ(m_win->calcFontScale(500.0), 500.0); // 钳制上限
+    // < 默认：线性缩小并钳制 10
+    EXPECT_DOUBLE_EQ(m_win->calcFontScale(10.0), 55.0);  // 100 - 90/4*... = 55
+    EXPECT_DOUBLE_EQ(m_win->calcFontScale(1.0), 10.0);   // 钳制下限
+}
+
+TEST_F(WindowTest, CalcFontSizeFromScale_Boundaries_ReturnsClampedSize)
+{
+    EXPECT_DOUBLE_EQ(m_win->calcFontSizeFromScale(100.0), 12.0);
+    EXPECT_DOUBLE_EQ(m_win->calcFontSizeFromScale(500.0), 50.0); // 上限
+    EXPECT_DOUBLE_EQ(m_win->calcFontSizeFromScale(10.0), 8.0);   // 下限
+    EXPECT_NEAR(m_win->calcFontSizeFromScale(300.0), 31.0, 0.01); // 12 + 0.095*200
+}
+
+TEST_F(WindowTest, FontSize_IncrementDecrementReset_WritesConfig)
+{
+    // Arrange: 复位到默认
+    m_win->resetFontSize();
+    EXPECT_EQ(Settings::instance()->settings->option("base.font.size")->value().toInt(), 12);
+
+    // Act: 增大 → 配置变大
+    m_win->incrementFontSize();
+    EXPECT_GT(Settings::instance()->settings->option("base.font.size")->value().toReal(), 12.0);
+
+    // Act: 减小 → 配置变小（不低于下限 8）
+    m_win->decrementFontSize();
+    m_win->decrementFontSize();
+    EXPECT_LT(Settings::instance()->settings->option("base.font.size")->value().toReal(), 50.0);
+    EXPECT_GE(Settings::instance()->settings->option("base.font.size")->value().toReal(), 8.0);
+
+    // Act: 复位
+    m_win->resetFontSize();
+    EXPECT_EQ(Settings::instance()->settings->option("base.font.size")->value().toInt(), 12);
+    EXPECT_EQ(m_win->m_fontSize, 12.0);
+}
+
+TEST_F(WindowTest, SetFontSizeWithConfig_AppliesToEditorAndBottomBar)
+{
+    // Arrange
+    EditWrapper *w = m_win->createEditor();
+    ASSERT_NE(w, nullptr);
+
+    // Act
+    m_win->setFontSizeWithConfig(w);
+
+    // Assert: m_fontSize 同步配置 + 编辑器为当前栈外对象（配置值默认 12）
+    const qreal cfg = Settings::instance()->settings->option("base.font.size")->value().toReal();
+    EXPECT_EQ(m_win->m_fontSize, cfg);
+    EXPECT_NE(w->textEditor(), nullptr);
+    w->deleteLater();
+    QApplication::processEvents();
+}
+
+// ============================================================
+// 查找 / 替换 / 跳行栏
+// ============================================================
+
+TEST_F(WindowTest, PopupFindBar_NoWrapperOrEmptyDoc_EarlyReturn)
+{
+    // Assert: 无 wrapper
+    m_win->popupFindBar();
+    EXPECT_FALSE(m_win->findBarIsVisiable());
+
+    // Arrange: 空文档标签
+    addBlankAndGetPath();
+    m_win->popupFindBar();
+
+    // Assert: 空文档不弹出
+    EXPECT_FALSE(m_win->findBarIsVisiable());
+}
+
+TEST_F(WindowTest, PopupFindBar_WithContent_ShowsBarAndKeywords)
+{
+    // Arrange: 有内容的标签（窗口须可见，否则子栏 isVisible 恒 false）
+    m_win->show();
+    const QString path = addFileTab(QStringLiteral("find.txt"), QByteArray("hello findable world\n"));
+    TextEdit *editor = m_win->getTextEditor(path);
+    ASSERT_NE(editor, nullptr);
+
+    // Act: 弹出后等待 10ms focus 定时器 lambda（QTimer::singleShot）
+    m_win->popupFindBar();
+    processEventsFor(60);
+
+    // Assert: 查找栏可见 + 关键词初始化为选中文本（空）
+    EXPECT_TRUE(m_win->findBarIsVisiable());
+    EXPECT_TRUE(m_win->m_findBar->isVisible());
+    EXPECT_EQ(m_win->getKeywordForSearch(), QString(""));
+}
+
+TEST_F(WindowTest, PopupReplaceBar_EmptyDocOrReadOnly_DoesNotShow)
+{
+    // Assert: 空（无选区空文档）→ 直接返回
+    m_win->show();
+    m_win->popupReplaceBar();
+    EXPECT_FALSE(m_win->replaceBarIsVisiable());
+
+    // Arrange: 只读模式编辑器 + 内容（m_readOnlyMode 经 toggleReadOnlyMode 置位）
+    const QString path = addFileTab(QStringLiteral("ro.txt"), QByteArray("read only content\n"));
+    m_win->getTextEditor(path)->toggleReadOnlyMode(true);
+    m_win->popupReplaceBar();
+
+    // Assert: 只读提示 + 不弹出（提示走浮动消息桩）
+    EXPECT_FALSE(m_win->replaceBarIsVisiable());
+    EXPECT_GE(m_floatMsgCalls, 1);
+    EXPECT_TRUE(m_lastFloatMsg.contains(QStringLiteral("Read-Only")));
+}
+
+TEST_F(WindowTest, PopupReplaceBar_EditableContent_ShowsBar)
+{
+    // Arrange
+    m_win->show();
+    addFileTab(QStringLiteral("rw.txt"), QByteArray("replaceable content\n"));
+
+    // Act: 弹出后等待 10ms focus 定时器 lambda
+    m_win->popupReplaceBar();
+    processEventsFor(60);
+
+    // Assert
+    EXPECT_TRUE(m_win->replaceBarIsVisiable());
+    EXPECT_TRUE(m_win->m_replaceBar->isVisible());
+}
+
+TEST_F(WindowTest, PopupJumpLineBar_States_ToggleAndEarlyReturn)
+{
+    // Assert: 无 wrapper 早退
+    m_win->popupJumpLineBar();
+    EXPECT_FALSE(m_win->m_jumpLineBar->isVisible());
+
+    // Arrange: 空文档 → 早退
+    m_win->show();
+    addBlankAndGetPath();
+    m_win->popupJumpLineBar();
+    EXPECT_FALSE(m_win->m_jumpLineBar->isVisible());
+
+    // Act: 有内容 → 显示
+    const QString path = addFileTab(QStringLiteral("jump.txt"), QByteArray("l1\nl2\nl3\n"));
+    m_win->popupJumpLineBar();
+    EXPECT_TRUE(m_win->m_jumpLineBar->isVisible());
+
+    // Act: 已可见 → 隐藏（toggle 分支）
+    m_win->popupJumpLineBar();
+    EXPECT_FALSE(m_win->m_jumpLineBar->isVisible());
+    EXPECT_EQ(m_win->getTabIndex(path), 1); // 前置空白标签占 0 号位
+}
+
+TEST_F(WindowTest, UpdateJumpLineBar_SyncsLineCountAndClearsSearch)
+{
+    // Arrange: 显示跳行栏
+    const QString path = addFileTab(QStringLiteral("sync.txt"), QByteArray("a\nb\nc\nd\n"));
+    TextEdit *editor = m_win->getTextEditor(path);
+    m_win->popupJumpLineBar();
+    ASSERT_TRUE(m_win->m_jumpLineBar->isVisible());
+
+    // Act: 追加一行后更新
+    editor->appendPlainText(QStringLiteral("e"));
+    m_win->updateJumpLineBar(editor);
+
+    // Assert: 行数同步 + 跳行栏保持可见
+    EXPECT_EQ(m_win->m_jumpLineBar->getLineCount(), editor->blockCount());
+    EXPECT_GE(editor->blockCount(), 5); // "a\nb\nc\nd\n" + append → ≥5 块（含尾块）
+    EXPECT_TRUE(m_win->m_jumpLineBar->isVisible());
+}
+
+TEST_F(WindowTest, HandleJumpLineBarJumpToLine_MovesCursor)
+{
+    // Arrange
+    const QString path = addFileTab(QStringLiteral("lines.txt"), QByteArray("one\ntwo\nthree\n"));
+    TextEdit *editor = m_win->getTextEditor(path);
+
+    // Act: 跳到第 3 行（focusEditor=true 分支）
+    m_win->handleJumpLineBarJumpToLine(path, 3, true);
+    QApplication::processEvents();
+
+    // Assert: 光标行号变更
+    EXPECT_EQ(editor->getCurrentLine(), 3);
+
+    // Act: 未知路径分支（不崩溃）
+    m_win->handleJumpLineBarJumpToLine(QStringLiteral("/none"), 1, false);
+    EXPECT_EQ(editor->getCurrentLine(), 3);
+}
+
+TEST_F(WindowTest, HandleBackToPosition_KnownAndUnknownPaths)
+{
+    // Arrange
+    const QString path = addFileTab(QStringLiteral("pos.txt"), QByteArray("p1\np2\n"));
+    TextEdit *editor = m_win->getTextEditor(path);
+
+    // Act: 已知路径滚动复位
+    m_win->handleBackToPosition(path, 2, 1, 0);
+
+    // Assert: 编辑器仍可用 + 未知路径不崩溃
+    EXPECT_NE(editor, nullptr);
+    m_win->handleBackToPosition(QStringLiteral("/none"), 1, 1, 0);
+    EXPECT_EQ(m_win->wrapper(path), m_win->currentWrapper());
+}
+
+TEST_F(WindowTest, HandleJumpLineBarExit_RefocusesEditor)
+{
+    // Arrange
+    const QString blank = addBlankAndGetPath();
+    TextEdit *editor = m_win->getTextEditor(blank);
+
+    // Act
+    m_win->handleJumpLineBarExit();
+    QApplication::processEvents();
+
+    // Assert: 焦点回到编辑器且标签未变
+    EXPECT_TRUE(editor->hasFocus());
+    EXPECT_EQ(m_tabbar->currentPath(), blank);
+}
+
+TEST_F(WindowTest, HandleFindKeywords_NextPrev_UpdateState)
+{
+    // Arrange
+    addFileTab(QStringLiteral("kw.txt"), QByteArray("alpha beta gamma\n"));
+
+    // Act: 向后查找
+    m_win->handleFindNextSearchKeyword(QStringLiteral("alpha"));
+
+    // Assert: 关键词记录
+    EXPECT_EQ(m_win->getKeywordForSearch(), QString("alpha"));
+
+    // Act: 向前查找（与 all 不同 → 清空 all 分支）
+    m_win->m_keywordForSearchAll = QStringLiteral("other");
+    m_win->handleFindPrevSearchKeyword(QStringLiteral("beta"));
+    EXPECT_EQ(m_win->getKeywordForSearch(), QString("beta"));
+    EXPECT_TRUE(m_win->m_keywordForSearchAll.isEmpty());
+}
+
+TEST_F(WindowTest, HandleFindKeyword_MatchAllBranch_HighlightsAll)
+{
+    // Arrange: all == search（相等分支）
+    addFileTab(QStringLiteral("kw2.txt"), QByteArray("x y x y\n"));
+    m_win->m_keywordForSearchAll = QStringLiteral("x");
+
+    // Act
+    m_win->handleFindKeyword(QStringLiteral("x"), true);
+
+    // Assert: 两侧关键词一致且未清空
+    EXPECT_EQ(m_win->getKeywordForSearch(), QString("x"));
+    EXPECT_EQ(m_win->m_keywordForSearchAll, QString("x"));
+}
+
+TEST_F(WindowTest, HandleReplaceAll_ReplacesDocumentText)
+{
+    // Arrange
+    const QString path = addFileTab(QStringLiteral("rep.txt"), QByteArray("aaa bbb aaa\n"));
+    TextEdit *editor = m_win->getTextEditor(path);
+
+    // Act
+    m_win->handleReplaceAll(QStringLiteral("aaa"), QStringLiteral("zzz"));
+
+    // Assert: 全部替换且关键词状态不变
+    EXPECT_EQ(editor->toPlainText(), QString("zzz bbb zzz\n"));
+    EXPECT_NE(m_win->currentWrapper(), nullptr);
+}
+
+TEST_F(WindowTest, HandleReplaceNextAndRest_UpdateKeywordsAndDocument)
+{
+    // Arrange
+    const QString path = addFileTab(QStringLiteral("rep2.txt"), QByteArray("n1 n1 n1\n"));
+    TextEdit *editor = m_win->getTextEditor(path);
+
+    // Act: replaceNext
+    m_win->handleReplaceNext(path, QStringLiteral("n1"), QStringLiteral("m"));
+
+    // Assert: 两个关键词均记录
+    EXPECT_EQ(m_win->getKeywordForSearch(), QString("n1"));
+    EXPECT_EQ(m_win->getKeywordForSearchAll(), QString("n1"));
+
+    // Act: replaceRest
+    m_win->handleReplaceRest(QStringLiteral("n1"), QStringLiteral("m"));
+    EXPECT_EQ(editor->toPlainText(), QString("m m m\n"));
+}
+
+TEST_F(WindowTest, HandleReplaceSkip_SyncsSearchKeywords)
+{
+    // Arrange
+    const QString path = addFileTab(QStringLiteral("skip.txt"), QByteArray("s1 s2\n"));
+    m_win->m_keywordForSearchAll = QStringLiteral("s1");
+
+    // Act: 跳过（当前标签路径 → 关键词更新；与 all 相等 → 高亮分支）
+    m_win->handleReplaceSkip(path, QStringLiteral("s1"));
+
+    // Assert
+    EXPECT_EQ(m_win->getKeywordForSearch(), QString("s1"));
+    EXPECT_EQ(m_win->m_keywordForSearchAll, QString("s1"));
+}
+
+TEST_F(WindowTest, HandleRemoveSearchKeyword_NoWrapperSafe)
+{
+    // Act: 无 wrapper（守卫分支）
+    m_win->handleRemoveSearchKeyword();
+
+    // Assert: 无崩溃 + 状态不变
+    EXPECT_EQ(m_win->getKeywordForSearch(), QString(""));
+
+    // Act: 有 wrapper
+    addFileTab(QStringLiteral("rm.txt"), QByteArray("rm me\n"));
+    m_win->handleRemoveSearchKeyword();
+    EXPECT_NE(m_win->currentWrapper(), nullptr);
+}
+
+TEST_F(WindowTest, HandleUpdateSearchKeyword_CurrentFile_UpdatesKeywords)
+{
+    // Arrange
+    const QString path = addFileTab(QStringLiteral("upd.txt"), QByteArray("updatable\n"));
+
+    // Act: 当前文件 + FindBar 控件（setMismatchAlert 分支）
+    m_win->handleUpdateSearchKeyword(m_win->m_findBar, path, QStringLiteral("upd"));
+
+    // Assert
+    EXPECT_EQ(m_win->getKeywordForSearch(), QString("upd"));
+    EXPECT_EQ(m_win->getKeywordForSearchAll(), QString("upd"));
+
+    // Act: 非当前文件 → 不更新关键词
+    m_win->handleUpdateSearchKeyword(m_win->m_findBar, QStringLiteral("/other"), QStringLiteral("zz"));
+    EXPECT_EQ(m_win->getKeywordForSearch(), QString("upd"));
+}
+
+TEST_F(WindowTest, SlotFindbarClose_ShowsBottomBar)
+{
+    // Arrange: 打开查找栏后关闭
+    m_win->show();
+    addFileTab(QStringLiteral("fbc.txt"), QByteArray("bottom bar test\n"));
+    m_win->popupFindBar();
+    QApplication::processEvents();
+    ASSERT_TRUE(m_win->m_findBar->isVisible());
+
+    // Act
+    m_win->slotFindbarClose();
+
+    // Assert: 底栏恢复默认高度并显示
+    BottomBar *bar = m_win->currentWrapper()->bottomBar();
+    EXPECT_TRUE(bar->isVisible());
+    EXPECT_EQ(bar->height(), BottomBar::defaultHeight());
+}
+
+TEST_F(WindowTest, SlotReplacebarClose_ShowsBottomBar)
+{
+    // Arrange
+    m_win->show();
+    addFileTab(QStringLiteral("rbc.txt"), QByteArray("replace close\n"));
+    m_win->popupReplaceBar();
+
+    // Act
+    m_win->slotReplacebarClose();
+
+    // Assert: 底栏恢复显示（替换栏由其自身 sigReplacebarClose 链路负责隐藏）
+    BottomBar *bar = m_win->currentWrapper()->bottomBar();
+    EXPECT_TRUE(bar->isVisible());
+    EXPECT_EQ(bar->height(), BottomBar::defaultHeight());
+    EXPECT_NE(m_win->currentWrapper(), nullptr);
+}
+
+TEST_F(WindowTest, SlotSwitchToReplaceBar_FromVisibleFindBar_CarriesText)
+{
+    // Arrange: 查找栏可见并输入关键词
+    m_win->show();
+    const QString path = addFileTab(QStringLiteral("sw.txt"), QByteArray("switch test\n"));
+    m_win->popupFindBar();
+    QApplication::processEvents();
+    ASSERT_TRUE(m_win->m_findBar->isVisible());
+    ASSERT_EQ(m_win->m_findBar->getCurrentSearchText(), QString(""));
+
+    // Act
+    m_win->slotSwitchToReplaceBar();
+
+    // Assert: 查找栏隐藏（替换栏被激活）
+    EXPECT_FALSE(m_win->m_findBar->isVisible());
+    EXPECT_NE(m_win->getTextEditor(path), nullptr);
+}
+
+TEST_F(WindowTest, SlotSwitchToReplaceBar_NoWrapper_NoCrash)
+{
+    // Act: 无 wrapper（findBar 不可见 → 直接守卫返回）
+    m_win->slotSwitchToReplaceBar();
+
+    // Assert
+    EXPECT_EQ(m_win->currentWrapper(), nullptr);
+    EXPECT_FALSE(m_win->findBarIsVisiable());
+}
+
+// ============================================================
+// 消息提示 / 对话框构造
+// ============================================================
+
+TEST_F(WindowTest, ShowNotify_NoWrapper_AddsBlankThenNotifies)
+{
+    // Act: 无标签时提示 → 先补空白标签再通知
+    const int beforeTabs = m_tabbar->count();
+    m_win->showNotify(QStringLiteral("hello notify"));
+
+    // Assert
+    EXPECT_EQ(m_tabbar->count(), beforeTabs + 1);
+    EXPECT_GE(m_widgetMsgCalls + m_iconMsgCalls + m_floatMsgCalls, 1);
+
+    // Act: 有 wrapper 时直接通知
+    m_win->showNotify(QStringLiteral("second"), true);
+    EXPECT_GE(m_widgetMsgCalls + m_iconMsgCalls + m_floatMsgCalls, 2);
+}
+
+TEST_F(WindowTest, CreateDialog_ThreeButtonsModalDialog)
+{
+    // Act
+    DDialog *dialog = m_win->createDialog(QStringLiteral("Title"), QStringLiteral("Content"));
+
+    // Assert: 三按钮 + 应用模态
+    ASSERT_NE(dialog, nullptr);
+    EXPECT_EQ(dialog->buttonCount(), 3);
+    EXPECT_EQ(dialog->windowModality(), Qt::ApplicationModal);
+    delete dialog;
+}
+
+TEST_F(WindowTest, ConfirmInvalidCharSave_ReturnsButtonIndex)
+{
+    // Arrange
+    m_ddialogResult = 1;
+
+    // Act / Assert
+    EXPECT_EQ(m_win->confirmInvalidCharSave(QStringLiteral("f.txt")), 1);
+    m_ddialogResult = 2;
+    EXPECT_EQ(m_win->confirmInvalidCharSave(QStringLiteral("f.txt")), 2);
+    QApplication::processEvents(); // deleteLater 清理
+}
+
+// ============================================================
+// 主题
+// ============================================================
+
+TEST_F(WindowTest, LoadTheme_NonexistentFile_EarlyReturn)
+{
+    // Arrange
+    const QString before = m_win->m_themePath;
+
+    // Act
+    m_win->loadTheme(QStringLiteral("/no/such/theme.theme"));
+
+    // Assert: 主题路径不变且未写入配置
+    EXPECT_EQ(m_win->m_themePath, before);
+    EXPECT_EQ(Settings::instance()->settings->option("advance.editor.theme")->value().toString(), before);
+}
+
+TEST_F(WindowTest, LoadTheme_ValidThemeFile_AppliesAndPersists)
+{
+    // Arrange: 构造合法主题 JSON
+    const QString themePath = m_tempDir->filePath(QStringLiteral("custom.theme"));
+    QFile f(themePath);
+    ASSERT_TRUE(f.open(QIODevice::WriteOnly));
+    f.write(R"({
+        "editor-colors": { "background-color": "#101010" },
+        "app-colors": {
+            "tab-background-start-color": "#111111",
+            "tab-background-end-color": "#222222",
+            "tab-dnd-start": "#333333",
+            "tab-dnd-end": "#444444",
+            "themebar-frame-selected": "#555555",
+            "themebar-frame-normal": "#666666"
+        }
+    })");
+    f.close();
+
+    // Act
+    m_win->loadTheme(themePath);
+
+    // Assert: 主题路径 + 配置持久化
+    EXPECT_EQ(m_win->m_themePath, themePath);
+    EXPECT_EQ(Settings::instance()->settings->option("advance.editor.theme")->value().toString(), themePath);
+}
+
+TEST_F(WindowTest, SlotLoadContentTheme_LightDarkUnknown_NoCrashAndTabPalette)
+{
+    // Act: Light → loadTheme(DEEPIN_THEME)（系统路径不存在 → 早退安全）
+    m_win->slotLoadContentTheme(DGuiApplicationHelper::LightType);
+
+    // Act: Dark
+    m_win->slotLoadContentTheme(DGuiApplicationHelper::DarkType);
+
+    // Act: Unknown（无分支）
+    m_win->slotLoadContentTheme(DGuiApplicationHelper::UnknownType);
+
+    // Assert: 主题路径未被系统路径覆盖 + 标签栏仍可用
+    EXPECT_FALSE(m_win->m_themePath.contains(QStringLiteral("/share/deepin-editor/themes/deepin.theme")));
+    EXPECT_NE(m_win->getTabbar(), nullptr);
+}
+
+TEST_F(WindowTest, SlotSettingResetTheme_SwitchesPaletteType)
+{
+    // Arrange: 确保当前为暗色（走 Light 切换分支）
+    DGuiApplicationHelper::instance()->setPaletteType(DGuiApplicationHelper::DarkType);
+
+    // Act: 请求浅色主题
+    m_win->slotSettingResetTheme(DEEPIN_THEME);
+
+    // Assert: 调色板切换为浅色
+    EXPECT_EQ(DGuiApplicationHelper::instance()->themeType(), DGuiApplicationHelper::LightType);
+
+    // Act: 同主题再设 → 早退；切暗色
+    m_win->slotSettingResetTheme(DEEPIN_THEME); // 已是 Light → return
+    m_win->slotSettingResetTheme(DEEPIN_DARK_THEME);
+    EXPECT_EQ(DGuiApplicationHelper::instance()->themeType(), DGuiApplicationHelper::DarkType);
+
+    // Act: 未知路径分支
+    m_win->slotSettingResetTheme(m_tempDir->filePath(QStringLiteral("x.theme")));
+    EXPECT_EQ(DGuiApplicationHelper::instance()->themeType(), DGuiApplicationHelper::DarkType);
+}
+
+TEST_F(WindowTest, SlotSigThemeChanged_SwitchesPaletteType)
+{
+    // Arrange: 当前暗色
+    DGuiApplicationHelper::instance()->setPaletteType(DGuiApplicationHelper::DarkType);
+
+    // Act: 浅色信号
+    m_win->slotSigThemeChanged(DEEPIN_THEME);
+    EXPECT_EQ(DGuiApplicationHelper::instance()->themeType(), DGuiApplicationHelper::LightType);
+
+    // Act: 同主题早退 + 暗色信号
+    m_win->slotSigThemeChanged(DEEPIN_THEME);
+    m_win->slotSigThemeChanged(DEEPIN_DARK_THEME);
+    EXPECT_EQ(DGuiApplicationHelper::instance()->themeType(), DGuiApplicationHelper::DarkType);
+
+    // Act: 未知路径
+    m_win->slotSigThemeChanged(QStringLiteral("/unknown"));
+    EXPECT_EQ(DGuiApplicationHelper::instance()->themeType(), DGuiApplicationHelper::DarkType);
+}
+
+TEST_F(WindowTest, PopupThemePanel_ShowsPanel)
+{
+    // Act
+    m_win->popupThemePanel();
+
+    // Assert: 主题面板可见（几何对齐由 UpdateThemePanelGeomerty 用例单独验证）
+    EXPECT_TRUE(m_win->m_themePanel->isVisible());
+    EXPECT_TRUE(m_win->m_themePanel->geometry().isValid());
+}
+
+TEST_F(WindowTest, UpdateThemePanelGeomerty_AlignsPanelToRight)
+{
+    // Arrange
+    m_win->resize(800, 600);
+
+    // Act
+    m_win->updateThemePanelGeomerty();
+
+    // Assert: 面板宽度 250、右对齐、顶部为标题栏高度
+    EXPECT_EQ(m_win->m_themePanel->width(), 250);
+    EXPECT_EQ(m_win->m_themePanel->geometry().right(), m_win->rect().right());
+}
+
+// ============================================================
+// 编辑器设置槽（Settings 信号族）
+// ============================================================
+
+TEST_F(WindowTest, SlotSigAdjustFontAndSize_AppliesToEditors)
+{
+    // Arrange
+    const QString blank = addBlankAndGetPath();
+    TextEdit *editor = m_win->getTextEditor(blank);
+    ASSERT_NE(editor, nullptr);
+
+    // Act
+    m_win->slotSigAdjustFont(QStringLiteral("monospace"));
+    m_win->slotSigAdjustFontSize(15.0);
+
+    // Assert: 字号状态记录 + 编辑器仍有效（字体族应用不崩溃）
+    EXPECT_EQ(m_win->m_fontSize, 15.0);
+    EXPECT_NE(m_win->getTextEditor(blank), nullptr);
+}
+
+TEST_F(WindowTest, SlotSigAdjustEditorFlags_AppliesToEditors)
+{
+    // Arrange
+    const QString blank = addBlankAndGetPath();
+    TextEdit *editor = m_win->getTextEditor(blank);
+    ASSERT_NE(editor, nullptr);
+
+    // Act: 依次触发全部编辑器设置槽
+    m_win->slotSigAdjustTabSpaceNumber(6);
+    m_win->slotSigAdjustWordWrap(true);
+    m_win->slotSigSetLineNumberShow(false);
+    m_win->slotSigAdjustBookmark(true);
+    m_win->slotSigShowBlankCharacter(true);
+    m_win->slotSigHightLightCurrentLine(false);
+    m_win->slotSigShowCodeFlodFlag(true);
+
+    // Assert: 自动换行开关真实生效 + 编辑器存活
+    EXPECT_EQ(editor->lineWrapMode(), QPlainTextEdit::WidgetWidth);
+    EXPECT_NE(m_win->getTextEditor(blank), nullptr);
+
+    // Act: 关闭换行复核反向分支
+    m_win->slotSigAdjustWordWrap(false);
+    EXPECT_EQ(editor->lineWrapMode(), QPlainTextEdit::NoWrap);
+}
+
+TEST_F(WindowTest, SlotClearDoubleCharaterEncode_ReplacesUnsupportedChars)
+{
+    // Arrange: 插入赛迪方要求清除的字符
+    const QString blank = addBlankAndGetPath();
+    TextEdit *editor = m_win->getTextEditor(blank);
+    editor->setPlainText(QStringLiteral("A\uE768B"));
+
+    // Act
+    m_win->slotClearDoubleCharaterEncode();
+
+    // Assert: 特殊字符被空格替换
+    EXPECT_FALSE(editor->toPlainText().contains(QChar(0xE768)));
+    EXPECT_TRUE(editor->toPlainText().contains(QStringLiteral("A B")));
+}
+
+// ============================================================
+// 位置记忆 / 阅读路径
+// ============================================================
+
+TEST_F(WindowTest, RemberPositionSaveAndRestore_RoundTrip)
+{
+    // Arrange: 有内容标签
+    const QString path = addFileTab(QStringLiteral("pos2.txt"), QByteArray("r1\nr2\nr3\n"));
+    TextEdit *editor = m_win->getTextEditor(path);
+    editor->setTextCursor(editor->textCursor());
+
+    // Act: 记忆当前位置
+    m_win->remberPositionSave();
+
+    // Assert: 记录当前标签路径 + 行列信息
+    EXPECT_EQ(m_win->m_remberPositionFilePath, path);
+    EXPECT_GE(m_win->m_remberPositionRow, 1);
+    EXPECT_GE(m_win->m_remberPositionColumn, 0);
+
+    // Act: 恢复（活跃标签 + 滚动复位）
+    m_win->remberPositionRestore();
+
+    // Assert: 当前标签即记忆标签
+    EXPECT_EQ(m_tabbar->currentPath(), path);
+}
+
+TEST_F(WindowTest, RemberPositionRestore_EmptyPath_EarlyReturn)
+{
+    // Act / Assert: 无记忆 → 安全返回且无标签副作用
+    m_win->remberPositionRestore();
+    EXPECT_TRUE(m_win->m_remberPositionFilePath.isEmpty());
+    EXPECT_EQ(m_tabbar->count(), 0);
+}
+
+TEST_F(WindowTest, SlotSaveReadingPath_TracksReadingEditor)
+{
+    // Arrange
+    const QString blank = addBlankAndGetPath();
+    TextEdit *editor = m_win->getTextEditor(blank);
+
+    // Act
+    m_win->slot_saveReadingPath();
+
+    // Assert: 阅读列表仅含当前编辑器
+    EXPECT_EQ(m_win->m_reading_list.count(), 1);
+    EXPECT_EQ(m_win->m_reading_list.first(), editor);
+}
+
+TEST_F(WindowTest, SlotBeforeReplace_ForwardsToEditor)
+{
+    // Arrange
+    addFileTab(QStringLiteral("br.txt"), QByteArray("before replace\n"));
+
+    // Act / Assert: 转发至编辑器（关键词进入编辑器状态）
+    m_win->slot_beforeReplace(QStringLiteral("kw"));
+    EXPECT_NE(m_win->currentWrapper(), nullptr);
+    EXPECT_NE(m_win->currentWrapper()->textEditor(), nullptr);
+}
+
+TEST_F(WindowTest, SlotSetTitleFocus_SetsTitlebarTabFocus)
+{
+    // Arrange
+    addBlankAndGetPath();
+
+    // Act
+    m_win->slot_setTitleFocus();
+
+    // Assert: 标题栏按钮进入 Tab 焦点链
+    EXPECT_EQ(m_win->titlebar()->focusPolicy(), Qt::TabFocus);
+    DIconButton *addButton = m_win->getTabbar()->findChild<DIconButton *>("AddButton");
+    ASSERT_NE(addButton, nullptr);
+    EXPECT_EQ(addButton->focusPolicy(), Qt::TabFocus);
+}
+
+TEST_F(WindowTest, SetChildrenFocus_TrueFalse_TogglesButtonFocus)
+{
+    // Act: true
+    m_win->setChildrenFocus(true);
+
+    // Assert
+    DIconButton *addButton = m_win->getTabbar()->findChild<DIconButton *>("AddButton");
+    ASSERT_NE(addButton, nullptr);
+    EXPECT_EQ(addButton->focusPolicy(), Qt::TabFocus);
+    EXPECT_EQ(m_win->titlebar()->focusPolicy(), Qt::TabFocus);
+
+    // Act: false
+    m_win->setChildrenFocus(false);
+    EXPECT_EQ(addButton->focusPolicy(), Qt::NoFocus);
+    EXPECT_EQ(m_win->titlebar()->focusPolicy(), Qt::NoFocus);
+}
+
+// ============================================================
+// getBlankFileIndex
+// ============================================================
+
+TEST_F(WindowTest, GetBlankFileIndex_FreshWindow_ReturnsOne)
+{
+    // Assert: 无空白标签 → 1（且不影响标签数）
+    EXPECT_EQ(m_win->getBlankFileIndex(), 1);
+    EXPECT_EQ(m_tabbar->count(), 0);
+}
+
+TEST_F(WindowTest, GetBlankFileIndex_SequentialAndGapFilling)
+{
+    // Arrange: 空白目录下两个标签 [Untitled 1, Untitled 2]
+    QDir().mkpath(m_win->m_blankFileDir);
+    m_tabbar->addTab(QDir(m_win->m_blankFileDir).filePath(QStringLiteral("b1")), QStringLiteral("Untitled 1"));
+    m_tabbar->addTab(QDir(m_win->m_blankFileDir).filePath(QStringLiteral("b2")), QStringLiteral("Untitled 2"));
+
+    // Act / Assert: 连续 → 下一个 3
+    EXPECT_EQ(m_win->getBlankFileIndex(), 3);
+
+    // Arrange: 空洞 [Untitled 1, Untitled 3]
+    m_tabbar->removeTab(1);
+    m_tabbar->addTab(QDir(m_win->m_blankFileDir).filePath(QStringLiteral("b3")), QStringLiteral("Untitled 3"));
+
+    // Act / Assert: 填补空洞 → 2
+    EXPECT_EQ(m_win->getBlankFileIndex(), 2);
+}
+
+// ============================================================
+// 待加载标签（懒加载）
+// ============================================================
+
+TEST_F(WindowTest, PendingTab_AddIsLoad_RoundTripWithBatchFlag)
+{
+    // Arrange: 真实文件
+    const QString path = createFile(QStringLiteral("pend.txt"));
+    Window::PendingTabInfo info;
+    info.filepath = path;
+    info.truePath = path;
+    info.displayName = QStringLiteral("pend.txt");
+    info.cursorPosition = 0;
+    info.bookmarks = QList<int> { 1 };
+
+    // Act: 添加 pending
+    m_win->addPendingTab(info);
+
+    // Assert: 标签占位 + 状态查询
+    EXPECT_EQ(m_tabbar->count(), 1);
+    EXPECT_TRUE(m_win->isPendingTab(path));
+    EXPECT_FALSE(m_win->isPendingTab(QStringLiteral("/other")));
+
+    // Act: 批量模式标记
+    m_win->setBatchAddingPendingTabs(true);
+    EXPECT_TRUE(m_win->m_bBatchAddingPendingTabs);
+    m_win->setBatchAddingPendingTabs(false);
+    EXPECT_FALSE(m_win->m_bBatchAddingPendingTabs);
+
+    // Act: 完整加载
+    EXPECT_TRUE(m_win->loadPendingTab(path));
+
+    // Assert: wrapper 已建 + 书签应用 + pending 清空
+    EXPECT_FALSE(m_win->isPendingTab(path));
+    ASSERT_NE(m_win->wrapper(path), nullptr);
+    EXPECT_EQ(m_win->wrapper(path)->textEditor()->getBookmarkInfo(), QList<int>({ 1 }));
+}
+
+TEST_F(WindowTest, LoadPendingTab_UnknownOrMissing_ReturnsFalse)
+{
+    // Assert: 未知路径
+    EXPECT_FALSE(m_win->loadPendingTab(QStringLiteral("/none")));
+
+    // Arrange: 文件已被删除的 pending
+    const QString path = m_tempDir->filePath(QStringLiteral("gone.txt"));
+    Window::PendingTabInfo info;
+    info.filepath = path;
+    info.truePath = path;
+    info.displayName = QStringLiteral("gone.txt");
+    m_win->addPendingTab(info);
+
+    // Act / Assert: 加载失败且 pending 恢复（可重试）
+    EXPECT_FALSE(m_win->loadPendingTab(path));
+    EXPECT_TRUE(m_win->isPendingTab(path));
+}
+
+TEST_F(WindowTest, HandleCurrentChanged_PendingTab_TriggersLazyLoad)
+{
+    // Arrange
+    const QString path = createFile(QStringLiteral("lazy.txt"));
+    Window::PendingTabInfo info;
+    info.filepath = path;
+    info.truePath = path;
+    info.displayName = QStringLiteral("lazy.txt");
+    m_win->addPendingTab(info);
+
+    // Act: 模拟标签切换
+    m_win->handleCurrentChanged(m_tabbar->indexOf(path));
+    QApplication::processEvents();
+
+    // Assert: 懒加载完成
+    EXPECT_FALSE(m_win->isPendingTab(path));
+    EXPECT_NE(m_win->wrapper(path), nullptr);
+}
+
+TEST_F(WindowTest, HandleCurrentChanged_WithWrapper_SwitchesStackAndShowsBar)
+{
+    // Arrange
+    const QString blank = addBlankAndGetPath();
+    EditWrapper *w = m_win->wrapper(blank);
+
+    // Act
+    m_win->handleCurrentChanged(0);
+    QApplication::processEvents();
+
+    // Assert: 当前编辑器切换 + 底栏显示
+    EXPECT_EQ(m_win->m_editorWidget->currentWidget(), w);
+    EXPECT_TRUE(w->bottomBar()->isVisible());
+}
+
+TEST_F(WindowTest, HandleTabCloseRequested_DelayedCloseClosesTab)
+{
+    // Arrange
+    addBlankAndGetPath();
+    ASSERT_EQ(m_tabbar->count(), 1);
+
+    // Act: 请求关闭（10ms 延迟定时器）
+    m_win->handleTabCloseRequested(0);
+    processEventsFor(80);
+
+    // Assert: 标签被关闭
+    EXPECT_EQ(m_tabbar->count(), 0);
+}
+
+TEST_F(WindowTest, TimerEvent_InvalidIndex_NoClose)
+{
+    // Arrange: 一个标签 + 直接启动延迟定时器（越界索引）
+    addBlankAndGetPath();
+    m_win->m_requestCloseTabIndex = 99;
+    m_win->m_delayCloseTabTimer.start(10, m_win);
+
+    // Act: 派发定时器事件
+    QTimerEvent ev(m_win->m_delayCloseTabTimer.timerId());
+    m_win->timerEvent(&ev);
+
+    // Assert: 索引越界不关闭
+    EXPECT_EQ(m_tabbar->count(), 1);
+    EXPECT_FALSE(m_win->m_delayCloseTabTimer.isActive());
+}
+
+TEST_F(WindowTest, HandleTabsClosed_EmptyAndRealList)
+{
+    // Act: 空列表早退
+    m_win->handleTabsClosed(QStringList());
+    EXPECT_EQ(m_tabbar->count(), 0);
+
+    // Arrange
+    const QString blank = addBlankAndGetPath();
+
+    // Act
+    m_win->handleTabsClosed(QStringList { blank });
+    QApplication::processEvents();
+
+    // Assert: 早退且无 wrapper
+    EXPECT_EQ(m_tabbar->count(), 0);
+    EXPECT_TRUE(m_win->m_wrappers.isEmpty());
+}
+
+// ============================================================
+// addTemFileTab（恢复备份标签）
+// ============================================================
+
+TEST_F(WindowTest, AddTemFileTab_MissingFile_EarlyReturn)
+{
+    // Act
+    m_win->addTemFileTab(QStringLiteral("/no/such/tem"), QStringLiteral("n"), QStringLiteral("/t"), QString());
+
+    // Assert: 早退且无 wrapper
+    EXPECT_EQ(m_tabbar->count(), 0);
+    EXPECT_TRUE(m_win->m_wrappers.isEmpty());
+}
+
+TEST_F(WindowTest, AddTemFileTab_PngInheritsOctetStream_TreatedAsSupported)
+{
+    // Arrange: 真实 PNG 文件。实测 image/png 经 mime.inherits("application/octet-stream")
+    // 兜底被判"受支持"（octet-stream 在 SupportedTextMimeTypes 白名单且为所有 mime 的
+    // 祖先）——addTemFileTab 的"不支持提示"分支对常规文件不可达（缺陷已记录 session）。
+    QImage img(2, 2, QImage::Format_RGB32);
+    img.fill(Qt::red);
+    const QString binPath = m_tempDir->filePath(QStringLiteral("blob.png"));
+    ASSERT_TRUE(img.save(binPath, "PNG"));
+
+    // Act
+    m_win->addTemFileTab(binPath, QStringLiteral("blob"), binPath, QString());
+    QApplication::processEvents();
+
+    // Assert: 走受支持分支创建 blob 标签（无无效提示）
+    EXPECT_EQ(m_iconMsgCalls, 0);
+    EXPECT_EQ(m_tabbar->count(), 1);
+    EXPECT_EQ(m_tabbar->currentName(), QString("blob"));
+    EXPECT_NE(m_win->wrapper(binPath), nullptr);
+}
+
+TEST_F(WindowTest, AddTemFileTab_SupportedTempFile_CreatesWrapperAndTab)
+{
+    // Arrange: 真实临时文件
+    const QString temPath = createFile(QStringLiteral("tem.txt"), QByteArray("tem content\n"));
+    const QString truePath = m_tempDir->filePath(QStringLiteral("true.txt"));
+
+    // Act: 临时标签（bIsTemFile=true + 修改时间）
+    m_win->addTemFileTab(temPath, QStringLiteral("tem.txt"), truePath,
+                         QStringLiteral("2026-01-01T00:00:00"), true);
+    QApplication::processEvents();
+
+    // Assert: 标签 + wrapper + 显示
+    EXPECT_EQ(m_win->getTabIndex(temPath), 0);
+    EditWrapper *w = m_win->wrapper(temPath);
+    ASSERT_NE(w, nullptr);
+    EXPECT_EQ(m_win->m_editorWidget->currentWidget(), w);
+}
+
+// ============================================================
+// backupFile / closeAllFiles / saveAllFloatingFiles
+// ============================================================
+
+TEST_F(WindowTest, BackupFile_WithTabs_WritesHistoryOption)
+{
+    // Arrange: 一个修改态真实文件标签
+    const QString path = addFileTab(QStringLiteral("bk.txt"), QByteArray("backup me\n"));
+    stub.set_lamda(&EditWrapper::isModified, [](EditWrapper *) -> bool { return true; });
+
+    // Act
+    m_win->backupFile();
+
+    // Assert: browsing_history_temfile 写入 JSON（含 localPath 与 focus）
+    const QStringList history = Settings::instance()
+                                    ->settings->option("advance.editor.browsing_history_temfile")
+                                    ->value().toStringList();
+    ASSERT_EQ(history.count(), 1);
+    EXPECT_TRUE(history.first().contains(QStringLiteral("localPath")));
+    EXPECT_TRUE(history.first().contains(QStringLiteral("focus")));
+    EXPECT_EQ(m_win->m_qlistTemFile.count(), 1);
+}
+
+TEST_F(WindowTest, BackupFile_PendingTab_RecordsPlaceHolder)
+{
+    // Arrange: pending 标签（书签 + 修改时间）
+    const QString path = createFile(QStringLiteral("pnd.txt"));
+    Window::PendingTabInfo info;
+    info.filepath = path;
+    info.truePath = path;
+    info.displayName = QStringLiteral("pnd.txt");
+    info.bookmarks = QList<int> { 2 };
+    info.lastModifiedTime = QStringLiteral("2026-01-02T03:04:05");
+    info.isTemFile = true;
+    m_win->addPendingTab(info);
+
+    // Act
+    m_win->backupFile();
+
+    // Assert: JSON 含书签与修改时间
+    const QStringList history = Settings::instance()
+                                    ->settings->option("advance.editor.browsing_history_temfile")
+                                    ->value().toStringList();
+    ASSERT_EQ(history.count(), 1);
+    EXPECT_TRUE(history.first().contains(QStringLiteral("bookMark")));
+    EXPECT_TRUE(history.first().contains(QStringLiteral("2026-01-02T03:04:05")));
+}
+
+TEST_F(WindowTest, CloseAllFiles_NoTabs_ReturnsTrue)
+{
+    // Act / Assert
+    EXPECT_TRUE(m_win->closeAllFiles());
+    EXPECT_EQ(m_tabbar->count(), 0);
+}
+
+TEST_F(WindowTest, CloseAllFiles_CleanTabs_ClosesAll)
+{
+    // Arrange: 两个干净标签
+    addFileTab(QStringLiteral("ca1.txt"));
+    addFileTab(QStringLiteral("ca2.txt"));
+    ASSERT_EQ(m_tabbar->count(), 2);
+
+    // Act
+    EXPECT_TRUE(m_win->closeAllFiles());
+    QApplication::processEvents();
+
+    // Assert
+    EXPECT_TRUE(m_win->m_wrappers.isEmpty());
+}
+
+TEST_F(WindowTest, CloseAllFiles_CancelledByDialog_ReturnsFalse)
+{
+    // Arrange: 修改态标签 + 取消
+    addFileTab(QStringLiteral("ca3.txt"));
+    stub.set_lamda(&EditWrapper::isModified, [](EditWrapper *) -> bool { return true; });
+    stub.set_lamda(&EditWrapper::isDraftFile, [](EditWrapper *) -> bool { return false; });
+    m_ddialogResult = 0;
+
+    // Act / Assert
+    EXPECT_FALSE(m_win->closeAllFiles());
+    EXPECT_EQ(m_tabbar->count(), 1);
+}
+
+TEST_F(WindowTest, SaveAllFloatingFiles_NoMissingFiles_ReturnsTrue)
+{
+    // Arrange: 正常存在文件
+    addFileTab(QStringLiteral("float1.txt"));
+
+    // Act / Assert: 无漂浮文件 → true 且不弹窗
+    EXPECT_TRUE(m_win->saveAllFloatingFiles());
+    EXPECT_EQ(m_ddialogExecCalls, 0);
+}
+
+TEST_F(WindowTest, SaveAllFloatingFiles_MissingFileDialogs_ThreeResponses)
+{
+    // Arrange: 文件加载后从磁盘删除（漂浮文件）
+    const QString path = addFileTab(QStringLiteral("float2.txt"));
+    QFile::remove(path);
+
+    // Act: 取消（0）→ false
+    m_ddialogResult = 0;
+    EXPECT_FALSE(m_win->saveAllFloatingFiles());
+
+    // Act: 不保存（1）→ 跳过返回 true
+    m_ddialogResult = 1;
+    EXPECT_TRUE(m_win->saveAllFloatingFiles());
+}
+
+// ============================================================
+// 键盘 / 拖放 / 焦点窗口
+// ============================================================
+
+TEST_F(WindowTest, KeyPressEvent_Escape_EmitsPressEsc)
+{
+    // Arrange: 以当前 keymap 值驱动（escape 默认 Esc）
+    const QString escKey = Utils::getKeyshortcutFromKeymap(Settings::instance(), "window", "escape");
+    stub.set_lamda(&Utils::getKeyshortcut, [escKey](QKeyEvent *) -> QString { return escKey; });
+    QSignalSpy spy(m_win, &Window::pressEsc);
+
+    // Act
+    QKeyEvent ev(QEvent::KeyPress, Qt::Key_Escape, Qt::NoModifier);
+    m_win->keyPressEvent(&ev);
+
+    // Assert
+    EXPECT_EQ(spy.count(), 1);
+    EXPECT_EQ(m_tabbar->count(), 0);
+}
+
+TEST_F(WindowTest, KeyPressEvent_NewWindow_EmitsSignal)
+{
+    // Arrange
+    const QString key = Utils::getKeyshortcutFromKeymap(Settings::instance(), "window", "newwindow");
+    stub.set_lamda(&Utils::getKeyshortcut, [key](QKeyEvent *) -> QString { return key; });
+    QSignalSpy spy(m_win, &Window::newWindow);
+
+    // Act
+    QKeyEvent ev(QEvent::KeyPress, Qt::Key_N, Qt::ControlModifier | Qt::ShiftModifier);
+    m_win->keyPressEvent(&ev);
+
+    // Assert
+    EXPECT_EQ(spy.count(), 1);
+    EXPECT_EQ(m_tabbar->count(), 0);
+}
+
+TEST_F(WindowTest, KeyPressEvent_AddBlankTabShortcut_CreatesTab)
+{
+    // Arrange
+    const QString key = Utils::getKeyshortcutFromKeymap(Settings::instance(), "window", "addblanktab");
+    stub.set_lamda(&Utils::getKeyshortcut, [key](QKeyEvent *) -> QString { return key; });
+
+    // Act
+    QKeyEvent ev(QEvent::KeyPress, Qt::Key_T, Qt::ControlModifier);
+    m_win->keyPressEvent(&ev);
+    QApplication::processEvents();
+
+    // Assert
+    EXPECT_EQ(m_tabbar->count(), 1);
+    EXPECT_EQ(m_tabbar->currentName(), QString("Untitled 1"));
+}
+
+TEST_F(WindowTest, KeyPressEvent_FontSizeShortcuts_ChangeConfig)
+{
+    // Arrange
+    m_win->resetFontSize();
+    const QString inc = Utils::getKeyshortcutFromKeymap(Settings::instance(), "window", "incrementfontsize");
+    const QString dec = Utils::getKeyshortcutFromKeymap(Settings::instance(), "window", "decrementfontsize");
+    QString current = inc;
+    stub.set_lamda(&Utils::getKeyshortcut, [&current](QKeyEvent *) -> QString { return current; });
+    addBlankAndGetPath(); // setCodeFoldWidgetHide 需要 wrapper
+
+    // Act: 增大
+    QKeyEvent incEv(QEvent::KeyPress, Qt::Key_Equal, Qt::ControlModifier);
+    m_win->keyPressEvent(&incEv);
+    const qreal afterInc = Settings::instance()->settings->option("base.font.size")->value().toReal();
+    EXPECT_GT(afterInc, 12.0);
+
+    // Act: 减小
+    current = dec;
+    QKeyEvent decEv(QEvent::KeyPress, Qt::Key_Minus, Qt::ControlModifier);
+    m_win->keyPressEvent(&decEv);
+    const qreal afterDec = Settings::instance()->settings->option("base.font.size")->value().toReal();
+    EXPECT_LT(afterDec, afterInc);
+
+    // Act: 复位
+    const QString rst = Utils::getKeyshortcutFromKeymap(Settings::instance(), "window", "resetfontsize");
+    current = rst;
+    QKeyEvent rstEv(QEvent::KeyPress, Qt::Key_0, Qt::ControlModifier);
+    m_win->keyPressEvent(&rstEv);
+    EXPECT_EQ(Settings::instance()->settings->option("base.font.size")->value().toInt(), 12);
+}
+
+TEST_F(WindowTest, KeyPressEvent_SelectNextPrevTab_SwitchesIndex)
+{
+    // Arrange: 两个标签
+    addBlankAndGetPath();
+    addBlankAndGetPath();
+    EXPECT_EQ(m_tabbar->currentIndex(), 1);
+    const QString next = Utils::getKeyshortcutFromKeymap(Settings::instance(), "window", "selectnexttab");
+    const QString prev = Utils::getKeyshortcutFromKeymap(Settings::instance(), "window", "selectprevtab");
+    QString current = prev;
+    stub.set_lamda(&Utils::getKeyshortcut, [&current](QKeyEvent *) -> QString { return current; });
+
+    // Act: 上一个标签
+    QKeyEvent prevEv(QEvent::KeyPress, Qt::Key_Tab, Qt::ControlModifier);
+    m_win->keyPressEvent(&prevEv);
+    EXPECT_EQ(m_tabbar->currentIndex(), 0);
+
+    // Act: 下一个标签
+    current = next;
+    QKeyEvent nextEv(QEvent::KeyPress, Qt::Key_Tab, Qt::ControlModifier | Qt::ShiftModifier);
+    m_win->keyPressEvent(&nextEv);
+    EXPECT_EQ(m_tabbar->currentIndex(), 1);
+}
+
+TEST_F(WindowTest, KeyPressEvent_AltDigitSwitch_JumpsToTab)
+{
+    // Arrange: 三个标签
+    for (int i = 0; i < 3; ++i)
+        addBlankAndGetPath();
+    stub.set_lamda(&Utils::getKeyshortcut, [](QKeyEvent *) -> QString { return QStringLiteral("Alt+2"); });
+
+    // Act: Alt+2 → 第二个标签（索引 1）
+    QKeyEvent ev2(QEvent::KeyPress, Qt::Key_2, Qt::AltModifier);
+    m_win->keyPressEvent(&ev2);
+    EXPECT_EQ(m_tabbar->currentIndex(), 1);
+
+    // Act: Alt+9 → 最后一个标签
+    stub.set_lamda(&Utils::getKeyshortcut, [](QKeyEvent *) -> QString { return QStringLiteral("Alt+9"); });
+    QKeyEvent ev9(QEvent::KeyPress, Qt::Key_9, Qt::AltModifier);
+    m_win->keyPressEvent(&ev9);
+    EXPECT_EQ(m_tabbar->currentIndex(), 2);
+}
+
+TEST_F(WindowTest, KeyPressEvent_UnmatchedKey_FallsThrough)
+{
+    // Arrange: 无匹配键
+    stub.set_lamda(&Utils::getKeyshortcut, [](QKeyEvent *) -> QString { return QStringLiteral("Ctrl+F12"); });
+
+    // Act
+    QKeyEvent ev(QEvent::KeyPress, Qt::Key_F12, Qt::ControlModifier);
+    m_win->keyPressEvent(&ev);
+
+    // Assert: 无副作用
+    EXPECT_EQ(m_tabbar->count(), 0);
+    EXPECT_EQ(m_win->currentWrapper(), nullptr);
+}
+
+TEST_F(WindowTest, KeyReleaseEvent_WithModifiers_NoOp)
+{
+    // Act
+    QKeyEvent ev(QEvent::KeyRelease, Qt::Key_Shift, Qt::ShiftModifier);
+    m_win->keyReleaseEvent(&ev);
+
+    // Assert: 无副作用
+    EXPECT_EQ(m_tabbar->count(), 0);
+    EXPECT_TRUE(m_win->isVisible() || m_win->isHidden()); // 状态未损坏
+}
+
+TEST_F(WindowTest, DragEnterEvent_Accepts)
+{
+    // Arrange
+    QMimeData mime;
+    mime.setUrls({ QUrl::fromLocalFile(m_tempDir->path()) });
+    QDragEnterEvent ev(QPoint(5, 5), Qt::DropActions(Qt::CopyAction), &mime, Qt::LeftButton, Qt::NoModifier);
+
+    // Act
+    m_win->dragEnterEvent(&ev);
+
+    // Assert: URL 拖入被接受且无标签副作用
+    EXPECT_TRUE(ev.isAccepted());
+    EXPECT_EQ(m_tabbar->count(), 0);
+}
+
+TEST_F(WindowTest, DropEvent_MixedUrls_AddsSupportedAndNotifies)
+{
+    // Arrange: 支持文件 + 不支持目录
+    const QString file = createFile(QStringLiteral("drop.txt"));
+    QMimeData mime;
+    mime.setUrls({ QUrl::fromLocalFile(file), QUrl::fromLocalFile(m_tempDir->path()) });
+    QDropEvent ev(QPointF(5, 5), Qt::DropActions(Qt::CopyAction), &mime, Qt::LeftButton, Qt::NoModifier);
+
+    // Act
+    m_win->dropEvent(&ev);
+    QApplication::processEvents();
+
+    // Assert: 支持文件加载 + 目录提示
+    EXPECT_NE(m_win->wrapper(file), nullptr);
+    EXPECT_GE(m_iconMsgCalls, 1);
+}
+
+TEST_F(WindowTest, DropEvent_NoUrls_NoOp)
+{
+    // Arrange: 无 URL 数据
+    QMimeData mime;
+    mime.setText(QStringLiteral("plain"));
+    QDropEvent ev(QPointF(5, 5), Qt::DropActions(Qt::CopyAction), &mime, Qt::LeftButton, Qt::NoModifier);
+
+    // Act
+    m_win->dropEvent(&ev);
+
+    // Assert: 无 URL 数据不触发任何添加
+    EXPECT_EQ(m_tabbar->count(), 0);
+    EXPECT_TRUE(m_win->m_wrappers.isEmpty());
+}
+
+TEST_F(WindowTest, HandleFocusWindowChanged_ForeignOrNullWindow_EarlyReturn)
+{
+    // Act: null 窗口句柄 + 无 wrapper → 守卫返回
+    m_win->handleFocusWindowChanged(nullptr);
+
+    // Assert
+    EXPECT_EQ(m_win->currentWrapper(), nullptr);
+    EXPECT_EQ(m_tabbar->count(), 0);
+}
+
+TEST_F(WindowTest, HideEvent_HidesBarsAndRefocuses)
+{
+    // Arrange: 显示窗口 + 内容标签 + 查找栏
+    m_win->show();
+    addFileTab(QStringLiteral("hide.txt"), QByteArray("hide me\n"));
+    m_win->popupFindBar();
+    QApplication::processEvents();
+
+    // Act: 直接调 hideEvent（isVisible 仍为 true 分支）
+    QHideEvent ev;
+    m_win->hideEvent(&ev);
+
+    // Assert: 底栏恢复显示（查找栏可见分支）且窗口仍在（未关闭）
+    EXPECT_TRUE(m_win->currentWrapper()->bottomBar()->isVisible());
+    EXPECT_TRUE(m_win->isVisible());
+}
+
+// ============================================================
+// 打印
+// ============================================================
+
+TEST_F(WindowTest, ClearPrintTextDocument_ReleasesDocsAndList)
+{
+    // Arrange: 注入打印文档与列表
+    m_win->m_printDoc = new QTextDocument();
+    m_win->m_printDoc->setPlainText(QStringLiteral("p"));
+    Window::PrintInfo info;
+    info.doc = new QTextDocument();
+    info.doc->setPlainText(QStringLiteral("q"));
+    info.highlighter = nullptr;
+    m_win->m_printDocList.append(info);
+
+    // Act
+    m_win->clearPrintTextDocument();
+
+    // Assert: 指针清空 / 列表清空（文档已 delete）
+    EXPECT_EQ(m_win->m_printDoc, nullptr);
+    EXPECT_TRUE(m_win->m_printDocList.isEmpty());
+}
+
+TEST_F(WindowTest, DoPrint_EarlyReturnBranches)
+{
+    // Arrange 1: 无打印文档
+    DPrinter printer(QPrinter::HighResolution);
+    QVector<int> range { 1 };
+
+    // Act / Assert: null doc
+    m_win->doPrint(&printer, range);
+
+    // Arrange 2: 空页码范围
+    m_win->m_printDoc = new QTextDocument();
+    m_win->doPrint(&printer, QVector<int>());
+
+    // Assert: 布局未记录（两分支早退）且文档未受破坏
+    EXPECT_FALSE(m_win->m_lastLayout.isValid());
+    EXPECT_NE(m_win->m_printDoc, nullptr);
+    delete m_win->m_printDoc;
+    m_win->m_printDoc = nullptr;
+}
+
+TEST_F(WindowTest, DoPrintWithLargeDoc_EarlyReturnBranches)
+{
+    // Arrange: 处理中标志
+    DPrinter printer(QPrinter::HighResolution);
+    m_win->m_bPrintProcessing = true;
+
+    // Act / Assert: 处理中
+    m_win->doPrintWithLargeDoc(&printer, QVector<int> { 1 });
+
+    // Act / Assert: 列表为空
+    m_win->m_bPrintProcessing = false;
+    m_win->doPrintWithLargeDoc(&printer, QVector<int> { 1 });
+
+    // Act / Assert: 页码为空
+    Window::PrintInfo info;
+    info.doc = new QTextDocument();
+    m_win->m_printDocList.append(info);
+    m_win->doPrintWithLargeDoc(&printer, QVector<int>());
+
+    // Assert: 未进入绘制（早退链全覆盖）
+    EXPECT_FALSE(m_win->m_bPrintProcessing);
+    EXPECT_EQ(m_win->m_printDocList.count(), 1);
+    m_win->clearPrintTextDocument();
+}
+
+TEST_F(WindowTest, AsynPrint_SmallDoc_RendersIntoImage)
+{
+    // Arrange: 打印文档 + 位图绘制设备（painter 活跃）
+    m_win->m_printDoc = new QTextDocument();
+    m_win->m_printDoc->setPlainText(QStringLiteral("async print line\n"));
+    QImage image(600, 800, QImage::Format_ARGB32);
+    image.fill(Qt::white);
+    const qint64 keyBefore = image.cacheKey();
+    DPrinter printer(QPrinter::HighResolution);
+    QPainter painter(&image);
+    ASSERT_TRUE(painter.isActive());
+
+    // Act: 同步预览打印（小文档路径 → printPage）
+    m_win->asynPrint(painter, &printer, QVector<int> { 1 });
+    painter.end();
+
+    // Assert: 位图被绘制修改 + 文档未受破坏
+    EXPECT_NE(image.cacheKey(), keyBefore);
+    EXPECT_FALSE(m_win->m_printDoc->isEmpty());
+}
+
+TEST_F(WindowTest, AsynPrint_LargeDocList_RendersMultiDoc)
+{
+    // Arrange: 大文档列表（无高亮 → else 分支）
+    Window::PrintInfo info;
+    info.doc = new QTextDocument();
+    info.doc->setPlainText(QStringLiteral("multi doc page\n"));
+    info.highlighter = nullptr;
+    m_win->m_printDocList.append(info);
+    m_win->m_bLargePrint = true;
+    m_win->m_multiDocPageCount = info.doc->pageCount();
+    QImage image(600, 800, QImage::Format_ARGB32);
+    image.fill(Qt::white);
+    const qint64 keyBefore = image.cacheKey();
+    DPrinter printer(QPrinter::HighResolution);
+    QPainter painter(&image);
+
+    // Act
+    m_win->asynPrint(painter, &printer, QVector<int> { 1 });
+    painter.end();
+
+    // Assert: printPageWithMultiDoc 执行
+    EXPECT_NE(image.cacheKey(), keyBefore);
+    EXPECT_TRUE(m_win->m_bLargePrint);
+}
+
+TEST_F(WindowTest, AsynPrint_InvalidDoc_EarlyReturn)
+{
+    // Arrange: 默认状态（无文档）
+    QImage image(60, 80, QImage::Format_ARGB32);
+    DPrinter printer(QPrinter::HighResolution);
+    QPainter painter(&image);
+
+    // Act
+    m_win->asynPrint(painter, &printer, QVector<int> { 1 });
+    painter.end();
+
+    // Assert: 早退未崩溃
+    EXPECT_TRUE(m_win->m_printDocList.isEmpty());
+    EXPECT_FALSE(m_win->m_bLargePrint);
+}
+
+TEST_F(WindowTest, PrintPage_Static_RendersPageAndNumber)
+{
+    // Arrange
+    QTextDocument doc;
+    doc.setPlainText(QStringLiteral("static print page\n"));
+    const int blocksBefore = doc.blockCount(); // 含尾块
+    QImage image(400, 600, QImage::Format_ARGB32);
+    image.fill(Qt::white);
+    const qint64 keyBefore = image.cacheKey();
+    QPainter painter(&image);
+
+    // Act: 静态页绘制（页码 + 正文）
+    Window::printPage(1, &painter, &doc, QRectF(20, 20, 360, 560), QRectF(200, 560, 160, 30));
+    painter.end();
+
+    // Assert
+    EXPECT_NE(image.cacheKey(), keyBefore);
+    EXPECT_EQ(doc.blockCount(), blocksBefore); // 只读绘制不改文档结构
+}
+
+TEST_F(WindowTest, CloneLargeDocument_NullWrapper_ReturnsFalse)
+{
+    // Act / Assert
+    EXPECT_FALSE(m_win->cloneLargeDocument(nullptr));
+    EXPECT_TRUE(m_win->m_printDocList.isEmpty());
+}
+
+TEST_F(WindowTest, CloneLargeDocument_SmallAndLargeDocs_SplitsByLimit)
+{
+    // Arrange 1: 小文档 → 单文档列表
+    const QString small = addFileTab(QStringLiteral("small.txt"), QByteArray("small doc\n"));
+    EditWrapper *wSmall = m_win->wrapper(small);
+    ASSERT_NE(wSmall, nullptr);
+
+    // Act / Assert
+    EXPECT_TRUE(m_win->cloneLargeDocument(wSmall));
+    EXPECT_EQ(m_win->m_printDocList.count(), 1);
+    m_win->clearPrintTextDocument();
+
+    // Arrange 2: >10 万文本块的文件 → 触发单文档块数上限拆分
+    QByteArray big(150000, '\n'); // 150001 块
+    const QString bigPath = addFileTab(QStringLiteral("big.txt"), big);
+    EditWrapper *wBig = m_win->wrapper(bigPath);
+    ASSERT_NE(wBig, nullptr);
+
+    // Act / Assert: 拆分为多个打印文档
+    EXPECT_TRUE(m_win->cloneLargeDocument(wBig));
+    EXPECT_GE(m_win->m_printDocList.count(), 2);
+}
+
+TEST_F(WindowTest, RehighlightPrintDoc_NullArgs_EarlyReturn)
+{
+    // Act / Assert: 空指针守卫（状态未损坏）
+    m_win->rehighlightPrintDoc(nullptr, nullptr);
+    EXPECT_TRUE(m_win->m_printDocList.isEmpty());
+    EXPECT_FALSE(m_win->m_bPrintProcessing);
+}
+
+TEST_F(WindowTest, RehighlightPrintDoc_RealObjects_Rehighlights)
+{
+    // Arrange: 真实文档 + 高亮器 + 打印 wrapper
+    const QString path = addFileTab(QStringLiteral("hl.txt"), QByteArray("int main() { return 0; }\n"));
+    m_win->m_printWrapper = m_win->wrapper(path);
+    ASSERT_NE(m_win->m_printWrapper, nullptr);
+    QTextDocument doc;
+    doc.setPlainText(QStringLiteral("int x = 1;\n"));
+    const int blocksBefore = doc.blockCount(); // 含尾块
+    CSyntaxHighlighter highlighter(&doc);
+
+    // Act: 亮色背景分支（rehighlight 全文）
+    m_win->rehighlightPrintDoc(&doc, &highlighter);
+
+    // Assert: 高亮器被启停过 + 文档结构不变
+    EXPECT_EQ(doc.blockCount(), blocksBefore);
+    EXPECT_FALSE(highlighter.definition().isValid()); // 未设置定义
+}
+
+// ============================================================
+// 打印入口 / 设置对话框 / 快捷键视图
+// ============================================================
+
+TEST_F(WindowTest, PopupPrintDialog_EmptyDoc_EarlyReturn)
+{
+    // Arrange: 空白标签（文档为空 → 打印文档无效 → 早退）
+    addBlankAndGetPath();
+
+    // Act
+    m_win->popupPrintDialog();
+
+    // Assert: 未创建打印预览（doc 无效分支）且无处理中标志
+    EXPECT_EQ(m_win->m_pPreview, nullptr);
+    EXPECT_FALSE(m_win->m_bPrintProcessing);
+}
+
+TEST_F(WindowTest, PopupSettingsDialog_BuildsExecAndSyncs)
+{
+    // Arrange: 拦截 setSettingDialog 防悬垂指针 + 对话框立即返回
+    int setDialogCalls = 0;
+    stub.set_lamda(&Settings::setSettingDialog,
+                   [&setDialogCalls](Settings *, DSettingsDialog *) { ++setDialogCalls; });
+    m_qdialogResult = QDialog::Rejected;
+
+    // Act
+    m_win->popupSettingsDialog();
+    QApplication::processEvents();
+
+    // Assert: 对话框注册 + 执行一次
+    EXPECT_EQ(setDialogCalls, 1);
+    EXPECT_GE(m_qdialogExecCalls, 1);
+}
+
+TEST_F(WindowTest, DisplayShortcuts_LaunchesShortcutViewer)
+{
+    // Arrange
+    m_win->show();
+
+    // Act
+    m_win->displayShortcuts();
+    QApplication::processEvents();
+
+    // Assert: deepin-shortcut-viewer 以 JSON 参数启动（进程被拦截）
+    EXPECT_EQ(m_startDetachedCalls, 1);
+    EXPECT_EQ(m_lastDetachedProgram, QString("deepin-shortcut-viewer"));
+    EXPECT_EQ(m_lastDetachedArgs.count(), 2);
+    EXPECT_TRUE(m_lastDetachedArgs.at(0).startsWith(QStringLiteral("-j=")));
+    delete m_win->m_shortcutViewProcess;
+    m_win->m_shortcutViewProcess = nullptr;
+}
+
+TEST_F(WindowTest, SetPrintEnabled_TogglesPrintAction)
+{
+    // Arrange: 标题菜单中的 Print action
+    QAction *printAction = nullptr;
+    for (QAction *a : m_win->m_menu->actions()) {
+        if (a->text() == QString("Print"))
+            printAction = a;
+    }
+    ASSERT_NE(printAction, nullptr);
+
+    // Act / Assert: 禁用 → 启用
+    m_win->setPrintEnabled(false);
+    EXPECT_FALSE(printAction->isEnabled());
+    m_win->setPrintEnabled(true);
+    EXPECT_TRUE(printAction->isEnabled());
+}
+
+TEST_F(WindowTest, GetStackedWgt_ReturnsEditorStack)
+{
+    // Assert
+    EXPECT_EQ(m_win->getStackedWgt(), m_win->m_editorWidget);
+    EXPECT_EQ(m_win->getStackedWgt()->count(), 0);
+}
+
+// ============================================================
+// 覆盖率补漏：私有辅助 / ctor 连接 lambda / 打印预览深路径
+// ============================================================
+
+TEST_F(WindowTest, GetCurrentOpenFilePath_DraftAndRealFile_ReturnsDirectories)
+{
+    // Assert: 无 wrapper → 空
+    EXPECT_TRUE(m_win->getCurrentOpenFilePath().isEmpty());
+
+    // Arrange: 草稿标签（blank 目录）
+    const QString blank = addBlankAndGetPath();
+
+    // Act / Assert: 草稿 → 家目录 Documents
+    EXPECT_EQ(m_win->getCurrentOpenFilePath(), QDir::homePath() + "/Documents");
+
+    // Arrange: 真实文件标签
+    const QString path = addFileTab(QStringLiteral("curdir.txt"));
+
+    // Act / Assert: 普通文件 → 其所在目录
+    EXPECT_EQ(m_win->getCurrentOpenFilePath(), QFileInfo(path).absolutePath());
+}
+
+TEST_F(WindowTest, UpdateSizeMode_WithVisibleBars_RepositionsBars)
+{
+    // Arrange: 查找栏与替换栏可见
+    m_win->show();
+    addFileTab(QStringLiteral("usm.txt"), QByteArray("size mode content\n"));
+    m_win->popupFindBar();
+    QApplication::processEvents();
+    ASSERT_TRUE(m_win->m_findBar->isVisible());
+
+    // Act: 布局模式变更槽（可见分支移动栏位）
+    m_win->updateSizeMode();
+
+    // Assert: 栏仍可见且窗口未损坏
+    EXPECT_TRUE(m_win->m_findBar->isVisible());
+    EXPECT_EQ(m_win->m_findBar->y(), m_win->height() - m_win->m_findBar->height() - 4);
+}
+
+TEST_F(WindowTest, Constructor_SearchKeywordLambdas_ForwardToHandlers)
+{
+    // Arrange: 有内容标签（ctor 连接的 updateSearchKeyword lambda）
+    const QString path = addFileTab(QStringLiteral("lamb.txt"), QByteArray("lambda content\n"));
+
+    // Act: 查找栏信号 → ctor lambda → handleUpdateSearchKeyword
+    emit m_win->m_findBar->updateSearchKeyword(path, QStringLiteral("lamb"));
+
+    // Assert: 关键词已记录
+    EXPECT_EQ(m_win->getKeywordForSearch(), QString("lamb"));
+
+    // Act: 替换栏信号（第二个 ctor lambda）
+    emit m_win->m_replaceBar->updateSearchKeyword(path, QStringLiteral("rep"));
+    EXPECT_EQ(m_win->getKeywordForSearch(), QString("rep"));
+    EXPECT_EQ(m_win->getKeywordForSearchAll(), QString("rep"));
+}
+
+TEST_F(WindowTest, AddTabWithWrapper_TextChangedLambda_UpdatesWordCount)
+{
+    // Arrange: 经 addTabWithWrapper 接入的编辑器（textChanged 连接的 lambda）
+    EditWrapper *w = m_win->createEditor();
+    const QString path = m_tempDir->filePath(QStringLiteral("twc.txt"));
+    m_win->addTabWithWrapper(w, path, path, QStringLiteral("twc.txt"));
+
+    // Act: 修改文本触发 textChanged → UpdateBottomBarWordCnt
+    w->textEditor()->setPlainText(QStringLiteral("0123456789abcd")); // 14 字符
+
+    // Assert: 字数统计已更新（14-1=13 → "Characters 13"）
+    EXPECT_EQ(w->bottomBar()->m_pCharCountLabel->text(), QString("Characters 14"));
+    EXPECT_EQ(w->textEditor()->toPlainText(), QString("0123456789abcd"));
+}
+
+TEST_F(WindowTest, PopupPrintDialog_WithContent_FullPreviewLifecycle)
+{
+    // Arrange: 有内容标签（走小文档克隆 → DPrintPreviewDialog 构建 + exec 拦截）
+    m_win->show();
+    addFileTab(QStringLiteral("print.txt"), QByteArray("printable line\nsecond line\n"));
+
+    // Act
+    m_win->popupPrintDialog();
+    QApplication::processEvents();
+
+    // Assert: 预览对话框已创建（finished/rejected/paintRequested lambda 已连接）
+    ASSERT_NE(m_win->m_pPreview, nullptr);
+    // 打印文档为克隆副本
+    EXPECT_NE(m_win->m_printDoc, nullptr);
+    EXPECT_FALSE(m_win->m_printDoc->isEmpty());
+
+    // Act: 手动触发 paintRequested lambda（重载信号需经 PMF 对象语法发射）
+    DPrinter paintPrinter(QPrinter::HighResolution);
+    auto paintSig = QOverload<DPrinter *, const QVector<int> &>::of(&DPrintPreviewDialog::paintRequested);
+    // 小文档分支 → doPrint 早退链
+    emit (m_win->m_pPreview->*paintSig)(&paintPrinter, QVector<int> { 1 });
+    // 大文档分支（doPrintWithLargeDoc 早退链）
+    Window::PrintInfo info;
+    info.doc = new QTextDocument();
+    m_win->m_printDocList.append(info);
+    m_win->m_bLargePrint = true;
+    emit (m_win->m_pPreview->*paintSig)(&paintPrinter, QVector<int> { 1 });
+    m_win->m_bLargePrint = false;
+
+    // Act: 手动触发 finished / rejected 清理 lambda
+    emit m_win->m_pPreview->finished(0);
+    emit m_win->m_pPreview->rejected();
+    QApplication::processEvents();
+
+    // Assert: 打印文档被清理（clearPrintTextDocument lambda 生效）
+    EXPECT_EQ(m_win->m_printDoc, nullptr);
+    EXPECT_FALSE(m_win->m_bPrintProcessing);
+    delete m_win->m_pPreview;
+    m_win->m_pPreview = nullptr;
+}
+
+// ============================================================
+// 关闭窗口（closeEvent 全链路）
+// ============================================================
+
+TEST_F(WindowTest, CloseEvent_CleanWindow_EmitsCloseWindow)
+{
+    // Arrange: 展示 + 一个干净标签
+    m_win->show();
+    addFileTab(QStringLiteral("closing.txt"));
+    QSignalSpy spy(m_win, &Window::closeWindow);
+
+    // Act
+    m_win->close();
+    QApplication::processEvents();
+
+    // Assert: 关闭信号发射 + wrapper 全部释放 + 窗口隐藏
+    EXPECT_EQ(spy.count(), 1);
+    EXPECT_TRUE(m_win->m_wrappers.isEmpty());
+    EXPECT_FALSE(m_win->isVisible());
+}
+
+TEST_F(WindowTest, CloseEvent_UnsavedCancel_IgnoresClose)
+{
+    // Arrange: 修改态 + 磁盘文件已删除（漂浮）+ 拒绝保存
+    //（save_tab_before_close 默认 true，只有漂浮文件才弹保存确认）
+    const QString path = addFileTab(QStringLiteral("cancel.txt"));
+    QFile::remove(path);
+    stub.set_lamda(&EditWrapper::isModified, [](EditWrapper *) -> bool { return true; });
+    m_ddialogResult = 0;
+    QSignalSpy spy(m_win, &Window::closeWindow);
+
+    // Act
+    m_win->close();
+    QApplication::processEvents();
+
+    // Assert: 关闭被忽略（无 closeWindow 信号）
+    EXPECT_EQ(spy.count(), 0);
+    EXPECT_TRUE(m_win->isVisible());
+}


### PR DESCRIPTION
## 内容

新增应用级（editorapplication）与查找/替换栏、标签栏、工具栏、设置对话框、底栏、主窗口等控件的 GTest 单元测试，共 20 个文件。

## 说明

- 基于 master 独立拉出，可独立评审与合并
- 仅新增单元测试代码，不改动编辑器本体功能
