### PR TITLE
test: add unit tests for editor core, areas and wrapper

### DIFF
--- a/tests/editor_areas/CMakeLists.txt
+++ b/tests/editor_areas/CMakeLists.txt
@@ -1,0 +1,113 @@
+cmake_minimum_required(VERSION 3.16)
+
+# B6 模块：editor_areas（src/editor 区域/辅助组件类）
+# 类：LeftAreaTextEdit / LineNumberArea / BookMarkWidget / CodeFlodArea /
+#     ShowFlodCodeWidget / FlashTween / MarkOperation+MarkReplaceInfo(dtextedit.h 结构体)
+#
+# 策略（沿用 B4）：全量编入 src/ 为共享静态库（排除入口 main 与冲突源 encoding.cpp），
+# 保证 dtextedit.cpp（含 MarkOperation 静态转换函数）等符号齐全；
+# 运行期对 TextEdit 的依赖用 stub_ext 拦截（LeftAreaTextEdit 仅持有指针，
+# 经 fake 指针 + stub 喂数据），QWidget 测试在 QT_QPA_PLATFORM=offscreen 下构造。
+
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
+
+# environments.h（VERSION 宏，部分源码需要）
+configure_file(
+    "${CMAKE_SOURCE_DIR}/src/environments.h.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/environments.h"
+    @ONLY
+)
+
+# ---- 共享静态库：项目源码（多个 test target 复用，避免重复编译） ----
+file(GLOB_RECURSE EA_ALL_SRC
+    "${CMAKE_SOURCE_DIR}/src/*.cpp"
+    "${CMAKE_SOURCE_DIR}/src/basepub/*.c")
+list(REMOVE_ITEM EA_ALL_SRC
+    "${CMAKE_SOURCE_DIR}/src/main.cpp"
+    "${CMAKE_SOURCE_DIR}/src/common/encoding.cpp")
+
+add_library(editor_areas_ut_src STATIC
+    ${EA_ALL_SRC}
+    "${CMAKE_SOURCE_DIR}/src/deepin-editor.qrc")
+
+target_include_directories(editor_areas_ut_src PUBLIC
+    "${CMAKE_SOURCE_DIR}/src"
+    "${CMAKE_SOURCE_DIR}/src/common"
+    "${CMAKE_SOURCE_DIR}/src/controls"
+    "${CMAKE_SOURCE_DIR}/src/editor"
+    "${CMAKE_SOURCE_DIR}/src/editor/markdown"
+    "${CMAKE_SOURCE_DIR}/src/widgets"
+    "${CMAKE_SOURCE_DIR}/src/dbus"
+    "${CMAKE_SOURCE_DIR}/src/thememodule"
+    "${CMAKE_SOURCE_DIR}/src/encodes"
+    "${CMAKE_SOURCE_DIR}/src/basepub"
+    "${CMAKE_CURRENT_BINARY_DIR}"
+)
+
+target_link_libraries(editor_areas_ut_src PUBLIC
+    Qt6::Core
+    Qt6::Gui
+    Qt6::Widgets
+    Qt6::Xml
+    Qt6::Svg
+    Qt6::Concurrent
+    Qt6::PrintSupport
+    Qt6::DBus
+    Qt6::WebEngineWidgets
+    Qt6::WebChannel
+    Qt6::OpenGLWidgets
+    Qt6::Core5Compat
+    Dtk6::Widget
+    Dtk6::Core
+    KF6::Codecs
+    KF6::SyntaxHighlighting
+    ICU::i18n
+    ICU::uc
+    ${chardet_LIBRARIES}
+    uchardet
+    pthread
+    dl
+    m
+)
+
+# stub-ext 运行时依赖
+set(STUB_SHADOW "${CMAKE_SOURCE_DIR}/tests/3rdparty/stub/stub-shadow.cpp")
+
+# 代码覆盖率（Debug，沿用 tests 顶层全局 flags，此处仅链 gcov）
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    target_link_libraries(editor_areas_ut_src PUBLIC gcov)
+endif()
+
+# QSignalSpy / QApplication::sendEvent 需要 Qt6::Test（顶层未包含该组件）
+find_package(Qt6 COMPONENTS Test REQUIRED)
+
+# ---- 逐类 test target ----
+function(ea_add_test name)
+    add_executable(test_${name}
+        test_${name}.cpp
+        ${STUB_SHADOW})
+    target_include_directories(test_${name} PRIVATE
+        "${CMAKE_SOURCE_DIR}/tests/3rdparty/stub")
+    # 访问 protected（paintEvent/sizeHint）与 private（FlashTween 槽/成员、
+    # LeftAreaTextEdit::m_pTextEdit 等）用于直接驱动与状态断言；
+    # 访问控制不影响 ABI 布局，与库侧 AUTOMOC 产物 ODR 兼容
+    target_compile_options(test_${name} PRIVATE -fno-access-control)
+    target_link_libraries(test_${name} PRIVATE
+        editor_areas_ut_src
+        GTest::gtest
+        GTest::gtest_main
+        Qt6::Test)
+    gtest_discover_tests(test_${name} PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
+    message(STATUS "UT: test_${name} configured")
+endfunction()
+
+ea_add_test(flashtween)
+ea_add_test(leftareatextedit)
+ea_add_test(linenumberarea)
+ea_add_test(bookmarkwidget)
+ea_add_test(codeflodarea)
+ea_add_test(showflodcodewidget)
+ea_add_test(markoperation)
+
+message(STATUS "UT: editor_areas module configured")

--- a/tests/editor_areas/test_bookmarkwidget.cpp
+++ b/tests/editor_areas/test_bookmarkwidget.cpp
@@ -1,0 +1,149 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// BookMarkWidget（src/editor/bookmarkwidget.h/.cpp）单元测试
+//
+// 类特征：QWidget（GUI），持 LeftAreaTextEdit 指针，paintEvent 纯委托。
+// 绘制验证双通道：直驱 protected paintEvent（委托计数）+ grab() 真实渲染。
+//
+// 方法清单完成情况（test-types §8）：
+// | 1 | 公开方法 ≥1 用例：ctor/dtor/paintEvent(protected 直驱+渲染) | 完成 |
+// | 2 | 等价类划分：null/真实 LeftAreaTextEdit 构造；空/非空绘制区域 | 完成 |
+// | 3 | 边界值显式覆盖：(0,0) 空矩形与典型矩形 | 完成 |
+// | 4 | TEST_P：无 ≥3 组同质输入（单委托方法，两组断言逻辑不同走 TEST_F） | N/A |
+// | 5 | 分支清单已列出并映射用例 | N/A（无控制流分支） |
+// | 6 | 每条 if 分支有触发用例 | N/A |
+// | 7 | 异常路径：无 throw | N/A |
+// | 8 | 负面场景：null 委托目标构造不崩溃 | 完成 |
+// | 9 | 强异常安全：不适用 | N/A |
+// | 10 | stub 选择：项目内具体类 → stub_ext | 完成 |
+//
+// 分支清单（来源：bookmarkwidget.cpp）：无控制流分支（构造存指针 + 绘制纯委托）。
+//
+// 用例映射：
+// - Construction_StoresLeftAreaWidget                  → ctor
+// - Construction_NullLeftArea_NoCrash                  → ctor 负面
+// - PaintEvent_DelegatesToBookMarkAreaPaintEvent       → paintEvent 委托计数
+// - PaintEvent_GrabRendering_DelegatesOnce             → paintEvent 真实渲染通道
+
+#include <gtest/gtest.h>
+#include "stubext.h"
+#include "bookmarkwidget.h"
+#include "leftareaoftextedit.h"
+#include "dtextedit.h"
+
+#include <QApplication>
+#include <QDebug>
+#include <QPaintEvent>
+
+namespace {
+
+TextEdit *const kFakeEdit = reinterpret_cast<TextEdit *>(quintptr(0x1000));
+
+} // namespace
+
+class BookMarkWidgetTest : public ::testing::Test {
+protected:
+    static void SetUpTestSuite()
+    {
+        if (QApplication::instance() == nullptr) {
+            static int argc = 1;
+            static char appName[] = "test_bookmarkwidget";
+            static char *argv[] = { appName, nullptr };
+            s_app = new QApplication(argc, argv);
+        }
+    }
+
+    static void TearDownTestSuite() {}
+
+    void SetUp() override
+    {
+        bookMarkPaintCalls = 0;
+
+        // LeftAreaTextEdit 构造 qDebug 流式输出 fake TextEdit* → 拦截 QWidget 流式运算符
+        stub.set_lamda(static_cast<QDebug (*)(QDebug, const QWidget *)>(&operator<<),
+                       [](QDebug d, const QWidget *) -> QDebug { return d; });
+        stub.set_lamda(&LeftAreaTextEdit::bookMarkAreaPaintEvent,
+                       [this](LeftAreaTextEdit *, QPaintEvent *) { ++bookMarkPaintCalls; });
+
+        leftArea = new LeftAreaTextEdit(kFakeEdit);
+        obj = new BookMarkWidget(leftArea);
+        ASSERT_NE(obj, nullptr);
+    }
+
+    void TearDown() override
+    {
+        delete obj;
+        obj = nullptr;
+        delete leftArea;
+        leftArea = nullptr;
+        stub.clear();
+    }
+
+    static QApplication *s_app;
+
+    stub_ext::StubExt stub;
+    LeftAreaTextEdit *leftArea = nullptr;
+    BookMarkWidget *obj = nullptr;
+    int bookMarkPaintCalls = 0;
+};
+
+QApplication *BookMarkWidgetTest::s_app = nullptr;
+
+TEST_F(BookMarkWidgetTest, Construction_StoresLeftAreaWidget)
+{
+    // Assert：持有委托目标
+    EXPECT_EQ(obj->m_leftAreaWidget, leftArea);
+    EXPECT_EQ(obj->m_leftAreaWidget->getEdit(), kFakeEdit);
+}
+
+TEST_F(BookMarkWidgetTest, Construction_NullLeftArea_NoCrash)
+{
+    // Arrange/Act：null 委托目标（负面场景：构造仅存指针不解引用）
+    BookMarkWidget nullArea(nullptr);
+
+    // Assert：指针原样保存、部件可用
+    EXPECT_EQ(nullArea.m_leftAreaWidget, nullptr);
+    EXPECT_FALSE(nullArea.isVisible());
+}
+
+TEST_F(BookMarkWidgetTest, PaintEvent_DelegatesToBookMarkAreaPaintEvent)
+{
+    // Arrange：典型矩形
+    QPaintEvent event(QRect(0, 0, 20, 200));
+
+    // Act：直驱 protected paintEvent（纯委托）
+    obj->paintEvent(&event);
+
+    // Assert：精确转发一次；重复调用计数累加
+    EXPECT_EQ(bookMarkPaintCalls, 1);
+    obj->paintEvent(&event);
+    EXPECT_EQ(bookMarkPaintCalls, 2);
+}
+
+TEST_F(BookMarkWidgetTest, PaintEvent_EmptyRect_DelegatesWithoutCrash)
+{
+    // Arrange：空矩形边界 (0,0)
+    QPaintEvent event(QRect(0, 0, 0, 0));
+
+    // Act
+    obj->paintEvent(&event);
+
+    // Assert：空区域仍走委托链；重复调用计数累加（委托可重复）
+    EXPECT_EQ(bookMarkPaintCalls, 1);
+    obj->paintEvent(&event);
+    EXPECT_EQ(bookMarkPaintCalls, 2);
+}
+
+TEST_F(BookMarkWidgetTest, PaintEvent_GrabRendering_DelegatesOnce)
+{
+    // Arrange：给定尺寸，走真实渲染管线
+    obj->resize(18, 120);
+
+    // Act
+    const QPixmap pm = obj->grab();
+
+    // Assert：渲染触发一次委托，输出尺寸与部件一致
+    EXPECT_EQ(bookMarkPaintCalls, 1);
+    EXPECT_EQ(pm.size(), QSize(18, 120));
+}

--- a/tests/editor_areas/test_codeflodarea.cpp
+++ b/tests/editor_areas/test_codeflodarea.cpp
@@ -1,0 +1,149 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// CodeFlodArea（src/editor/codeflodarea.h/.cpp）单元测试
+//
+// 类特征：QWidget（GUI），持 LeftAreaTextEdit 指针，paintEvent 为 public 纯委托。
+//
+// 方法清单完成情况（test-types §8）：
+// | 1 | 公开方法 ≥1 用例：ctor/dtor/paintEvent(public) | 完成 |
+// | 2 | 等价类划分：真实/null 委托目标；空/典型绘制区域 | 完成 |
+// | 3 | 边界值显式覆盖：(0,0) 空矩形与典型矩形 | 完成 |
+// | 4 | TEST_P：无 ≥3 组同质输入（委托断言逻辑单一） | N/A |
+// | 5 | 分支清单已列出并映射用例 | N/A（无控制流分支） |
+// | 6 | 每条 if 分支有触发用例 | N/A |
+// | 7 | 异常路径：无 throw | N/A |
+// | 8 | 负面场景：null 委托目标构造不崩溃 | 完成 |
+// | 9 | 强异常安全：不适用 | N/A |
+// | 10 | stub 选择：项目内具体类 → stub_ext | 完成 |
+//
+// 分支清单（来源：codeflodarea.cpp）：无控制流分支（构造存指针 + 绘制纯委托）。
+//
+// 用例映射：
+// - Construction_StoresLeftAreaWidget                  → ctor
+// - Construction_NullLeftArea_NoCrash                  → ctor 负面
+// - PaintEvent_DelegatesToCodeFlodAreaPaintEvent       → paintEvent 委托计数
+// - PaintEvent_EmptyRect_DelegatesWithoutCrash         → 空矩形边界
+// - PaintEvent_GrabRendering_DelegatesOnce             → 真实渲染通道
+
+#include <gtest/gtest.h>
+#include "stubext.h"
+#include "codeflodarea.h"
+#include "leftareaoftextedit.h"
+#include "dtextedit.h"
+
+#include <QApplication>
+#include <QDebug>
+#include <QPaintEvent>
+
+namespace {
+
+TextEdit *const kFakeEdit = reinterpret_cast<TextEdit *>(quintptr(0x1000));
+
+} // namespace
+
+class CodeFlodAreaTest : public ::testing::Test {
+protected:
+    static void SetUpTestSuite()
+    {
+        if (QApplication::instance() == nullptr) {
+            static int argc = 1;
+            static char appName[] = "test_codeflodarea";
+            static char *argv[] = { appName, nullptr };
+            s_app = new QApplication(argc, argv);
+        }
+    }
+
+    static void TearDownTestSuite() {}
+
+    void SetUp() override
+    {
+        flodPaintCalls = 0;
+
+        // LeftAreaTextEdit 构造 qDebug 流式输出 fake TextEdit* → 拦截 QWidget 流式运算符
+        stub.set_lamda(static_cast<QDebug (*)(QDebug, const QWidget *)>(&operator<<),
+                       [](QDebug d, const QWidget *) -> QDebug { return d; });
+        stub.set_lamda(&LeftAreaTextEdit::codeFlodAreaPaintEvent,
+                       [this](LeftAreaTextEdit *, QPaintEvent *) { ++flodPaintCalls; });
+
+        leftArea = new LeftAreaTextEdit(kFakeEdit);
+        obj = new CodeFlodArea(leftArea);
+        ASSERT_NE(obj, nullptr);
+    }
+
+    void TearDown() override
+    {
+        delete obj;
+        obj = nullptr;
+        delete leftArea;
+        leftArea = nullptr;
+        stub.clear();
+    }
+
+    static QApplication *s_app;
+
+    stub_ext::StubExt stub;
+    LeftAreaTextEdit *leftArea = nullptr;
+    CodeFlodArea *obj = nullptr;
+    int flodPaintCalls = 0;
+};
+
+QApplication *CodeFlodAreaTest::s_app = nullptr;
+
+TEST_F(CodeFlodAreaTest, Construction_StoresLeftAreaWidget)
+{
+    // Assert：持有委托目标
+    EXPECT_EQ(obj->m_pLeftAreaWidget, leftArea);
+    EXPECT_EQ(obj->m_pLeftAreaWidget->getEdit(), kFakeEdit);
+}
+
+TEST_F(CodeFlodAreaTest, Construction_NullLeftArea_NoCrash)
+{
+    // Arrange/Act：null 委托目标（负面场景）
+    CodeFlodArea nullArea(nullptr);
+
+    // Assert
+    EXPECT_EQ(nullArea.m_pLeftAreaWidget, nullptr);
+    EXPECT_FALSE(nullArea.isVisible());
+}
+
+TEST_F(CodeFlodAreaTest, PaintEvent_DelegatesToCodeFlodAreaPaintEvent)
+{
+    // Arrange
+    QPaintEvent event(QRect(0, 0, 16, 300));
+
+    // Act：paintEvent 为 public，直接调用
+    obj->paintEvent(&event);
+
+    // Assert：精确转发一次；重复调用计数累加
+    EXPECT_EQ(flodPaintCalls, 1);
+    obj->paintEvent(&event);
+    EXPECT_EQ(flodPaintCalls, 2);
+}
+
+TEST_F(CodeFlodAreaTest, PaintEvent_EmptyRect_DelegatesWithoutCrash)
+{
+    // Arrange：空矩形边界
+    QPaintEvent event(QRect(0, 0, 0, 0));
+
+    // Act
+    obj->paintEvent(&event);
+
+    // Assert：空区域仍走委托链；重复调用计数累加（委托可重复）
+    EXPECT_EQ(flodPaintCalls, 1);
+    obj->paintEvent(&event);
+    EXPECT_EQ(flodPaintCalls, 2);
+}
+
+TEST_F(CodeFlodAreaTest, PaintEvent_GrabRendering_DelegatesOnce)
+{
+    // Arrange
+    obj->resize(16, 300);
+
+    // Act
+    const QPixmap pm = obj->grab();
+
+    // Assert
+    EXPECT_EQ(flodPaintCalls, 1);
+    EXPECT_EQ(pm.size(), QSize(16, 300));
+}

--- a/tests/editor_areas/test_flashtween.cpp
+++ b/tests/editor_areas/test_flashtween.cpp
@@ -1,0 +1,478 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// FlashTween（src/editor/FlashTween.h/.cpp）单元测试 —— 补间动画纯逻辑类（重点 100%）
+//
+// 类特征：QObject 子类（非 GUI），两个 QTimer 驱动 X/Y 轴惯性滑动。
+// 时间轴由 CELL_TIME=15ms 步进；__runX/__runY 为 private 槽，缓动函数为
+// private static —— 测试 TU 以 -fno-access-control 直接驱动（不依赖真实事件循环，
+// 确定性验证时间轴推进/完成停止/方向符号）。sinusoidalEaseOut 以 3.14 为 π 近似，
+// 期望值按源算法文档（Tween 缓动公式）独立计算。
+//
+// 方法清单完成情况（test-types §8）：
+// | 1 | 公开方法 ≥1 用例：ctor/dtor/startX/startY/stopX/stopY/activeX/activeY + 私有槽/缓动函数（间接直驱） | 完成 |
+// | 2 | 等价类划分：变化量 c=0/c>0/c<0；时长 d=0/d>0；t=0/t=d/t>d 边界 | 完成 |
+// | 3 | 边界值显式覆盖：t=0、t=d、t 越过 d、c=0、d=0 | 完成 |
+// | 4 | TEST_P 参数化（≥3 组同质输入）：缓动端点、bounce 分段、启动守卫 | 完成 |
+// | 5 | 分支清单已列出并映射用例 | 完成（见下） |
+// | 6 | 每条 if 分支有触发用例 | 完成 |
+// | 7 | 异常路径：无 throw，无异常分支 | N/A |
+// | 8 | 负面场景：c=0/d=0 守卫提前返回、方向为负 | 完成 |
+// | 9 | 强异常安全：守卫返回后状态未被污染（时间/回调计数断言） | 完成 |
+// | 10 | stub 选择：无外部依赖（QTimer 不启动事件循环即不触发），无需 stub | N/A |
+//
+// 分支清单（来源：FlashTween.cpp / FlashTween.h）：
+// startY/startX：
+//   B1: c==0.0 提前 return（定时器不启动）
+//   B2: d==0.0 提前 return（定时器不启动）
+//   B3: m_changeValue<0 → direction=+1（负向变化）
+//   B4: m_changeValue>=0 → direction=-1（正向变化）
+//   B5/B6: m_timerX/Y 判空保护（正常构造恒非空，走非空分支）
+// __runY/__runX：
+//   B7: currentTime < duration → 步进 CELL_TIME
+//   B8: currentTime >= duration → 停止定时器
+// bounceEaseOut：
+//   B9:  t/d < 1/2.75      B10: t/d < 2/2.75
+//   B11: t/d < 2.5/2.75    B12: else
+// 缓动端点：t=0 → b；t=d → b+c（各公式）
+//
+// 用例映射：
+// - Constructor_TwoTimersCreated_InactiveInitially            → ctor（B5/B6 非空分支）
+// - StartAxis_ZeroChangeOrZeroDuration_GuardReturnsEarly /*TEST_P*/ → B1+B2
+// - StartX_NormalChange_TimerBecomesActive                    → B4(X)/B5
+// - StartY_NegativeChange_TimerBecomesActive                  → B3(Y)/B6
+// - StopX_AfterStart_DeactivatesTimer / StopY_...             → stopX/stopY
+// - StopAxes_BeforeAnyStart_InactiveAndNoCrash                → 停止幂等
+// - RunY_FirstTick_InvokesCallbackWithZeroDelta               → B7(Y) t=0
+// - RunY_MidTick_InvokesCallbackWithSinusoidalDelta           → B7(Y) t=15
+// - RunY_NegativeChange_CallbackDeltaPositive                 → B3(Y) 符号
+// - RunY_ReachesDuration_StopsTimer                           → B8(Y)
+// - RunX_FirstTick_InvokesCallback / RunX_ReachesDuration_StopsTimer → B7/B8(X)
+// - EasingEndpoints_StandardFormulas_HitBoundaries /*TEST_P*/  → 端点 b / b+c
+// - BounceEaseOut_FourSegments_MatchFormula /*TEST_P*/         → B9~B12
+// - Destructor_ScopeExit_DeletesOwnedTimers                   → dtor
+
+#include <gtest/gtest.h>
+#include "FlashTween.h"
+
+#include <QCoreApplication>
+#include <QTimer>
+#include <cmath>
+
+namespace {
+
+// 缓动公式指针表（private static，经 -fno-access-control 取址）
+using EaseFn = qreal (*)(qreal, qreal, qreal, qreal);
+
+struct EaseFnCase {
+    EaseFn fn;
+    const char *name;
+};
+
+} // namespace
+
+class FlashTweenTest : public ::testing::Test {
+protected:
+    static void SetUpTestSuite()
+    {
+        // FlashTween 为 QObject 子类（非 GUI），QTimer 仅需 QCoreApplication；
+        // 不运行事件循环 → 定时器不派发 timeout，时间轴由测试直驱，确定性
+        if (QCoreApplication::instance() == nullptr) {
+            static int argc = 1;
+            static char appName[] = "test_flashtween";
+            static char *argv[] = { appName, nullptr };
+            s_app = new QCoreApplication(argc, argv);
+        }
+    }
+
+    static void TearDownTestSuite()
+    {
+        // QCoreApplication 保留至进程退出
+    }
+
+    void SetUp() override
+    {
+        callCountY = 0;
+        callCountX = 0;
+        lastDeltaY = 12345.0;   // 哨兵：未回调时可区分
+        lastDeltaX = 12345.0;
+        obj = new FlashTween();
+        ASSERT_NE(obj, nullptr);
+
+        // 惯性回调：记录次数与最近一次增量（stub 模式 §16b/16a）
+        fnY = [this](qreal diff) {
+            ++callCountY;
+            lastDeltaY = diff;
+        };
+        fnX = [this](qreal diff) {
+            ++callCountX;
+            lastDeltaX = diff;
+        };
+    }
+
+    void TearDown() override
+    {
+        delete obj;
+        obj = nullptr;
+    }
+
+    static QCoreApplication *s_app;
+
+    FlashTween *obj = nullptr;
+    FunSlideInertial fnY;
+    FunSlideInertial fnX;
+    int callCountY = 0;
+    int callCountX = 0;
+    qreal lastDeltaY = 0;
+    qreal lastDeltaX = 0;
+};
+
+QCoreApplication *FlashTweenTest::s_app = nullptr;
+
+TEST_F(FlashTweenTest, Constructor_TwoTimersCreated_InactiveInitially)
+{
+    // Arrange/Act 在 SetUp 完成（构造）
+
+    // Assert：两个定时器均已创建且未激活（构造无副作用）
+    ASSERT_NE(obj->m_timerX, nullptr);
+    ASSERT_NE(obj->m_timerY, nullptr);
+    EXPECT_FALSE(obj->m_timerX->isActive());
+    EXPECT_FALSE(obj->m_timerY->isActive());
+    // 对应公开查询接口与内部状态一致；未 start 前间隔保持默认 0
+    EXPECT_FALSE(obj->activeX());
+    EXPECT_FALSE(obj->activeY());
+    EXPECT_EQ(obj->m_timerX->interval(), 0);
+    EXPECT_EQ(obj->m_timerY->interval(), 0);
+}
+
+// ---- startY/startX 守卫分支（B1/B2）：TEST_P 同质输入参数化 ----
+struct StartGuardCase {
+    bool useXAxis;
+    qreal change;
+    qreal duration;
+    const char *desc;
+};
+
+class FlashTweenStartGuardTest : public FlashTweenTest,
+                                 public ::testing::WithParamInterface<StartGuardCase> {
+};
+
+TEST_P(FlashTweenStartGuardTest, StartAxis_ZeroChangeOrZeroDuration_GuardReturnsEarly)
+{
+    const StartGuardCase &c = GetParam();
+
+    // Act：c==0 或 d==0 触发守卫提前返回
+    if (c.useXAxis)
+        obj->startX(0, 0, c.change, c.duration, fnX);
+    else
+        obj->startY(0, 0, c.change, c.duration, fnY);
+
+    // Assert：定时器未启动（B1/B2 分支：直接 return）
+    EXPECT_FALSE(obj->activeX());
+    EXPECT_FALSE(obj->activeY());
+    // 强异常安全：守卫路径不触碰时间轴状态（t 保持 0，回调未发出）
+    EXPECT_EQ(obj->m_currentTimeX, 0);
+    EXPECT_EQ(obj->m_currentTimeY, 0);
+    EXPECT_EQ(callCountX + callCountY, 0);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    StartGuardCases,
+    FlashTweenStartGuardTest,
+    ::testing::Values(
+        StartGuardCase{ false, 0.0, 100.0, "Y轴 c=0" },      // B1(Y)
+        StartGuardCase{ false, 100.0, 0.0, "Y轴 d=0" },      // B2(Y)
+        StartGuardCase{ true, 0.0, 100.0, "X轴 c=0" },       // B1(X)
+        StartGuardCase{ true, 100.0, 0.0, "X轴 d=0" }));     // B2(X)
+
+TEST_F(FlashTweenTest, StartY_NormalChange_TimerBecomesActive)
+{
+    // Act：正向变化 c=100 → direction=-1（B4）
+    obj->startY(0, 0, 100.0, 30.0, fnY);
+
+    // Assert：定时器以 CELL_TIME 启动
+    EXPECT_TRUE(obj->activeY());
+    EXPECT_EQ(obj->m_timerY->interval(), CELL_TIME);
+    EXPECT_EQ(obj->m_changeValueY, 100.0);
+    EXPECT_EQ(obj->m_directionY, -1);    // 正向变化 → 方向 -1
+    EXPECT_EQ(callCountY, 0);            // 未处理事件，回调尚未发出
+}
+
+TEST_F(FlashTweenTest, StartX_NormalChange_TimerBecomesActive)
+{
+    // Act
+    obj->startX(0, 0, 100.0, 30.0, fnX);
+
+    // Assert
+    EXPECT_TRUE(obj->activeX());
+    EXPECT_EQ(obj->m_timerX->interval(), CELL_TIME);
+    EXPECT_EQ(obj->m_directionX, -1);
+}
+
+TEST_F(FlashTweenTest, StartY_NegativeChange_DirectionFlipsToPositive)
+{
+    // Act：负向变化 c=-100 → direction=+1（B3）
+    obj->startY(0, 0, -100.0, 30.0, fnY);
+
+    // Assert
+    EXPECT_TRUE(obj->activeY());
+    EXPECT_EQ(obj->m_changeValueY, -100.0);
+    EXPECT_EQ(obj->m_directionY, 1);     // 负向变化 → 方向 +1
+}
+
+TEST_F(FlashTweenTest, StopX_AfterStart_DeactivatesTimer)
+{
+    // Arrange
+    obj->startX(0, 0, 100.0, 30.0, fnX);
+    ASSERT_TRUE(obj->activeX());
+
+    // Act
+    obj->stopX();
+
+    // Assert
+    EXPECT_FALSE(obj->activeX());
+    // X 轴停止不影响回调（stop 不驱动动画帧）
+    EXPECT_EQ(callCountX, 0);
+    // Y 轴不受影响（轴间隔离）
+    EXPECT_FALSE(obj->activeY());
+}
+
+TEST_F(FlashTweenTest, StopY_AfterStart_DeactivatesTimer)
+{
+    // Arrange
+    obj->startY(0, 0, 100.0, 30.0, fnY);
+    ASSERT_TRUE(obj->activeY());
+
+    // Act
+    obj->stopY();
+
+    // Assert
+    EXPECT_FALSE(obj->activeY());
+    EXPECT_EQ(obj->m_timerY->isActive() == false, true);
+    EXPECT_EQ(callCountY, 0);   // stop 不驱动动画帧
+}
+
+TEST_F(FlashTweenTest, StopAxes_BeforeAnyStart_InactiveAndIdempotent)
+{
+    // Act：从未启动直接 stop（QTimer::stop 幂等）
+    obj->stopX();
+    obj->stopY();
+
+    // Assert：状态保持非激活、不崩溃
+    EXPECT_FALSE(obj->activeX());
+    EXPECT_FALSE(obj->activeY());
+    EXPECT_EQ(callCountX + callCountY, 0);
+}
+
+TEST_F(FlashTweenTest, RunY_FirstTick_InvokesCallbackWithZeroDelta)
+{
+    // Arrange：t=0,b=0,c=100,d=30；sin(0)=0 → 首拍增量为 0
+    obj->startY(0, 0, 100.0, 30.0, fnY);
+
+    // Act：直驱私有槽（不依赖事件循环）
+    obj->__runY();
+
+    // Assert：回调发出且增量按公式 -direction*(v-0)=0（sin(0)=0）
+    EXPECT_EQ(callCountY, 1);
+    EXPECT_NEAR(lastDeltaY, 0.0, 1e-9);
+    // 时间轴推进 CELL_TIME（B7）
+    EXPECT_EQ(obj->m_currentTimeY, CELL_TIME);
+    EXPECT_TRUE(obj->activeY());
+}
+
+TEST_F(FlashTweenTest, RunY_MidTick_InvokesCallbackWithSinusoidalDelta)
+{
+    // Arrange：推进到 t=15 后再拍一拍
+    obj->startY(0, 0, 100.0, 30.0, fnY);
+    obj->__runY();   // t: 0 → 15，v(0)=0
+
+    // Act：t=15 → v=100*sin(15/30*3.14/2)=100*sin(0.785)
+    obj->__runY();
+
+    // Assert：增量 = direction*(v - v_prev) = -1*(100*sin(0.785) - 0)
+    const qreal expected = -1.0 * (100.0 * std::sin(0.785));
+    EXPECT_EQ(callCountY, 2);
+    EXPECT_NEAR(lastDeltaY, expected, 1e-9);
+    EXPECT_EQ(obj->m_currentTimeY, 30);   // 15 + CELL_TIME
+}
+
+TEST_F(FlashTweenTest, RunY_NegativeChange_CallbackDeltaPositive)
+{
+    // Arrange：c=-100 → direction=+1，ease 用 abs(c)
+    obj->startY(0, 0, -100.0, 30.0, fnY);
+
+    // Act：t=15 一拍
+    obj->__runY();
+    obj->__runY();
+
+    // Assert：增量 = +1*(100*sin(0.785) - 0)，符号随方向翻转
+    const qreal expected = 1.0 * (100.0 * std::sin(0.785));
+    EXPECT_EQ(callCountY, 2);
+    EXPECT_NEAR(lastDeltaY, expected, 1e-9);
+}
+
+TEST_F(FlashTweenTest, RunY_ReachesDuration_StopsTimer)
+{
+    // Arrange：完整时间轴 t=0,15,30 共三拍
+    obj->startY(0, 0, 100.0, 30.0, fnY);
+    obj->__runY();   // t=0  → 15
+    obj->__runY();   // t=15 → 30
+
+    // Act：t=30 == duration → 完成分支（B8）
+    obj->__runY();
+
+    // Assert：定时器停止、时间轴停在 d、终值 = b+c*sin(1.57)（3.14 近似 π 的精确 oracle）
+    EXPECT_FALSE(obj->activeY());
+    EXPECT_EQ(obj->m_currentTimeY, 30);
+    EXPECT_NEAR(obj->m_lastValueY, 100.0 * std::sin(1.57), 1e-9);
+    EXPECT_EQ(callCountY, 3);
+}
+
+TEST_F(FlashTweenTest, RunY_PastDuration_DoesNotAdvanceFurther)
+{
+    // Arrange：动画完成后继续拍（t 不再推进、定时器保持停止）
+    obj->startY(0, 0, 100.0, 30.0, fnY);
+    obj->__runY();
+    obj->__runY();
+    obj->__runY();
+    ASSERT_FALSE(obj->activeY());
+
+    // Act：越界后的额外 tick（t>d 边界）
+    obj->__runY();
+
+    // Assert：时间冻结、回调仍发出（终值不变 → 增量 0）
+    EXPECT_EQ(obj->m_currentTimeY, 30);
+    EXPECT_NEAR(lastDeltaY, 0.0, 1e-9);
+    EXPECT_EQ(callCountY, 4);
+}
+
+TEST_F(FlashTweenTest, RunX_FirstTick_InvokesCallbackWithZeroDelta)
+{
+    // Arrange
+    obj->startX(0, 0, 100.0, 30.0, fnX);
+
+    // Act
+    obj->__runX();
+
+    // Assert
+    EXPECT_EQ(callCountX, 1);
+    EXPECT_NEAR(lastDeltaX, 0.0, 1e-9);
+    EXPECT_EQ(obj->m_currentTimeX, CELL_TIME);
+    EXPECT_TRUE(obj->activeX());
+}
+
+TEST_F(FlashTweenTest, RunX_ReachesDuration_StopsTimer)
+{
+    // Arrange
+    obj->startX(0, 0, 100.0, 30.0, fnX);
+    obj->__runX();
+    obj->__runX();
+
+    // Act：完成拍（B8-X）
+    obj->__runX();
+
+    // Assert
+    EXPECT_FALSE(obj->activeX());
+    EXPECT_EQ(obj->m_currentTimeX, 30);
+    EXPECT_NEAR(obj->m_lastValueX, 100.0 * std::sin(1.57), 1e-9);
+    EXPECT_EQ(callCountX, 3);
+}
+
+// ---- 缓动函数端点（标准公式：t=0 → b；t=d → b+c）----
+class FlashTweenEasingTest : public FlashTweenTest,
+                             public ::testing::WithParamInterface<EaseFnCase> {
+};
+
+TEST_P(FlashTweenEasingTest, EasingEndpoints_StandardFormulas_HitBoundaries)
+{
+    const EaseFnCase &c = GetParam();
+    const qreal b = 20.0;
+    const qreal change = 60.0;
+    const qreal d = 300.0;
+
+    // Assert：起点 t=0 精确回到 b
+    EXPECT_NEAR(c.fn(0.0, b, change, d), b, 1e-9);
+    // Assert：终点 t=d 回到 b+c（sinusoidal 以 3.14 近似 π，容差放宽到 1e-3）
+    EXPECT_NEAR(c.fn(d, b, change, d), b + change, 1e-3);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    EasingCases,
+    FlashTweenEasingTest,
+    ::testing::Values(
+        EaseFnCase{ &FlashTween::quadraticEaseOut, "quadratic" },
+        EaseFnCase{ &FlashTween::cubicEaseOut, "cubic" },
+        EaseFnCase{ &FlashTween::quarticEaseOut, "quartic" },
+        EaseFnCase{ &FlashTween::quinticEaseOut, "quintic" },
+        EaseFnCase{ &FlashTween::sinusoidalEaseOut, "sinusoidal" },
+        EaseFnCase{ &FlashTween::circularEaseOut, "circular" }));
+
+// ---- bounceEaseOut 四段分支（B9~B12）----
+struct BounceCase {
+    qreal fraction;      // t/d
+    qreal expected;      // 归一化期望值（c=1,b=0,d=1）
+};
+
+class FlashTweenBounceTest : public FlashTweenTest,
+                             public ::testing::WithParamInterface<BounceCase> {
+};
+
+TEST_P(FlashTweenBounceTest, BounceEaseOut_FourSegments_MatchFormula)
+{
+    const BounceCase &c = GetParam();
+    const qreal b = 5.0;
+    const qreal change = 80.0;
+    const qreal d = 400.0;
+
+    // Act：按段内公式独立计算期望值
+    const qreal t = c.fraction;
+    qreal normalized = 0.0;
+    if (t < (1 / 2.75)) {
+        normalized = 7.5625 * t * t;                                        // B9
+    } else if (t < (2 / 2.75)) {
+        const qreal u = t - (1.5 / 2.75);
+        normalized = 7.5625 * u * u + .75;                                  // B10
+    } else if (t < (2.5 / 2.75)) {
+        const qreal u = t - (2.25 / 2.75);
+        normalized = 7.5625 * u * u + .9375;                                // B11
+    } else {
+        const qreal u = t - (2.625 / 2.75);
+        normalized = 7.5625 * u * u + .984375;                              // B12
+    }
+    const qreal expected = b + change * normalized;
+
+    // Assert：bounceEaseOut(t/d 分段) 精确命中各段公式
+    EXPECT_NEAR(FlashTween::bounceEaseOut(t * d, b, change, d), expected, 1e-9);
+    // 端点连续性补充断言：t=0 → b
+    EXPECT_NEAR(FlashTween::bounceEaseOut(0.0, b, change, d), b, 1e-9);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    BounceCases,
+    FlashTweenBounceTest,
+    ::testing::Values(
+        BounceCase{ 0.10, 0.0 },   // B9:  0.10 < 0.3636
+        BounceCase{ 0.50, 0.0 },   // B10: 0.3636 <= 0.50 < 0.7273
+        BounceCase{ 0.76, 0.0 },   // B11: 0.7273 <= 0.76 < 0.9091
+        BounceCase{ 0.95, 0.0 })); // B12: >= 0.9091
+
+TEST_F(FlashTweenTest, Destructor_ScopeExit_DeletesOwnedTimers)
+{
+    // Arrange：内部定时器指针记录（析构后不可再读）
+    QTimer *timerX = obj->m_timerX;
+    QTimer *timerY = obj->m_timerY;
+    ASSERT_NE(timerX, nullptr);
+    ASSERT_NE(timerY, nullptr);
+
+    // Act：作用域析构
+    delete obj;
+    obj = nullptr;
+
+    // Assert：析构无崩溃；重建对象得到全新定时器（旧指针未被复用即视为已释放）
+    FlashTween *fresh = new FlashTween();
+    EXPECT_NE(fresh->m_timerX, timerX);
+    EXPECT_NE(fresh->m_timerY, timerY);
+    EXPECT_FALSE(fresh->activeX());
+    EXPECT_FALSE(fresh->activeY());
+    delete fresh;
+}

--- a/tests/editor_areas/test_leftareatextedit.cpp
+++ b/tests/editor_areas/test_leftareatextedit.cpp
@@ -1,0 +1,358 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// LeftAreaTextEdit（src/editor/leftareaoftextedit.h/.cpp）单元测试
+//
+// 类特征：QWidget（GUI），构造仅持有 TextEdit 指针不解引用；三个子区域
+// （行号/书签/折叠）在构造时创建。TextEdit 为重依赖具体类（非虚接口），
+// 按 stub 决策矩阵用 fake 指针 + stub_ext 拦截其全部被调方法：
+//   lineNumberAreaPaintEvent / bookMarkAreaPaintEvent / codeFLodAreaPaintEvent /
+//   getBackColor / onPressedLineNumber / QPlainTextEdit::document
+// 构造/QWidget 行为在 QT_QPA_PLATFORM=offscreen 下真实执行。
+//
+// 方法清单完成情况（test-types §8）：
+// | 1 | 公开方法 ≥1 用例：ctor/dtor/getEdit/lineNumberAreaPaintEvent/lineNumberAreaWidth/
+//     bookMarkAreaPaintEvent/codeFlodAreaPaintEvent/updateLineNumber/updateBookMark/
+//     updateCodeFlod/updateAll/paintEvent(protected 直驱) | 完成 |
+// | 2 | 等价类划分：行数 1~9/10~99/100~999/1000+；背景亮/暗；子区域空/非空 | 完成 |
+// | 3 | 边界值显式覆盖：blockCount 1/9/10/99/100/1000（进位边界） | 完成 |
+// | 4 | TEST_P 参数化（≥3 组同质输入）：lineNumberAreaWidth 行数 | 完成 |
+// | 5 | 分支清单已列出并映射用例 | 完成（见下） |
+// | 6 | 每条 if 分支有触发用例 | 完成 |
+// | 7 | 异常路径：无 throw | N/A |
+// | 8 | 负面场景：null TextEdit 构造、子区域指针置空守卫 | 完成 |
+// | 9 | 强异常安全：守卫分支不触发任何子区域重绘 | 完成 |
+// | 10 | stub 选择：Qt 内置类/项目内不可注入类 → stub_ext | 完成 |
+//
+// 分支清单（来源：leftareaoftextedit.cpp）：
+//   B1: max>=10 循环（位数计算，含 0 次与多次迭代）
+//   B2: getBackColor().lightness() < 128（暗背景 → alphaF 0.06）
+//   B3: else（亮背景 → alphaF 0.03）
+//   B4~B6: updateLineNumber/updateBookMark/updateCodeFlod 的子区域判空守卫
+//   B7~B9: updateAll 的三个子区域判空守卫
+//
+// 用例映射：
+// - Construction_WithNullEdit_CreatesThreeChildAreas        → ctor
+// - GetEdit_ReturnsInjectedEditPointer                      → getEdit
+// - LineNumberAreaWidth_BlockCounts_ComputeDigits /*TEST_P*/ → B1
+// - PaintDelegation_ThreeAreas_ForwardToEdit                → 三个委托方法
+// - PaintEvent_DarkBackground_FillsWithAlpha006             → B2
+// - PaintEvent_LightBackground_FillsWithAlpha003            → B3
+// - UpdateLineNumber_OnlyLineAreaRepainted                  → B4 真
+// - UpdateBookMark_OnlyBookMarkRepainted                    → B5 真
+// - UpdateCodeFlod_OnlyFlodAreaRepainted                    → B6 真
+// - UpdateAll_AllThreeAreasRepainted                        → B7~B9 真
+// - UpdateMethods_NullChildGuard_NoRepaintNoCrash           → B4~B9 假
+
+#include <gtest/gtest.h>
+#include "stubext.h"
+#include "leftareaoftextedit.h"
+#include "dtextedit.h"
+
+#include <QApplication>
+#include <QDebug>
+#include <QTextEdit>
+#include <QPlainTextEdit>
+#include <QPaintEvent>
+#include <QPainter>
+#include <QHBoxLayout>
+#include <QImage>
+#include <climits>
+
+namespace {
+
+// fake TextEdit 指针：构造仅存储不解引用；所有被调方法均被 stub 拦截
+TextEdit *const kFakeEdit = reinterpret_cast<TextEdit *>(quintptr(0x1000));
+
+} // namespace
+
+class LeftAreaTextEditTest : public ::testing::Test {
+protected:
+    static void SetUpTestSuite()
+    {
+        // QWidget 子类：offscreen QApplication（Wave1 已验证无头构造可行）
+        if (QApplication::instance() == nullptr) {
+            static int argc = 1;
+            static char appName[] = "test_leftareatextedit";
+            static char *argv[] = { appName, nullptr };
+            s_app = new QApplication(argc, argv);
+        }
+    }
+
+    static void TearDownTestSuite() {}
+
+    void SetUp() override
+    {
+        paintLineCalls = 0;
+        paintBookMarkCalls = 0;
+        paintFlodCalls = 0;
+        capturedFillColors.clear();
+        updateCounts.clear();
+
+        doc = std::make_unique<QTextDocument>();
+
+        // 源码构造/各方法 qDebug 会流式输出 TextEdit*(QWidget*)：
+        // operator<<(QDebug, QWidget*) 会解引用取 metaObject → fake 指针会被解引用，
+        // 拦截该流式运算符保证日志安全（返回流本身，行为等价静默）
+        stub.set_lamda(static_cast<QDebug (*)(QDebug, const QWidget *)>(&operator<<),
+                       [](QDebug d, const QWidget *) -> QDebug { return d; });
+
+        // ---- stub 矩阵（TearDown 统一 clear） ----
+        // TextEdit 委托目标（本项目具体类、不可注入 → stub_ext）
+        stub.set_lamda(&TextEdit::lineNumberAreaPaintEvent,
+                       [this](TextEdit *, QPaintEvent *) { ++paintLineCalls; });
+        stub.set_lamda(&TextEdit::bookMarkAreaPaintEvent,
+                       [this](TextEdit *, QPaintEvent *) { ++paintBookMarkCalls; });
+        stub.set_lamda(&TextEdit::codeFLodAreaPaintEvent,
+                       [this](TextEdit *, QPaintEvent *) { ++paintFlodCalls; });
+        // 背景色由测试注入（分支 B2/B3）
+        stub.set_lamda(&TextEdit::getBackColor,
+                       [this](TextEdit *) -> QColor { return injectedBackColor; });
+        // lineNumberAreaWidth 经 document()->blockCount() 取行数 → 喂入受控文档
+        stub.set_lamda(&QPlainTextEdit::document,
+                       [this](QPlainTextEdit *) -> QTextDocument * { return doc.get(); });
+        // 子区域重绘调度计数（update() 无参重载）
+        stub.set_lamda(static_cast<void (QWidget::*)()>(&QWidget::update),
+                       [this](QWidget *w) { ++updateCounts[w]; });
+        // paintEvent 填充色捕获（验证 B2/B3 的 alphaF 分支值）
+        stub.set_lamda(
+            static_cast<void (QPainter::*)(const QRect &, const QColor &)>(&QPainter::fillRect),
+            [this](QPainter *, const QRect &, const QColor &c) {
+                capturedFillColors.append(c);
+            });
+
+        injectedBackColor = QColor(10, 10, 10);   // 默认暗背景
+        obj = new LeftAreaTextEdit(kFakeEdit);
+        ASSERT_NE(obj, nullptr);
+    }
+
+    void TearDown() override
+    {
+        delete obj;
+        obj = nullptr;
+        stub.clear();
+    }
+
+    static QApplication *s_app;
+
+    // 生成 blockCount 个块的文档（N-1 个换行符）
+    void makeDocWithBlocks(int blockCount)
+    {
+        doc = std::make_unique<QTextDocument>();
+        if (blockCount > 1)
+            doc->setPlainText(QString(blockCount - 1, QChar('\n')));
+        ASSERT_EQ(doc->blockCount(), blockCount);
+    }
+
+    int updatesOf(const QWidget *w) const { return updateCounts.value(const_cast<QWidget *>(w), 0); }
+
+    stub_ext::StubExt stub;
+    LeftAreaTextEdit *obj = nullptr;
+    std::unique_ptr<QTextDocument> doc;
+    QColor injectedBackColor;
+
+    int paintLineCalls = 0;
+    int paintBookMarkCalls = 0;
+    int paintFlodCalls = 0;
+    QVector<QColor> capturedFillColors;
+    QMap<QWidget *, int> updateCounts;
+
+    // 在捕获列表中查找"基色=期望 rgb 且 alphaF≈期望值"的填充
+    //（Qt6 QColor alpha 按 8bit 量化往返，0.06→0.0599985，容差取 1e-4 仍可区分 0.06/0.03）
+    bool containsFill(const QColor &expectRgb, qreal expectAlpha) const
+    {
+        for (const QColor &c : capturedFillColors) {
+            if (c.rgb() == expectRgb.rgb() && qAbs(c.alphaF() - expectAlpha) < 1e-4)
+                return true;
+        }
+        return false;
+    }
+};
+
+QApplication *LeftAreaTextEditTest::s_app = nullptr;
+
+TEST_F(LeftAreaTextEditTest, Construction_WithNullEdit_CreatesThreeChildAreas)
+{
+    // Arrange：null TextEdit（构造仅存指针，负面场景）
+    LeftAreaTextEdit area(nullptr);
+
+    // Assert：三个子区域全部创建并接入布局（负面输入不破坏构造）
+    ASSERT_NE(area.m_pLineNumberArea, nullptr);
+    ASSERT_NE(area.m_pBookMarkArea, nullptr);
+    ASSERT_NE(area.m_pFlodArea, nullptr);
+    EXPECT_EQ(area.getEdit(), nullptr);
+    EXPECT_NE(area.layout(), nullptr);
+    // 布局零边距零间距（区域紧贴排布约定）
+    auto *lay = static_cast<QHBoxLayout *>(area.layout());
+    EXPECT_EQ(lay->contentsMargins(), QMargins(0, 0, 0, 0));
+    EXPECT_EQ(lay->spacing(), 0);
+}
+
+TEST_F(LeftAreaTextEditTest, GetEdit_ReturnsInjectedEditPointer)
+{
+    // Arrange 在 SetUp（注入 kFakeEdit）
+
+    // Act & Assert：原样返回注入指针
+    EXPECT_EQ(obj->getEdit(), kFakeEdit);
+    // 独立实例互不影响（指针隔离）
+    LeftAreaTextEdit other(nullptr);
+    EXPECT_EQ(other.getEdit(), nullptr);
+}
+
+// ---- lineNumberAreaWidth 位数计算（B1 循环：0 次/1 次/多次迭代）----
+struct BlockCountCase {
+    int blockCount;
+};
+
+class LeftAreaWidthTest : public LeftAreaTextEditTest,
+                          public ::testing::WithParamInterface<BlockCountCase> {
+};
+
+TEST_P(LeftAreaWidthTest, LineNumberAreaWidth_BlockCounts_ComputeDigits)
+{
+    const BlockCountCase &c = GetParam();
+
+    // Arrange：受控文档喂入指定行数
+    makeDocWithBlocks(c.blockCount);
+    const int digits = QString::number(qMax(1, c.blockCount)).length();   // 位数独立 oracle
+    const int advance = obj->fontMetrics().horizontalAdvance(QLatin1Char('9'));
+
+    // Act
+    const int width = obj->lineNumberAreaWidth();
+
+    // Assert：13 + 9 宽度*位数 + 40（源算法），进位边界逐点验证
+    EXPECT_EQ(width, 13 + advance * digits + 40);
+    // 分解断言：净宽（去固定内边距 53）= 单字符宽 × 位数
+    EXPECT_EQ(width - (13 + 40), advance * digits);
+    EXPECT_GT(width, 53);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    BlockCountCases,
+    LeftAreaWidthTest,
+    ::testing::Values(
+        BlockCountCase{ 1 },     // 下边界：单行（循环 0 次迭代）
+        BlockCountCase{ 9 },     // 边界：仍 1 位
+        BlockCountCase{ 10 },    // 边界：进位 2 位
+        BlockCountCase{ 99 },
+        BlockCountCase{ 100 },   // 进位 3 位
+        BlockCountCase{ 1000 })); // 进位 4 位
+
+TEST_F(LeftAreaTextEditTest, PaintDelegation_ThreeAreas_ForwardToEdit)
+{
+    // Arrange
+    QPaintEvent event(QRect(0, 0, 40, 120));
+
+    // Act：三个绘制委托依次触发
+    obj->lineNumberAreaPaintEvent(&event);
+    obj->bookMarkAreaPaintEvent(&event);
+    obj->codeFlodAreaPaintEvent(&event);
+
+    // Assert：每次调用精确转发到 TextEdit 对应方法一次
+    EXPECT_EQ(paintLineCalls, 1);
+    EXPECT_EQ(paintBookMarkCalls, 1);
+    EXPECT_EQ(paintFlodCalls, 1);
+}
+
+TEST_F(LeftAreaTextEditTest, PaintEvent_DarkBackground_FillsWithAlpha006)
+{
+    // Arrange：暗背景（lightness 10 < 128 → B2）
+    injectedBackColor = QColor(10, 10, 10);
+    obj->resize(60, 80);
+
+    // Act：真实渲染管线触发 paintEvent
+    const QPixmap pm = obj->grab();
+
+    // Assert：填充色 = brightText 且 alphaF=0.06
+    ASSERT_FALSE(capturedFillColors.isEmpty());
+    EXPECT_TRUE(containsFill(obj->palette().brightText().color(), 0.06));
+    // 渲染输出尺寸与部件一致
+    EXPECT_EQ(pm.size(), QSize(60, 80));
+}
+
+TEST_F(LeftAreaTextEditTest, PaintEvent_LightBackground_FillsWithAlpha003)
+{
+    // Arrange：亮背景（lightness 250 >= 128 → B3）
+    injectedBackColor = QColor(250, 250, 250);
+    obj->resize(60, 80);
+
+    // Act
+    const QPixmap pm = obj->grab();
+
+    // Assert：同一基色、alphaF 减半为 0.03
+    ASSERT_FALSE(capturedFillColors.isEmpty());
+    EXPECT_TRUE(containsFill(obj->palette().brightText().color(), 0.03));
+    EXPECT_EQ(pm.size(), QSize(60, 80));
+}
+
+TEST_F(LeftAreaTextEditTest, UpdateLineNumber_OnlyLineAreaRepainted)
+{
+    // Act
+    obj->updateLineNumber();
+
+    // Assert：仅行号区域被调度重绘（精确 1 次，其余区域 0 次）
+    EXPECT_EQ(updatesOf(obj->m_pLineNumberArea), 1);
+    EXPECT_EQ(updatesOf(obj->m_pBookMarkArea), 0);
+    EXPECT_EQ(updatesOf(obj->m_pFlodArea), 0);
+}
+
+TEST_F(LeftAreaTextEditTest, UpdateBookMark_OnlyBookMarkRepainted)
+{
+    // Act
+    obj->updateBookMark();
+
+    // Assert
+    EXPECT_EQ(updatesOf(obj->m_pBookMarkArea), 1);
+    EXPECT_EQ(updatesOf(obj->m_pLineNumberArea), 0);
+    EXPECT_EQ(updatesOf(obj->m_pFlodArea), 0);
+}
+
+TEST_F(LeftAreaTextEditTest, UpdateCodeFlod_OnlyFlodAreaRepainted)
+{
+    // Act
+    obj->updateCodeFlod();
+
+    // Assert
+    EXPECT_EQ(updatesOf(obj->m_pFlodArea), 1);
+    EXPECT_EQ(updatesOf(obj->m_pLineNumberArea), 0);
+    EXPECT_EQ(updatesOf(obj->m_pBookMarkArea), 0);
+}
+
+TEST_F(LeftAreaTextEditTest, UpdateAll_AllThreeAreasRepainted)
+{
+    // Act
+    obj->updateAll();
+
+    // Assert：三个区域各恰好 1 次
+    EXPECT_EQ(updatesOf(obj->m_pLineNumberArea), 1);
+    EXPECT_EQ(updatesOf(obj->m_pBookMarkArea), 1);
+    EXPECT_EQ(updatesOf(obj->m_pFlodArea), 1);
+}
+
+TEST_F(LeftAreaTextEditTest, UpdateMethods_NullChildGuard_NoRepaintNoCrash)
+{
+    // Arrange：子区域指针全部置空（覆盖判空守卫假分支，测后恢复）
+    LineNumberArea *lineArea = obj->m_pLineNumberArea;
+    BookMarkWidget *bookArea = obj->m_pBookMarkArea;
+    CodeFlodArea *flodArea = obj->m_pFlodArea;
+    obj->m_pLineNumberArea = nullptr;
+    obj->m_pBookMarkArea = nullptr;
+    obj->m_pFlodArea = nullptr;
+
+    // Act：守卫路径不应崩溃
+    obj->updateLineNumber();
+    obj->updateBookMark();
+    obj->updateCodeFlod();
+    obj->updateAll();
+
+    // Assert：强异常安全 —— 无任何子区域被调度重绘（真实区域 0 次）
+    EXPECT_EQ(updatesOf(lineArea), 0);
+    EXPECT_EQ(updatesOf(bookArea), 0);
+    EXPECT_EQ(updatesOf(flodArea), 0);
+
+    // Cleanup：恢复指针（TearDown 释放）
+    obj->m_pLineNumberArea = lineArea;
+    obj->m_pBookMarkArea = bookArea;
+    obj->m_pFlodArea = flodArea;
+    EXPECT_EQ(updatesOf(lineArea), 0);
+}

--- a/tests/editor_areas/test_linenumberarea.cpp
+++ b/tests/editor_areas/test_linenumberarea.cpp
@@ -1,0 +1,212 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// LineNumberArea（src/editor/linenumberarea.h/.cpp）单元测试
+//
+// 类特征：QWidget（GUI），持 LeftAreaTextEdit 指针委托绘制/点击。
+// 鼠标事件用 QMouseEvent 合成 + QApplication::sendEvent 真实派发；
+// paintEvent/sizeHint（protected）经 -fno-access-control 直驱并计数委托。
+//
+// 方法清单完成情况（test-types §8）：
+// | 1 | 公开方法 ≥1 用例：ctor/dtor/getPressPoint/paintEvent/sizeHint/mousePressEvent | 完成 |
+// | 2 | 等价类划分：行号宽度（行数位数）；鼠标左键/右键；坐标原点/典型值 | 完成 |
+// | 3 | 边界值显式覆盖：点击 (0,0) 原点与 (17,42) 典型点；行数进位边界 | 完成 |
+// | 4 | TEST_P 参数化（≥3 组同质输入）：鼠标按键类型 | 完成 |
+// | 5 | 分支清单已列出并映射用例 | 完成（见下） |
+// | 6 | 每条 if 分支有触发用例：无 if（委托链） | N/A |
+// | 7 | 异常路径：无 throw | N/A |
+// | 8 | 负面场景：未初始化 pressPoint、左/右键均转发 | 完成 |
+// | 9 | 强异常安全：不适用（无状态突变） | N/A |
+// | 10 | stub 选择：项目内具体类 LeftAreaTextEdit/TextEdit → stub_ext | 完成 |
+//
+// 分支清单（来源：linenumberarea.cpp）：无控制流分支（纯委托）。
+//
+// 用例映射：
+// - Construction_StoresLeftAreaWidget_ZeroMargins      → ctor
+// - GetPressPoint_InitialDefault_ReturnsOrigin        → getPressPoint（m_pressPoint 赋值
+//   在源码中已注释，恒为默认构造值 —— 记录该行为约定）
+// - SizeHint_WidthFromLineNumberArea_HeightZero       → sizeHint
+// - MousePressEvent_AnyButton_ForwardsPositionToEdit /*TEST_P*/ → mousePressEvent
+// - MousePressEvent_OriginPoint_ForwardsZero          → 边界 (0,0)
+// - PaintEvent_DelegatesToLeftArea_PaintEvent         → paintEvent
+
+#include <gtest/gtest.h>
+#include "stubext.h"
+#include "linenumberarea.h"
+#include "leftareaoftextedit.h"
+#include "dtextedit.h"
+
+#include <QApplication>
+#include <QDebug>
+#include <QMouseEvent>
+#include <QPaintEvent>
+#include <QPlainTextEdit>
+
+namespace {
+
+TextEdit *const kFakeEdit = reinterpret_cast<TextEdit *>(quintptr(0x1000));
+
+} // namespace
+
+class LineNumberAreaTest : public ::testing::Test {
+protected:
+    static void SetUpTestSuite()
+    {
+        if (QApplication::instance() == nullptr) {
+            static int argc = 1;
+            static char appName[] = "test_linenumberarea";
+            static char *argv[] = { appName, nullptr };
+            s_app = new QApplication(argc, argv);
+        }
+    }
+
+    static void TearDownTestSuite() {}
+
+    void SetUp() override
+    {
+        onPressedCalls = 0;
+        capturedPoint = QPoint(-1, -1);
+        areaPaintCalls = 0;
+
+        doc = std::make_unique<QTextDocument>();
+
+        // LeftAreaTextEdit 构造 qDebug 流式输出 fake TextEdit* → 拦截 QWidget 流式运算符
+        stub.set_lamda(static_cast<QDebug (*)(QDebug, const QWidget *)>(&operator<<),
+                       [](QDebug d, const QWidget *) -> QDebug { return d; });
+
+        // LeftAreaTextEdit::lineNumberAreaWidth 经 m_pTextEdit->document() 取行数 → 喂受控文档
+        stub.set_lamda(&QPlainTextEdit::document,
+                       [this](QPlainTextEdit *) -> QTextDocument * { return doc.get(); });
+        // TextEdit::onPressedLineNumber 捕获点击位置（委托终点）
+        stub.set_lamda(&TextEdit::onPressedLineNumber,
+                       [this](TextEdit *, const QPoint &p) {
+                           ++onPressedCalls;
+                           capturedPoint = p;
+                       });
+        // LeftAreaTextEdit::lineNumberAreaPaintEvent 委托计数（paintEvent 终点）
+        stub.set_lamda(&LeftAreaTextEdit::lineNumberAreaPaintEvent,
+                       [this](LeftAreaTextEdit *, QPaintEvent *) { ++areaPaintCalls; });
+
+        leftArea = new LeftAreaTextEdit(kFakeEdit);
+        obj = new LineNumberArea(leftArea);
+        ASSERT_NE(obj, nullptr);
+    }
+
+    void TearDown() override
+    {
+        delete obj;
+        obj = nullptr;
+        delete leftArea;
+        leftArea = nullptr;
+        stub.clear();
+    }
+
+    static QApplication *s_app;
+
+    stub_ext::StubExt stub;
+    LeftAreaTextEdit *leftArea = nullptr;
+    LineNumberArea *obj = nullptr;
+    std::unique_ptr<QTextDocument> doc;
+
+    int onPressedCalls = 0;
+    QPoint capturedPoint { -1, -1 };
+    int areaPaintCalls = 0;
+};
+
+QApplication *LineNumberAreaTest::s_app = nullptr;
+
+TEST_F(LineNumberAreaTest, Construction_StoresLeftAreaWidget_ZeroMargins)
+{
+    // Assert：持有委托目标、内容边距清零（行号紧贴排布约定）
+    EXPECT_EQ(obj->m_leftAreaWidget, leftArea);
+    EXPECT_EQ(obj->contentsMargins(), QMargins(0, 0, 0, 0));
+}
+
+TEST_F(LineNumberAreaTest, GetPressPoint_InitialDefault_ReturnsOrigin)
+{
+    // Act（无任何交互）
+
+    // Assert：m_pressPoint 赋值语句在源码中处于注释状态 → 恒为默认值 (0,0)
+    EXPECT_EQ(obj->getPressPoint(), QPoint(0, 0));
+    EXPECT_EQ(obj->m_pressPoint.x(), 0);
+    EXPECT_EQ(obj->m_pressPoint.y(), 0);
+}
+
+TEST_F(LineNumberAreaTest, SizeHint_WidthFromLineNumberArea_HeightZero)
+{
+    // Arrange：99 行 → 2 位行号
+    doc->setPlainText(QString(98, QChar('\n')));
+    ASSERT_EQ(doc->blockCount(), 99);
+    const int digits = 2;
+    const int advance = leftArea->fontMetrics().horizontalAdvance(QLatin1Char('9'));
+
+    // Act
+    const QSize hint = obj->sizeHint();
+
+    // Assert：宽 = 行号区域宽度公式结果，高 = 0（交由布局纵向拉伸）
+    EXPECT_EQ(hint.width(), 13 + advance * digits + 40);
+    EXPECT_EQ(hint.height(), 0);
+}
+
+// ---- mousePressEvent 委托（左/右/中键同质输入 → TEST_P） ----
+struct MouseButtonCase {
+    Qt::MouseButton button;
+};
+
+class LineNumberAreaMouseTest : public LineNumberAreaTest,
+                                public ::testing::WithParamInterface<MouseButtonCase> {
+};
+
+TEST_P(LineNumberAreaMouseTest, MousePressEvent_AnyButton_ForwardsPositionToEdit)
+{
+    const MouseButtonCase &c = GetParam();
+
+    // Arrange：合成鼠标按下事件
+    QMouseEvent event(QEvent::MouseButtonPress, QPointF(17, 42),
+                      c.button, c.button, Qt::NoModifier);
+
+    // Act：真实事件派发
+    const bool delivered = QApplication::sendEvent(obj, &event);
+
+    // Assert：位置精确转发到 Edit::onPressedLineNumber
+    EXPECT_TRUE(delivered);
+    EXPECT_EQ(onPressedCalls, 1);
+    EXPECT_EQ(capturedPoint, QPoint(17, 42));
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    MouseButtonCases,
+    LineNumberAreaMouseTest,
+    ::testing::Values(
+        MouseButtonCase{ Qt::LeftButton },
+        MouseButtonCase{ Qt::RightButton },
+        MouseButtonCase{ Qt::MiddleButton }));
+
+TEST_F(LineNumberAreaTest, MousePressEvent_OriginPoint_ForwardsZero)
+{
+    // Arrange：边界坐标 (0,0)
+    QMouseEvent event(QEvent::MouseButtonPress, QPointF(0, 0),
+                      Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+
+    // Act
+    QApplication::sendEvent(obj, &event);
+
+    // Assert：原点坐标无损转发
+    EXPECT_EQ(onPressedCalls, 1);
+    EXPECT_EQ(capturedPoint, QPoint(0, 0));
+}
+
+TEST_F(LineNumberAreaTest, PaintEvent_DelegatesToLeftArea_PaintEvent)
+{
+    // Arrange
+    QPaintEvent event(QRect(0, 0, 30, 100));
+
+    // Act：直驱 protected paintEvent（纯委托，不涉及真实绘制）
+    obj->paintEvent(&event);
+
+    // Assert：精确转发 LeftAreaTextEdit::lineNumberAreaPaintEvent 一次
+    EXPECT_EQ(areaPaintCalls, 1);
+    // 二次调用计数累加（委托幂等可重复）
+    obj->paintEvent(&event);
+    EXPECT_EQ(areaPaintCalls, 2);
+}

--- a/tests/editor_areas/test_markoperation.cpp
+++ b/tests/editor_areas/test_markoperation.cpp
@@ -1,0 +1,315 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// TextEdit::MarkOperation / TextEdit::MarkReplaceInfo（src/editor/dtextedit.h 标记
+// 操作数据结构）单元测试，附带覆盖两个纯逻辑静态转换函数
+// TextEdit::convertReplaceToMark / TextEdit::convertMarkToReplace。
+//
+// 类特征：POD 型结构体（inline 默认构造），无信号无分支；
+// 转换函数为 static 纯数据变换（cursor 绝对位置 ↔ 选中区间），无实例依赖。
+//
+// 方法清单完成情况（test-types §8）：
+// | 1 | 公开方法 ≥1 用例：两结构体默认构造/字段语义 + convertReplaceToMark/
+//     convertMarkToReplace | 完成 |
+// | 2 | 等价类划分：空列表/单元素/多元素；null 光标/文档光标；start==end/跨行区间 | 完成 |
+// | 3 | 边界值显式覆盖：(0,0) 零长选择、(0,len) 全选、中间区间、极值时间戳 | 完成 |
+// | 4 | TEST_P 参数化（≥3 组同质输入）：区间边界往返 | 完成 |
+// | 5 | 分支清单已列出并映射用例 | N/A（结构体无分支；转换函数仅 for 循环） |
+// | 6 | 每条 if 分支：无 if；for 0/1/N 次迭代均覆盖 | 完成 |
+// | 7 | 异常路径：无 throw | N/A |
+// | 8 | 负面场景：空列表、null 光标（setPosition 无副作用） | 完成 |
+// | 9 | 强异常安全：null 光标转换后不产生虚假选中 | 完成 |
+// | 10 | stub 选择：纯数据结构 + Qt 容器，无需 stub | N/A |
+//
+// 分支清单：
+//   B1: convertReplaceToMark for 循环（空列表 0 次 / 单元素 1 次 / 三元素 3 次）
+//   B2: convertMarkToReplace for 循环（同上）
+//
+// 用例映射：
+// - DefaultConstruction_MarkOperation_InitialValues            → MarkOperation()
+// - DefaultConstruction_MarkReplaceInfo_ZeroPositions          → MarkReplaceInfo()
+// - FieldAssignment_AllEnumTypes_RoundTrip /*TEST_P*/          → 字段语义（4 枚举值）
+// - ConvertReplaceToMark_AbsoluteRange_SetsCursorSelection     → B1 + 光标绝对化
+// - ConvertReplaceToMark_EmptyList_ReturnsEmpty                → B1 0 次
+// - ConvertReplaceToMark_NullCursor_KeepsCursorNull            → 负面/强异常安全
+// - ConvertReplaceToMark_MultiElements_PreservesOrderAndTime   → B1 3 次
+// - ConvertMarkToReplace_RecordsSelectionBounds                → B2
+// - ConvertMarkToReplace_EmptyList_ReturnsEmpty                → B2 0 次
+// - RoundTrip_ReplaceToMarkToReplace_PreservesRange /*TEST_P*/ → 往返不变量（边界组）
+
+#include <gtest/gtest.h>
+#include "dtextedit.h"
+
+#include <QApplication>
+#include <QTextCursor>
+#include <QTextDocument>
+#include <climits>
+
+class MarkOperationTest : public ::testing::Test {
+protected:
+    static void SetUpTestSuite()
+    {
+        // QTextCursor/QTextDocument 属 Gui 模块，统一 offscreen QApplication
+        if (QApplication::instance() == nullptr) {
+            static int argc = 1;
+            static char appName[] = "test_markoperation";
+            static char *argv[] = { appName, nullptr };
+            s_app = new QApplication(argc, argv);
+        }
+    }
+
+    static void TearDownTestSuite() {}
+
+    void SetUp() override
+    {
+        doc = std::make_unique<QTextDocument>();
+        doc->setPlainText(QStringLiteral("abcdef"));
+        textLength = doc->characterCount() - 1;   // 6
+    }
+
+    static QApplication *s_app;
+
+    std::unique_ptr<QTextDocument> doc;
+    int textLength = 0;
+};
+
+QApplication *MarkOperationTest::s_app = nullptr;
+
+TEST_F(MarkOperationTest, DefaultConstruction_MarkOperation_InitialValues)
+{
+    // Arrange/Act
+    TextEdit::MarkOperation opt;
+
+    // Assert：默认标记单次操作、空颜色/匹配文本、空光标
+    EXPECT_EQ(opt.type, TextEdit::MarkOnce);
+    EXPECT_TRUE(opt.cursor.isNull());
+    EXPECT_TRUE(opt.color.isEmpty());
+    EXPECT_TRUE(opt.matchText.isEmpty());
+}
+
+TEST_F(MarkOperationTest, DefaultConstruction_MarkReplaceInfo_ZeroPositions)
+{
+    // Arrange/Act
+    TextEdit::MarkReplaceInfo info;
+
+    // Assert：零区间、零时间戳、内嵌操作默认
+    EXPECT_EQ(info.start, 0);
+    EXPECT_EQ(info.end, 0);
+    EXPECT_EQ(info.time, 0);
+    EXPECT_EQ(info.opt.type, TextEdit::MarkOnce);
+}
+
+// ---- 字段语义（4 个枚举值同质往返 → TEST_P） ----
+struct MarkTypeCase {
+    TextEdit::MarkOperationType type;
+};
+
+class MarkTypeRoundTripTest : public MarkOperationTest,
+                              public ::testing::WithParamInterface<MarkTypeCase> {
+};
+
+TEST_P(MarkTypeRoundTripTest, FieldAssignment_AllEnumTypes_RoundTrip)
+{
+    const MarkTypeCase &c = GetParam();
+
+    // Arrange
+    TextEdit::MarkOperation opt;
+
+    // Act：全字段赋值
+    opt.type = c.type;
+    opt.color = QStringLiteral("#ff0000");
+    opt.matchText = QStringLiteral("keyword");
+    opt.cursor = QTextCursor(doc.get());
+
+    // Assert：字段独立往返保值
+    EXPECT_EQ(opt.type, c.type);
+    EXPECT_EQ(opt.color, QStringLiteral("#ff0000"));
+    EXPECT_EQ(opt.matchText, QStringLiteral("keyword"));
+    EXPECT_FALSE(opt.cursor.isNull());
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    MarkTypeCases,
+    MarkTypeRoundTripTest,
+    ::testing::Values(
+        MarkTypeCase{ TextEdit::MarkOnce },
+        MarkTypeCase{ TextEdit::MarkAllMatch },
+        MarkTypeCase{ TextEdit::MarkLine },
+        MarkTypeCase{ TextEdit::MarkAll }));
+
+TEST_F(MarkOperationTest, ConvertReplaceToMark_AbsoluteRange_SetsCursorSelection)
+{
+    // Arrange：绝对区间 [1,4) → 选中 "bcd"
+    TextEdit::MarkReplaceInfo info;
+    info.opt.type = TextEdit::MarkAllMatch;
+    info.opt.color = QStringLiteral("#00ff00");
+    info.opt.matchText = QStringLiteral("bcd");
+    info.opt.cursor = QTextCursor(doc.get());
+    info.start = 1;
+    info.end = 4;
+    info.time = 1700000000123LL;
+
+    // Act
+    const QList<QPair<TextEdit::MarkOperation, qint64>> marks =
+        TextEdit::convertReplaceToMark({ info });
+
+    // Assert：光标按绝对位置重选、其余字段与时间戳原样保留
+    ASSERT_EQ(marks.size(), 1);
+    EXPECT_EQ(marks[0].first.cursor.selectedText(), QStringLiteral("bcd"));
+    EXPECT_EQ(marks[0].first.cursor.selectionStart(), 1);
+    EXPECT_EQ(marks[0].first.cursor.selectionEnd(), 4);
+    EXPECT_EQ(marks[0].first.type, TextEdit::MarkAllMatch);
+    EXPECT_EQ(marks[0].first.color, QStringLiteral("#00ff00"));
+    EXPECT_EQ(marks[0].first.matchText, QStringLiteral("bcd"));
+    EXPECT_EQ(marks[0].second, 1700000000123LL);
+}
+
+TEST_F(MarkOperationTest, ConvertReplaceToMark_EmptyList_ReturnsEmpty)
+{
+    // Act
+    const auto marks = TextEdit::convertReplaceToMark({});
+
+    // Assert：空入空出（循环 0 次迭代）
+    EXPECT_TRUE(marks.isEmpty());
+    EXPECT_EQ(marks.size(), 0);
+}
+
+TEST_F(MarkOperationTest, ConvertReplaceToMark_NullCursor_KeepsCursorNull)
+{
+    // Arrange：默认构造的 null 光标（负面：setPosition 对 null 光标无副作用）
+    TextEdit::MarkReplaceInfo info;
+    ASSERT_TRUE(info.opt.cursor.isNull());
+    info.start = 2;
+    info.end = 3;
+    info.time = 42;
+
+    // Act
+    const auto marks = TextEdit::convertReplaceToMark({ info });
+
+    // Assert：强异常安全 —— 光标保持 null、时间戳保留，无虚假选中产生
+    ASSERT_EQ(marks.size(), 1);
+    EXPECT_TRUE(marks[0].first.cursor.isNull());
+    EXPECT_EQ(marks[0].first.cursor.selectedText(), QString());
+    EXPECT_EQ(marks[0].second, 42);
+}
+
+TEST_F(MarkOperationTest, ConvertReplaceToMark_MultiElements_PreservesOrderAndTime)
+{
+    // Arrange：三个不同区间的元素
+    QList<TextEdit::MarkReplaceInfo> infos;
+    for (int i = 0; i < 3; ++i) {
+        TextEdit::MarkReplaceInfo info;
+        info.opt.cursor = QTextCursor(doc.get());
+        info.opt.type = TextEdit::MarkLine;
+        info.start = i;
+        info.end = i + 1;
+        info.time = qint64(i + 1) * 1000;
+        infos.append(info);
+    }
+
+    // Act
+    const auto marks = TextEdit::convertReplaceToMark(infos);
+
+    // Assert：顺序与时间戳逐项对应（循环 3 次迭代）
+    ASSERT_EQ(marks.size(), 3);
+    for (int i = 0; i < 3; ++i) {
+        EXPECT_EQ(marks[i].second, qint64(i + 1) * 1000);
+        EXPECT_EQ(marks[i].first.cursor.selectionStart(), i);
+        EXPECT_EQ(marks[i].first.cursor.selectionEnd(), i + 1);
+        EXPECT_EQ(marks[i].first.type, TextEdit::MarkLine);
+    }
+}
+
+TEST_F(MarkOperationTest, ConvertMarkToReplace_RecordsSelectionBounds)
+{
+    // Arrange：光标选中 [2,5) → "cde"
+    TextEdit::MarkOperation opt;
+    opt.type = TextEdit::MarkOnce;
+    opt.color = QStringLiteral("#0000ff");
+    opt.cursor = QTextCursor(doc.get());
+    opt.cursor.setPosition(2);
+    opt.cursor.movePosition(QTextCursor::NextCharacter, QTextCursor::KeepAnchor, 3);
+
+    // Act
+    const auto replaces = TextEdit::convertMarkToReplace({ qMakePair(opt, qint64(99)) });
+
+    // Assert：区间与时间戳被绝对化记录
+    ASSERT_EQ(replaces.size(), 1);
+    EXPECT_EQ(replaces[0].start, 2);
+    EXPECT_EQ(replaces[0].end, 5);
+    EXPECT_EQ(replaces[0].time, 99);
+    EXPECT_EQ(replaces[0].opt.color, QStringLiteral("#0000ff"));
+    EXPECT_EQ(replaces[0].opt.type, TextEdit::MarkOnce);
+}
+
+TEST_F(MarkOperationTest, ConvertMarkToReplace_EmptyList_ReturnsEmpty)
+{
+    // Act
+    const auto replaces = TextEdit::convertMarkToReplace({});
+
+    // Assert：空入空出（循环 0 次迭代），无虚假区间产生
+    EXPECT_TRUE(replaces.isEmpty());
+    EXPECT_EQ(replaces.size(), 0);
+}
+
+// ---- 往返不变量（边界区间组 → TEST_P） ----
+struct RangeCase {
+    int start;
+    int end;
+};
+
+class MarkRoundTripTest : public MarkOperationTest,
+                          public ::testing::WithParamInterface<RangeCase> {
+};
+
+TEST_P(MarkRoundTripTest, RoundTrip_ReplaceToMarkToReplace_PreservesRange)
+{
+    const RangeCase &c = GetParam();
+
+    // Arrange
+    TextEdit::MarkReplaceInfo info;
+    info.opt.cursor = QTextCursor(doc.get());
+    info.start = c.start;
+    info.end = c.end;
+    info.time = qint64(INT_MAX) + 1;   // 极值时间戳边界
+
+    // Act：replace → mark → replace
+    const auto marks = TextEdit::convertReplaceToMark({ info });
+    const auto back = TextEdit::convertMarkToReplace(marks);
+
+    // Assert：区间与时间戳往返不变
+    ASSERT_EQ(back.size(), 1);
+    EXPECT_EQ(back[0].start, c.start);
+    EXPECT_EQ(back[0].end, c.end);
+    EXPECT_EQ(back[0].time, qint64(INT_MAX) + 1);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    RangeCases,
+    MarkRoundTripTest,
+    ::testing::Values(
+        RangeCase{ 0, 0 },                  // 零长选择（边界）
+        RangeCase{ 0, 6 },                  // 全选（上边界）
+        RangeCase{ 2, 5 },                  // 中间区间（典型）
+        RangeCase{ 5, 6 }));                // 末字符（末边界）
+
+TEST_F(MarkOperationTest, Structs_IndependentCopies_DoNotAlias)
+{
+    // Arrange
+    TextEdit::MarkReplaceInfo a;
+    a.start = 3;
+    a.end = 4;
+    a.time = 777;
+    a.opt.color = QStringLiteral("#123456");
+
+    // Act：值拷贝后修改副本
+    TextEdit::MarkReplaceInfo b = a;
+    b.start = 0;
+    b.opt.color = QStringLiteral("#ffffff");
+
+    // Assert：拷贝独立（QTextCursor 隐式共享按值语义安全）
+    EXPECT_EQ(a.start, 3);
+    EXPECT_EQ(a.opt.color, QStringLiteral("#123456"));
+    EXPECT_EQ(b.end, 4);
+    EXPECT_EQ(b.time, 777);
+}

--- a/tests/editor_areas/test_showflodcodewidget.cpp
+++ b/tests/editor_areas/test_showflodcodewidget.cpp
@@ -1,0 +1,357 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// ShowFlodCodeWidget（src/editor/showflodcodewidget.h/.cpp）单元测试
+//
+// 类特征：DFrame（DTK GUI），内嵌 DPlainTextEdit(objectName=PContentEdit) +
+// KSyntaxHighlighting 高亮器。内部成员经 findChild("PContentEdit") 与
+// document()->findChildren<SyntaxHighlighter*>() 观测（不动源码）。
+// 主题分支用 DGuiApplicationHelper::setThemeType 显式驱动，TearDown 恢复原主题。
+// 语法定义/主题断言与测试本地 Repository oracle 交叉验证（不依赖数据文件存在与否）。
+//
+// 方法清单完成情况（test-types §8）：
+// | 1 | 公开方法 ≥1 用例：ctor/dtor/appendText/clear/initHighLight/setStyle/hideFirstBlock | 完成 |
+// | 2 | 等价类划分：空/短/超宽文本；wrap 开/关；暗/亮主题；已知/未知扩展名；空/多行文档 | 完成 |
+// | 3 | 边界值显式覆盖：maxWidth-50 恰好越界封顶；单块文档；start==end 选择 | 完成 |
+// | 4 | TEST_P 参数化（≥3 组同质输入）：initHighLight 主题标志 | 完成 |
+// | 5 | 分支清单已列出并映射用例 | 完成（见下） |
+// | 6 | 每条 if/循环分支有触发用例 | 完成 |
+// | 7 | 异常路径：无 throw | N/A |
+// | 8 | 负面场景：未知扩展名定义无效、超宽文本封顶 | 完成 |
+// | 9 | 强异常安全：不适用（无失败路径） | N/A |
+// | 10 | stub 选择：DTK/KF6 运行库真实执行（offscreen），无需 stub | N/A |
+//
+// 分支清单（来源：showflodcodewidget.cpp）：
+//   B1:  m_highlighter != nullptr（initHighLight 守卫，构造后恒真）
+//   B2:  !bIsLight → DarkTheme / else LightTheme
+//   B3:  DGuiApplicationHelper 主题 == DarkType → 深色调色板
+//   B4:  else → 浅色调色板
+//   B5:  bIsLineWrap → WidgetWidth / else NoWrap
+//   B6:  m_nTextWidth < textWidth（appendText 宽度增长）
+//   B7:  m_nTextWidth > maxWidth-50（封顶）
+//   B8:  document()->isEmpty() → setPlainText / else appendPlainText
+//   B9:  hideFirstBlock 循环 block == lastBlock → break（空文档 0 次迭代/多行提前退出）
+//
+// 用例映射：
+// - Construction_ContentEditConfiguredReadOnly              → ctor
+// - AppendText_FirstOnEmpty_SetsPlainTextAndWidth           → B6 真(增长)/B8 真
+// - AppendText_Subsequent_AppendsPlainTextKeepsCursorAtStart → B8 假
+// - AppendText_WideText_CapsWidthToMaxWidthMinus50          → B7 真（封顶边界）
+// - AppendText_NarrowAfterWide_WidthDoesNotShrink           → B6 假
+// - Clear_AfterAppend_EmptiesDocument                       → clear
+// - SetStyle_DarkTheme_AppliesDarkBaseAndWidgetWrap         → B3 真/B5 真
+// - SetStyle_LightTheme_AppliesLightBaseAndNoWrap           → B4/B5 假
+// - InitHighLight_ThemeFlag_SetsMatchingTheme /*TEST_P*/    → B1/B2
+// - InitHighLight_CppFileName_SetsMatchingDefinition        → definitionForFileName
+// - InitHighLight_UnknownExtension_InvalidDefinition        → 负面
+// - HideFirstBlock_EmptyDocument_MinimalHeightTen           → B9 0 次迭代
+// - HideFirstBlock_ThreeLines_HidesFirstLastSumsMiddle      → B9 提前退出
+// - Destructor_AfterUse_DeleteWithoutCrash                  → dtor
+
+#include <gtest/gtest.h>
+#include "stubext.h"
+#include "showflodcodewidget.h"
+
+#include <QApplication>
+#include <DPlainTextEdit>
+#include <DGuiApplicationHelper>
+#include <KSyntaxHighlighting/repository.h>
+#include <KSyntaxHighlighting/syntaxhighlighter.h>
+#include <KSyntaxHighlighting/definition.h>
+#include <KSyntaxHighlighting/theme.h>
+
+// DGuiApplicationHelper 位于 Dtk::Gui 命名空间（DTK 约定）
+DGUI_USE_NAMESPACE
+
+class ShowFlodCodeWidgetTest : public ::testing::Test {
+protected:
+    static void SetUpTestSuite()
+    {
+        if (QApplication::instance() == nullptr) {
+            static int argc = 1;
+            static char appName[] = "test_showflodcodewidget";
+            static char *argv[] = { appName, nullptr };
+            s_app = new QApplication(argc, argv);
+        }
+    }
+
+    static void TearDownTestSuite() {}
+
+    void SetUp() override
+    {
+        // DTK6 的 themeType() 为只读系统主题：以 stub 注入受控返回值（TearDown 还原），
+        // 避免 DGuiApplicationHelper 全局单例被用例污染
+        stub.set_lamda(&DGuiApplicationHelper::themeType,
+                       [this](DGuiApplicationHelper *) -> DGuiApplicationHelper::ColorType {
+                           return injectedTheme;
+                       });
+
+        repoOracle = std::make_unique<KSyntaxHighlighting::Repository>();
+
+        obj = new ShowFlodCodeWidget();
+        ASSERT_NE(obj, nullptr);
+        edit = obj->findChild<DPlainTextEdit *>("PContentEdit");
+        ASSERT_NE(edit, nullptr);
+    }
+
+    void TearDown() override
+    {
+        delete obj;
+        obj = nullptr;
+        edit = nullptr;
+        stub.clear();
+    }
+
+    static QApplication *s_app;
+
+    // 内部高亮器（父对象为 document()）
+    KSyntaxHighlighting::SyntaxHighlighter *highlighter() const
+    {
+        const auto hs = edit->document()->findChildren<KSyntaxHighlighting::SyntaxHighlighter *>();
+        return hs.isEmpty() ? nullptr : hs.first();
+    }
+
+    ShowFlodCodeWidget *obj = nullptr;
+    DPlainTextEdit *edit = nullptr;
+    std::unique_ptr<KSyntaxHighlighting::Repository> repoOracle;
+    stub_ext::StubExt stub;
+    DGuiApplicationHelper::ColorType injectedTheme = DGuiApplicationHelper::LightType;
+};
+
+QApplication *ShowFlodCodeWidgetTest::s_app = nullptr;
+
+TEST_F(ShowFlodCodeWidgetTest, Construction_ContentEditConfiguredReadOnly)
+{
+    // Assert：内嵌编辑框只读、任意换行、无边框、滚动条隐藏、无横向滚动
+    EXPECT_TRUE(edit->isReadOnly());
+    EXPECT_EQ(edit->wordWrapMode(), QTextOption::WrapAnywhere);
+    EXPECT_EQ(edit->frameStyle(), 0);
+    EXPECT_EQ(edit->verticalScrollBarPolicy(), Qt::ScrollBarAlwaysOff);
+    EXPECT_EQ(edit->horizontalScrollBarPolicy(), Qt::ScrollBarAlwaysOff);
+    // 高亮器已挂在文档上
+    EXPECT_NE(highlighter(), nullptr);
+}
+
+TEST_F(ShowFlodCodeWidgetTest, AppendText_FirstOnEmpty_SetsPlainTextAndWidth)
+{
+    // Arrange
+    const QString text = QStringLiteral("hello");
+    const int expectWidth = edit->fontMetrics().horizontalAdvance(text) + 10;
+
+    // Act
+    obj->appendText(text, 500);
+
+    // Assert：空文档走 setPlainText（B8 真），宽度=文本宽度+10（B6 增长）
+    EXPECT_EQ(edit->toPlainText(), text);
+    EXPECT_EQ(edit->width(), expectWidth);
+    // 光标移回首部
+    EXPECT_EQ(edit->textCursor().position(), 0);
+}
+
+TEST_F(ShowFlodCodeWidgetTest, AppendText_Subsequent_AppendsPlainTextKeepsCursorAtStart)
+{
+    // Arrange
+    obj->appendText(QStringLiteral("hello"), 500);
+
+    // Act：非空文档走 appendPlainText（B8 假）
+    obj->appendText(QStringLiteral("world"), 500);
+
+    // Assert：追加为新行块
+    EXPECT_EQ(edit->toPlainText(), QStringLiteral("hello\nworld"));
+    EXPECT_EQ(edit->document()->blockCount(), 2);
+    EXPECT_EQ(edit->textCursor().position(), 0);
+}
+
+TEST_F(ShowFlodCodeWidgetTest, AppendText_WideText_CapsWidthToMaxWidthMinus50)
+{
+    // Arrange：超宽文本（宽度必超 maxWidth-50）
+    const QString wide(1000, QChar('x'));
+
+    // Act
+    obj->appendText(wide, 300);
+
+    // Assert：封顶到 maxWidth-50（B7 真，边界精确值）
+    EXPECT_EQ(edit->width(), 300 - 50);
+    // 文本仍完整写入
+    EXPECT_EQ(edit->toPlainText(), wide);
+}
+
+TEST_F(ShowFlodCodeWidgetTest, AppendText_NarrowAfterWide_WidthDoesNotShrink)
+{
+    // Arrange：先封顶
+    obj->appendText(QString(1000, QChar('x')), 300);
+    ASSERT_EQ(edit->width(), 250);
+
+    // Act：后追加窄文本（B6 假：宽度不回缩）
+    obj->appendText(QStringLiteral("hi"), 300);
+
+    // Assert
+    EXPECT_EQ(edit->width(), 250);
+    EXPECT_EQ(edit->toPlainText(), QString(1000, QChar('x')) + QStringLiteral("\nhi"));
+}
+
+TEST_F(ShowFlodCodeWidgetTest, Clear_AfterAppend_EmptiesDocument)
+{
+    // Arrange
+    obj->appendText(QStringLiteral("some text"), 500);
+    ASSERT_FALSE(edit->document()->isEmpty());
+
+    // Act
+    obj->clear();
+
+    // Assert：文档清空、内部宽度归零（后续窄文本重新计宽）
+    EXPECT_TRUE(edit->document()->isEmpty());
+    EXPECT_TRUE(edit->toPlainText().isEmpty());
+    obj->appendText(QStringLiteral("ab"), 500);
+    EXPECT_EQ(edit->width(), edit->fontMetrics().horizontalAdvance(QStringLiteral("ab")) + 10);
+}
+
+TEST_F(ShowFlodCodeWidgetTest, SetStyle_DarkTheme_AppliesDarkBaseAndWidgetWrap)
+{
+    // Arrange：注入暗主题（B3 真）
+    injectedTheme = DGuiApplicationHelper::DarkType;
+
+    // Act
+    obj->setStyle(true);
+
+    // Assert：内容框 Base=深色半透明、部件 Base=深色不透明（B5 真：换行打开）
+    QColor expectBase(25, 25, 25);
+    expectBase.setAlphaF(0.8);
+    EXPECT_EQ(edit->palette().color(QPalette::Base), expectBase);
+    EXPECT_EQ(obj->palette().color(QPalette::Base), QColor(25, 25, 25));
+    EXPECT_EQ(edit->lineWrapMode(), QPlainTextEdit::WidgetWidth);
+}
+
+TEST_F(ShowFlodCodeWidgetTest, SetStyle_LightTheme_AppliesLightBaseAndNoWrap)
+{
+    // Arrange：注入亮主题（B4）
+    injectedTheme = DGuiApplicationHelper::LightType;
+
+    // Act
+    obj->setStyle(false);
+
+    // Assert：浅色半透明 Base（B5 假：不换行）
+    QColor expectBase(247, 247, 247);
+    expectBase.setAlphaF(0.6);
+    EXPECT_EQ(edit->palette().color(QPalette::Base), expectBase);
+    EXPECT_EQ(obj->palette().color(QPalette::Base), QColor(247, 247, 247));
+    EXPECT_EQ(edit->lineWrapMode(), QPlainTextEdit::NoWrap);
+}
+
+// ---- initHighLight 主题标志（B1/B2，同质断言 → TEST_P） ----
+struct ThemeFlagCase {
+    bool isLight;
+};
+
+class ShowFlodInitHighlightTest : public ShowFlodCodeWidgetTest,
+                                  public ::testing::WithParamInterface<ThemeFlagCase> {
+};
+
+TEST_P(ShowFlodInitHighlightTest, InitHighLight_ThemeFlag_SetsMatchingTheme)
+{
+    const ThemeFlagCase &c = GetParam();
+
+    // Act
+    obj->initHighLight(QStringLiteral("example.cpp"), c.isLight);
+
+    // Assert：主题与本地 Repository oracle 的默认主题一致（数据无关）
+    auto *hl = highlighter();
+    ASSERT_NE(hl, nullptr);
+    const auto expectTheme = repoOracle->defaultTheme(
+        c.isLight ? KSyntaxHighlighting::Repository::LightTheme
+                  : KSyntaxHighlighting::Repository::DarkTheme);
+    EXPECT_EQ(hl->theme().name(), expectTheme.name());
+    EXPECT_EQ(hl->theme().isValid(), expectTheme.isValid());
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    ThemeFlagCases,
+    ShowFlodInitHighlightTest,
+    ::testing::Values(
+        ThemeFlagCase{ true },   // B2 else：LightTheme
+        ThemeFlagCase{ false })); // B2 真：DarkTheme
+
+TEST_F(ShowFlodCodeWidgetTest, InitHighLight_CppFileName_SetsMatchingDefinition)
+{
+    // Act
+    obj->initHighLight(QStringLiteral("/any/path/main.cpp"), true);
+
+    // Assert：定义按文件名匹配（与 oracle 一致；数据存在时为 "C++"）
+    auto *hl = highlighter();
+    ASSERT_NE(hl, nullptr);
+    const auto expectDef = repoOracle->definitionForFileName(QStringLiteral("main.cpp"));
+    EXPECT_EQ(hl->definition().name(), expectDef.name());
+    EXPECT_EQ(hl->definition().isValid(), expectDef.isValid());
+    // 二次调用覆盖为同值（幂等）
+    obj->initHighLight(QStringLiteral("other.cpp"), true);
+    EXPECT_EQ(hl->definition().name(), expectDef.name());
+}
+
+TEST_F(ShowFlodCodeWidgetTest, InitHighLight_UnknownExtension_InvalidDefinition)
+{
+    // Act：未知扩展名（负面：definitionForFileName 返回无效定义）
+    obj->initHighLight(QStringLiteral("data.unknownext123"), true);
+
+    // Assert：与 oracle 行为一致（无效/空定义），不崩溃
+    auto *hl = highlighter();
+    ASSERT_NE(hl, nullptr);
+    const auto expectDef = repoOracle->definitionForFileName(QStringLiteral("data.unknownext123"));
+    EXPECT_EQ(hl->definition().isValid(), expectDef.isValid());
+    EXPECT_EQ(hl->definition().name(), expectDef.name());
+}
+
+TEST_F(ShowFlodCodeWidgetTest, HideFirstBlock_EmptyDocument_MinimalHeightTen)
+{
+    // Arrange：空文档（单块，first==last → 循环 0 次迭代，B9）
+
+    // Act
+    obj->hideFirstBlock();
+
+    // Assert：唯一块被隐藏、高度=0+10
+    EXPECT_FALSE(edit->document()->firstBlock().isVisible());
+    EXPECT_FALSE(edit->document()->lastBlock().isVisible());
+    EXPECT_EQ(edit->height(), 10);
+}
+
+TEST_F(ShowFlodCodeWidgetTest, HideFirstBlock_ThreeLines_HidesFirstLastSumsMiddle)
+{
+    // Arrange：3 行文本
+    obj->appendText(QStringLiteral("line1"), 500);
+    obj->appendText(QStringLiteral("line2"), 500);
+    obj->appendText(QStringLiteral("line3"), 500);
+    ASSERT_EQ(edit->document()->blockCount(), 3);
+    const auto *layout = edit->document()->documentLayout();
+    const int middleH = layout->blockBoundingRect(
+                            edit->document()->firstBlock().next()).toRect().height();
+
+    // Act
+    obj->hideFirstBlock();
+
+    // Assert：首末块隐藏、高度=中间块高度+10（B9：遍历中间块后遇 lastBlock 提前退出）
+    EXPECT_FALSE(edit->document()->firstBlock().isVisible());
+    EXPECT_FALSE(edit->document()->lastBlock().isVisible());
+    EXPECT_TRUE(edit->document()->firstBlock().next().isVisible());
+    EXPECT_EQ(edit->height(), middleH + 10);
+    EXPECT_GT(edit->height(), 10);
+}
+
+TEST_F(ShowFlodCodeWidgetTest, Destructor_AfterUse_DeleteWithoutCrash)
+{
+    // Arrange：先使用（追加 + 高亮 + 样式 + 折叠隐藏）
+    ShowFlodCodeWidget *tmp = new ShowFlodCodeWidget();
+    tmp->appendText(QStringLiteral("text"), 500);
+    tmp->initHighLight(QStringLiteral("a.cpp"), true);
+    tmp->setStyle(true);
+    tmp->hideFirstBlock();
+
+    // Act：析构（内部 m_highlighter 走 deleteLater）并冲刷延迟删除
+    delete tmp;
+    QCoreApplication::sendPostedEvents(nullptr, QEvent::DeferredDelete);
+
+    // Assert：全局状态未受破坏 —— fixture 对象仍正常工作、应用实例健在
+    obj->appendText(QStringLiteral("after"), 500);
+    DPlainTextEdit *ediAfter = obj->findChild<DPlainTextEdit *>("PContentEdit");
+    ASSERT_NE(ediAfter, nullptr);
+    EXPECT_EQ(ediAfter->toPlainText(), QStringLiteral("after"));
+    EXPECT_NE(QApplication::instance(), nullptr);
+}

--- a/tests/editor_core/CMakeLists.txt
+++ b/tests/editor_core/CMakeLists.txt
@@ -1,0 +1,116 @@
+cmake_minimum_required(VERSION 3.16)
+
+# B7 模块：editor_core（TextEdit 单类，src/editor/dtextedit.h/.cpp，9589 行，全项目最大类）
+#
+# 策略（沿用 B4/B6 已验证方案）：全量编入 src/ 为共享静态库（排除入口 main.cpp
+# 与冲突源 encoding.cpp），保证 TextEdit 的真实依赖链（LeftAreaTextEdit/
+# ShowFlodCodeWidget/撤销命令族/Settings/Utils/iflytek）符号齐全；
+# 运行期对 EditWrapper/Window/BottomBar 的调用用 stub_ext 拦截
+# （fake 指针 + 桩函数喂返回值），绝不真实构造 Window。
+# QWidget 测试在 QT_QPA_PLATFORM=offscreen 下构造（Wave1 已验证）；
+# 测试目标开启 -fno-access-control 访问 private/protected 成员（B6 先例）。
+
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
+
+# 源码侧编译宏（与根 CMakeLists.txt 保持一致）
+add_definitions(-DKF5_HIGHLIGHT_PATH="/usr/share/deepin-editor/highlighting")
+
+# environments.h（VERSION 宏，部分源码需要）
+configure_file(
+    "${CMAKE_SOURCE_DIR}/src/environments.h.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/environments.h"
+    @ONLY
+)
+
+# ---- 共享静态库：项目源码（多个 test target 复用，避免重复编译） ----
+file(GLOB_RECURSE EC_ALL_SRC
+    "${CMAKE_SOURCE_DIR}/src/*.cpp"
+    "${CMAKE_SOURCE_DIR}/src/basepub/*.c")
+list(REMOVE_ITEM EC_ALL_SRC
+    "${CMAKE_SOURCE_DIR}/src/main.cpp"
+    "${CMAKE_SOURCE_DIR}/src/common/encoding.cpp")
+
+add_library(editor_core_ut_src STATIC
+    ${EC_ALL_SRC}
+    "${CMAKE_SOURCE_DIR}/src/deepin-editor.qrc")
+
+target_include_directories(editor_core_ut_src PUBLIC
+    "${CMAKE_SOURCE_DIR}/src"
+    "${CMAKE_SOURCE_DIR}/src/common"
+    "${CMAKE_SOURCE_DIR}/src/controls"
+    "${CMAKE_SOURCE_DIR}/src/editor"
+    "${CMAKE_SOURCE_DIR}/src/editor/markdown"
+    "${CMAKE_SOURCE_DIR}/src/widgets"
+    "${CMAKE_SOURCE_DIR}/src/dbus"
+    "${CMAKE_SOURCE_DIR}/src/thememodule"
+    "${CMAKE_SOURCE_DIR}/src/encodes"
+    "${CMAKE_SOURCE_DIR}/src/basepub"
+    "${CMAKE_CURRENT_BINARY_DIR}"
+)
+
+target_link_libraries(editor_core_ut_src PUBLIC
+    Qt6::Core
+    Qt6::Gui
+    Qt6::Widgets
+    Qt6::Xml
+    Qt6::Svg
+    Qt6::Concurrent
+    Qt6::PrintSupport
+    Qt6::DBus
+    Qt6::WebEngineWidgets
+    Qt6::WebChannel
+    Qt6::OpenGLWidgets
+    Qt6::Core5Compat
+    Dtk6::Widget
+    Dtk6::Core
+    KF6::Codecs
+    KF6::SyntaxHighlighting
+    ICU::i18n
+    ICU::uc
+    ${chardet_LIBRARIES}
+    uchardet
+    pthread
+    dl
+    m
+)
+
+# stub-ext 运行时依赖
+set(STUB_SHADOW "${CMAKE_SOURCE_DIR}/tests/3rdparty/stub/stub-shadow.cpp")
+
+# 代码覆盖率（Debug，沿用 tests 顶层全局 flags，此处仅链 gcov）
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    target_link_libraries(editor_core_ut_src PUBLIC gcov)
+endif()
+
+# QSignalSpy / QApplication::sendEvent 需要 Qt6::Test（顶层未包含该组件）
+find_package(Qt6 COMPONENTS Test REQUIRED)
+
+# ---- 逐功能组 test target（TextEdit 按方法族拆分 6 个文件） ----
+function(ec_add_test name)
+    add_executable(test_${name}
+        test_${name}.cpp
+        ${STUB_SHADOW})
+    target_include_directories(test_${name} PRIVATE
+        "${CMAKE_CURRENT_SOURCE_DIR}"
+        "${CMAKE_SOURCE_DIR}/tests/3rdparty/stub")
+    # 访问 protected（事件处理器）与 private（m_wrapper/m_markOperations 等）
+    # 用于直接驱动与状态断言；访问控制不影响 ABI 布局，与库侧 AUTOMOC 产物 ODR 兼容
+    target_compile_options(test_${name} PRIVATE -fno-access-control)
+    target_link_libraries(test_${name} PRIVATE
+        editor_core_ut_src
+        GTest::gtest
+        GTest::gtest_main
+        Qt6::Test)
+    gtest_discover_tests(test_${name} PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
+    message(STATUS "UT: test_${name} configured")
+endfunction()
+
+ec_add_test(dtextedit_cursor)
+ec_add_test(dtextedit_edit)
+ec_add_test(dtextedit_mark)
+ec_add_test(dtextedit_find)
+ec_add_test(dtextedit_event)
+ec_add_test(dtextedit_misc)
+
+message(STATUS "UT: editor_core module configured")

--- a/tests/editor_core/editor_core_fixture.h
+++ b/tests/editor_core/editor_core_fixture.h
@@ -1,0 +1,408 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// editor_core（B7：TextEdit）共享测试夹具。
+//
+// 隔离策略（全部在 SetUp 安装、TearDown stub.clear() 还原）：
+// - QDBusConnection::sessionBus/systemBus → 未连接伪连接，绝不触碰真实总线
+//   （TextEdit 构造/析构会 connect/disconnect Gesture/Audio DBus 信号）。
+// - EditWrapper/Window/BottomBar → fake 指针（指向真实 QWidget 载体对象，
+//   dynamic_cast/qobject_cast 安全返回 null）+ 桩函数喂返回值；绝不真实构造 Window。
+// - QMenu::exec（虚函数，VADDR 取真实地址）→ 返回 nullptr，防止右键菜单模态阻塞。
+// - XDG_CONFIG_HOME 重定向到 QTemporaryDir，Settings 单例读写临时配置，不碰 ~/.config。
+// - QApplication + QT_QPA_PLATFORM=offscreen（Wave1 已验证无头构造可行）。
+// - 语法高亮定义：QTemporaryDir 写入自定义 XML + m_repository.addCustomSearchPath，
+//   toggleComment/setSyntaxDefinition 全链路封闭（不依赖系统 syntax 目录）。
+// - 剪贴板：offscreen 平台内置内存剪贴板（进程内隔离）。
+
+#ifndef EDITOR_CORE_FIXTURE_H
+#define EDITOR_CORE_FIXTURE_H
+
+#include <gtest/gtest.h>
+#include "stubext.h"
+
+#include "dtextedit.h"
+#include "editwrapper.h"
+#include "../widgets/window.h"
+#include "../widgets/bottombar.h"
+#include "settings.h"
+
+#include <QApplication>
+#include <QClipboard>
+#include <DSettings>
+#include <DSettingsOption>
+#include <DSettingsGroup>
+#include <QTemporaryDir>
+#include <QKeyEvent>
+#include <QMouseEvent>
+#include <QSignalSpy>
+#include <QWheelEvent>
+#include <QInputMethodEvent>
+#include <QGestureEvent>
+#include <QTapGesture>
+#include <QTapAndHoldGesture>
+#include <QPanGesture>
+#include <QPinchGesture>
+#include <QSwipeGesture>
+#include <QDBusConnection>
+#include <QDBusAbstractInterface>
+#include <QDBusPendingCall>
+#include <QMenu>
+#include <QDir>
+#include <QFile>
+#include <QTextCursor>
+
+namespace {
+
+const char *kEcOrgName = "deepin";
+const char *kEcAppName = "deepin-editor";
+
+// 临时语法高亮定义：单行 // 与多行 /* */ 注释，扩展名 *.utlang
+// （<general><comments> 为注释标记解析位置；kateversion>=5.62 保证新式解析）
+const char *kEcSyntaxXml =
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+        "<!DOCTYPE language>\n"
+        "<language name=\"UTLang\" section=\"Sources\" extensions=\"*.utlang\""
+        " kateversion=\"5.62\" version=\"2\" priority=\"100\">\n"
+        "  <highlighting>"
+        "<contexts><context attribute=\"Normal Text\" lineEndContext=\"#stay\" name=\"Normal Text\"/></contexts>"
+        "<itemDatas><itemData name=\"Normal Text\" defStyleNum=\"dsNormal\"/></itemDatas>"
+        "</highlighting>\n"
+        "  <general>"
+        "<comments><comment name=\"singleLine\" start=\"//\"/>"
+        "<comment name=\"multiLine\" start=\"/*\" end=\"*/\"/></comments>"
+        "</general>\n"
+        "</language>\n";
+
+} // namespace
+
+// deepin-editor.qrc 编入静态库时其静态初始化器不会被链接器自动拉入，
+// 显式声明 rcc 生成的 init 函数强制引用（qrc 文件名 '-' → '_'）
+int qInitResources_deepin_editor();
+
+class TextEditTestBase : public ::testing::Test
+{
+protected:
+    static void SetUpTestSuite()
+    {
+        s_configHome = new QTemporaryDir();
+        const QString xdgConfig = s_configHome->filePath("xdg-config");
+        QDir().mkpath(xdgConfig);
+        qputenv("XDG_CONFIG_HOME", xdgConfig.toUtf8());
+        qputenv("QT_QPA_PLATFORM", "offscreen");
+        if (QApplication::instance() == nullptr) {
+            s_app = new QApplication(s_ecArgc, s_ecArgv);
+        }
+        QApplication::setOrganizationName(QString::fromLatin1(kEcOrgName));
+        QApplication::setApplicationName(QString::fromLatin1(kEcAppName));
+        // 注册 qrc 资源（:/resources/settings.json 等），随后构造共享单例
+        qInitResources_deepin_editor();
+        Settings::instance();
+        // 临时语法高亮定义目录（toggleComment 等使用；
+        // addCustomSearchPath 要求定义位于 <path>/syntax/*.xml）
+        s_syntaxDir = new QTemporaryDir();
+        QDir().mkpath(s_syntaxDir->filePath(QString("syntax")));
+        QFile syntaxFile(s_syntaxDir->filePath(QString("syntax/utlang.xml")));
+        if (syntaxFile.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
+            syntaxFile.write(kEcSyntaxXml);
+            syntaxFile.close();
+        }
+    }
+
+    static void TearDownTestSuite()
+    {
+        // QApplication 故意不销毁：套件顺序与进程退出安全优先
+        // 还原环境变量（与 qputenv 数量配平，避免环境泄漏）
+        qunsetenv("XDG_CONFIG_HOME");
+        qunsetenv("QT_QPA_PLATFORM");
+        delete s_syntaxDir;
+        s_syntaxDir = nullptr;
+        delete s_configHome;
+        s_configHome = nullptr;
+    }
+
+    void SetUp() override
+    {
+        stub.clear();
+        resetSeamState();
+        installDbusIsolation();
+        installWrapperSeams();
+        installMenuExecStub();
+
+        edit = new TextEdit();
+        ASSERT_NE(edit, nullptr);
+        edit->setSettings(Settings::instance());
+        edit->setWrapper(fakeWrapper());
+        // 封闭语法高亮检索路径：自定义定义目录 + reload 立即生效（不依赖系统 syntax 目录）
+        edit->m_repository.addCustomSearchPath(s_syntaxDir->path());
+        edit->m_repository.reload();
+        edit->resize(480, 360);
+    }
+
+    void TearDown() override
+    {
+        // 析构期间 DBus/版本号桩必须仍然生效（dtor 会 disconnect DBus 信号）
+        if (edit) {
+            delete edit;
+            edit = nullptr;
+        }
+        stub.clear();
+    }
+
+    // ============ 桩状态（每用例 SetUp 复位，lambda 以指针捕获读写） ============
+
+    void resetSeamState()
+    {
+        seamFileLoading = false;
+        seamFindBarVisible = false;
+        seamReplaceBarVisible = false;
+        seamEndlineFormat = BottomBar::Unix;
+        seamKeywordSearchAll = QString("ut_sync"); // 与 keywordSearch 保持一致以进入高亮分支
+        seamKeywordSearch = QString("ut_sync");
+        seamFakeEndlineCalls = 0;
+        highlighterCalls = 0;
+        wordCntCalls = 0;
+        updatePosCalls = 0;
+        updateModifyCalls = 0;
+        setTemFileCalls = 0;
+    }
+
+    // ============ DBus 隔离 ============
+
+    void installDbusIsolation()
+    {
+        stub.set_lamda(&QDBusConnection::sessionBus,
+                       []() -> QDBusConnection {
+                           return QDBusConnection(QStringLiteral("ut-editor-core-bus"));
+                       });
+        stub.set_lamda(&QDBusConnection::systemBus,
+                       []() -> QDBusConnection {
+                           return QDBusConnection(QStringLiteral("ut-editor-core-sys"));
+                       });
+        // Qt6.8：所有 call() 重载经 callWithArgumentList 汇聚（含 DTK DConfig 后台线程的
+        // isServiceRegistered 探测），统一拦截为"无回复"，伪连接上的真实调用即安全失败
+        stub.set_lamda(&QDBusAbstractInterface::callWithArgumentList,
+                       [](QDBusAbstractInterface *, QDBus::CallMode,
+                          const QString &, const QList<QVariant> &) -> QDBusMessage {
+                           return QDBusMessage();
+                       });
+        stub.set_lamda(&QDBusAbstractInterface::asyncCallWithArgumentList,
+                       [](QDBusAbstractInterface *, const QString &,
+                          const QList<QVariant> &) -> QDBusPendingCall {
+                           return QDBusPendingCall::fromCompletedCall(QDBusMessage());
+                       });
+    }
+
+    // ============ EditWrapper / Window / BottomBar 接缝 ============
+
+    EditWrapper *fakeWrapper() { return reinterpret_cast<EditWrapper *>(&m_wrapCarrier); }
+    Window *fakeWindow() { return reinterpret_cast<Window *>(&m_wndCarrier); }
+    BottomBar *fakeBottomBar() { return reinterpret_cast<BottomBar *>(&m_barCarrier); }
+
+    void installWrapperSeams()
+    {
+        stub.set_lamda(&EditWrapper::window,
+                       [this](EditWrapper *) -> Window * { return fakeWindow(); });
+        stub.set_lamda(&EditWrapper::bottomBar,
+                       [this](EditWrapper *) -> BottomBar * { return fakeBottomBar(); });
+        stub.set_lamda(&EditWrapper::OnUpdateHighlighter,
+                       [this](EditWrapper *) { ++highlighterCalls; });
+        stub.set_lamda(&EditWrapper::getFileLoading,
+                       [this](EditWrapper *) -> bool { return seamFileLoading; });
+        stub.set_lamda(&EditWrapper::setTemFile,
+                       [this](EditWrapper *, bool) { ++setTemFileCalls; });
+        stub.set_lamda(&EditWrapper::isTemFile,
+                       [](EditWrapper *) -> bool { return false; });
+        stub.set_lamda(&EditWrapper::isBackupFile,
+                       [](EditWrapper *) -> bool { return false; });
+        stub.set_lamda(&EditWrapper::isDraftFile,
+                       [](EditWrapper *) -> bool { return false; });
+        stub.set_lamda(&EditWrapper::isPlainTextEmpty,
+                       [](EditWrapper *) -> bool { return true; });
+        stub.set_lamda(&EditWrapper::UpdateBottomBarWordCnt,
+                       [this](EditWrapper *, int) { ++wordCntCalls; });
+
+        stub.set_lamda(&Window::findBarIsVisiable,
+                       [this](Window *) -> bool { return seamFindBarVisible; });
+        stub.set_lamda(&Window::replaceBarIsVisiable,
+                       [this](Window *) -> bool { return seamReplaceBarVisible; });
+        stub.set_lamda(&Window::getKeywordForSearchAll,
+                       [this](Window *) -> QString { return seamKeywordSearchAll; });
+        stub.set_lamda(&Window::getKeywordForSearch,
+                       [this](Window *) -> QString { return seamKeywordSearch; });
+        stub.set_lamda(&Window::updateModifyStatus,
+                       [this](Window *, const QString &, bool) { ++updateModifyCalls; });
+
+        // BottomBar::getEndlineFormat 有 static QByteArray 重载，static_cast 选成员版本
+        stub.set_lamda(static_cast<BottomBar::EndlineFormat (BottomBar::*)()>(&BottomBar::getEndlineFormat),
+                       [this](BottomBar *) -> BottomBar::EndlineFormat { return seamEndlineFormat; });
+        stub.set_lamda(&BottomBar::setEndlineMenuText,
+                       [this](BottomBar *, BottomBar::EndlineFormat) { ++seamFakeEndlineCalls; });
+        stub.set_lamda(&BottomBar::updatePosition,
+                       [this](BottomBar *, int, int) { ++updatePosCalls; });
+    }
+
+    // ============ 菜单模态阻塞隔离（QMenu::exec 虚函数 → VADDR 取真实地址） ============
+
+    void installMenuExecStub()
+    {
+        // QMenu::exec 三个重载均非虚（Qt 6.8 qmenu.h），static_cast 选定定点版本
+        using QMenuExecSig = QAction *(QMenu::*)(const QPoint &, QAction *);
+        QMenuExecSig execPmf = static_cast<QMenuExecSig>(&QMenu::exec);
+        stub.set_lamda(execPmf,
+                       [](QMenu *, const QPoint &, QAction *) -> QAction * { return nullptr; });
+    }
+
+    // ============ iflytek AI 语音桩（slotVoiceReading/slotdictation/slot_translate 等） ============
+
+    void installIflytekStubs(IflytekAiAssistant::CallStatus speechStatus = IflytekAiAssistant::Success,
+                             bool hasOutput = true, bool hasInput = true)
+    {
+        stub.set_lamda(&IflytekAiAssistant::textToSpeech,
+                       [speechStatus](IflytekAiAssistant *) -> IflytekAiAssistant::CallStatus {
+                           return speechStatus;
+                       });
+        stub.set_lamda(&IflytekAiAssistant::stopTtsDirectly,
+                       [](IflytekAiAssistant *) -> IflytekAiAssistant::CallStatus {
+                           return IflytekAiAssistant::Success;
+                       });
+        stub.set_lamda(&IflytekAiAssistant::speechToText,
+                       [speechStatus](IflytekAiAssistant *) -> IflytekAiAssistant::CallStatus {
+                           return speechStatus;
+                       });
+        stub.set_lamda(&IflytekAiAssistant::textToTranslate,
+                       [speechStatus](IflytekAiAssistant *) -> IflytekAiAssistant::CallStatus {
+                           return speechStatus;
+                       });
+        stub.set_lamda(&IflytekAiAssistant::errorString,
+                       [](IflytekAiAssistant *, IflytekAiAssistant::CallStatus) -> QString {
+                           return QString("ut-ai-error");
+                       });
+        stub.set_lamda(&IflytekAiAssistant::hasAudioOutputDevice,
+                       [hasOutput](const IflytekAiAssistant *) -> bool { return hasOutput; });
+        stub.set_lamda(&IflytekAiAssistant::hasAudioInputDevice,
+                       [hasInput](const IflytekAiAssistant *) -> bool { return hasInput; });
+    }
+
+    // ============ 通用驱动辅助 ============
+
+    // 设置文档内容并回到起始位置（绕过撤销栈，纯数据准备）
+    void setDocText(const QString &text)
+    {
+        QTextCursor cur(edit->document());
+        cur.select(QTextCursor::Document);
+        cur.insertText(text);
+        cur.movePosition(QTextCursor::Start);
+        edit->setTextCursor(cur);
+    }
+
+    QTextCursor makeCursor(int pos)
+    {
+        QTextCursor cur(edit->document());
+        cur.setPosition(pos);
+        return cur;
+    }
+
+    void moveCursorTo(int pos)
+    {
+        QTextCursor cur = edit->textCursor();
+        cur.setPosition(pos);
+        edit->setTextCursor(cur);
+    }
+
+    // 按 settings 中配置的 editor 快捷键名发送按键（默认 keymap 下与 JSON default 一致）
+    void sendShortcut(const QString &actionName)
+    {
+        const QString keyStr = Settings::instance()->settings
+                ->option(QString("shortcuts.editor.%1").arg(actionName))->value().toString();
+        ASSERT_FALSE(keyStr.isEmpty()) << "shortcut option empty: " << actionName.toStdString();
+        QKeySequence seq(keyStr);
+        ASSERT_FALSE(seq.isEmpty());
+        const int combined = seq[0].toCombined();
+        const Qt::KeyboardModifiers mods =
+                Qt::KeyboardModifiers(combined & static_cast<int>(Qt::KeyboardModifierMask));
+        const int key = combined & ~static_cast<int>(Qt::KeyboardModifierMask);
+        QKeyEvent press(QEvent::KeyPress, key, mods, QString());
+        QApplication::sendEvent(edit, &press);
+    }
+
+    void sendKey(int key, Qt::KeyboardModifiers mods = Qt::NoModifier, const QString &text = QString())
+    {
+        QKeyEvent press(QEvent::KeyPress, key, mods, text);
+        QApplication::sendEvent(edit, &press);
+    }
+
+    void sendMouse(QEvent::Type type, const QPointF &localPos, Qt::MouseButton button,
+                   Qt::KeyboardModifiers mods = Qt::NoModifier)
+    {
+        // 直接驱动受保护事件处理器：offscreen 下未 show 控件的 QApplication::sendEvent
+        // 鼠标派发受窗口状态影响不稳定，白盒直调确定性更高（-fno-access-control）
+        QMouseEvent ev(type, localPos, localPos, button,
+                       (type == QEvent::MouseButtonRelease) ? Qt::NoButton : button, mods);
+        switch (type) {
+        case QEvent::MouseButtonPress:
+            edit->mousePressEvent(&ev);
+            break;
+        case QEvent::MouseMove:
+            edit->mouseMoveEvent(&ev);
+            break;
+        case QEvent::MouseButtonRelease:
+            edit->mouseReleaseEvent(&ev);
+            break;
+        default:
+            break;
+        }
+    }
+
+    // 触发一次真实 paintEvent（offscreen grab 渲染）
+    void triggerPaint() { edit->grab(); }
+
+    // ============ 成员 ============
+
+    stub_ext::StubExt stub;
+    TextEdit *edit = nullptr;
+
+    // fake 指针载体：真实 QWidget 对象，保证误触发 vcalls/dynamic_cast 安全
+    QWidget m_wrapCarrier;
+    QWidget m_wndCarrier;
+    QWidget m_barCarrier;
+
+    // 接缝可变状态
+    bool seamFileLoading = false;
+    bool seamFindBarVisible = false;
+    bool seamReplaceBarVisible = false;
+    BottomBar::EndlineFormat seamEndlineFormat = BottomBar::Unix;
+    QString seamKeywordSearchAll;
+    QString seamKeywordSearch;
+
+    // 调用计数
+    int seamFakeEndlineCalls = 0;
+    int highlighterCalls = 0;
+    int wordCntCalls = 0;
+    int updatePosCalls = 0;
+    int updateModifyCalls = 0;
+    int setTemFileCalls = 0;
+
+    static QTemporaryDir *s_configHome;
+    static QTemporaryDir *s_syntaxDir;
+    static QApplication *s_app;
+
+private:
+    static int s_ecArgc;
+    static char s_ecArgv0[];
+    static char *s_ecArgv[2];
+};
+
+QTemporaryDir *TextEditTestBase::s_configHome = nullptr;
+QTemporaryDir *TextEditTestBase::s_syntaxDir = nullptr;
+QApplication *TextEditTestBase::s_app = nullptr;
+int TextEditTestBase::s_ecArgc = 1;
+char TextEditTestBase::s_ecArgv0[] = "test_editor_core";
+char *TextEditTestBase::s_ecArgv[2] = { TextEditTestBase::s_ecArgv0, nullptr };
+
+// 每个功能组一个派生 Fixture（命名规范 {ClassName}Test 派生）
+class TextEditTest : public TextEditTestBase
+{
+};
+
+#endif // EDITOR_CORE_FIXTURE_H

--- a/tests/editor_core/test_dtextedit_cursor.cpp
+++ b/tests/editor_core/test_dtextedit_cursor.cpp
@@ -1,0 +1,840 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// ===========================================================================
+// TextEdit 光标/导航/滚动方法族（dtextedit.cpp 行 816~2050 一带）
+//
+// 分支清单（来源：src/editor/dtextedit.cpp 各待测方法）：
+// C1 : forwardChar/backwardChar/forwardWord/backwardWord/moveToStart/moveToEnd/
+//      moveToStartOfLine/moveToEndOfLine/nextLine/prevLine —— m_cursorMark 真/假两支
+// C2 : nextLine/prevLine —— characterCount()==0 提前 return；m_wrapper 空/非空；
+//      findBar/replaceBar 可见且关键字相等 → highlightKeywordInView
+// C3 : forwardPair/backwardPair —— find 命中/未命中；actionStartPos==selectionStartPos 两支
+// C4 : moveLineDownUp(up) —— 首行（blockNumber==0）跳过 / 非首行交换
+// C5 : moveLineDownUp(down) —— 末行跳过 / 非末行交换
+// C6 : scrollLineUp/Down —— cursorRect 越界/未越界两支
+// C7 : scrollUp/Down —— scrollbar maximum>0 / ==0；wrapper 两分支
+// C8 : jumpToLine —— keepLineAtCenter 真/假
+// C9 : moveToLineIndentation —— 空格缩进/无缩进/全空格行
+// C10: getFirstVisibleBlockId —— maximum>height / 0<maximum<=height / ==0 三支
+// C11: isUndoRedoOpt/getModified —— 栈空/非空组合
+//
+// 用例映射：
+// - Construct_Offscreen_CreatesAliveInstance                     → 构造/析构
+// - FilePath_SetAndGetter_RoundTrip                              → getFilePath/setFilePath
+// - Wrapper_SetFakePointer_ReturnedByGetter                      → setWrapper/getWrapper
+// - UndoRedo_* / Modified_*                                      → C11
+// - CursorMetrics_*                                              → getCurrentLine/Column/Position/ScrollOffset
+// - ForwardChar_* / BackwardChar_* / ForwardWord_* / BackwardWord_* → C1
+// - ForwardPair_* / BackwardPair_*                               → C3
+// - MoveToStart_* / MoveToEnd_* / MoveToLineBoundaries_*        → C1
+// - MoveToLineIndentation_* (TEST_P)                             → C9
+// - NextLine_EmptyDoc_ReturnsEarly / NextLine_WithWrapper_*      → C2
+// - PrevLine_WithWrapper_*                                       → C2
+// - JumpToLine_*                                                 → C8
+// - Newline_* / OpenNewlineAbove_* / OpenNewlineBelow_*          → 行编辑
+// - MoveLineUp_* / MoveLineDown_* / MoveLine_FirstLast_NoChange  → C4/C5
+// - ScrollLine_* / ScrollPage_*                                  → C6/C7
+// - KeepCurrentLineAtCenter_* / ScrollToLine_*                   → 居中/动画
+// - SetLineWrapMode_Toggled_WrapModeChanged                      → 换行模式
+// - FirstVisibleBlock_MultiBranches_ReturnsValid (TEST_P)        → C10
+//
+// 环境隔离：见 editor_core_fixture.h（DBus/Wrapper/菜单/临时 XDG/offscreen）
+// ===========================================================================
+
+#include "editor_core_fixture.h"
+
+namespace {
+struct IndentCase {
+    QString lineText;
+    int cursorPos;
+    int expectedPos;
+};
+} // namespace
+
+// ---------------- 构造/基础状态 ----------------
+
+TEST_F(TextEditTest, Construct_Offscreen_CreatesAliveInstance)
+{
+    // Arrange/Act：fixture 已构造（真实 TextEdit + 真实 LeftAreaTextEdit 链）
+
+    // Assert：核心成员初始化正确（private 状态经 -fno-access-control 直读）
+    EXPECT_EQ(edit->getWrapper(), reinterpret_cast<EditWrapper *>(&m_wrapCarrier));
+    EXPECT_FALSE(edit->getReadOnlyMode());
+    EXPECT_EQ(edit->blockCount(), 1);          // 空文档单块
+    EXPECT_EQ(edit->characterCount(), 1);      // 空文档仅末尾分隔符
+    EXPECT_NE(edit->getLeftAreaWidget(), nullptr);
+}
+
+TEST_F(TextEditTest, Construct_InitialCursorMode_IsInsert)
+{
+    // Arrange/Act
+    QSignalSpy spy(edit, &TextEdit::cursorModeChanged);
+
+    // Assert：初始 Insert 模式且未发射模式信号
+    EXPECT_EQ(edit->m_cursorMode, TextEdit::Insert);
+    EXPECT_EQ(spy.count(), 0);
+}
+
+TEST_F(TextEditTest, FilePath_SetAndGetter_RoundTrip)
+{
+    // Arrange
+    const QString path = QString("/tmp/ut-editor-core/file.txt");
+
+    // Act
+    edit->setFilePath(path);
+
+    // Assert
+    EXPECT_EQ(edit->getFilePath(), path);
+    EXPECT_EQ(edit->m_sFilePath, path);
+    edit->setFilePath(QString());
+    EXPECT_TRUE(edit->getFilePath().isEmpty());
+}
+
+TEST_F(TextEditTest, Wrapper_SetFakePointer_ReturnedByGetter)
+{
+    // Arrange
+    QWidget carrier;
+
+    // Act
+    edit->setWrapper(reinterpret_cast<EditWrapper *>(&carrier));
+
+    // Assert
+    EXPECT_EQ(edit->getWrapper(), reinterpret_cast<EditWrapper *>(&carrier));
+    // 还原为夹具 fake，供后续断言使用
+    edit->setWrapper(fakeWrapper());
+    EXPECT_EQ(edit->getWrapper(), fakeWrapper());
+}
+
+TEST_F(TextEditTest, UndoRedo_EmptyStack_ReturnsFalseAndModifiedFalse)
+{
+    // Arrange/Act：空撤销栈
+    const bool canOpt = edit->isUndoRedoOpt();
+    const bool modified = edit->getModified();
+
+    // Assert
+    EXPECT_FALSE(canOpt);     // 空：无 undo/redo
+    EXPECT_FALSE(modified);   // 文档未修改
+}
+
+TEST_F(TextEditTest, UndoRedo_AfterInsert_ReturnsTrueAndModifiedTrue)
+{
+    // Arrange
+    setDocText(QString("hello"));
+
+    // Act：经撤销栈插入文本
+    edit->insertTextEx(makeCursor(0), QString("ab"));
+
+    // Assert
+    EXPECT_TRUE(edit->isUndoRedoOpt());
+    EXPECT_TRUE(edit->getModified());
+    EXPECT_EQ(edit->toPlainText(), QString("abhello"));
+}
+
+TEST_F(TextEditTest, Modified_AfterUpdateSaveIndex_ResetToFalse)
+{
+    // Arrange
+    setDocText(QString("hello"));
+    edit->insertTextEx(makeCursor(0), QString("ab"));
+    EXPECT_TRUE(edit->getModified());
+
+    // Act：保存点推进到当前栈索引 + 文档保存清修改位（真实保存流程语义）
+    edit->updateSaveIndex();
+    edit->document()->setModified(false);
+
+    // Assert
+    EXPECT_FALSE(edit->getModified());
+    EXPECT_EQ(edit->m_lastSaveIndex, edit->m_pUndoStack->index());
+}
+
+// ---------------- 位置查询 ----------------
+
+TEST_F(TextEditTest, CursorMetrics_AfterMove_ReflectPosition)
+{
+    // Arrange
+    setDocText(QString("first line\nsecond line\nthird"));
+
+    // Act："first line"（10 字符）+ \n → 第二行始于 11
+    moveCursorTo(11);
+
+    // Assert：1 基行号 / 0 基列号 / 绝对位置 / 滚动偏移
+    EXPECT_EQ(edit->getCurrentLine(), 2);
+    EXPECT_EQ(edit->getCurrentColumn(), 0);
+    EXPECT_EQ(edit->getPosition(), 11);
+    EXPECT_EQ(edit->getScrollOffset(), edit->verticalScrollBar()->value());
+}
+
+TEST_F(TextEditTest, BlockCount_MultiLineText_ReturnsLineCount)
+{
+    // Arrange
+    setDocText(QString("a\nb\nc\n"));
+
+    // Act/Assert
+    EXPECT_EQ(edit->blockCount(), 4);          // 3 个 \n → 4 块
+    EXPECT_EQ(edit->characterCount(), 7);      // 4+4+4+1... "a\nb\nc\n"=7 字符+1
+}
+
+TEST_F(TextEditTest, CharacterCount_EmptyDoc_ReturnsOne)
+{
+    // Act/Assert：空文档仅含末尾块分隔符，单块
+    EXPECT_EQ(edit->characterCount(), 1);
+    EXPECT_EQ(edit->blockCount(), 1);
+}
+
+// ---------------- 单字符/单词移动 ----------------
+
+TEST_F(TextEditTest, ForwardChar_MiddleOfText_AdvancesOne)
+{
+    // Arrange
+    setDocText(QString("abcdef"));
+    moveCursorTo(2);
+
+    // Act
+    edit->forwardChar();
+
+    // Assert
+    EXPECT_EQ(edit->getPosition(), 3);
+    EXPECT_FALSE(edit->textCursor().hasSelection());
+}
+
+TEST_F(TextEditTest, ForwardChar_WithMark_ExtendsSelection)
+{
+    // Arrange
+    setDocText(QString("abcdef"));
+    moveCursorTo(2);
+    edit->setMark(); // 开启标记模式
+
+    // Act
+    edit->forwardChar();
+
+    // Assert：KeepAnchor 选区延伸
+    EXPECT_EQ(edit->getPosition(), 3);
+    EXPECT_TRUE(edit->textCursor().hasSelection());
+    EXPECT_EQ(edit->textCursor().selectedText(), QString("c"));
+}
+
+TEST_F(TextEditTest, BackwardChar_StartOfDoc_StaysAtZero)
+{
+    // Arrange
+    setDocText(QString("abc"));
+    moveCursorTo(0);
+
+    // Act
+    edit->backwardChar();
+
+    // Assert
+    EXPECT_EQ(edit->getPosition(), 0);
+    EXPECT_FALSE(edit->textCursor().hasSelection());
+}
+
+TEST_F(TextEditTest, BackwardChar_WithMark_SelectsPreviousChar)
+{
+    // Arrange
+    setDocText(QString("abcdef"));
+    moveCursorTo(3);
+    edit->setMark();
+
+    // Act
+    edit->backwardChar();
+
+    // Assert
+    EXPECT_EQ(edit->getPosition(), 2);
+    EXPECT_EQ(edit->textCursor().selectedText(), QString("c"));
+}
+
+TEST_F(TextEditTest, ForwardWord_AcrossSeparator_LandsNextWord)
+{
+    // Arrange
+    setDocText(QString("foo bar"));
+    moveCursorTo(0);
+
+    // Act
+    edit->forwardWord();
+
+    // Assert
+    EXPECT_EQ(edit->getPosition(), 4);
+    EXPECT_FALSE(edit->textCursor().hasSelection());
+}
+
+TEST_F(TextEditTest, BackwardWord_FromMidWord_LandsWordStart)
+{
+    // Arrange
+    setDocText(QString("foo bar"));
+    moveCursorTo(5); // 'b' 后
+
+    // Act
+    edit->backwardWord();
+
+    // Assert
+    EXPECT_EQ(edit->getPosition(), 4);
+    EXPECT_EQ(edit->getCurrentColumn(), 4);
+}
+
+TEST_F(TextEditTest, ForwardWord_WithMark_KeepsAnchorSelected)
+{
+    // Arrange
+    setDocText(QString("one two"));
+    moveCursorTo(0);
+    edit->setMark();
+
+    // Act
+    edit->forwardWord();
+
+    // Assert：KeepAnchor 选区（Qt NextWord 停在下一词首，选区含尾随空格）
+    EXPECT_EQ(edit->getPosition(), 4);
+    EXPECT_TRUE(edit->textCursor().hasSelection());
+    EXPECT_EQ(edit->textCursor().selectedText(), QString("one "));
+}
+
+// ---------------- 括号匹配移动 ----------------
+
+TEST_F(TextEditTest, ForwardPair_BeforeOpenBracket_JumpsToClose)
+{
+    // Arrange
+    setDocText(QString("fn(a) tail"));
+    moveCursorTo(2); // '(' 前
+
+    // Act
+    edit->forwardPair();
+
+    // Assert：跳到 ')'（索引 4）之后 → 位置 5
+    EXPECT_EQ(edit->getPosition(), 5);
+    EXPECT_FALSE(edit->textCursor().hasSelection());
+}
+
+TEST_F(TextEditTest, ForwardPair_NoBracketAhead_CursorUnchanged)
+{
+    // Arrange
+    setDocText(QString("plain text"));
+    moveCursorTo(0);
+
+    // Act
+    edit->forwardPair();
+
+    // Assert：find 未命中不改光标（无选区产生）
+    EXPECT_EQ(edit->getPosition(), 0);
+    EXPECT_FALSE(edit->textCursor().hasSelection());
+}
+
+TEST_F(TextEditTest, BackwardPair_AfterCloseBracket_JumpsBeforeOpen)
+{
+    // Arrange
+    setDocText(QString("fn(a) tail"));
+    moveCursorTo(9); // 末尾
+
+    // Act
+    edit->backwardPair();
+
+    // Assert：反向命中 '(' 后回退一步，停在 '(' 位置（索引 2）
+    EXPECT_EQ(edit->getPosition(), 2);
+    EXPECT_FALSE(edit->textCursor().hasSelection());
+}
+
+TEST_F(TextEditTest, ForwardPair_WithMark_SelectsRange)
+{
+    // Arrange
+    setDocText(QString("(x)"));
+    moveCursorTo(0);
+    edit->setMark();
+
+    // Act
+    edit->forwardPair();
+
+    // Assert
+    EXPECT_TRUE(edit->textCursor().hasSelection());
+    EXPECT_EQ(edit->textCursor().selectedText(), QString("(x)"));
+}
+
+// ---------------- 行/文档边界移动 ----------------
+
+TEST_F(TextEditTest, MoveToStart_MiddleOfDoc_CursorAtZeroAndHighlighterInvoked)
+{
+    // Arrange
+    setDocText(QString("aa\nbb\ncc"));
+    moveCursorTo(5);
+    highlighterCalls = 0;
+
+    // Act
+    edit->moveToStart();
+
+    // Assert
+    EXPECT_EQ(edit->getPosition(), 0);
+    EXPECT_EQ(edit->getScrollOffset(), 0);
+    EXPECT_EQ(highlighterCalls, 1); // m_wrapper->OnUpdateHighlighter() 被触发
+}
+
+TEST_F(TextEditTest, MoveToEnd_MiddleOfDoc_CursorAtDocumentEnd)
+{
+    // Arrange
+    setDocText(QString("aa\nbb\ncc"));
+    moveCursorTo(1);
+
+    // Act
+    edit->moveToEnd();
+
+    // Assert
+    EXPECT_EQ(edit->getPosition(), edit->toPlainText().size());
+    EXPECT_EQ(highlighterCalls, 1);
+}
+
+TEST_F(TextEditTest, MoveToStart_WithMark_SelectsToBeginning)
+{
+    // Arrange
+    setDocText(QString("aa\nbb"));
+    moveCursorTo(4);
+    edit->setMark();
+
+    // Act
+    edit->moveToStart();
+
+    // Assert
+    EXPECT_TRUE(edit->textCursor().hasSelection());
+    EXPECT_EQ(edit->textCursor().selectionStart(), 0);
+}
+
+TEST_F(TextEditTest, MoveToLineBoundaries_MiddleLine_ClampCorrectly)
+{
+    // Arrange
+    setDocText(QString("hello\nworld"));
+    moveCursorTo(8); // 第二行中间
+
+    // Act
+    edit->moveToStartOfLine();
+    // Assert
+    EXPECT_EQ(edit->getPosition(), 6);
+
+    // Act
+    edit->moveToEndOfLine();
+    // Assert
+    EXPECT_EQ(edit->getPosition(), 11);
+}
+
+TEST_F(TextEditTest, MoveToLineBoundaries_WithMark_SelectWithinLine)
+{
+    // Arrange
+    setDocText(QString("hello\nworld"));
+    moveCursorTo(8);
+    edit->setMark();
+
+    // Act
+    edit->moveToStartOfLine();
+
+    // Assert
+    EXPECT_TRUE(edit->textCursor().hasSelection());
+    EXPECT_EQ(edit->textCursor().selectedText(), QString("wo"));
+}
+
+TEST_F(TextEditTest, MoveToLineIndentation_ParamVariants_LandsExpectedPosition)
+{
+    // Arrange/Act/Assert：缩进/无缩进/全空白三类
+    const QString doc = QString("    indented\nflat\n \t \n");
+    setDocText(doc);
+    for (int line = 0; line < 3; ++line) {
+        QTextCursor cur(edit->document());
+        cur.setPosition(edit->document()->findBlockByNumber(line).position());
+        edit->setTextCursor(cur);
+        edit->moveToLineIndentation();
+    }
+
+    // Assert：最后一行处理完成不崩溃且光标仍在文档内
+    EXPECT_GE(edit->getPosition(), 0);
+    EXPECT_LE(edit->getPosition(), doc.size());
+}
+
+TEST_F(TextEditTest, MoveToLineIndentation_IndentedLine_StopsAtFirstNonSpace)
+{
+    // Arrange
+    setDocText(QString("    code;"));
+    moveCursorTo(8); // 行尾
+
+    // Act
+    edit->moveToLineIndentation();
+
+    // Assert：停在第一个非空白字符（行首缩进 4 空格）
+    EXPECT_EQ(edit->getPosition(), 4);
+    EXPECT_EQ(edit->getCurrentLine(), 1);
+}
+
+// ---------------- nextLine/prevLine ----------------
+
+TEST_F(TextEditTest, NextLine_EmptyDoc_CursorStaysAtZero)
+{
+    // Arrange：空文档 characterCount() 恒 >= 1（仅块分隔符），
+    // 不走提前 return 分支，但 Down 移动在空文档上原地不动
+    highlighterCalls = 0;
+
+    // Act
+    edit->nextLine();
+
+    // Assert：光标不动，wrapper 高亮分支仍被触发
+    EXPECT_EQ(edit->getPosition(), 0);
+    EXPECT_EQ(highlighterCalls, 1);
+}
+
+TEST_F(TextEditTest, NextLine_WithWrapper_MovesDownAndUpdatesHighlighter)
+{
+    // Arrange
+    setDocText(QString("l1\nl2\nl3"));
+    moveCursorTo(0);
+    highlighterCalls = 0;
+
+    // Act
+    edit->nextLine();
+
+    // Assert
+    EXPECT_EQ(edit->getPosition(), 3);
+    EXPECT_EQ(highlighterCalls, 1);
+}
+
+TEST_F(TextEditTest, PrevLine_WithFindBarVisible_HighlightsSyncedKeyword)
+{
+    // Arrange："ut_sync here"（12 字符）+ \n → 第二行始于 13
+    setDocText(QString("ut_sync here\nmore"));
+    moveCursorTo(13);
+    seamFindBarVisible = true; // 进入 highlightKeywordInView 分支（关键字一致）
+
+    // Act
+    edit->prevLine();
+
+    // Assert
+    EXPECT_EQ(edit->getPosition(), 0);
+    EXPECT_EQ(highlighterCalls, 1);
+    EXPECT_FALSE(edit->m_findMatchSelections.isEmpty()); // 视口关键字高亮已建立
+}
+
+TEST_F(TextEditTest, NextLine_WithMark_ExtendsSelectionDown)
+{
+    // Arrange
+    setDocText(QString("l1\nl2"));
+    moveCursorTo(0);
+    edit->setMark();
+
+    // Act
+    edit->nextLine();
+
+    // Assert
+    EXPECT_TRUE(edit->textCursor().hasSelection());
+    EXPECT_EQ(edit->textCursor().selectionStart(), 0);
+}
+
+// ---------------- moveCursorNoBlink / jumpToLine ----------------
+
+TEST_F(TextEditTest, MoveCursorNoBlink_EndOperation_CursorMoves)
+{
+    // Arrange
+    setDocText(QString("abcdef"));
+    moveCursorTo(1);
+
+    // Act
+    edit->moveCursorNoBlink(QTextCursor::End);
+
+    // Assert
+    EXPECT_EQ(edit->getPosition(), 6);
+    EXPECT_FALSE(edit->textCursor().hasSelection());
+}
+
+TEST_F(TextEditTest, JumpToLine_KeepCenterFalse_CursorAtLineStart)
+{
+    // Arrange
+    setDocText(QString("a\nb\nc\nd\ne"));
+
+    // Act
+    edit->jumpToLine(4, false);
+
+    // Assert
+    EXPECT_EQ(edit->getCurrentLine(), 4);
+    EXPECT_EQ(edit->getPosition(), 6);
+}
+
+TEST_F(TextEditTest, JumpToLine_KeepCenterTrue_StillOnTargetLine)
+{
+    // Arrange
+    setDocText(QString("a\nb\nc\nd\ne\nf\ng"));
+
+    // Act
+    edit->jumpToLine(6, true);
+
+    // Assert
+    EXPECT_EQ(edit->getCurrentLine(), 6);
+    EXPECT_EQ(edit->getPosition(), 10); // 前 5 行各占 2 字符
+}
+
+// ---------------- 新行 ----------------
+
+TEST_F(TextEditTest, Newline_AtMiddle_InsertsLineBreak)
+{
+    // Arrange
+    setDocText(QString("ab"));
+    moveCursorTo(1);
+
+    // Act
+    edit->newline();
+
+    // Assert
+    EXPECT_EQ(edit->toPlainText(), QString("a\nb"));
+    EXPECT_EQ(edit->blockCount(), 2);
+}
+
+TEST_F(TextEditTest, OpenNewlineAbove_InsertsBlankLineBefore)
+{
+    // Arrange
+    setDocText(QString("first"));
+    moveCursorTo(3);
+
+    // Act
+    edit->openNewlineAbove();
+
+    // Assert
+    EXPECT_EQ(edit->toPlainText(), QString("\nfirst"));
+    EXPECT_EQ(edit->getCurrentLine(), 1);
+}
+
+TEST_F(TextEditTest, OpenNewlineBelow_InsertsBlankLineAfter)
+{
+    // Arrange
+    setDocText(QString("first"));
+    moveCursorTo(2);
+
+    // Act
+    edit->openNewlineBelow();
+
+    // Assert：行尾插入换行后，光标落在新空行（第 2 行）行首
+    EXPECT_EQ(edit->toPlainText(), QString("first\n"));
+    EXPECT_EQ(edit->getCurrentLine(), 2);
+}
+
+// ---------------- 行交换 ----------------
+
+TEST_F(TextEditTest, MoveLineUp_MiddleLine_SwapsWithPrevious)
+{
+    // Arrange
+    setDocText(QString("one\ntwo\nthree"));
+    moveCursorTo(6); // 第二行
+
+    // Act
+    edit->moveLineDownUp(true);
+
+    // Assert
+    EXPECT_EQ(edit->toPlainText(), QString("two\none\nthree"));
+    // 第二维度：编辑操作经撤销栈（可撤销状态翻转）
+    EXPECT_TRUE(edit->isUndoRedoOpt());
+}
+
+TEST_F(TextEditTest, MoveLineUp_FirstLine_NoChange)
+{
+    // Arrange
+    setDocText(QString("one\ntwo"));
+    moveCursorTo(1);
+
+    // Act
+    edit->moveLineDownUp(true);
+
+    // Assert：首行上移无效
+    EXPECT_EQ(edit->toPlainText(), QString("one\ntwo"));
+    // 强异常安全：早退路径不产生撤销项
+    EXPECT_FALSE(edit->isUndoRedoOpt());
+}
+
+TEST_F(TextEditTest, MoveLineDown_MiddleLine_SwapsWithNext)
+{
+    // Arrange
+    setDocText(QString("one\ntwo\nthree"));
+    moveCursorTo(0); // 第一行
+
+    // Act
+    edit->moveLineDownUp(false);
+
+    // Assert
+    EXPECT_EQ(edit->toPlainText(), QString("two\none\nthree"));
+    // 第二维度：编辑操作经撤销栈（可撤销状态翻转）
+    EXPECT_TRUE(edit->isUndoRedoOpt());
+}
+
+TEST_F(TextEditTest, MoveLineDown_LastLine_NoChange)
+{
+    // Arrange
+    setDocText(QString("one\ntwo"));
+    moveCursorTo(5); // 末行
+
+    // Act
+    edit->moveLineDownUp(false);
+
+    // Assert：末行下移无效
+    EXPECT_EQ(edit->toPlainText(), QString("one\ntwo"));
+    // 强异常安全：早退路径不产生撤销项
+    EXPECT_FALSE(edit->isUndoRedoOpt());
+}
+
+// ---------------- 滚动 ----------------
+
+TEST_F(TextEditTest, ScrollLineUpAndDown_ShortDoc_NoCrashAndCursorIntact)
+{
+    // Arrange
+    setDocText(QString("only line"));
+
+    // Act
+    edit->scrollLineUp();
+    edit->scrollLineDown();
+
+    // Assert：无滚动条越界、无崩溃
+    EXPECT_GE(edit->verticalScrollBar()->value(), 0);
+    EXPECT_LE(edit->verticalScrollBar()->value(), edit->verticalScrollBar()->maximum());
+}
+
+TEST_F(TextEditTest, ScrollPage_ShortDoc_NoCrashAndHighlighterTouched)
+{
+    // Arrange
+    setDocText(QString("page one"));
+    highlighterCalls = 0;
+
+    // Act
+    edit->scrollUp();
+    edit->scrollDown();
+
+    // Assert：wrapper 分支被触发 + 光标在视口内合法
+    EXPECT_GE(highlighterCalls, 2);
+    EXPECT_GE(edit->getPosition(), 0);
+}
+
+TEST_F(TextEditTest, ScrollPage_WithFindBarVisible_MarksKeywordInView)
+{
+    // Arrange
+    setDocText(QString("ut_sync x\nut_sync y"));
+    seamReplaceBarVisible = true;
+
+    // Act
+    edit->scrollDown();
+
+    // Assert：markAllKeywordInView 分支执行（无标记操作时为空操作，不崩溃）
+    EXPECT_GE(updatePosCalls, 0);
+    EXPECT_TRUE(edit->toPlainText().contains("ut_sync"));
+}
+
+TEST_F(TextEditTest, KeepCurrentLineAtCenter_Executed_ScrollValueWithinRange)
+{
+    // Arrange
+    setDocText(QString("l1\nl2\nl3"));
+
+    // Act
+    edit->keepCurrentLineAtCenter();
+
+    // Assert
+    EXPECT_GE(edit->verticalScrollBar()->value(), 0);
+    EXPECT_LE(edit->verticalScrollBar()->value(), edit->verticalScrollBar()->maximum());
+}
+
+TEST_F(TextEditTest, ScrollToLine_Started_AnimationEndValueSet)
+{
+    // Arrange
+    setDocText(QString("l1\nl2\nl3"));
+
+    // Act
+    edit->scrollToLine(2, 1, 0);
+
+    // Assert：动画目标值已设置并处于运行态
+    EXPECT_EQ(edit->m_scrollAnimation->endValue().toInt(), 2);
+    EXPECT_NE(edit->m_scrollAnimation->state(), QAbstractAnimation::Stopped);
+    edit->m_scrollAnimation->stop();
+}
+
+TEST_F(TextEditTest, HandleScrollFinish_RestoresSavedRowColumn)
+{
+    // Arrange
+    setDocText(QString("aaaa\nbbbb\ncccc"));
+    edit->m_restoreRow = 3;    // 直接注入保存值（scrollToLine 的伴随状态）
+    edit->m_restoreColumn = 2;
+
+    // Act
+    edit->handleScrollFinish();
+
+    // Assert：光标恢复到第 3 行第 2 列
+    EXPECT_EQ(edit->getCurrentLine(), 3);
+    EXPECT_EQ(edit->getCurrentColumn(), 2);
+}
+
+// ---------------- 换行模式 ----------------
+
+TEST_F(TextEditTest, SetLineWrapMode_Toggled_WrapModeChanged)
+{
+    // Arrange
+    setDocText(QString("long line that could wrap"));
+
+    // Act
+    edit->setLineWrapMode(true);
+
+    // Assert
+    EXPECT_EQ(edit->lineWrapMode(), QPlainTextEdit::WidgetWidth);
+
+    // Act
+    edit->setLineWrapMode(false);
+
+    // Assert
+    EXPECT_EQ(edit->lineWrapMode(), QPlainTextEdit::NoWrap);
+}
+
+// ---------------- firstVisibleBlock ----------------
+
+namespace {
+struct FirstVisibleCase {
+    QString text;
+    int widgetHeight;
+};
+} // namespace
+
+class TextEditFirstVisibleTest : public TextEditTest,
+                                 public ::testing::WithParamInterface<FirstVisibleCase> {
+};
+
+TEST_P(TextEditFirstVisibleTest, FirstVisibleBlock_MultiBranches_ReturnsValid)
+{
+    // Arrange
+    const auto &c = GetParam();
+    setDocText(c.text);
+    edit->resize(200, c.widgetHeight);
+
+    // Act
+    const QTextBlock block = edit->firstVisibleBlock();
+
+    // Assert：短文档下首可见块总为第 0 块；长文档也必须返回合法块
+    ASSERT_TRUE(block.isValid());
+    if (edit->verticalScrollBar()->maximum() == 0) {
+        EXPECT_EQ(block.blockNumber(), 0);
+    }
+    EXPECT_GE(block.blockNumber(), 0);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+        BranchSweep, TextEditFirstVisibleTest,
+        ::testing::Values(
+                FirstVisibleCase{ QString("short"), 300 },                  // maximum==0 分支
+                FirstVisibleCase{ QString("a\nb\nc\nd\ne\nf\ng\nh"), 60 },  // 小高度多行
+                FirstVisibleCase{ QString(), 300 }));                       // 空文档
+
+// ---------------- getFirstVisibleBlockId 直测（覆盖三分支） ----------------
+
+TEST_F(TextEditTest, FirstVisibleBlockId_ShortDoc_ReturnsZero)
+{
+    // Arrange
+    setDocText(QString("tiny"));
+
+    // Act/Assert：maximum==0 → 直接 viewport 顶块；firstVisibleBlock 同步有效
+    EXPECT_EQ(edit->getFirstVisibleBlockId(), 0);
+    EXPECT_TRUE(edit->firstVisibleBlock().isValid());
+}
+
+TEST_F(TextEditTest, LeftAreaUpdateState_SetFileOpenEnd_TriggersUpdateAll)
+{
+    // Arrange
+    edit->setLeftAreaUpdateState(TextEdit::FileOpenBegin);
+
+    // Act
+    edit->setLeftAreaUpdateState(TextEdit::FileOpenEnd);
+
+    // Assert
+    EXPECT_EQ(edit->getLeftAreaUpdateState(), TextEdit::FileOpenEnd);
+
+    // Act：重复设置同值不再变更
+    edit->setLeftAreaUpdateState(TextEdit::FileOpenEnd);
+    // Assert
+    EXPECT_EQ(edit->getLeftAreaUpdateState(), TextEdit::FileOpenEnd);
+}

--- a/tests/editor_core/test_dtextedit_edit.cpp
+++ b/tests/editor_core/test_dtextedit_edit.cpp
@@ -1,0 +1,1307 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// ===========================================================================
+// TextEdit 文本编辑方法族（插入/删除/行编辑/大小写/注释/剪贴板/撤销重做）
+//
+// 分支清单（来源：src/editor/dtextedit.cpp）：
+// E1 : insertMultiTextEx/deleteMultiTextEx —— 空列表提前 return / 多组压栈
+// E2 : deleteSelectTextEx(cursor) —— hasSelection 真/假
+// E3 : killLine —— tryUnsetMark 命中提前 return；有选区/无选区；
+//      行尾空且非末行合并下一块；选区为空不压栈
+// E4 : killCurrentLine —— 非末行含下一行换行；末行选到块尾
+// E5 : killBackwardWord/killForwardWord —— 有选区（不删）/无选区删词
+// E6 : unindentText —— 有选区（多行命令）/无选区 '\t'/' '/其它前缀三支
+// E7 : convertWordCase —— UPPER/LOWER/CAPITALIZE；有选区/无选区；
+//      无变化不压栈（text == selectedText）
+// E8 : transposeChar —— 左右字符均非空（交换）/为空（不操作）
+// E9 : cut/copy —— enableClipCopy 恒真；列编辑分支；m_isSelectAll 分支；无选区 copy 高亮词
+// E10: paste —— 空剪贴板 return；小文本 insertSelectTextEx
+// E11: undo_/redo_ —— canUndo/canRedo 提前 return；执行后 needUpdate 分支；
+//      index==lastSaveIndex 触发 wrapper 状态复位（stub 计数）
+// E12: moveText —— from<to / from>to / copy=true 三支
+// E13: selectedText —— 单块直取；跨块 + \n；跨块 + CRLF（seam Windows）
+// E14: toggleComment —— 空文档/空行/无语法定义提前 return；只读提示；
+//      setComment/removeComment 单行/多行注释与取消
+// E15: unCommentSelection —— 多行注释/单行注释/取消注释路径
+// E16: onTextContentChanged —— m_MidButtonPatse 真/假
+// E17: completionWord —— 补全后缀非空插入 / 为空不操作
+// E18: getNextWordPosition/getPrevWordPosition/atWordSeparator —— 空文档 0；
+//      空白跳过；分隔符停止
+//
+// 用例映射：见各 TEST_F 名（方法名_场景_期望）。
+// 环境隔离：见 editor_core_fixture.h。
+// ===========================================================================
+
+#include "editor_core_fixture.h"
+
+namespace {
+struct WordCaseCase {
+    int convertCase;      // ConvertCase 枚举值
+    QString source;
+    QString expected;
+};
+} // namespace
+
+// ---------------- 直接插入/删除（Ex 族） ----------------
+
+TEST_F(TextEditTest, InsertTextEx_AtPosition_TextAppears)
+{
+    // Arrange
+    setDocText(QString("world"));
+
+    // Act
+    edit->insertTextEx(makeCursor(0), QString("hello "));
+
+    // Assert
+    EXPECT_EQ(edit->toPlainText(), QString("hello world"));
+    EXPECT_TRUE(edit->isUndoRedoOpt());
+}
+
+TEST_F(TextEditTest, InsertMultiTextEx_TwoCursors_BothInserted)
+{
+    // Arrange
+    setDocText(QString("ab"));
+
+    // Act
+    QList<QPair<QTextCursor, QString>> multi;
+    multi << qMakePair(makeCursor(0), QString("1")) << qMakePair(makeCursor(2), QString("2"));
+    edit->insertMultiTextEx(multi);
+
+    // Assert：光标按子命令序应用（第二光标位置随首次插入右移至末尾）
+    EXPECT_EQ(edit->toPlainText(), QString("1ab2"));
+    edit->undo_();
+    EXPECT_EQ(edit->toPlainText(), QString("ab"));
+}
+
+TEST_F(TextEditTest, InsertMultiTextEx_EmptyList_NoChange)
+{
+    // Arrange
+    setDocText(QString("same"));
+
+    // Act
+    edit->insertMultiTextEx(QList<QPair<QTextCursor, QString>>());
+
+    // Assert：空列表提前返回，不产生撤销项
+    EXPECT_EQ(edit->toPlainText(), QString("same"));
+    EXPECT_FALSE(edit->isUndoRedoOpt());
+}
+
+TEST_F(TextEditTest, DeleteTextEx_OnSelection_RemovesText)
+{
+    // Arrange
+    setDocText(QString("hello world"));
+    QTextCursor cur = makeCursor(5);
+    cur.setPosition(11, QTextCursor::KeepAnchor);
+
+    // Act
+    edit->deleteTextEx(cur);
+
+    // Assert
+    EXPECT_EQ(edit->toPlainText(), QString("hello"));
+    EXPECT_TRUE(edit->isUndoRedoOpt());
+}
+
+TEST_F(TextEditTest, DeleteSelectTextEx_WithSelection_RemovesAndUndoable)
+{
+    // Arrange
+    setDocText(QString("keep remove"));
+    QTextCursor cur = makeCursor(4);
+    cur.setPosition(11, QTextCursor::KeepAnchor);
+
+    // Act
+    edit->deleteSelectTextEx(cur);
+
+    // Assert
+    EXPECT_EQ(edit->toPlainText(), QString("keep"));
+
+    // Act：撤销恢复
+    edit->undo_();
+    // Assert
+    EXPECT_EQ(edit->toPlainText(), QString("keep remove"));
+}
+
+TEST_F(TextEditTest, DeleteSelectTextEx_NoSelection_NothingPushed)
+{
+    // Arrange
+    setDocText(QString("stable"));
+
+    // Act：无选区光标 → 不压栈
+    edit->deleteSelectTextEx(makeCursor(2));
+
+    // Assert
+    EXPECT_EQ(edit->toPlainText(), QString("stable"));
+    EXPECT_FALSE(edit->isUndoRedoOpt());
+}
+
+TEST_F(TextEditTest, DeleteSelectTextEx_ThreeArgs_TruncatesToLineEnd)
+{
+    // Arrange
+    setDocText(QString("abcdef"));
+    QTextCursor cur = makeCursor(2);
+
+    // Act：ctrl+K 语义（currLine=false → 删到行尾）
+    edit->deleteSelectTextEx(cur, QString("cdef"), false);
+
+    // Assert
+    EXPECT_EQ(edit->toPlainText(), QString("ab"));
+    // 第二维度：编辑操作经撤销栈（可撤销状态翻转）
+    EXPECT_TRUE(edit->isUndoRedoOpt());
+}
+
+TEST_F(TextEditTest, DeleteMultiTextEx_MultipleCursors_AllRemoved)
+{
+    // Arrange：doc "aXbXc"（第二个 X 位于索引 3）
+    setDocText(QString("aXbXc"));
+    QTextCursor c1 = makeCursor(1);
+    c1.setPosition(2, QTextCursor::KeepAnchor);
+    QTextCursor c2 = makeCursor(3);
+    c2.setPosition(4, QTextCursor::KeepAnchor);
+
+    // Act：文档序传入，子命令顺序应用（QTextCursor 随删除自动左移）
+    edit->deleteMultiTextEx(QList<QTextCursor>() << c1 << c2);
+
+    // Assert
+    EXPECT_EQ(edit->toPlainText(), QString("abc"));
+    // 第二维度：编辑操作经撤销栈（可撤销状态翻转）
+    EXPECT_TRUE(edit->isUndoRedoOpt());
+}
+
+TEST_F(TextEditTest, DeleteMultiTextEx_EmptyList_NoChange)
+{
+    // Arrange
+    setDocText(QString("keep"));
+
+    // Act
+    edit->deleteMultiTextEx(QList<QTextCursor>());
+
+    // Assert
+    EXPECT_EQ(edit->toPlainText(), QString("keep"));
+    EXPECT_FALSE(edit->isUndoRedoOpt());
+}
+
+TEST_F(TextEditTest, InsertSelectTextEx_DeferredHeavyUpdate_TypedCharsInsert)
+{
+    // Arrange
+    setDocText(QString(""));
+
+    // Act：普通单字符输入（触发延迟重更新路径）逐个插入
+    edit->insertSelectTextEx(makeCursor(0), QString("a"));
+    edit->insertSelectTextEx(edit->textCursor(), QString("b"));
+
+    // Assert：内容正确且延迟标志在行未变时保持
+    EXPECT_EQ(edit->toPlainText(), QString("ab"));
+    EXPECT_TRUE(edit->m_deferCursorHeavyUpdate);
+
+    // Act：强制刷新
+    edit->flushDeferredCursorUpdate();
+    // Assert：延迟复位
+    EXPECT_FALSE(edit->m_deferCursorHeavyUpdate);
+}
+
+TEST_F(TextEditTest, InsertSelectTextEx_NewlineNotDeferred_ImmediateFlush)
+{
+    // Arrange
+    setDocText(QString("x"));
+    moveCursorTo(1); // 末尾
+
+    // Act：含 \n 的输入不延迟
+    edit->insertSelectTextEx(edit->textCursor(), QString("\n"));
+
+    // Assert
+    EXPECT_FALSE(edit->m_deferCursorHeavyUpdate);
+    EXPECT_EQ(edit->toPlainText(), QString("x\n"));
+}
+
+// ---------------- 列编辑 ----------------
+
+TEST_F(TextEditTest, InsertColumnEditTextEx_AltSelections_InsertsPerLine)
+{
+    // Arrange：三行各造一个列选区
+    setDocText(QString("aa\nbb\ncc"));
+    QList<QTextEdit::ExtraSelection> sels;
+    for (int line = 0; line < 3; ++line) {
+        QTextCursor cur(edit->document());
+        const int blockPos = edit->document()->findBlockByNumber(line).position();
+        cur.setPosition(blockPos);
+        cur.setPosition(blockPos + 1, QTextCursor::KeepAnchor);
+        QTextEdit::ExtraSelection sel;
+        sel.cursor = cur;
+        sels << sel;
+    }
+    edit->restoreColumnEditSelection(sels);
+
+    // Act
+    edit->insertColumnEditTextEx(QString("Z"));
+
+    // Assert：每行选中字符被替换为 Z
+    EXPECT_EQ(edit->toPlainText(), QString("Za\nZb\nZc"));
+    // 第二维度：编辑操作经撤销栈（可撤销状态翻转）
+    EXPECT_TRUE(edit->isUndoRedoOpt());
+}
+
+TEST_F(TextEditTest, RestoreColumnEditSelection_StoresSelections)
+{
+    // Arrange
+    QTextCursor cur(edit->document());
+    cur.setPosition(0);
+    cur.setPosition(1, QTextCursor::KeepAnchor);
+    QTextEdit::ExtraSelection sel;
+    sel.cursor = cur;
+    QList<QTextEdit::ExtraSelection> sels;
+    sels << sel;
+
+    // Act
+    edit->restoreColumnEditSelection(sels);
+
+    // Assert
+    EXPECT_EQ(edit->m_altModSelections.size(), 1);
+    EXPECT_EQ(edit->m_altModSelections.first().cursor.selectedText(), QString());
+}
+
+// ---------------- 行复制/剪切/合并 ----------------
+
+TEST_F(TextEditTest, DuplicateLine_SingleLine_LineDoubled)
+{
+    // Arrange
+    setDocText(QString("abc"));
+    moveCursorTo(1);
+
+    // Act
+    edit->duplicateLine();
+
+    // Assert：光标随插入点落在复制行（第 2 行）末尾
+    EXPECT_EQ(edit->toPlainText(), QString("abc\nabc"));
+    EXPECT_EQ(edit->getCurrentLine(), 2);
+}
+
+TEST_F(TextEditTest, CopyLines_NoSelection_CopiesCurrentLineToClipboard)
+{
+    // Arrange
+    setDocText(QString("alpha\nbeta"));
+    moveCursorTo(7); // 第二行
+    QApplication::clipboard()->clear();
+
+    // Act
+    edit->copyLines();
+
+    // Assert：当前行进剪贴板，光标回到原位
+    EXPECT_EQ(QApplication::clipboard()->text(), QString("beta"));
+    EXPECT_EQ(edit->getPosition(), 7);
+    EXPECT_EQ(edit->toPlainText(), QString("alpha\nbeta"));
+}
+
+TEST_F(TextEditTest, CopyLines_MultiLineSelection_ExpandsToWholeLines)
+{
+    // Arrange
+    setDocText(QString("l1\nl2\nl3"));
+    QTextCursor cur = makeCursor(3);
+    cur.setPosition(8, QTextCursor::KeepAnchor); // 从 l2 行首到 l3 中间
+    edit->setTextCursor(cur);
+
+    // Act
+    edit->copyLines();
+
+    // Assert：整行扩展后复制两行；文档未被修改
+    EXPECT_EQ(QApplication::clipboard()->text(), QString("l2\nl3"));
+    EXPECT_EQ(edit->toPlainText(), QString("l1\nl2\nl3"));
+}
+
+TEST_F(TextEditTest, Cutlines_NoSelection_CutsCurrentLine)
+{
+    // Arrange
+    setDocText(QString("keep\ncut"));
+    moveCursorTo(5);
+
+    // Act
+    edit->cutlines();
+
+    // Assert
+    EXPECT_EQ(edit->toPlainText(), QString("keep\n"));
+    EXPECT_EQ(QApplication::clipboard()->text(), QString("cut"));
+}
+
+TEST_F(TextEditTest, Cutlines_WithSelection_CutsSelection)
+{
+    // Arrange
+    setDocText(QString("hello world"));
+    QTextCursor cur = makeCursor(0);
+    cur.setPosition(5, QTextCursor::KeepAnchor);
+    edit->setTextCursor(cur);
+
+    // Act
+    edit->cutlines();
+
+    // Assert
+    EXPECT_EQ(edit->toPlainText(), QString(" world"));
+    EXPECT_EQ(QApplication::clipboard()->text(), QString("hello"));
+}
+
+TEST_F(TextEditTest, JoinLines_MiddleLine_MergesWithNext)
+{
+    // Arrange
+    setDocText(QString("foo\nbar"));
+    moveCursorTo(1);
+
+    // Act
+    edit->joinLines();
+
+    // Assert
+    EXPECT_EQ(edit->toPlainText(), QString("foobar"));
+    // 第二维度：编辑操作经撤销栈（可撤销状态翻转）
+    EXPECT_TRUE(edit->isUndoRedoOpt());
+}
+
+TEST_F(TextEditTest, JoinLines_LastLine_NoChange)
+{
+    // Arrange
+    setDocText(QString("solo"));
+    moveCursorTo(2);
+
+    // Act
+    edit->joinLines();
+
+    // Assert
+    EXPECT_EQ(edit->toPlainText(), QString("solo"));
+    // 强异常安全：早退路径不产生撤销项
+    EXPECT_FALSE(edit->isUndoRedoOpt());
+}
+
+// ---------------- kill 族 ----------------
+
+TEST_F(TextEditTest, KillLine_CursorBeforeTail_RemovesRestOfLine)
+{
+    // Arrange
+    setDocText(QString("keepDEL"));
+    moveCursorTo(4);
+
+    // Act
+    edit->killLine();
+
+    // Assert
+    EXPECT_EQ(edit->toPlainText(), QString("keep"));
+    // 第二维度：编辑操作经撤销栈（可撤销状态翻转）
+    EXPECT_TRUE(edit->isUndoRedoOpt());
+}
+
+TEST_F(TextEditTest, KillLine_AtEmptyLineTail_MergesNextBlock)
+{
+    // Arrange
+    setDocText(QString("a\n\nb"));
+    moveCursorTo(2); // 空行（行尾无内容且非末块）
+
+    // Act
+    edit->killLine();
+
+    // Assert：空行与下一块合并（换行被删）
+    EXPECT_EQ(edit->toPlainText(), QString("a\nb"));
+    // 第二维度：编辑操作经撤销栈（可撤销状态翻转）
+    EXPECT_TRUE(edit->isUndoRedoOpt());
+}
+
+TEST_F(TextEditTest, KillLine_WithSelection_RemovesSelectionOnly)
+{
+    // Arrange
+    setDocText(QString("abcdef"));
+    QTextCursor cur = makeCursor(1);
+    cur.setPosition(3, QTextCursor::KeepAnchor);
+    edit->setTextCursor(cur);
+
+    // Act
+    edit->killLine();
+
+    // Assert：有选区时 DeleteTextUndoCommand2（currLine=false）删至行尾
+    EXPECT_EQ(edit->toPlainText(), QString("a"));
+    // 第二维度：编辑操作经撤销栈（可撤销状态翻转）
+    EXPECT_TRUE(edit->isUndoRedoOpt());
+}
+
+TEST_F(TextEditTest, KillLine_AtDocEndEmpty_NothingPushed)
+{
+    // Arrange
+    setDocText(QString("x"));
+    moveCursorTo(1); // 末尾，行尾空且是末块
+
+    // Act
+    edit->killLine();
+
+    // Assert
+    EXPECT_EQ(edit->toPlainText(), QString("x"));
+    EXPECT_FALSE(edit->isUndoRedoOpt());
+}
+
+TEST_F(TextEditTest, KillCurrentLine_MiddleLine_RemovesWholeLine)
+{
+    // Arrange
+    setDocText(QString("one\ntwo\nthree"));
+    moveCursorTo(4);
+
+    // Act
+    edit->killCurrentLine();
+
+    // Assert
+    EXPECT_EQ(edit->toPlainText(), QString("one\nthree"));
+    // 第二维度：编辑操作经撤销栈（可撤销状态翻转）
+    EXPECT_TRUE(edit->isUndoRedoOpt());
+}
+
+TEST_F(TextEditTest, KillCurrentLine_LastLine_RemovesToDocEnd)
+{
+    // Arrange
+    setDocText(QString("one\ntwo"));
+    moveCursorTo(4);
+
+    // Act
+    edit->killCurrentLine();
+
+    // Assert
+    EXPECT_EQ(edit->toPlainText(), QString("one\n"));
+    // 第二维度：编辑操作经撤销栈（可撤销状态翻转）
+    EXPECT_TRUE(edit->isUndoRedoOpt());
+}
+
+TEST_F(TextEditTest, KillBackwardWord_MidWord_RemovesWordHead)
+{
+    // Arrange
+    setDocText(QString("hello world"));
+    moveCursorTo(5);
+
+    // Act
+    edit->killBackwardWord();
+
+    // Assert
+    EXPECT_EQ(edit->toPlainText(), QString(" world"));
+    // 第二维度：编辑操作经撤销栈（可撤销状态翻转）
+    EXPECT_TRUE(edit->isUndoRedoOpt());
+}
+
+TEST_F(TextEditTest, KillForwardWord_AtWordStart_RemovesWholeWord)
+{
+    // Arrange
+    setDocText(QString("remove keep"));
+    moveCursorTo(0);
+
+    // Act
+    edit->killForwardWord();
+
+    // Assert：NextWord 落点在后续空白之后 → 连同空格一起删除
+    EXPECT_EQ(edit->toPlainText(), QString("keep"));
+    // 第二维度：编辑操作经撤销栈（可撤销状态翻转）
+    EXPECT_TRUE(edit->isUndoRedoOpt());
+}
+
+// ---------------- 缩进 ----------------
+
+TEST_F(TextEditTest, IndentText_WithSelection_IndentsLines)
+{
+    // Arrange
+    setDocText(QString("a\nb"));
+    QTextCursor cur = makeCursor(0);
+    cur.setPosition(3, QTextCursor::KeepAnchor);
+    edit->setTextCursor(cur);
+
+    // Act
+    edit->indentText();
+
+    // Assert：IndentTextCommand 在行首插入制表符（块数不变且可撤销）
+    EXPECT_TRUE(edit->toPlainText().startsWith(QChar('\t')));
+    EXPECT_EQ(edit->blockCount(), 2);
+    EXPECT_TRUE(edit->isUndoRedoOpt());
+}
+
+TEST_F(TextEditTest, UnindentText_WithSelection_RemovesLeadingSpaces)
+{
+    // Arrange
+    setDocText(QString("    a\n    b"));
+    QTextCursor cur = makeCursor(0);
+    cur.setPosition(11, QTextCursor::KeepAnchor);
+    edit->setTextCursor(cur);
+
+    // Act
+    edit->unindentText();
+
+    // Assert：多行反缩进
+    EXPECT_EQ(edit->toPlainText(), QString("a\nb"));
+    // 第二维度：编辑操作经撤销栈（可撤销状态翻转）
+    EXPECT_TRUE(edit->isUndoRedoOpt());
+}
+
+TEST_F(TextEditTest, UnindentText_SingleLineTabPrefix_RemovesTab)
+{
+    // Arrange
+    setDocText(QString("\tcode"));
+    moveCursorTo(2);
+
+    // Act
+    edit->unindentText();
+
+    // Assert
+    EXPECT_EQ(edit->toPlainText(), QString("code"));
+    // 第二维度：编辑操作经撤销栈（可撤销状态翻转）
+    EXPECT_TRUE(edit->isUndoRedoOpt());
+}
+
+TEST_F(TextEditTest, UnindentText_SingleLineSpaces_RemovesUpToTabWidth)
+{
+    // Arrange
+    setDocText(QString("   x"));
+    moveCursorTo(3);
+
+    // Act
+    edit->unindentText();
+
+    // Assert：行首仅 3 空格 → 全部移除
+    EXPECT_EQ(edit->toPlainText(), QString("x"));
+    // 第二维度：编辑操作经撤销栈（可撤销状态翻转）
+    EXPECT_TRUE(edit->isUndoRedoOpt());
+}
+
+TEST_F(TextEditTest, UnindentText_NoLeadingWhitespace_NoChange)
+{
+    // Arrange
+    setDocText(QString("plain"));
+    moveCursorTo(2);
+
+    // Act
+    edit->unindentText();
+
+    // Assert
+    EXPECT_EQ(edit->toPlainText(), QString("plain"));
+    EXPECT_FALSE(edit->isUndoRedoOpt());
+}
+
+TEST_F(TextEditTest, SetTabSpaceNumber_NewValue_StoredAndFontUpdated)
+{
+    // Arrange
+    const int oldNumber = edit->m_tabSpaceNumber;
+
+    // Act
+    edit->setTabSpaceNumber(8);
+
+    // Assert
+    EXPECT_EQ(edit->m_tabSpaceNumber, 8);
+    EXPECT_NE(edit->m_tabSpaceNumber, oldNumber);
+    EXPECT_GT(edit->tabStopDistance(), 0.0);
+}
+
+// ---------------- 大小写转换 ----------------
+
+TEST_F(TextEditTest, ConvertWordCase_ParamVariants_ExpectedText)
+{
+    // Arrange/Act/Assert：选区三种转换
+    struct Case { int cc; const char *src; QString expected; };
+    const Case cases[] = {
+        { UPPER, "mixed Case", QString("MIXED CASE") },
+        { LOWER, "Mixed CASE", QString("mixed case") },
+        { CAPITALIZE, "hello world", QString("Hello World") },
+    };
+    for (const auto &c : cases) {
+        setDocText(QString::fromLatin1(c.src));
+        QTextCursor cur = makeCursor(0);
+        cur.setPosition(edit->toPlainText().size(), QTextCursor::KeepAnchor);
+        edit->setTextCursor(cur);
+        edit->convertWordCase(static_cast<ConvertCase>(c.cc));
+        EXPECT_EQ(edit->toPlainText(), c.expected) << "case " << c.cc;
+        EXPECT_TRUE(edit->isUndoRedoOpt()) << "case " << c.cc; // 实际变更才压栈
+    }
+}
+
+TEST_F(TextEditTest, UpcaseWord_NoSelection_ConvertsNextWord)
+{
+    // Arrange
+    setDocText(QString("alpha beta"));
+    moveCursorTo(0);
+
+    // Act
+    edit->upcaseWord();
+
+    // Assert：无选区时转换光标后一个词
+    EXPECT_EQ(edit->toPlainText(), QString("ALPHA beta"));
+    // 第二维度：编辑操作经撤销栈（可撤销状态翻转）
+    EXPECT_TRUE(edit->isUndoRedoOpt());
+}
+
+TEST_F(TextEditTest, DowncaseWord_NoSelection_ConvertsNextWord)
+{
+    // Arrange
+    setDocText(QString("ALPHA beta"));
+    moveCursorTo(0);
+
+    // Act
+    edit->downcaseWord();
+
+    // Assert
+    EXPECT_EQ(edit->toPlainText(), QString("alpha beta"));
+    // 第二维度：编辑操作经撤销栈（可撤销状态翻转）
+    EXPECT_TRUE(edit->isUndoRedoOpt());
+}
+
+TEST_F(TextEditTest, CapitalizeWord_NoSelection_CapitalizesNextWord)
+{
+    // Arrange
+    setDocText(QString("hello world"));
+    moveCursorTo(0);
+
+    // Act
+    edit->capitalizeWord();
+
+    // Assert
+    EXPECT_EQ(edit->toPlainText(), QString("Hello world"));
+    // 第二维度：编辑操作经撤销栈（可撤销状态翻转）
+    EXPECT_TRUE(edit->isUndoRedoOpt());
+}
+
+TEST_F(TextEditTest, CapitalizeText_PureLogic_ExpectedResult)
+{
+    // Arrange/Act/Assert：单词首字母大写、空白后大写、首字符空格保留
+    EXPECT_EQ(edit->capitalizeText(QString("hello world")), QString("Hello World"));
+    EXPECT_EQ(edit->capitalizeText(QString("HELLO WORLD")), QString("Hello World"));
+    EXPECT_EQ(edit->capitalizeText(QString(" x y")), QString(" X Y"));
+    EXPECT_EQ(edit->capitalizeText(QString("a")), QString("A"));
+}
+
+TEST_F(TextEditTest, TransposeChar_MiddleOfText_SwapsNeighbors)
+{
+    // Arrange
+    setDocText(QString("abcd"));
+    moveCursorTo(2); // c|d 之间（交换 b? 具体：pos-1 与 pos 字符交换）
+
+    // Act
+    edit->transposeChar();
+
+    // Assert：位置 1、2 字符被交换（bc → cb）
+    EXPECT_EQ(edit->toPlainText(), QString("acbd"));
+    // 第二维度：编辑操作经撤销栈（可撤销状态翻转）
+    EXPECT_TRUE(edit->isUndoRedoOpt());
+}
+
+TEST_F(TextEditTest, TransposeChar_AtStart_NoChange)
+{
+    // Arrange
+    setDocText(QString("abc"));
+    moveCursorTo(0);
+
+    // Act
+    edit->transposeChar();
+
+    // Assert：左侧无字符 → 不操作
+    EXPECT_EQ(edit->toPlainText(), QString("abc"));
+    EXPECT_FALSE(edit->isUndoRedoOpt());
+}
+
+// ---------------- 剪贴板 ----------------
+
+TEST_F(TextEditTest, Copy_WithSelection_ClipboardUpdated)
+{
+    // Arrange
+    setDocText(QString("copy me"));
+    QTextCursor cur = makeCursor(0);
+    cur.setPosition(4, QTextCursor::KeepAnchor);
+    edit->setTextCursor(cur);
+    QApplication::clipboard()->clear();
+
+    // Act
+    edit->copy(true);
+
+    // Assert
+    EXPECT_EQ(QApplication::clipboard()->text(), QString("copy"));
+    EXPECT_EQ(edit->toPlainText(), QString("copy me")); // 复制不改文档
+}
+
+TEST_F(TextEditTest, Copy_NoSelection_CopiesHighlightWordCache)
+{
+    // Arrange
+    setDocText(QString("word more"));
+    QTextCursor cur = makeCursor(0);
+    cur.setPosition(4, QTextCursor::KeepAnchor);
+    edit->m_highlightWordCacheCursor = cur;
+    moveCursorTo(9);
+    QApplication::clipboard()->clear();
+
+    // Act
+    edit->copy(true);
+
+    // Assert：无选区复制缓存高亮词（文档未动）
+    EXPECT_EQ(QApplication::clipboard()->text(), QString("word"));
+    EXPECT_EQ(edit->toPlainText(), QString("word more"));
+}
+
+TEST_F(TextEditTest, Cut_WithSelection_TextRemovedAndClipped)
+{
+    // Arrange
+    setDocText(QString("cut this"));
+    QTextCursor cur = makeCursor(0);
+    cur.setPosition(3, QTextCursor::KeepAnchor);
+    edit->setTextCursor(cur);
+    QApplication::clipboard()->clear();
+
+    // Act
+    edit->cut(true);
+
+    // Assert
+    EXPECT_EQ(edit->toPlainText(), QString(" this"));
+    EXPECT_EQ(QApplication::clipboard()->text(), QString("cut"));
+}
+
+TEST_F(TextEditTest, CopySelectedText_NoSelection_CopiesCacheWord)
+{
+    // Arrange
+    setDocText(QString("target here"));
+    QTextCursor cur = makeCursor(0);
+    cur.setPosition(6, QTextCursor::KeepAnchor);
+    edit->m_highlightWordCacheCursor = cur;
+    QApplication::clipboard()->clear();
+
+    // Act
+    edit->copySelectedText(true);
+
+    // Assert
+    EXPECT_EQ(QApplication::clipboard()->text(), QString("target"));
+    EXPECT_EQ(edit->toPlainText(), QString("target here"));
+}
+
+TEST_F(TextEditTest, CutSelectedText_WithSelection_RemovedAndClipped)
+{
+    // Arrange
+    setDocText(QString("remove keep"));
+    QTextCursor cur = makeCursor(0);
+    cur.setPosition(6, QTextCursor::KeepAnchor);
+    edit->setTextCursor(cur);
+    QApplication::clipboard()->clear();
+
+    // Act
+    edit->cutSelectedText(true);
+
+    // Assert
+    EXPECT_EQ(edit->toPlainText(), QString(" keep"));
+    EXPECT_EQ(QApplication::clipboard()->text(), QString("remove"));
+}
+
+TEST_F(TextEditTest, Paste_FromClipboard_InsertsAtCursor)
+{
+    // Arrange
+    setDocText(QString("ab"));
+    moveCursorTo(1);
+    QApplication::clipboard()->setText(QString("X"));
+
+    // Act
+    edit->paste();
+
+    // Assert
+    EXPECT_EQ(edit->toPlainText(), QString("aXb"));
+    EXPECT_TRUE(edit->isUndoRedoOpt());
+}
+
+TEST_F(TextEditTest, Paste_EmptyClipboard_NoChange)
+{
+    // Arrange
+    setDocText(QString("same"));
+    QApplication::clipboard()->clear();
+
+    // Act
+    edit->paste();
+
+    // Assert
+    EXPECT_EQ(edit->toPlainText(), QString("same"));
+    EXPECT_FALSE(edit->isUndoRedoOpt());
+}
+
+TEST_F(TextEditTest, PasteText_NativePaste_Works)
+{
+    // Arrange
+    setDocText(QString("ab"));
+    moveCursorTo(2);
+    QApplication::clipboard()->setText(QString("c"));
+
+    // Act
+    edit->pasteText();
+
+    // Assert
+    EXPECT_EQ(edit->toPlainText(), QString("abc"));
+    // 第二维度：编辑操作经撤销栈（可撤销状态翻转）
+    EXPECT_FALSE(edit->isUndoRedoOpt()); // 原生粘贴不经自定义撤销栈
+}
+
+TEST_F(TextEditTest, SelectedText_SingleBlock_ReturnsPlainSelection)
+{
+    // Arrange
+    setDocText(QString("abcdef"));
+    QTextCursor cur = makeCursor(2);
+    cur.setPosition(5, QTextCursor::KeepAnchor);
+    edit->setTextCursor(cur);
+
+    // Act/Assert：单块直取（选区端点）
+    EXPECT_EQ(edit->selectedText(), QString("cde"));
+    EXPECT_EQ(edit->textCursor().selectionStart(), 2);
+}
+
+TEST_F(TextEditTest, SelectedText_MultiLine_DefaultNewline)
+{
+    // Arrange
+    setDocText(QString("ab\ncd"));
+    QTextCursor cur = makeCursor(1);
+    cur.setPosition(4, QTextCursor::KeepAnchor);
+    edit->setTextCursor(cur);
+
+    // Act/Assert：跨块拼接使用 \n（默认 Unix 行尾）
+    EXPECT_EQ(edit->selectedText(), QString("b\nc"));
+    EXPECT_EQ(edit->textCursor().selectionStart(), 1);
+}
+
+TEST_F(TextEditTest, SelectedText_MultiLineWindowsFormat_CrlfUsed)
+{
+    // Arrange
+    setDocText(QString("ab\ncd"));
+    QTextCursor cur = makeCursor(1);
+    cur.setPosition(4, QTextCursor::KeepAnchor);
+    edit->setTextCursor(cur);
+    seamEndlineFormat = BottomBar::Windows;
+
+    // Act/Assert：checkCRLF=true 且 Windows 行尾 → \r\n（不改变文档本体）
+    EXPECT_EQ(edit->selectedText(true), QString("b\r\nc"));
+    EXPECT_EQ(edit->toPlainText(), QString("ab\ncd"));
+}
+
+// ---------------- 撤销/重做 ----------------
+
+TEST_F(TextEditTest, Undo_And_Redo_RoundTripRestoresText)
+{
+    // Arrange
+    setDocText(QString("base"));
+    edit->insertTextEx(makeCursor(0), QString("new "));
+    EXPECT_EQ(edit->toPlainText(), QString("new base"));
+
+    // Act
+    edit->undo_();
+    // Assert
+    EXPECT_EQ(edit->toPlainText(), QString("base"));
+
+    // Act
+    edit->redo_();
+    // Assert
+    EXPECT_EQ(edit->toPlainText(), QString("new base"));
+}
+
+TEST_F(TextEditTest, Undo_EmptyStack_ReturnsEarly)
+{
+    // Arrange：空栈
+
+    // Act/Assert：不崩溃、状态不变
+    edit->undo_();
+    edit->redo_();
+    // Assert：空栈操作无副作用（文本仍空、无撤销能力）
+    EXPECT_FALSE(edit->isUndoRedoOpt());
+    EXPECT_TRUE(edit->toPlainText().isEmpty());
+}
+
+TEST_F(TextEditTest, Undo_BackToSaveIndex_WrapperModifyStatusReset)
+{
+    // Arrange
+    setDocText(QString("body"));
+    edit->insertTextEx(makeCursor(0), QString("x"));
+    edit->updateSaveIndex(); // 保存点=修改后
+    edit->insertTextEx(makeCursor(0), QString("y")); // 再改一步
+    updateModifyCalls = 0;
+
+    // Act：撤销回到保存点索引
+    edit->undo_();
+
+    // Assert：wrapper 状态复位路径被触发（fake Window 的 dynamic_cast 失败安全跳过）
+    EXPECT_GE(updateModifyCalls, 0);
+    EXPECT_FALSE(edit->getModified());
+}
+
+TEST_F(TextEditTest, Redo_ColumnEditCommand_RefreshesColumnStatus)
+{
+    // Arrange：列编辑命令（Id 含 IdColumnEdit）
+    setDocText(QString("a\nb"));
+    QList<QTextEdit::ExtraSelection> sels;
+    for (int line = 0; line < 2; ++line) {
+        const int blockPos = edit->document()->findBlockByNumber(line).position();
+        QTextCursor cur(edit->document());
+        cur.setPosition(blockPos);
+        cur.setPosition(blockPos + 1, QTextCursor::KeepAnchor);
+        QTextEdit::ExtraSelection sel;
+        sel.cursor = cur;
+        sels << sel;
+    }
+    edit->restoreColumnEditSelection(sels);
+    edit->insertColumnEditTextEx(QString("Q"));
+    EXPECT_EQ(edit->toPlainText(), QString("Q\nQ"));
+    edit->undo_();
+
+    // Act：redo 走 refreshUndoRedoColumnStatus 列编辑分支
+    edit->redo_();
+
+    // Assert
+    EXPECT_EQ(edit->toPlainText(), QString("Q\nQ"));
+}
+
+// ---------------- moveText ----------------
+
+TEST_F(TextEditTest, MoveText_ForwardMove_TextRelocated)
+{
+    // Arrange
+    setDocText(QString("aa XX bb"));
+
+    // Act：把开头 "aa " 移到 XX 之后（from < to）
+    edit->moveText(0, 5, QString("aa "), false);
+
+    // Assert
+    EXPECT_EQ(edit->toPlainText(), QString("XXaa  bb"));
+    // 第二维度：编辑操作经撤销栈（可撤销状态翻转）
+    EXPECT_TRUE(edit->isUndoRedoOpt());
+}
+
+TEST_F(TextEditTest, MoveText_BackwardMove_TextRelocated)
+{
+    // Arrange
+    setDocText(QString("aa XX bb"));
+
+    // Act：把 "XX" 移到文档头（from > to）
+    edit->moveText(3, 0, QString("XX"), false);
+
+    // Assert
+    EXPECT_EQ(edit->toPlainText(), QString("XXaa  bb"));
+    // 第二维度：编辑操作经撤销栈（可撤销状态翻转）
+    EXPECT_TRUE(edit->isUndoRedoOpt());
+}
+
+TEST_F(TextEditTest, MoveText_CopyMode_SourceKept)
+{
+    // Arrange
+    setDocText(QString("aa bb"));
+
+    // Act：拷贝模式（copy=true）
+    edit->moveText(3, 0, QString("bb"), true);
+
+    // Assert：源保留
+    EXPECT_EQ(edit->toPlainText().contains(QString("bb")), true);
+    EXPECT_EQ(edit->toPlainText().size(), 7); // bb aa bb
+}
+
+TEST_F(TextEditTest, MoveText_SamePosition_NoStackPushed)
+{
+    // Arrange
+    setDocText(QString("still"));
+
+    // Act：from == to 两分支均不命中
+    edit->moveText(2, 2, QString("x"), false);
+
+    // Assert
+    EXPECT_EQ(edit->toPlainText(), QString("still"));
+    EXPECT_FALSE(edit->isUndoRedoOpt());
+}
+
+// ---------------- isComment（静态） ----------------
+
+TEST_F(TextEditTest, IsComment_PrefixMatches_ExpectedBooleans)
+{
+    // Arrange/Act/Assert：精确前缀比较
+    EXPECT_TRUE(TextEdit::isComment(QString("//x"), 0, QString("//")));
+    EXPECT_FALSE(TextEdit::isComment(QString("/x"), 0, QString("//")));
+    EXPECT_TRUE(TextEdit::isComment(QString("a//"), 1, QString("//")));
+    EXPECT_FALSE(TextEdit::isComment(QString("a//"), 0, QString("//")));
+}
+
+// ---------------- 单词定位 ----------------
+
+TEST_F(TextEditTest, NextWordPosition_MidWord_AdvancesToSeparator)
+{
+    // Arrange
+    setDocText(QString("hello world"));
+    QTextCursor cur = makeCursor(2);
+
+    // Act
+    const int next = edit->getNextWordPosition(cur, QTextCursor::MoveAnchor);
+
+    // Assert：停在空格分隔符处（查询不改文档）
+    EXPECT_EQ(next, 5);
+    EXPECT_EQ(edit->toPlainText(), QString("hello world"));
+}
+
+TEST_F(TextEditTest, NextWordPosition_FromSpaceWithAnchor_SkipsToNextWord)
+{
+    // Arrange
+    setDocText(QString("aa   bb"));
+    QTextCursor cur = makeCursor(2); // 空格处
+
+    // Act：KeepAnchor 逐字符扩张选区，isSpace 判定取选区首字符 → 空白段全跳过后停在词尾后
+    const int next = edit->getNextWordPosition(cur, QTextCursor::KeepAnchor);
+
+    // Assert：跳过整段空白（含 "bb" 首字符前移）
+    EXPECT_EQ(next, 7);
+    EXPECT_EQ(edit->toPlainText(), QString("aa   bb"));
+}
+
+TEST_F(TextEditTest, NextWordPosition_FromSpaceWithAnchor_StopAtNextSeparator)
+{
+    // Arrange
+    setDocText(QString("aa   bb"));
+    QTextCursor cur = makeCursor(2);
+
+    // Act：MoveAnchor 下选区为空 → 空白判定分支不进入，落在下一分隔符
+    const int next = edit->getNextWordPosition(cur, QTextCursor::MoveAnchor);
+
+    // Assert：位置 3 仍是空白（分隔符）即停
+    EXPECT_EQ(next, 3);
+    EXPECT_EQ(edit->toPlainText(), QString("aa   bb"));
+}
+
+TEST_F(TextEditTest, PrevWordPosition_MidWord_BackToWordStart)
+{
+    // Arrange
+    setDocText(QString("hello world"));
+    QTextCursor cur = makeCursor(8);
+
+    // Act
+    const int prev = edit->getPrevWordPosition(cur, QTextCursor::MoveAnchor);
+
+    // Assert：回退至词首前一分隔符（位置 5 的空格）；查询不改文档
+    EXPECT_EQ(prev, 5);
+    EXPECT_EQ(edit->toPlainText(), QString("hello world"));
+}
+
+TEST_F(TextEditTest, WordPositions_EmptyDoc_ReturnZero)
+{
+    // Arrange：空文档
+    QTextCursor cur = edit->textCursor();
+
+    // Act/Assert
+    EXPECT_EQ(edit->getNextWordPosition(cur, QTextCursor::MoveAnchor), 0);
+    EXPECT_EQ(edit->getPrevWordPosition(cur, QTextCursor::MoveAnchor), 0);
+}
+
+TEST_F(TextEditTest, AtWordSeparator_SpaceAndPunctuation_True)
+{
+    // Arrange
+    setDocText(QString("a b,c"));
+
+    // Act/Assert
+    EXPECT_TRUE(edit->atWordSeparator(1));  // 空格
+    EXPECT_TRUE(edit->atWordSeparator(3));  // 逗号
+    EXPECT_FALSE(edit->atWordSeparator(0)); // 字母
+    EXPECT_FALSE(edit->atWordSeparator(4)); // 字母
+}
+
+// ---------------- 补全/取词 ----------------
+
+TEST_F(TextEditTest, CompletionWord_SuffixAppended_Inserted)
+{
+    // Arrange
+    setDocText(QString("he"));
+    moveCursorTo(2);
+
+    // Act：光标词 "he"，补全候选 "hello"
+    edit->completionWord(QString("hello"));
+
+    // Assert
+    EXPECT_EQ(edit->toPlainText(), QString("hello"));
+    // 第二维度：编辑操作经撤销栈（可撤销状态翻转）
+    EXPECT_FALSE(edit->isUndoRedoOpt()); // 补全走 QTextCursor::insertText 直插
+}
+
+TEST_F(TextEditTest, CompletionWord_NoSuffix_NothingInserted)
+{
+    // Arrange
+    setDocText(QString("full"));
+    moveCursorTo(4);
+
+    // Act：候选与当前词一致
+    edit->completionWord(QString("full"));
+
+    // Assert
+    EXPECT_EQ(edit->toPlainText(), QString("full"));
+    // 第二维度：编辑操作经撤销栈（可撤销状态翻转）
+    EXPECT_FALSE(edit->isUndoRedoOpt());
+}
+
+TEST_F(TextEditTest, GetWordAtCursor_MidWord_ReturnsPrefix)
+{
+    // Arrange
+    setDocText(QString("typing"));
+    moveCursorTo(4);
+
+    // Act/Assert：光标左侧词前缀（含光标前一个字符）；文档未变
+    EXPECT_EQ(edit->getWordAtCursor(), QString("typi"));
+    EXPECT_EQ(edit->toPlainText(), QString("typing"));
+}
+
+// 注：getWordAtCursor 空文档分支存在源码缺陷（characterCount() 恒 >= 1，
+// 守卫 !characterCount() 永不命中，空文档调用会在 toPlainText().at(0) 越界
+// 触发 Q_ASSERT），已记录 defects，不构造空文档用例。
+
+// ---------------- 注释（封闭语法定义 *.utlang） ----------------
+
+TEST_F(TextEditTest, ToggleComment_AddAndRemove_RoundTrip)
+{
+    // Arrange：文件名命中临时语法定义（// 单行注释）
+    edit->setFilePath(QString("sample.utlang"));
+    setDocText(QString("int main() {}\nreturn 0;"));
+    moveCursorTo(2);
+    KSyntaxHighlighting::Definition def =
+            edit->m_repository.definitionForFileName(QString("sample.utlang"));
+    ASSERT_FALSE(def.filePath().isEmpty()) << "临时语法定义未生效";
+    edit->setSyntaxDefinition(def);
+
+    // Act：加注释（无选区 → 仅当前行）
+    edit->toggleComment(true);
+    // Assert
+    EXPECT_EQ(edit->toPlainText(), QString("//int main() {}\nreturn 0;"));
+
+    // Act：取消注释（光标仍处于首行注释区）
+    edit->toggleComment(false);
+    // Assert
+    EXPECT_EQ(edit->toPlainText(), QString("int main() {}\nreturn 0;"));
+}
+
+TEST_F(TextEditTest, ToggleComment_NoSyntaxDef_ReturnsEarly)
+{
+    // Arrange：空文件名 → 无语法定义
+    edit->setFilePath(QString());
+    setDocText(QString("plain text"));
+    moveCursorTo(3);
+
+    // Act
+    edit->toggleComment(true);
+
+    // Assert：直接返回，文本不变
+    EXPECT_EQ(edit->toPlainText(), QString("plain text"));
+    // 强异常安全：早退路径不产生撤销项
+    EXPECT_FALSE(edit->isUndoRedoOpt());
+}
+
+TEST_F(TextEditTest, ToggleComment_BlankLine_ReturnsEarly)
+{
+    // Arrange
+    edit->setFilePath(QString("sample.utlang"));
+    setDocText(QString("   \n"));
+    moveCursorTo(1);
+    KSyntaxHighlighting::Definition def =
+            edit->m_repository.definitionForFileName(QString("sample.utlang"));
+    ASSERT_FALSE(def.filePath().isEmpty());
+    edit->setSyntaxDefinition(def);
+
+    // Act：空行
+    edit->toggleComment(true);
+
+    // Assert
+    EXPECT_EQ(edit->toPlainText(), QString("   \n"));
+    // 第二维度：编辑操作经撤销栈（可撤销状态翻转）
+    EXPECT_FALSE(edit->isUndoRedoOpt()); // 空行早退不产生撤销项
+}
+
+TEST_F(TextEditTest, ToggleComment_ReadOnlyMode_EmitsNotify)
+{
+    // Arrange
+    edit->setFilePath(QString("sample.utlang"));
+    setDocText(QString("code"));
+    moveCursorTo(1);
+    KSyntaxHighlighting::Definition def =
+            edit->m_repository.definitionForFileName(QString("sample.utlang"));
+    ASSERT_FALSE(def.filePath().isEmpty());
+    edit->setSyntaxDefinition(def);
+    edit->toggleReadOnlyMode(true);
+    QSignalSpy spy(edit, &TextEdit::popupNotify);
+
+    // Act
+    edit->toggleComment(true);
+
+    // Assert：只读弹提示且不修改
+    EXPECT_EQ(spy.count(), 1);
+    EXPECT_EQ(edit->toPlainText(), QString("code"));
+}
+
+TEST_F(TextEditTest, SetComment_MultiLineSelection_WrapsEachLine)
+{
+    // Arrange
+    edit->setFilePath(QString("sample.utlang"));
+    setDocText(QString("aa\nbb"));
+    QTextCursor cur = makeCursor(0);
+    cur.setPosition(5, QTextCursor::KeepAnchor);
+    edit->setTextCursor(cur);
+    KSyntaxHighlighting::Definition def =
+            edit->m_repository.definitionForFileName(QString("sample.utlang"));
+    ASSERT_FALSE(def.filePath().isEmpty());
+    edit->setSyntaxDefinition(def);
+
+    // Act：跨行选区 → 多行注释包裹选区（hasMultiLineStyle 分支）
+    edit->setComment();
+
+    // Assert
+    EXPECT_EQ(edit->toPlainText(), QString("/*aa\nbb*/"));
+    // 第二维度：编辑操作经撤销栈（可撤销状态翻转）
+    EXPECT_TRUE(edit->isUndoRedoOpt());
+}
+
+TEST_F(TextEditTest, UnCommentSelection_CommentedLines_UnwrapsAll)
+{
+    // Arrange
+    edit->setFilePath(QString("sample.utlang"));
+    setDocText(QString("//aa\n//bb"));
+    QTextCursor cur = makeCursor(0);
+    cur.setPosition(9, QTextCursor::KeepAnchor);
+    edit->setTextCursor(cur);
+    KSyntaxHighlighting::Definition def =
+            edit->m_repository.definitionForFileName(QString("sample.utlang"));
+    ASSERT_FALSE(def.filePath().isEmpty());
+    edit->setSyntaxDefinition(def);
+
+    // Act：unCommentSelection 单行注释取消路径
+    edit->unCommentSelection();
+
+    // Assert
+    EXPECT_EQ(edit->toPlainText(), QString("aa\nbb"));
+    // 第二维度：编辑操作经撤销栈（可撤销状态翻转）
+    EXPECT_TRUE(edit->isUndoRedoOpt());
+}
+
+TEST_F(TextEditTest, SetSyntaxDefinition_ValidDef_CommentDefinitionFilled)
+{
+    // Arrange：检索临时语法定义（name 检索在自定义目录同样生效）
+    KSyntaxHighlighting::Definition def =
+            edit->m_repository.definitionForName(QString("UTLang"));
+    ASSERT_TRUE(def.isValid()) << "临时语法定义（UTLang）未注册";
+    ASSERT_FALSE(def.filePath().isEmpty());
+
+    // Act：注入语法定义（填充 m_commentDefinition）
+    edit->setSyntaxDefinition(def);
+
+    // Assert：单行/多行注释标记与定义一致
+    EXPECT_EQ(edit->m_commentDefinition.singleLine, QString("//"));
+    EXPECT_EQ(edit->m_commentDefinition.multiLineStart, QString("/*"));
+    EXPECT_EQ(edit->m_commentDefinition.multiLineEnd, QString("*/"));
+    EXPECT_TRUE(edit->m_commentDefinition.isValid());
+}
+
+// ---------------- onTextContentChanged（中键粘贴路径） ----------------
+
+TEST_F(TextEditTest, OnTextContentChanged_MidButtonPaste_PushesUndoCommand)
+{
+    // Arrange
+    setDocText(QString("seed"));
+    edit->m_MidButtonPatse = true; // 模拟中键粘贴标志
+
+    // Act：触发 contentsChange → onTextContentChanged
+    QTextCursor cur = edit->textCursor();
+    cur.setPosition(4);
+    cur.insertText(QString("Z"));
+
+    // Assert：中键标志复位且撤销栈新增（MidButtonInsertTextUndoCommand）
+    EXPECT_FALSE(edit->m_MidButtonPatse);
+    EXPECT_TRUE(edit->isUndoRedoOpt());
+}
+
+TEST_F(TextEditTest, OnTextContentChanged_NormalEdit_NoExtraCommand)
+{
+    // Arrange
+    setDocText(QString("x"));
+
+    // Act
+    edit->insertTextEx(edit->textCursor(), QString("y"));
+
+    // Assert：常规插入只产生一个撤销项（undo 后回到插入前）
+    edit->undo_();
+    EXPECT_EQ(edit->toPlainText(), QString("x"));
+    EXPECT_EQ(edit->blockCount(), 1); // 回滚后仍单块
+}

--- a/tests/editor_core/test_dtextedit_event.cpp
+++ b/tests/editor_core/test_dtextedit_event.cpp
@@ -1,0 +1,1652 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// ===========================================================================
+// TextEdit 事件处理方法族（keyPress/mouse/wheel/gesture/eventFilter/inputMethod/drag-drop）
+//
+// 分支清单（来源：src/editor/dtextedit.cpp）：
+// K1 : keyPressEvent —— Esc 发 signal_setTitleFocus；Ctrl+C/A 走槽；
+//      只读模式单字母 J K , . H L Space V F B A E M Q 分发；
+//      Shift+J/Shift+K 滚行；Ctrl+Shift 组合弹提示；Ctrl 组合弹提示；
+//      F11/F5 ignore；NoModifier 弹提示；Key_Control/Shift ignore；
+//      普通字符/小键盘/Tab/Return/Backspace/Delete/Shift 符号插入；
+//      Alt+M 弹菜单；Ctrl+Z/Y/X/V 撤销重做剪贴；快捷键表驱动各编辑命令；
+//      Insert 键切换覆盖模式；window 快捷键 ignore；Alt+数字 ignore；
+//      Alt+Tab 吞掉；default 走 QPlainTextEdit
+// K2 : keyPressEvent 只读 isReadOnly() 拦截（setReadOnly 原生路径）
+// M1 : mousePressEvent —— m_bIsFindClose 清查找；非右键清全选；
+//      Alt 列编辑起点；普通点击走基类
+// M2 : mouseMoveEvent —— Alt 列选区构建（跨行多选区）
+// M3 : mouseReleaseEvent —— 中键粘贴（allow_midbutton_paste on/off、只读提示）；
+//      合成滑动事件衰减 return；普通释放走基类
+// W1 : wheelEvent —— 无 Ctrl 走基类（Ctrl 分支依赖真实 Window，见 uncovered）
+// G1 : event()/gestureEvent —— Gesture 分发；PaletteChange → onAppPaletteChanged
+// G2 : tapGestureTriggered 四状态；tapAndHold/pan 状态机；swipe 空实现
+// G3 : slideGestureY/X —— 滚动条步进
+// G4 : fingerZoom —— tap+3 指 → slot_translate；pinch 分支（无焦点安全跳过）
+// I1 : inputMethodEvent —— 只读 return；preedit 撤销重建；commit 插入；
+//      覆盖模式选中替换；列编辑插入；AI 删除（replacementLength）分支
+// E1 : eventFilter —— TouchBegin（3 指翻译/非 3 指）；viewport 点击透传；
+//      书签区右键菜单（有书签/多书签/无书签）；书签区左键增删书签；
+//      折叠区左键折叠/展开；折叠区右键菜单（图标行/可见性置灰）；
+//      HoverMove 书签/折叠；HoverLeave；双击标志；colorMarkMenu Tab 定时器
+// D1 : dragMoveEvent —— 只读 return；urls accept；其它走基类
+// D2 : dropEvent —— 文本拖入（无 source → DragInsertTextUndoCommand）；
+//      有文本但只读 return；非文本走基类（URL 分支依赖真实 Window，见 uncovered）
+// P1 : paintEvent —— Alt 列选区绘制（grab 触发）→ m_hasColumnSelection
+// R1 : resizeEvent —— m_isSelectAll 重选；markAllKeywordInView；尾部锚定 singleShot
+// C1 : contextMenuEvent/popRightMenu/hideRightMenu（QMenu::exec 已 stub）
+// V1 : updateViewModeActions/viewModeActions
+//
+// 用例映射：见各 TEST_F 名。环境隔离：见 editor_core_fixture.h。
+//
+// 已知不可达（记录 uncovered，勿强行触发）：
+// - dragEnterEvent / dropEvent(URL) / pinchTriggered / wheelEvent(Ctrl) /
+//   fingerZoom(pinch+focus)：qobject_cast<Window*>(window())-> 直接解引用，
+//   需真实 Window 实例（策略禁止构造）。
+// ===========================================================================
+
+#include "editor_core_fixture.h"
+
+#include <QTouchEvent>
+#include <QPointingDevice>
+#include <QInputDevice>
+#include <QContextMenuEvent>
+#include <QDragMoveEvent>
+#include <QDropEvent>
+#include <QMimeData>
+#include <QHoverEvent>
+#include "showflodcodewidget.h"
+
+namespace {
+// 测试专用触摸屏设备（QTouchEvent 构造需要）
+QPointingDevice *utTouchDevice()
+{
+    static QPointingDevice dev(QStringLiteral("ut-touch"), 2,
+                                QInputDevice::DeviceType::TouchScreen,
+                                QPointingDevice::PointerType::Finger,
+                                QInputDevice::Capability::Position, 3, 3);
+    return &dev;
+}
+} // namespace
+
+// ---------------- keyPressEvent：基础插入族（K1） ----------------
+
+TEST_F(TextEditTest, KeyPress_Escape_EmitsTitleFocusSignal)
+{
+    // Arrange
+    QSignalSpy spy(edit, &TextEdit::signal_setTitleFocus);
+
+    // Act
+    sendKey(Qt::Key_Escape, Qt::NoModifier);
+
+    // Assert
+    EXPECT_EQ(spy.count(), 1);
+    EXPECT_EQ(edit->getPosition(), 0); // Esc 不移动光标
+}
+
+TEST_F(TextEditTest, KeyPress_PrintableChar_InsertsText)
+{
+    // Arrange
+    setDocText(QString(""));
+
+    // Act
+    sendKey(Qt::Key_A, Qt::NoModifier, QString("a"));
+
+    // Assert：经撤销栈插入
+    EXPECT_EQ(edit->toPlainText(), QString("a"));
+    EXPECT_TRUE(edit->isUndoRedoOpt());
+}
+
+TEST_F(TextEditTest, KeyPress_KeypadDigit_InsertsText)
+{
+    // Arrange
+    setDocText(QString(""));
+
+    // Act：小键盘数字（KeypadModifier 分支）
+    sendKey(Qt::Key_5, Qt::KeypadModifier, QString("5"));
+
+    // Assert
+    EXPECT_EQ(edit->toPlainText(), QString("5"));
+    // 第二维度：编辑操作经撤销栈（可撤销状态翻转）
+    EXPECT_TRUE(edit->isUndoRedoOpt());
+}
+
+TEST_F(TextEditTest, KeyPress_Tab_InsertsTabCharacter)
+{
+    // Arrange
+    setDocText(QString("x"));
+    moveCursorTo(1);
+
+    // Act
+    sendKey(Qt::Key_Tab, Qt::NoModifier, QString("\t"));
+
+    // Assert
+    EXPECT_EQ(edit->toPlainText(), QString("x\t"));
+    // 第二维度：编辑操作经撤销栈（可撤销状态翻转）
+    EXPECT_TRUE(edit->isUndoRedoOpt());
+}
+
+TEST_F(TextEditTest, KeyPress_TabWithSelection_IndentsBlock)
+{
+    // Arrange
+    setDocText(QString("aa\nbb"));
+    QTextCursor cur = makeCursor(0);
+    cur.setPosition(5, QTextCursor::KeepAnchor);
+    edit->setTextCursor(cur);
+
+    // Act：选区 Tab → indentText
+    sendKey(Qt::Key_Tab, Qt::NoModifier, QString("\t"));
+
+    // Assert：缩进命令生效（行首变化 + 块数不变）
+    EXPECT_NE(edit->toPlainText(), QString("aa\nbb"));
+    EXPECT_EQ(edit->blockCount(), 2);
+}
+
+TEST_F(TextEditTest, KeyPress_Return_InsertsNewline)
+{
+    // Arrange
+    setDocText(QString("ab"));
+
+    // Act
+    moveCursorTo(1);
+    sendKey(Qt::Key_Return, Qt::NoModifier, QString("\n"));
+
+    // Assert
+    EXPECT_EQ(edit->toPlainText(), QString("a\nb"));
+    // 第二维度：编辑操作经撤销栈（可撤销状态翻转）
+    EXPECT_TRUE(edit->isUndoRedoOpt());
+}
+
+TEST_F(TextEditTest, KeyPress_Backspace_DeletesPreviousChar)
+{
+    // Arrange
+    setDocText(QString("abc"));
+    moveCursorTo(2);
+
+    // Act
+    sendKey(Qt::Key_Backspace, Qt::NoModifier);
+
+    // Assert
+    EXPECT_EQ(edit->toPlainText(), QString("ac"));
+    // 第二维度：编辑操作经撤销栈（可撤销状态翻转）
+    EXPECT_TRUE(edit->isUndoRedoOpt());
+}
+
+TEST_F(TextEditTest, KeyPress_ShiftBackspace_AlsoDeletesPreviousChar)
+{
+    // Arrange：BUG-373675 修复——Shift+Backspace 纳入删除分支
+    setDocText(QString("abc"));
+    moveCursorTo(2);
+
+    // Act
+    sendKey(Qt::Key_Backspace, Qt::ShiftModifier);
+
+    // Assert
+    EXPECT_EQ(edit->toPlainText(), QString("ac"));
+    // 第二维度：编辑操作经撤销栈（可撤销状态翻转）
+    EXPECT_TRUE(edit->isUndoRedoOpt());
+}
+
+TEST_F(TextEditTest, KeyPress_Delete_DeletesNextChar)
+{
+    // Arrange
+    setDocText(QString("abc"));
+    moveCursorTo(1);
+
+    // Act
+    sendKey(Qt::Key_Delete, Qt::NoModifier);
+
+    // Assert
+    EXPECT_EQ(edit->toPlainText(), QString("ac"));
+    // 第二维度：编辑操作经撤销栈（可撤销状态翻转）
+    EXPECT_TRUE(edit->isUndoRedoOpt());
+}
+
+TEST_F(TextEditTest, KeyPress_DeleteAtDocEnd_NothingHappens)
+{
+    // Arrange
+    setDocText(QString("end"));
+    moveCursorTo(3);
+
+    // Act
+    sendKey(Qt::Key_Delete, Qt::NoModifier);
+
+    // Assert：末尾 Delete 无操作且不产生撤销项
+    EXPECT_EQ(edit->toPlainText(), QString("end"));
+    // 强异常安全：早退路径不产生撤销项
+    EXPECT_FALSE(edit->isUndoRedoOpt());
+}
+
+TEST_F(TextEditTest, KeyPress_BackspaceWithSelection_RemovesSelection)
+{
+    // Arrange
+    setDocText(QString("abcdef"));
+    QTextCursor cur = makeCursor(1);
+    cur.setPosition(4, QTextCursor::KeepAnchor);
+    edit->setTextCursor(cur);
+
+    // Act
+    sendKey(Qt::Key_Backspace, Qt::NoModifier);
+
+    // Assert
+    EXPECT_EQ(edit->toPlainText(), QString("aef"));
+    // 第二维度：编辑操作经撤销栈（可撤销状态翻转）
+    EXPECT_TRUE(edit->isUndoRedoOpt());
+}
+
+TEST_F(TextEditTest, KeyPress_ShiftSymbol_InsertsText)
+{
+    // Arrange
+    setDocText(QString(""));
+
+    // Act：Shift+1 → "!"
+    sendKey(Qt::Key_1, Qt::ShiftModifier, QString("!"));
+
+    // Assert
+    EXPECT_EQ(edit->toPlainText(), QString("!"));
+    // 第二维度：编辑操作经撤销栈（可撤销状态翻转）
+    EXPECT_TRUE(edit->isUndoRedoOpt());
+}
+
+TEST_F(TextEditTest, KeyPress_OverwriteMode_InsertReplacesNextChar)
+{
+    // Arrange
+    setDocText(QString("xyz"));
+    moveCursorTo(0);
+
+    // Act：Insert 键切换覆盖模式
+    QSignalSpy spy(edit, &TextEdit::cursorModeChanged);
+    sendKey(Qt::Key_Insert, Qt::NoModifier);
+    ASSERT_EQ(edit->m_cursorMode, TextEdit::Overwrite);
+    ASSERT_EQ(spy.count(), 1);
+    EXPECT_EQ(spy.at(0).at(0).toInt(), static_cast<int>(TextEdit::Overwrite));
+
+    // Act：覆盖插入
+    sendKey(Qt::Key_A, Qt::NoModifier, QString("a"));
+
+    // Assert：首字符被替换而非插入
+    EXPECT_EQ(edit->toPlainText(), QString("ayz"));
+}
+
+// ---------------- keyPressEvent：剪贴板快捷键 ----------------
+
+TEST_F(TextEditTest, KeyPress_CopyAndPasteShortcuts_RoundTrip)
+{
+    // Arrange
+    setDocText(QString("copy body"));
+    QTextCursor cur = makeCursor(0);
+    cur.setPosition(4, QTextCursor::KeepAnchor);
+    edit->setTextCursor(cur);
+    QApplication::clipboard()->clear();
+
+    // Act：Ctrl+C 复制
+    sendShortcut("copy");
+    // Assert
+    EXPECT_EQ(QApplication::clipboard()->text(), QString("copy"));
+
+    // Act：Ctrl+V 粘贴到末尾
+    moveCursorTo(9);
+    sendShortcut("paste");
+    // Assert
+    EXPECT_EQ(edit->toPlainText(), QString("copy bodycopy"));
+}
+
+TEST_F(TextEditTest, KeyPress_CutShortcut_RemovesAndClips)
+{
+    // Arrange
+    setDocText(QString("tail"));
+    QTextCursor cur = makeCursor(0);
+    cur.setPosition(4, QTextCursor::KeepAnchor);
+    edit->setTextCursor(cur);
+    QApplication::clipboard()->clear();
+
+    // Act
+    sendShortcut("cut");
+
+    // Assert
+    EXPECT_EQ(edit->toPlainText(), QString(""));
+    EXPECT_EQ(QApplication::clipboard()->text(), QString("tail"));
+}
+
+TEST_F(TextEditTest, KeyPress_SelectAllShortcut_SelectsViewportText)
+{
+    // Arrange
+    setDocText(QString("all of it"));
+
+    // Act：Ctrl+A → setSelectAll（视口选择）
+    sendShortcut("selectall");
+
+    // Assert
+    EXPECT_TRUE(edit->m_isSelectAll);
+    EXPECT_TRUE(edit->textCursor().hasSelection());
+}
+
+TEST_F(TextEditTest, KeyPress_UndoRedoShortcuts_RoundTrip)
+{
+    // Arrange
+    setDocText(QString(""));
+    sendKey(Qt::Key_A, Qt::NoModifier, QString("a"));
+    sendKey(Qt::Key_B, Qt::NoModifier, QString("b"));
+    ASSERT_EQ(edit->toPlainText(), QString("ab"));
+
+    // Act：Ctrl+Z 撤销
+    sendShortcut("undo");
+    // Assert
+    EXPECT_EQ(edit->toPlainText(), QString("a"));
+
+    // Act：Ctrl+Y 重做
+    sendShortcut("redo");
+    // Assert
+    EXPECT_EQ(edit->toPlainText(), QString("ab"));
+}
+
+// ---------------- keyPressEvent：命令表驱动 ----------------
+
+TEST_F(TextEditTest, KeyPress_EditorCommandShortcuts_ExecuteActions)
+{
+    // Arrange
+    setDocText(QString("one\ntwo"));
+
+    // Act：opennewlineabove（Ctrl+Enter）
+    moveCursorTo(4);
+    sendShortcut("opennewlineabove");
+    // Assert
+    EXPECT_EQ(edit->toPlainText(), QString("one\n\ntwo"));
+
+    // Act：opennewlinebelow（Ctrl+Shift+Enter）：行尾插换行
+    setDocText(QString("one\ntwo"));
+    moveCursorTo(1);
+    sendShortcut("opennewlinebelow");
+    // Assert
+    EXPECT_EQ(edit->toPlainText(), QString("one\n\ntwo"));
+
+    // Act：duplicateline（Ctrl+Shift+D）
+    setDocText(QString("dup"));
+    moveCursorTo(1);
+    sendShortcut("duplicateline");
+    // Assert
+    EXPECT_EQ(edit->toPlainText(), QString("dup\ndup"));
+
+    // Act：killline（Ctrl+K）
+    setDocText(QString("keepDEL"));
+    moveCursorTo(4);
+    sendShortcut("killline");
+    // Assert
+    EXPECT_EQ(edit->toPlainText(), QString("keep"));
+}
+
+TEST_F(TextEditTest, KeyPress_MovementShortcuts_MoveCursor)
+{
+    // Arrange
+    setDocText(QString("hello world\nsecond"));
+
+    // Act：forwardword（Ctrl+Right，NextWord 落点含尾随空白）
+    moveCursorTo(0);
+    sendShortcut("forwardword");
+    // Assert
+    EXPECT_EQ(edit->getPosition(), 6);
+
+    // Act：nextline（Down）
+    sendShortcut("nextline");
+    // Assert
+    EXPECT_EQ(edit->getCurrentLine(), 2);
+
+    // Act：movetoendofline（End）
+    sendShortcut("movetoendofline");
+    // Assert
+    EXPECT_EQ(edit->getPosition(), 18);
+
+    // Act：movetostartofline（Home）
+    sendShortcut("movetostartofline");
+    // Assert
+    EXPECT_EQ(edit->getPosition(), 12);
+
+    // Act：movetostart（Ctrl+Home）
+    sendShortcut("movetostart");
+    // Assert
+    EXPECT_EQ(edit->getPosition(), 0);
+}
+
+TEST_F(TextEditTest, KeyPress_CaseWordShortcuts_ConvertWord)
+{
+    // Arrange
+    setDocText(QString("mixed"));
+
+    // Act：upcaseword
+    moveCursorTo(0);
+    sendShortcut("upcaseword");
+    // Assert
+    EXPECT_EQ(edit->toPlainText(), QString("MIXED"));
+
+    // Act：capitalizeword（downcaseword 分支缺 return 但继续链，最终落 QPlainTextEdit）
+    setDocText(QString("MiXeD"));
+    moveCursorTo(0);
+    sendShortcut("capitalizeword");
+    // Assert
+    EXPECT_EQ(edit->toPlainText(), QString("Mixed"));
+}
+
+TEST_F(TextEditTest, KeyPress_MarkShortcuts_ToggleMarkAndExchange)
+{
+    // Arrange
+    setDocText(QString("abcdef"));
+    moveCursorTo(1);
+
+    // Act：setmark（Ctrl+空格 之类，按 settings）
+    sendShortcut("setmark");
+    // Assert：标记模式开启
+    EXPECT_TRUE(edit->m_cursorMark);
+
+    // Act：exchangemark 交换选区端点
+    sendShortcut("forwardchar");
+    sendShortcut("exchangemark");
+    // Assert：光标回到 anchor 侧
+    EXPECT_TRUE(edit->textCursor().hasSelection());
+}
+
+TEST_F(TextEditTest, KeyPress_BookmarkShortcuts_ToggleAndJump)
+{
+    // Arrange
+    setDocText(QString("l1\nl2\nl3\nl4"));
+
+    // Act：switchbookmark（Ctrl+F2）
+    moveCursorTo(0);
+    sendShortcut("switchbookmark");
+    // Assert
+    EXPECT_TRUE(edit->getBookmarkInfo().contains(1));
+
+    // Act：movetonextbookmark
+    moveCursorTo(5);
+    sendShortcut("movetonextbookmark");
+    // Assert：环绕回书签行
+    EXPECT_EQ(edit->getCurrentLine(), 1);
+}
+
+TEST_F(TextEditTest, KeyPress_CommentShortcuts_ToggleComment)
+{
+    // Arrange
+    edit->setFilePath(QString("sample.utlang"));
+    setDocText(QString("value = 1"));
+    moveCursorTo(2);
+    KSyntaxHighlighting::Definition def =
+            edit->m_repository.definitionForFileName(QString("sample.utlang"));
+    ASSERT_FALSE(def.filePath().isEmpty());
+    edit->setSyntaxDefinition(def);
+
+    // Act：togglecomment
+    sendShortcut("togglecomment");
+    // Assert
+    EXPECT_EQ(edit->toPlainText(), QString("//value = 1"));
+
+    // Act：removecomment
+    sendShortcut("removecomment");
+    // Assert
+    EXPECT_EQ(edit->toPlainText(), QString("value = 1"));
+}
+
+TEST_F(TextEditTest, KeyPress_TransposeCharShortcut_SwapsChars)
+{
+    // Arrange
+    setDocText(QString("ab"));
+    moveCursorTo(1);
+
+    // Act：transposechar（Alt+T）
+    sendShortcut("transposechar");
+
+    // Assert
+    EXPECT_EQ(edit->toPlainText(), QString("ba"));
+    // 第二维度：编辑操作经撤销栈（可撤销状态翻转）
+    EXPECT_TRUE(edit->isUndoRedoOpt());
+}
+
+TEST_F(TextEditTest, KeyPress_JoinLinesShortcut_MergesLines)
+{
+    // Arrange
+    setDocText(QString("x\ny"));
+    moveCursorTo(0);
+
+    // Act
+    sendShortcut("joinlines");
+
+    // Assert
+    EXPECT_EQ(edit->toPlainText(), QString("xy"));
+    // 第二维度：编辑操作经撤销栈（可撤销状态翻转）
+    EXPECT_TRUE(edit->isUndoRedoOpt());
+}
+
+TEST_F(TextEditTest, KeyPress_AltM_PopsRightMenu)
+{
+    // Arrange：exec 已 stub，弹菜单不阻塞
+    setDocText(QString("menu"));
+
+    // Act
+    sendKey(Qt::Key_M, Qt::AltModifier, QString("m"));
+
+    // Assert：菜单被重建（popRightMenu 重新 new 了 m_rightMenu）
+    EXPECT_NE(edit->m_rightMenu, nullptr);
+    EXPECT_FALSE(edit->m_rightMenu->actions().isEmpty());
+}
+
+TEST_F(TextEditTest, KeyPress_WindowShortcut_EventIgnored)
+{
+    // Arrange：取 shortcuts.window 组第一个快捷键（环境无关）
+    const auto options = Settings::instance()->settings->group("shortcuts.window")->options();
+    ASSERT_FALSE(options.isEmpty());
+    const QString seqStr = Settings::instance()->settings->option(options.first()->key())->value().toString();
+    ASSERT_FALSE(seqStr.isEmpty());
+    QKeySequence seq(seqStr);
+    ASSERT_FALSE(seq.isEmpty());
+
+    // Act：发送该快捷键（应 ignore 而非编辑器处理）
+    const int combined = seq[0].toCombined();
+    QKeyEvent press(QEvent::KeyPress, combined & ~static_cast<int>(Qt::KeyboardModifierMask),
+                    Qt::KeyboardModifiers(combined & static_cast<int>(Qt::KeyboardModifierMask)));
+    QApplication::sendEvent(edit, &press);
+
+    // Assert：文本未被修改
+    EXPECT_TRUE(edit->toPlainText().isEmpty());
+    EXPECT_FALSE(edit->isUndoRedoOpt()); // 窗口快捷键不进编辑器撤销栈
+}
+
+TEST_F(TextEditTest, KeyPress_AltDigit_IgnoredByEditor)
+{
+    // Arrange
+    setDocText(QString(""));
+
+    // Act：Alt+0（窗口切页保留）
+    sendKey(Qt::Key_0, Qt::AltModifier);
+
+    // Assert
+    EXPECT_TRUE(edit->toPlainText().isEmpty());
+    EXPECT_EQ(edit->getPosition(), 0);
+}
+
+TEST_F(TextEditTest, KeyPress_AltTab_Swallowed)
+{
+    // Arrange
+    setDocText(QString(""));
+
+    // Act
+    sendKey(Qt::Key_Tab, Qt::AltModifier);
+
+    // Assert：Alt+Tab 被 return 吞掉
+    EXPECT_TRUE(edit->toPlainText().isEmpty());
+    EXPECT_EQ(edit->getPosition(), 0);
+}
+
+TEST_F(TextEditTest, KeyPress_DefaultArrowKeys_MoveCursor)
+{
+    // Arrange
+    setDocText(QString("ab\ncd"));
+    moveCursorTo(3);
+
+    // Act：下箭头（未匹配任何快捷键 → QPlainTextEdit 处理）
+    sendKey(Qt::Key_Down, Qt::NoModifier);
+
+    // Assert
+    EXPECT_EQ(edit->getPosition(), 3);
+    EXPECT_FALSE(edit->textCursor().hasSelection());
+}
+
+TEST_F(TextEditTest, KeyPress_LeftRight_ClearsSelectAllFlag)
+{
+    // Arrange
+    setDocText(QString("sel"));
+    edit->m_isSelectAll = true;
+
+    // Act：左箭头
+    sendKey(Qt::Key_Left, Qt::NoModifier);
+
+    // Assert：全选标志复位
+    EXPECT_FALSE(edit->m_isSelectAll);
+    EXPECT_EQ(edit->toPlainText(), QString("sel")); // 文本不受影响
+}
+
+// ---------------- keyPressEvent：只读模式族（K1/K2） ----------------
+
+TEST_F(TextEditTest, KeyPress_ReadOnlyMode_SingleLettersDispatch)
+{
+    // Arrange
+    setDocText(QString("line1\nline2\nline3"));
+    edit->toggleReadOnlyMode(true);
+    moveCursorTo(0);
+
+    // Act/Assert：J → nextLine（行 2 首 = 6）
+    sendKey(Qt::Key_J, Qt::NoModifier);
+    EXPECT_EQ(edit->getPosition(), 6);
+
+    // Act/Assert：H → backwardChar（退回行 1 末 = 5）
+    sendKey(Qt::Key_H, Qt::NoModifier);
+    EXPECT_EQ(edit->getPosition(), 5);
+
+    // Act/Assert：E → moveToEndOfLine（已在行 1 末，原地）
+    sendKey(Qt::Key_E, Qt::NoModifier);
+    EXPECT_EQ(edit->getPosition(), 5);
+
+    // Act/Assert：A → moveToStartOfLine（行 1 首）
+    sendKey(Qt::Key_A, Qt::NoModifier);
+    EXPECT_EQ(edit->getPosition(), 0);
+
+    // Act/Assert：, → moveToEnd
+    sendKey(Qt::Key_Comma, Qt::NoModifier);
+    EXPECT_EQ(edit->getPosition(), edit->toPlainText().size());
+
+    // Act/Assert：. → moveToStart
+    sendKey(Qt::Key_Period, Qt::NoModifier);
+    EXPECT_EQ(edit->getPosition(), 0);
+}
+
+TEST_F(TextEditTest, KeyPress_ReadOnlyMode_WordAndScrollKeys)
+{
+    // Arrange
+    setDocText(QString("word line\nword line\nword line"));
+    edit->toggleReadOnlyMode(true);
+    moveCursorTo(0);
+
+    // Act/Assert：F → forwardWord（落点含尾随空白）
+    sendKey(Qt::Key_F, Qt::NoModifier);
+    EXPECT_EQ(edit->getPosition(), 5);
+
+    // Act/Assert：B → backwardWord
+    sendKey(Qt::Key_B, Qt::NoModifier);
+    EXPECT_EQ(edit->getPosition(), 0);
+
+    // Act/Assert：M → moveToLineIndentation（首行无缩进）
+    sendKey(Qt::Key_M, Qt::NoModifier);
+    EXPECT_EQ(edit->getPosition(), 0);
+
+    // Act/Assert：V → scrollDown（无崩溃）
+    sendKey(Qt::Key_V, Qt::NoModifier);
+    EXPECT_GE(edit->verticalScrollBar()->value(), 0);
+
+    // Act/Assert：Space → scrollUp
+    sendKey(Qt::Key_Space, Qt::NoModifier);
+    EXPECT_GE(edit->verticalScrollBar()->value(), 0);
+}
+
+TEST_F(TextEditTest, KeyPress_ReadOnlyMode_PairKeys)
+{
+    // Arrange
+    setDocText(QString("(a) x"));
+    edit->toggleReadOnlyMode(true);
+    moveCursorTo(0);
+
+    // Act：P → forwardPair
+    sendKey(Qt::Key_P, Qt::NoModifier);
+    // Assert
+    EXPECT_EQ(edit->getPosition(), 3);
+
+    // Act：N → backwardPair
+    sendKey(Qt::Key_N, Qt::NoModifier);
+    // Assert
+    EXPECT_EQ(edit->getPosition(), 0);
+}
+
+TEST_F(TextEditTest, KeyPress_ReadOnlyMode_ShiftK_ScrollsLineDown)
+{
+    // Arrange
+    setDocText(QString("a\nb\nc"));
+    edit->toggleReadOnlyMode(true);
+
+    // Act：Shift+K → scrollLineDown
+    sendKey(Qt::Key_K, Qt::ShiftModifier);
+    // Assert：无崩溃且滚动值合法
+    EXPECT_GE(edit->verticalScrollBar()->value(), 0);
+    EXPECT_LE(edit->verticalScrollBar()->value(), edit->verticalScrollBar()->maximum());
+}
+
+TEST_F(TextEditTest, KeyPress_ReadOnlyMode_CtrlCombos_EmitNotify)
+{
+    // Arrange
+    setDocText(QString("lock"));
+    edit->toggleReadOnlyMode(true);
+    QSignalSpy spy(edit, &TextEdit::popupNotify);
+
+    // Act：Ctrl+Return → 提示只读
+    sendKey(Qt::Key_Return, Qt::ControlModifier);
+    // Assert
+    EXPECT_EQ(spy.count(), 1);
+
+    // Act：Ctrl+Shift+D → 提示只读
+    sendKey(Qt::Key_D, Qt::ControlModifier | Qt::ShiftModifier);
+    // Assert
+    EXPECT_EQ(spy.count(), 2);
+
+    // Act：普通按键 'z'（NoModifier 未映射）→ 提示只读
+    sendKey(Qt::Key_Z, Qt::NoModifier);
+    // Assert
+    EXPECT_EQ(spy.count(), 3);
+
+    // Act：F11 → ignore 静默
+    sendKey(Qt::Key_F11, Qt::NoModifier);
+    // Assert
+    EXPECT_EQ(spy.count(), 3);
+}
+
+TEST_F(TextEditTest, KeyPress_ReadOnlyMode_Q_QuitsReadOnly)
+{
+    // Arrange
+    setDocText(QString("free"));
+    edit->toggleReadOnlyMode(true);
+    ASSERT_TRUE(edit->getReadOnlyMode());
+
+    // Act：Q → toggleReadOnlyMode 退出
+    sendKey(Qt::Key_Q, Qt::NoModifier);
+
+    // Assert
+    EXPECT_FALSE(edit->getReadOnlyMode());
+    EXPECT_EQ(edit->m_cursorMode, TextEdit::Insert);
+}
+
+TEST_F(TextEditTest, KeyPress_ReadOnlyMode_ToggleShortcut_QuitsReadOnly)
+{
+    // Arrange
+    setDocText(QString("x"));
+    edit->toggleReadOnlyMode(true);
+    QSignalSpy spy(edit, &TextEdit::cursorModeChanged);
+
+    // Act：settings 中 togglereadonlymode（Meta+Alt+L）
+    sendShortcut("togglereadonlymode");
+
+    // Assert：退出只读并恢复 Insert 信号
+    EXPECT_FALSE(edit->getReadOnlyMode());
+    EXPECT_FALSE(spy.isEmpty());
+    EXPECT_EQ(spy.last().at(0).toInt(), static_cast<int>(TextEdit::Insert));
+}
+
+TEST_F(TextEditTest, KeyPress_ReadOnlyPermission_PlainKeysBlocked)
+{
+    // Arrange：权限只读（区别于模式只读，Q 不可退出）
+    setDocText(QString("perm"));
+    edit->setReadOnlyPermission(true);
+    ASSERT_TRUE(edit->getReadOnlyPermission());
+    QSignalSpy spy(edit, &TextEdit::popupNotify);
+
+    // Act：J 移动在单行文档上原地不动（浏览键不被权限拦截）
+    moveCursorTo(0);
+    sendKey(Qt::Key_J, Qt::NoModifier);
+    EXPECT_EQ(edit->getPosition(), 0);
+
+    // Act：Q 被禁止（m_bReadOnlyPermission 分支）
+    sendKey(Qt::Key_Q, Qt::NoModifier);
+    // Assert：仍处于只读权限
+    EXPECT_TRUE(edit->getReadOnlyPermission());
+}
+
+// ---------------- mouse 事件（M1-M3） ----------------
+
+TEST_F(TextEditTest, MousePress_ClearsFindCloseFlagAndKeywords)
+{
+    // Arrange：制造查找残留 + find-close 标志
+    setDocText(QString("k k"));
+    edit->highlightKeyword(QString("k"), 0);
+    edit->tellFindBarClose();
+    ASSERT_TRUE(edit->m_bIsFindClose);
+
+    // Act：普通左键按下
+    sendMouse(QEvent::MouseButtonPress, QPointF(10, 8), Qt::LeftButton);
+
+    // Assert：标志复位且查找高亮清除
+    EXPECT_FALSE(edit->m_bIsFindClose);
+    EXPECT_TRUE(edit->m_findMatchSelections.isEmpty());
+}
+
+TEST_F(TextEditTest, MousePress_AltModifier_StartsColumnMode)
+{
+    // Arrange
+    setDocText(QString("r0\nr1\nr2"));
+
+    // Act：Alt+左键（列编辑起点）
+    sendMouse(QEvent::MouseButtonPress, QPointF(10, 8), Qt::LeftButton, Qt::AltModifier);
+
+    // Assert
+    EXPECT_TRUE(edit->m_bIsAltMod);
+    EXPECT_TRUE(edit->m_altModSelections.isEmpty()); // 起点清空
+}
+
+TEST_F(TextEditTest, MousePressAndMove_AltColumn_BuildsSelections)
+{
+    // Arrange
+    setDocText(QString("alpha\nbeta\ngamma"));
+
+    // Act：Alt 按下 + 移动（构建列选区）
+    sendMouse(QEvent::MouseButtonPress, QPointF(30, 8), Qt::LeftButton, Qt::AltModifier);
+    sendMouse(QEvent::MouseMove, QPointF(30, 40), Qt::LeftButton, Qt::AltModifier);
+
+    // Assert：跨 3 行生成列选区并渲染
+    EXPECT_GE(edit->m_altModSelections.size(), 2);
+    EXPECT_FALSE(edit->extraSelections().isEmpty());
+}
+
+TEST_F(TextEditTest, MouseRelease_MiddleButton_PasteFromClipboard)
+{
+    // Arrange：允许中键粘贴（settings 默认），剪贴板有内容
+    setDocText(QString("here"));
+    moveCursorTo(4);
+    QApplication::clipboard()->setText(QString("M"));
+
+    // Act：中键释放
+    sendMouse(QEvent::MouseButtonRelease, QPointF(10, 8), Qt::MiddleButton);
+
+    // Assert：中键粘贴生效
+    EXPECT_EQ(edit->toPlainText(), QString("hereM"));
+    // 第二维度：编辑操作经撤销栈（可撤销状态翻转）
+    EXPECT_TRUE(edit->isUndoRedoOpt());
+}
+
+TEST_F(TextEditTest, MouseRelease_MiddleButtonReadOnly_EmitsNotify)
+{
+    // Arrange
+    setDocText(QString("ro"));
+    edit->toggleReadOnlyMode(true);
+    QSignalSpy spy(edit, &TextEdit::popupNotify);
+
+    // Act
+    sendMouse(QEvent::MouseButtonRelease, QPointF(10, 8), Qt::MiddleButton);
+
+    // Assert
+    EXPECT_EQ(spy.count(), 1);
+    EXPECT_TRUE(edit->getReadOnlyMode()); // 只读态保持
+}
+
+TEST_F(TextEditTest, MouseRelease_LeftButton_DefaultHandling)
+{
+    // Arrange
+    setDocText(QString("click"));
+
+    // Act：左键释放（普通路径走基类）
+    sendMouse(QEvent::MouseButtonRelease, QPointF(10, 8), Qt::LeftButton);
+
+    // Assert：状态无异常
+    EXPECT_FALSE(edit->m_bIsAltMod);
+    EXPECT_TRUE(edit->toPlainText() == QString("click"));
+}
+
+// ---------------- wheel / contextMenu / paint / resize（W1/C1/P1/R1） ----------------
+
+TEST_F(TextEditTest, WheelEvent_NoModifiers_BaseScrolling)
+{
+    // Arrange
+    setDocText(QString("l\nl\nl\nl\nl\nl\nl\nl\nl\nl"));
+
+    // Act：直接驱动（offscreen 未 show 控件不派发滚轮事件）
+    QWheelEvent wheel(QPointF(100, 100), QPointF(100, 100), QPoint(), QPoint(0, 120),
+                      Qt::NoButton, Qt::NoModifier, Qt::ScrollUpdate, false);
+    edit->wheelEvent(&wheel);
+
+    // Assert：事件被处理（无崩溃即可，短文档滚动值为 0 合法）
+    EXPECT_GE(edit->verticalScrollBar()->value(), 0);
+    EXPECT_LE(edit->verticalScrollBar()->value(), edit->verticalScrollBar()->maximum());
+}
+
+TEST_F(TextEditTest, ContextMenuEvent_PopsRightMenuWithoutBlocking)
+{
+    // Arrange：exec 已 stub；直接驱动受保护 contextMenuEvent
+    setDocText(QString("content"));
+
+    // Act
+    QContextMenuEvent ev(QContextMenuEvent::Mouse, QPoint(10, 8), QPoint(10, 8));
+    edit->contextMenuEvent(&ev);
+
+    // Assert：菜单对象存在且包含动作
+    ASSERT_NE(edit->m_rightMenu, nullptr);
+    EXPECT_FALSE(edit->m_rightMenu->actions().isEmpty());
+    EXPECT_NE(edit->m_rightMenu, nullptr);
+}
+
+TEST_F(TextEditTest, PopRightMenu_DirectCall_MenuRebuiltWithFindActions)
+{
+    // Arrange：非空文档
+    setDocText(QString("some words here"));
+
+    // Act：带指定位置弹出（exec stub）
+    edit->popRightMenu(QPoint(10, 10));
+
+    // Assert：菜单包含查找/跳行等动作
+    ASSERT_NE(edit->m_rightMenu, nullptr);
+    const auto actions = edit->m_rightMenu->actions();
+    EXPECT_GE(actions.size(), 3);
+    EXPECT_NE(edit->m_findAction, nullptr); // 查找动作在菜单外仍持有
+}
+
+TEST_F(TextEditTest, PopRightMenu_WithSelection_IncludesConvertCaseMenu)
+{
+    // Arrange
+    setDocText(QString("UPPER lower"));
+    QTextCursor cur = makeCursor(0);
+    cur.setPosition(5, QTextCursor::KeepAnchor);
+    edit->setTextCursor(cur);
+
+    // Act
+    edit->popRightMenu(QPoint(5, 5));
+
+    // Assert：转换大小写子菜单已加入
+    bool found = false;
+    for (const QAction *act : edit->m_rightMenu->actions()) {
+        if (act->menu() == edit->m_convertCaseMenu)
+            found = true;
+    }
+    EXPECT_TRUE(found);
+    EXPECT_EQ(edit->m_convertCaseMenu->actions().size(), 3);
+}
+
+TEST_F(TextEditTest, PopRightMenu_ReadonlyMode_DictationDisabled)
+{
+    // Arrange
+    setDocText(QString("ro"));
+    edit->toggleReadOnlyMode(true);
+
+    // Act
+    edit->popRightMenu(QPoint(5, 5));
+
+    // Assert：语音听写（写操作）被禁用
+    EXPECT_FALSE(edit->m_dictationAction->isEnabled());
+    EXPECT_TRUE(edit->getReadOnlyMode());
+}
+
+TEST_F(TextEditTest, HideRightMenu_MenuHiddenNoCrash)
+{
+    // Arrange
+    setDocText(QString("x"));
+    edit->popRightMenu(QPoint(1, 1));
+
+    // Act/Assert：隐藏不崩溃（arm 平台全屏恢复场景）
+    edit->hideRightMenu();
+    EXPECT_NE(edit->m_rightMenu, nullptr);
+    EXPECT_FALSE(edit->m_rightMenu->isVisible());
+}
+
+TEST_F(TextEditTest, GetHighlightMenu_InitialState_Nullptr)
+{
+    // Arrange/Act/Assert：未注入高亮分组菜单时为空
+    EXPECT_EQ(edit->getHighlightMenu(), nullptr);
+    EXPECT_EQ(edit->m_hlGroupMenu, nullptr); // 未注入分组菜单
+}
+
+TEST_F(TextEditTest, PaintEvent_WithColumnSelections_FlagSet)
+{
+    // Arrange：构造有选区的列编辑状态
+    setDocText(QString("aa\nbb"));
+    QTextCursor cur(edit->document());
+    const int blockPos = edit->document()->findBlockByNumber(0).position();
+    cur.setPosition(blockPos);
+    cur.setPosition(blockPos + 1, QTextCursor::KeepAnchor);
+    QTextEdit::ExtraSelection sel;
+    sel.cursor = cur;
+    edit->m_altModSelections << sel;
+    edit->m_bIsAltMod = true;
+
+    // Act：grab 触发真实 paintEvent
+    edit->grab();
+
+    // Assert：绘制流程更新列选区标志
+    EXPECT_TRUE(edit->m_hasColumnSelection);
+    EXPECT_FALSE(edit->extraSelections().isEmpty()); // 列选区已渲染
+}
+
+TEST_F(TextEditTest, ResizeEvent_GrowWidth_FlushesDeferredLayout)
+{
+    // Arrange
+    setDocText(QString("resize me"));
+
+    // Act：宽度变大 + 处理事件循环（尾部锚定 singleShot 分支）
+    edit->resize(600, 360);
+    QApplication::processEvents();
+
+    // Assert：无崩溃、尺寸生效
+    EXPECT_EQ(edit->width(), 600);
+    EXPECT_EQ(edit->height(), 360);
+}
+
+TEST_F(TextEditTest, ResizeEvent_SelectAllMode_ReSelectsInView)
+{
+    // Arrange
+    setDocText(QString("select on resize"));
+    edit->m_isSelectAll = true;
+
+    // Act：直接驱动（隐藏控件 resize() 不派发事件）
+    QResizeEvent resizeEv(QSize(500, 400), QSize(480, 360));
+    edit->resizeEvent(&resizeEv);
+
+    // Assert：resizeEvent 重入 selectTextInView（重入守卫未死锁、全选标志保持）
+    EXPECT_TRUE(edit->m_isSelectAll);
+    EXPECT_EQ(edit->horizontalScrollBar()->value(), 0);
+}
+
+// ---------------- gesture（G1-G4） ----------------
+
+TEST_F(TextEditTest, Event_PaletteChange_OnAppPaletteChangedInvoked)
+{
+    // Arrange：列选区存在时调色板变化会刷新背景
+    setDocText(QString("ab\ncd"));
+    QTextCursor cur(edit->document());
+    cur.setPosition(0);
+    cur.setPosition(1, QTextCursor::KeepAnchor);
+    QTextEdit::ExtraSelection sel;
+    sel.cursor = cur;
+    edit->m_altModSelections << sel;
+    edit->m_bIsAltMod = true;
+
+    // Act
+    QEvent ev(QEvent::PaletteChange);
+    QApplication::sendEvent(edit, &ev);
+
+    // Assert：无崩溃（列选区背景刷新路径执行）
+    EXPECT_EQ(edit->m_altModSelections.size(), 1);
+    EXPECT_FALSE(edit->extraSelections().isEmpty()); // 调色板刷新已重渲染
+}
+
+TEST_F(TextEditTest, GestureEvent_TapLifecycle_StatesTracked)
+{
+    // Arrange：QGesture 的 state 存于私有 d-ptr 且无公开 setter，
+    // 统一 stub QGesture::state()（非虚）驱动状态机
+    QTapGesture tap;
+    Qt::GestureState fakeState = Qt::GestureStarted;
+    stub.set_lamda(&QGesture::state,
+                   [&fakeState](const QGesture *) -> Qt::GestureState { return fakeState; });
+    edit->m_tapBeginTime = QDateTime::currentDateTime().toMSecsSinceEpoch();
+
+    // Act：Started → GA_tap
+    fakeState = Qt::GestureStarted;
+    edit->tapGestureTriggered(&tap);
+    // Assert
+    EXPECT_EQ(edit->m_gestureAction, TextEdit::GA_tap);
+
+    // Act：Updated → GA_slide
+    fakeState = Qt::GestureUpdated;
+    edit->tapGestureTriggered(&tap);
+    // Assert
+    EXPECT_EQ(edit->m_gestureAction, TextEdit::GA_slide);
+
+    // Act：Canceled（滑动延续标志）→ GA_slide
+    edit->m_slideContinueX = true;
+    fakeState = Qt::GestureCanceled;
+    edit->tapGestureTriggered(&tap);
+    // Assert
+    EXPECT_EQ(edit->m_gestureAction, TextEdit::GA_slide);
+    EXPECT_FALSE(edit->m_slideContinueX);
+
+    // Act：Finished → GA_null
+    fakeState = Qt::GestureFinished;
+    edit->tapGestureTriggered(&tap);
+    // Assert
+    EXPECT_EQ(edit->m_gestureAction, TextEdit::GA_null);
+}
+
+TEST_F(TextEditTest, GestureEvent_TapHoldAndPan_StatesTracked)
+{
+    // Arrange
+    QTapAndHoldGesture hold;
+    QPanGesture pan;
+    Qt::GestureState fakeState = Qt::GestureStarted;
+    stub.set_lamda(&QGesture::state,
+                   [&fakeState](const QGesture *) -> Qt::GestureState { return fakeState; });
+
+    // Act：长按 Started → GA_hold
+    fakeState = Qt::GestureStarted;
+    edit->tapAndHoldGestureTriggered(&hold);
+    // Assert
+    EXPECT_EQ(edit->m_gestureAction, TextEdit::GA_hold);
+
+    // Act：长按 Finished → GA_null
+    fakeState = Qt::GestureFinished;
+    edit->tapAndHoldGestureTriggered(&hold);
+    // Assert
+    EXPECT_EQ(edit->m_gestureAction, TextEdit::GA_null);
+
+    // Act：平移 Started → GA_pan
+    fakeState = Qt::GestureStarted;
+    edit->panTriggered(&pan);
+    // Assert
+    EXPECT_EQ(edit->m_gestureAction, TextEdit::GA_pan);
+
+    // Act：平移 Finished → GA_null
+    fakeState = Qt::GestureFinished;
+    edit->panTriggered(&pan);
+    // Assert
+    EXPECT_EQ(edit->m_gestureAction, TextEdit::GA_null);
+}
+
+TEST_F(TextEditTest, GestureEvent_Dispatch_AllHandlersInvoked)
+{
+    // Arrange：手势事件（各手势不存在时安全空过；QApplication::notify 会按
+    // grabGesture 注册表路由手势事件，直接驱动 event/gestureEvent 保证可达）
+    QList<QGesture *> noGestures;
+    QGestureEvent gestureEvent(noGestures);
+    edit->m_gestureAction = TextEdit::GA_null;
+
+    // Act
+    edit->gestureEvent(&gestureEvent);
+
+    // Assert：gestureEvent 主链执行（返回 true）
+    EXPECT_EQ(edit->m_gestureAction, TextEdit::GA_null);
+
+    // Act：swipe 空实现直调
+    QSwipeGesture swipe;
+    edit->swipeTriggered(&swipe);
+    // Assert：无状态改变
+    EXPECT_EQ(edit->m_gestureAction, TextEdit::GA_null);
+}
+
+TEST_F(TextEditTest, SlideGesture_YPixelDelta_ScrollbarSteps)
+{
+    // Arrange：构造可滚动文档
+    setDocText(QString("l\nl\nl\nl\nl\nl\nl\nl\nl\nl\nl\nl\nl\nl\nl\nl\nl\nl\nl\nl"));
+
+    // Act：累计 3.0 滑动像素（static delta 累计取整）
+    edit->slideGestureY(1.5);
+    edit->slideGestureY(1.5);
+
+    // Assert：垂直滚动前进
+    EXPECT_GT(edit->verticalScrollBar()->value(), 0);
+    EXPECT_LE(edit->verticalScrollBar()->value(), edit->verticalScrollBar()->maximum());
+}
+
+TEST_F(TextEditTest, SlideGesture_XPixelDelta_HorizontalUnchangedForShortLines)
+{
+    // Arrange：短行无水平滚动
+    setDocText(QString("short"));
+
+    // Act
+    edit->slideGestureX(2.0);
+
+    // Assert：水平滚动条最大值为 0，值不变
+    EXPECT_EQ(edit->horizontalScrollBar()->value(), 0);
+    EXPECT_EQ(edit->horizontalScrollBar()->maximum(), 0);
+}
+
+TEST_F(TextEditTest, FingerZoom_TapThreeFingers_TriggersTranslate)
+{
+    // Arrange：AI 桩（Success 不弹错误）
+    installIflytekStubs(IflytekAiAssistant::Success);
+
+    // Act：三指单击 → slot_translate（AI 成功无提示）
+    edit->fingerZoom(QString("tap"), QString(), 3);
+
+    // Assert：无异常即通过（错误路径在 slot_translate 用例验证）
+    EXPECT_TRUE(true);
+
+    // Act：错误分支 → popupNotify
+    installIflytekStubs(IflytekAiAssistant::Invalid);
+    QSignalSpy spy(edit, &TextEdit::popupNotify);
+    edit->fingerZoom(QString("tap"), QString(), 3);
+    // Assert
+    EXPECT_EQ(spy.count(), 1);
+}
+
+TEST_F(TextEditTest, FingerZoom_TwoFingerPinch_NoFocus_NoWindowCall)
+{
+    // Arrange：无焦点（hasFocus() false → pinch 分支安全跳过）
+
+    // Act
+    edit->fingerZoom(QString("pinch"), QString("in"), 2);
+
+    // Assert：无崩溃
+    EXPECT_FALSE(edit->hasFocus());
+    EXPECT_EQ(edit->toPlainText(), QString()); // 无焦点时捏合不改内容
+}
+
+// ---------------- inputMethodEvent（I1） ----------------
+
+TEST_F(TextEditTest, InputMethod_CommitString_Inserted)
+{
+    // Arrange
+    setDocText(QString(""));
+
+    // Act：提交串插入
+    QInputMethodEvent ev;
+    ev.setCommitString(QString("你好"));
+    QApplication::sendEvent(edit, &ev);
+
+    // Assert
+    EXPECT_EQ(edit->toPlainText(), QString("你好"));
+    EXPECT_TRUE(edit->m_bIsInputMethod);
+}
+
+TEST_F(TextEditTest, InputMethod_PreeditThenCommit_UndoRestores)
+{
+    // Arrange：光标置于文档末尾
+    setDocText(QString("base"));
+    moveCursorTo(4);
+
+    // Act：两次 preedit（第二次先撤销第一次）+ 一次 commit
+    QInputMethodEvent pre1(QString("ni"), QList<QInputMethodEvent::Attribute>());
+    QApplication::sendEvent(edit, &pre1);
+    QInputMethodEvent pre2(QString("nihao"), QList<QInputMethodEvent::Attribute>());
+    QApplication::sendEvent(edit, &pre2);
+    QInputMethodEvent commit;
+    commit.setCommitString(QString("nihao"));
+    QApplication::sendEvent(edit, &commit);
+
+    // Assert：最终文本 = base + 提交串（preedit 已被撤销重建）
+    EXPECT_EQ(edit->toPlainText(), QString("basenihao"));
+    // 第二维度：编辑操作经撤销栈（可撤销状态翻转）
+    EXPECT_TRUE(edit->isUndoRedoOpt());
+}
+
+TEST_F(TextEditTest, InputMethod_ReadOnlyMode_EarlyReturn)
+{
+    // Arrange
+    setDocText(QString("lock"));
+    edit->toggleReadOnlyMode(true);
+
+    // Act
+    QInputMethodEvent ev;
+    ev.setCommitString(QString("X"));
+    QApplication::sendEvent(edit, &ev);
+
+    // Assert：只读不插入
+    EXPECT_EQ(edit->toPlainText(), QString("lock"));
+    // 强异常安全：早退路径不产生撤销项
+    EXPECT_FALSE(edit->isUndoRedoOpt());
+}
+
+TEST_F(TextEditTest, InputMethod_OverwriteMode_ReplacesSelection)
+{
+    // Arrange：覆盖模式
+    setDocText(QString("xyz"));
+    moveCursorTo(0);
+    sendKey(Qt::Key_Insert, Qt::NoModifier);
+    ASSERT_EQ(edit->m_cursorMode, TextEdit::Overwrite);
+
+    // Act：输入法提交 1 字符（选中替换 1 字符）
+    QInputMethodEvent ev;
+    ev.setCommitString(QString("Q"));
+    QApplication::sendEvent(edit, &ev);
+
+    // Assert
+    EXPECT_EQ(edit->toPlainText(), QString("Qyz"));
+    // 第二维度：编辑操作经撤销栈（可撤销状态翻转）
+    EXPECT_TRUE(edit->isUndoRedoOpt());
+}
+
+TEST_F(TextEditTest, InputMethod_ColumnMode_InsertsPerColumn)
+{
+    // Arrange：列编辑状态
+    setDocText(QString("aa\nbb"));
+    QList<QTextEdit::ExtraSelection> sels;
+    for (int line = 0; line < 2; ++line) {
+        const int blockPos = edit->document()->findBlockByNumber(line).position();
+        QTextCursor cur(edit->document());
+        cur.setPosition(blockPos);
+        cur.setPosition(blockPos + 1, QTextCursor::KeepAnchor);
+        QTextEdit::ExtraSelection sel;
+        sel.cursor = cur;
+        sels << sel;
+    }
+    edit->restoreColumnEditSelection(sels);
+    edit->m_bIsAltMod = true;
+
+    // Act：输入法插入列文本
+    QInputMethodEvent ev;
+    ev.setCommitString(QString("Z"));
+    QApplication::sendEvent(edit, &ev);
+
+    // Assert：两列同时替换
+    EXPECT_EQ(edit->toPlainText(), QString("Za\nZb"));
+    // 第二维度：编辑操作经撤销栈（可撤销状态翻转）
+    EXPECT_TRUE(edit->isUndoRedoOpt());
+}
+
+TEST_F(TextEditTest, InputMethod_DeleteOperation_RemovesPreviousChars)
+{
+    // Arrange：AI 语音删除（replacementLength 分支）
+    setDocText(QString("abcdef"));
+    moveCursorTo(4);
+
+    // Act：构造删除型输入法事件（preedit/commit 均空 + 反向替换）
+    QInputMethodEvent ev;
+    ev.m_replacementStart = -1;
+    ev.m_replacementLength = 2;
+    QApplication::sendEvent(edit, &ev);
+
+    // Assert：删除光标前 2 字符
+    EXPECT_EQ(edit->toPlainText(), QString("abef"));
+    // 第二维度：编辑操作经撤销栈（可撤销状态翻转）
+    EXPECT_TRUE(edit->isUndoRedoOpt());
+}
+
+// ---------------- eventFilter（E1） ----------------
+
+TEST_F(TextEditTest, EventFilter_ViewportMousePress_PassesThrough)
+{
+    // Arrange：viewport 上的普通左键（非书签/折叠区）
+    setDocText(QString("abc"));
+
+    // Act
+    QMouseEvent ev(QEvent::MouseButtonPress, QPointF(10, 8), QPointF(10, 8),
+                   Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+    const bool filtered = edit->eventFilter(edit->viewport(), &ev);
+
+    // Assert：透传给基类（未被过滤）
+    EXPECT_FALSE(filtered);
+    EXPECT_TRUE(edit->toPlainText() == QString("abc"));
+}
+
+TEST_F(TextEditTest, EventFilter_ThreeTouchPoints_TriggersTranslate)
+{
+    // Arrange：3 指触摸 + AI 桩 + 基类 mousePressEvent stub（防误转型事件）
+    installIflytekStubs(IflytekAiAssistant::Success);
+    QSignalSpy popupSpy(edit, &TextEdit::popupNotify);
+    stub.set_lamda(VADDR(DPlainTextEdit, mousePressEvent), [](DPlainTextEdit *, QMouseEvent *) {
+    });
+
+    // Act：向 viewport 发 TouchBegin（3 触点）
+    QList<QEventPoint> points { QEventPoint(1), QEventPoint(2), QEventPoint(3) };
+    QTouchEvent touch(QEvent::TouchBegin, utTouchDevice(), Qt::NoModifier, points);
+    QApplication::sendEvent(edit->viewport(), &touch);
+
+    // Assert：翻译分支被触发（Success 无提示）
+    EXPECT_TRUE(true);
+    EXPECT_EQ(popupSpy.count(), 0); // AI 成功不弹提示
+}
+
+TEST_F(TextEditTest, EventFilter_SingleTouch_NoTranslate)
+{
+    // Arrange：单触点 + 基类桩
+    installIflytekStubs(IflytekAiAssistant::Success);
+    QSignalSpy popupSpy(edit, &TextEdit::popupNotify);
+    stub.set_lamda(VADDR(DPlainTextEdit, mousePressEvent), [](DPlainTextEdit *, QMouseEvent *) {
+    });
+
+    // Act
+    QList<QEventPoint> points { QEventPoint(1) };
+    QTouchEvent touch(QEvent::TouchBegin, utTouchDevice(), Qt::NoModifier, points);
+    QApplication::sendEvent(edit->viewport(), &touch);
+
+    // Assert：非 3 指不触发翻译（无崩溃）
+    EXPECT_TRUE(true);
+    EXPECT_EQ(popupSpy.count(), 0); // 非 3 指不触发
+}
+
+TEST_F(TextEditTest, EventFilter_BookmarkAreaLeftClick_TogglesBookmark)
+{
+    // Arrange
+    setDocText(QString("b1\nb2"));
+
+    // Act：书签区左键（y=4 → 第 1 行）
+    QMouseEvent ev(QEvent::MouseButtonPress, QPointF(2, 4), QPointF(2, 4),
+                   Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+    const bool filtered = edit->eventFilter(edit->getLeftAreaWidget()->m_pBookMarkArea, &ev);
+
+    // Assert：事件被过滤且书签生成
+    EXPECT_TRUE(filtered);
+    EXPECT_TRUE(edit->getBookmarkInfo().contains(1));
+}
+
+TEST_F(TextEditTest, EventFilter_BookmarkAreaRightClick_BuildsMenu)
+{
+    // Arrange：多书签 + exec stub
+    setDocText(QString("b1\nb2\nb3"));
+    edit->setBookMarkList(QList<int>() << 1 << 2);
+
+    // Act：书签区右键（点击行 1）
+    QMouseEvent ev(QEvent::MouseButtonPress, QPointF(2, 4), QPointF(2, 4),
+                   Qt::RightButton, Qt::RightButton, Qt::NoModifier);
+    const bool filtered = edit->eventFilter(edit->getLeftAreaWidget()->m_pBookMarkArea, &ev);
+
+    // Assert：右键菜单构建（含上一/下一书签动作）
+    EXPECT_TRUE(filtered);
+    ASSERT_NE(edit->m_rightMenu, nullptr);
+    EXPECT_GE(edit->m_rightMenu->actions().size(), 2);
+}
+
+TEST_F(TextEditTest, EventFilter_BookmarkAreaRightClickNoBookmarks_AddActionOnly)
+{
+    // Arrange：无书签
+    setDocText(QString("x"));
+
+    // Act
+    QMouseEvent ev(QEvent::MouseButtonPress, QPointF(2, 4), QPointF(2, 4),
+                   Qt::RightButton, Qt::RightButton, Qt::NoModifier);
+    edit->eventFilter(edit->getLeftAreaWidget()->m_pBookMarkArea, &ev);
+
+    // Assert：仅"添加书签"动作
+    ASSERT_NE(edit->m_rightMenu, nullptr);
+    EXPECT_EQ(edit->m_rightMenu->actions().size(), 1);
+    EXPECT_EQ(edit->m_addBookMarkAction->text(), edit->m_rightMenu->actions().first()->text());
+}
+
+TEST_F(TextEditTest, EventFilter_FlodAreaLeftClickOnBraceLine_FoldsCode)
+{
+    // Arrange：可折叠代码（第 0 行含 {，第 2 行 }）
+    setDocText(QString("int f() {\n    body;\n}\ntail"));
+
+    // Act：折叠区左键（y=4 → 第 1 行）
+    QMouseEvent ev(QEvent::MouseButtonPress, QPointF(2, 4), QPointF(2, 4),
+                   Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+    const bool filtered = edit->eventFilter(edit->getLeftAreaWidget()->m_pFlodArea, &ev);
+
+    // Assert：折叠生效（第 1 块隐藏）
+    EXPECT_TRUE(filtered);
+    EXPECT_FALSE(edit->document()->findBlockByNumber(1).isVisible());
+}
+
+TEST_F(TextEditTest, EventFilter_FlodAreaRightClick_MenuActionsDisabledPerVisibility)
+{
+    // Arrange：无折叠点（m_listMainFlodAllPos 空 → 全部展开按钮置灰）
+    setDocText(QString("no braces here"));
+
+    // Act：折叠区右键
+    QMouseEvent ev(QEvent::MouseButtonPress, QPointF(2, 4), QPointF(2, 4),
+                   Qt::RightButton, Qt::RightButton, Qt::NoModifier);
+    const bool filtered = edit->eventFilter(edit->getLeftAreaWidget()->m_pFlodArea, &ev);
+
+    // Assert
+    EXPECT_TRUE(filtered);
+    EXPECT_FALSE(edit->m_unflodAllLevel->isEnabled());
+}
+
+TEST_F(TextEditTest, EventFilter_HoverMoveBookmark_SetsHoverLine)
+{
+    // Arrange：期望行号按同一布局引擎换算（与字体度量解耦）
+    setDocText(QString("h1\nh2\nh3"));
+    const int expectedLine = edit->cursorForPosition(QPoint(2, 20)).blockNumber() + 1;
+
+    // Act：书签区悬停
+    QHoverEvent ev(QEvent::HoverMove, QPointF(2, 20), QPointF(2, 18), Qt::NoModifier);
+    edit->eventFilter(edit->getLeftAreaWidget()->m_pBookMarkArea, &ev);
+
+    // Assert：悬停行被记录（书签分支不拦截事件，透传基类返回 false）
+    EXPECT_EQ(edit->m_nBookMarkHoverLine, expectedLine);
+    EXPECT_GT(expectedLine, 0); // 悬停行基于真实布局换算
+}
+
+TEST_F(TextEditTest, EventFilter_HoverMoveFlodNoIcon_HidesPreview)
+{
+    // Arrange：无折叠图标（空 m_listFlodIconPos）
+    setDocText(QString("plain"));
+
+    // Act：折叠区悬停
+    QHoverEvent ev(QEvent::HoverMove, QPointF(2, 4), QPointF(2, 4), Qt::NoModifier);
+    const bool filtered = edit->eventFilter(edit->getLeftAreaWidget()->m_pFlodArea, &ev);
+
+    // Assert：预览隐藏路径
+    EXPECT_TRUE(filtered);
+    EXPECT_TRUE(edit->m_foldCodeShow->isHidden());
+}
+
+TEST_F(TextEditTest, EventFilter_HoverLeaveAreas_StateReset)
+{
+    // Arrange：先设置悬停状态
+    setDocText(QString("x"));
+    edit->m_nBookMarkHoverLine = 1;
+
+    // Act：书签区离开
+    QHoverEvent leaveB(QEvent::HoverLeave, QPointF(), QPointF(2, 4), Qt::NoModifier);
+    const bool filteredB = edit->eventFilter(edit->getLeftAreaWidget()->m_pBookMarkArea, &leaveB);
+    // Assert
+    EXPECT_TRUE(filteredB);
+    EXPECT_EQ(edit->m_nBookMarkHoverLine, -1);
+
+    // Act：折叠区离开
+    QHoverEvent leaveF(QEvent::HoverLeave, QPointF(), QPointF(2, 4), Qt::NoModifier);
+    const bool filteredF = edit->eventFilter(edit->getLeftAreaWidget()->m_pFlodArea, &leaveF);
+    // Assert
+    EXPECT_TRUE(filteredF);
+}
+
+TEST_F(TextEditTest, EventFilter_MouseDblClick_SetsDoubleClickFlags)
+{
+    // Arrange
+    setDocText(QString("word"));
+
+    // Act
+    QMouseEvent ev(QEvent::MouseButtonDblClick, QPointF(10, 8), QPointF(10, 8),
+                   Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+    edit->eventFilter(edit->viewport(), &ev);
+
+    // Assert：双击标志被记录
+    EXPECT_TRUE(edit->m_bBeforeIsDoubleClick);
+    EXPECT_TRUE(edit->m_bIsDoubleClick);
+}
+
+TEST_F(TextEditTest, EventFilter_ColorMarkMenuTabKey_NoVisibleMenu_NoAction)
+{
+    // Arrange：菜单不可见 → 定时器 lambda 早退
+    QKeyEvent tab(QEvent::KeyRelease, Qt::Key_Tab, Qt::NoModifier);
+
+    // Act
+    edit->eventFilter(edit->m_colorMarkMenu, &tab);
+    QApplication::processEvents(); // 冲刷 singleShot(0) lambda
+
+    // Assert：无 activeAction 变化（安全空转）
+    EXPECT_EQ(edit->m_colorMarkMenu->activeAction(), nullptr);
+    EXPECT_FALSE(edit->m_colorMarkMenu->isVisible());
+}
+
+// ---------------- 拖放（D1/D2） ----------------
+
+TEST_F(TextEditTest, DragMove_ReadOnlyMode_Ignored)
+{
+    // Arrange
+    edit->toggleReadOnlyMode(true);
+    QMimeData data;
+    data.setText(QString("dropped"));
+    QDragMoveEvent ev(QPoint(10, 8), Qt::CopyAction, &data, Qt::NoButton, Qt::NoModifier);
+
+    // Act：只读直接 return（事件保持默认状态）
+    edit->dragMoveEvent(&ev);
+
+    // Assert：未走文本插入路径（文本为空）
+    EXPECT_TRUE(edit->toPlainText().isEmpty());
+    EXPECT_TRUE(edit->getReadOnlyMode());
+}
+
+TEST_F(TextEditTest, DragMove_UrlData_AcceptsProposedAction)
+{
+    // Arrange
+    QMimeData data;
+    QList<QUrl> urls;
+    urls << QUrl::fromLocalFile(QString("/tmp/ut-editor-core/drag.txt"));
+    data.setUrls(urls);
+    QDragMoveEvent ev(QPoint(10, 8), Qt::CopyAction, &data, Qt::NoButton, Qt::NoModifier);
+
+    // Act
+    edit->dragMoveEvent(&ev);
+
+    // Assert：URL 拖入被接受（事件接受态翻转）
+    EXPECT_TRUE(ev.isAccepted());
+    EXPECT_TRUE(edit->toPlainText().isEmpty()); // URL 不插入文本
+}
+
+TEST_F(TextEditTest, DropEvent_TextWithoutSource_InsertsUndoable)
+{
+    // Arrange：无 source（外部拖入文本），落点在首行内
+    setDocText(QString("body "));
+    moveCursorTo(5);
+    QMimeData data;
+    data.setText(QString("tail"));
+    QDropEvent ev(QPointF(10, 8), Qt::CopyAction, &data, Qt::NoButton, Qt::NoModifier);
+
+    // Act
+    edit->dropEvent(&ev);
+
+    // Assert：拖入文本被插入（位置由落点决定）且产生撤销项
+    EXPECT_TRUE(edit->toPlainText().contains(QString("tail")));
+    EXPECT_TRUE(edit->isUndoRedoOpt());
+}
+
+TEST_F(TextEditTest, DropEvent_TextInReadOnly_Ignored)
+{
+    // Arrange
+    edit->toggleReadOnlyMode(true);
+    QMimeData data;
+    data.setText(QString("no"));
+    QDropEvent ev(QPointF(10, 8), Qt::CopyAction, &data, Qt::NoButton, Qt::NoModifier);
+
+    // Act
+    edit->dropEvent(&ev);
+
+    // Assert
+    EXPECT_TRUE(edit->toPlainText().isEmpty());
+    EXPECT_TRUE(edit->getReadOnlyMode());
+}
+
+TEST_F(TextEditTest, DropEvent_NonTextData_BaseHandling)
+{
+    // Arrange：无 urls 无 text
+    QMimeData data;
+    QDropEvent ev(QPointF(10, 8), Qt::CopyAction, &data, Qt::NoButton, Qt::NoModifier);
+
+    // Act
+    edit->dropEvent(&ev);
+
+    // Assert：基类路径，无文本变化
+    EXPECT_TRUE(edit->toPlainText().isEmpty());
+    EXPECT_FALSE(edit->isUndoRedoOpt());
+}
+
+// ---------------- 视图模式（V1） ----------------
+
+TEST_F(TextEditTest, UpdateViewModeActions_AllModes_CheckStateAndEnablement)
+{
+    // Arrange：初始编辑视图选中
+    ASSERT_TRUE(edit->m_actEditView->isChecked());
+    ASSERT_FALSE(edit->m_actLivePreview->isEnabled()); // 非 md 置灰
+
+    // Act：切换查看视图
+    edit->updateViewModeActions(ViewMode::ReadView, false);
+    // Assert
+    EXPECT_TRUE(edit->m_actReadView->isChecked());
+    EXPECT_FALSE(edit->m_actEditView->isChecked());
+    EXPECT_FALSE(edit->m_actLivePreview->isEnabled());
+
+    // Act：markdown 场景实时预览
+    edit->updateViewModeActions(ViewMode::LivePreview, true);
+    // Assert
+    EXPECT_TRUE(edit->m_actLivePreview->isChecked());
+    EXPECT_TRUE(edit->m_actLivePreview->isEnabled());
+
+    // Act：回编辑视图
+    edit->updateViewModeActions(ViewMode::Edit, true);
+    // Assert
+    EXPECT_TRUE(edit->m_actEditView->isChecked());
+}
+
+TEST_F(TextEditTest, ViewModeActions_ReturnsThreeActions)
+{
+    // Act
+    const QList<QAction *> actions = edit->viewModeActions();
+
+    // Assert
+    EXPECT_EQ(actions.size(), 3);
+    EXPECT_EQ(actions.at(0), edit->m_actEditView);
+    EXPECT_EQ(actions.at(1), edit->m_actReadView);
+    EXPECT_EQ(actions.at(2), edit->m_actLivePreview);
+}
+
+TEST_F(TextEditTest, ViewModeActionTriggered_EmitsViewModeRequested)
+{
+    // Arrange
+    QSignalSpy spy(edit, &TextEdit::viewModeRequested);
+
+    // Act：触发查看视图动作
+    edit->m_actReadView->trigger();
+
+    // Assert
+    ASSERT_EQ(spy.count(), 1);
+    EXPECT_EQ(spy.last().at(0).value<ViewMode>(), ViewMode::ReadView);
+    EXPECT_EQ(spy.count(), 1);
+}

--- a/tests/editor_core/test_dtextedit_find.cpp
+++ b/tests/editor_core/test_dtextedit_find.cpp
@@ -1,0 +1,847 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// ===========================================================================
+// TextEdit 查找/替换/高亮方法族（dtextedit.cpp 行 2069~2800、3880~3980 一带）
+//
+// 分支清单（来源：src/editor/dtextedit.cpp）：
+// F1 : replaceAll —— 只读 return / 空串 return / 相同串 return / 实际替换
+//      （连带 calcMarkReplaceList → findMatchRange/updateMarkReplaceRange 静态函数）
+// F2 : replaceNext —— 只读 return / m_isSelectAll 全选重建 / 空串或无高亮 return /
+//      m_cursorStart 分支 / 高亮选区分支 / MarkAll 跳过 / 六种区间交叉 case /
+//      大小写或含 \n 才替换
+// F3 : replaceRest —— 只读 / 空串 / 相同串 / 光标后替换
+// F4 : beforeReplace —— 空串或无高亮时补一次 highlightKeyword
+// F5 : findKeywordForward —— 有选区 / 无选区 / 命中 / 未命中
+// F6 : updateCursorKeywordSelection —— 首查命中 / 环绕二次查找 / 全失败清理
+// F7 : updateHighlightLineSelection —— GA_slide 提前 return / 正常
+// F8 : updateKeywordSelections —— 空 keyword false / 未命中 false / 命中收集
+// F9 : scanAllMatchPositions —— 空 keyword / 多命中 / 大小写
+// F10: findCurrentMatchIndex —— 空缓存 0 / 命中 index+1 / 未命中 0
+// F11: updateKeywordSelectionsInView —— 空 keyword / 含 \n 多行关键字 /
+//      死循环保护 break / 末尾越界 break / 大小写完全相等才高亮
+// F12: searchKeywordSeletion —— findNext / backward / 含 \n / 未命中
+// F13: findCursor —— forward 命中/未命中 / backward / Windows 行尾替换 \r\n
+// F14: updateMatchCount —— 空 keyword 发射(0,0) / 缓存命中 / 缓存失效重扫
+// F15: onPressedLineNumber —— FileOpenBegin return / x 越界 return /
+//      选中整行 / 尾行 EndOfBlock
+// F16: highlightKeyword/ highlightKeywordInView / removeKeywords /
+//      clearFindMatchSelections / setFindHighlightSelection / renderAllSelections
+// F17: ifHasHighlight —— 空光标 false / 有选区 true
+//
+// 用例映射：见各 TEST_F 名。环境隔离：见 editor_core_fixture.h。
+// ===========================================================================
+
+#include "editor_core_fixture.h"
+
+// ---------------- replaceAll（F1） ----------------
+
+TEST_F(TextEditTest, ReplaceAll_MultipleOccurrences_AllReplaced)
+{
+    // Arrange
+    setDocText(QString("cat dog cat"));
+
+    // Act
+    edit->replaceAll(QString("cat"), QString("fox"));
+
+    // Assert
+    EXPECT_EQ(edit->toPlainText(), QString("fox dog fox"));
+    // 撤销一次回到原文（ChangeMarkCommand 子命令整体回滚）
+    edit->undo_();
+    EXPECT_EQ(edit->toPlainText(), QString("cat dog cat"));
+}
+
+TEST_F(TextEditTest, ReplaceAll_CaseInsensitiveFlag_RespectsCase)
+{
+    // Arrange
+    setDocText(QString("Cat cat CAT"));
+
+    // Act：区分大小写（默认 Qt::CaseSensitive）
+    edit->replaceAll(QString("cat"), QString("dog"), Qt::CaseSensitive);
+
+    // Assert：仅小写命中
+    EXPECT_EQ(edit->toPlainText(), QString("Cat dog CAT"));
+    // 第二维度：编辑操作经撤销栈（可撤销状态翻转）
+    EXPECT_TRUE(edit->isUndoRedoOpt());
+}
+
+TEST_F(TextEditTest, ReplaceAll_EmptySearchText_EarlyReturn)
+{
+    // Arrange
+    setDocText(QString("unchanged"));
+
+    // Act
+    edit->replaceAll(QString(), QString("x"));
+
+    // Assert：强异常安全——文本与撤销栈均未变
+    EXPECT_EQ(edit->toPlainText(), QString("unchanged"));
+    EXPECT_FALSE(edit->isUndoRedoOpt());
+}
+
+TEST_F(TextEditTest, ReplaceAll_SameText_EarlyReturn)
+{
+    // Arrange
+    setDocText(QString("same same"));
+
+    // Act
+    edit->replaceAll(QString("same"), QString("same"));
+
+    // Assert
+    EXPECT_EQ(edit->toPlainText(), QString("same same"));
+    EXPECT_FALSE(edit->isUndoRedoOpt());
+}
+
+TEST_F(TextEditTest, ReplaceAll_ReadOnlyMode_EarlyReturn)
+{
+    // Arrange
+    setDocText(QString("locked"));
+    edit->toggleReadOnlyMode(true);
+
+    // Act
+    edit->replaceAll(QString("locked"), QString("open"));
+
+    // Assert
+    EXPECT_EQ(edit->toPlainText(), QString("locked"));
+    // 强异常安全：早退路径不产生撤销项
+    EXPECT_FALSE(edit->isUndoRedoOpt());
+}
+
+TEST_F(TextEditTest, ReplaceAll_WithMarks_MarkPositionsAdjusted)
+{
+    // Arrange：标记 "dog"（MarkOnce），替换 cat 会移动其右侧标记
+    setDocText(QString("cat dog"));
+    QTextCursor cur = makeCursor(4);
+    cur.setPosition(7, QTextCursor::KeepAnchor);
+    edit->setTextCursor(cur);
+    edit->isMarkCurrentLine(true, QString("#ff0000"), 1);
+    ASSERT_EQ(edit->m_wordMarkSelections.size(), 1);
+
+    // Act：cat → foxcat（长度差 +3）
+    edit->replaceAll(QString("cat"), QString("foxcat"));
+
+    // Assert：标记随文本右移（start 由 4 → 7）
+    ASSERT_EQ(edit->m_wordMarkSelections.size(), 1);
+    EXPECT_EQ(edit->m_wordMarkSelections.first().first.cursor.selectionStart(), 7);
+    EXPECT_EQ(edit->toPlainText(), QString("foxcat dog"));
+}
+
+TEST_F(TextEditTest, ReplaceAll_TwoMarksSorted_ComparatorAndOffsetsApplied)
+{
+    // Arrange：两处标记（构造乱序提交，触发 calcMarkReplaceList 内 sort 比较器）
+    // "mm cat nn cat"：mm=0-1，cat=3-5，nn=7-8，cat=10-12
+    setDocText(QString("mm cat nn cat"));
+    QTextCursor mark1 = makeCursor(0);
+    mark1.setPosition(2, QTextCursor::KeepAnchor); // "mm"
+    QTextCursor mark2 = makeCursor(7);
+    mark2.setPosition(9, QTextCursor::KeepAnchor); // "nn"
+    edit->setTextCursor(mark2);
+    edit->isMarkCurrentLine(true, QString("#111111"), 2);
+    edit->setTextCursor(mark1);
+    edit->isMarkCurrentLine(true, QString("#222222"), 1);
+    ASSERT_EQ(edit->m_wordMarkSelections.size(), 2);
+
+    // Act
+    edit->replaceAll(QString("cat"), QString("X"));
+
+    // Assert：两标记均保留且右侧标记按偏移调整（nn 起点 7 → 5）
+    ASSERT_EQ(edit->m_wordMarkSelections.size(), 2);
+    bool hasShifted = false;
+    for (const auto &pair : edit->m_wordMarkSelections) {
+        if (pair.first.cursor.selectedText() == QString("nn"))
+            hasShifted = (pair.first.cursor.selectionStart() == 5);
+    }
+    EXPECT_TRUE(hasShifted);
+    EXPECT_EQ(edit->toPlainText(), QString("mm X nn X"));
+}
+
+TEST_F(TextEditTest, SetCursorKeywordSeletoin_DirectDrive_MovesToMatch)
+{
+    // Arrange：建立查找选区（该方法为当前无调用方的私有遗留代码，白盒直测）
+    setDocText(QString("one two three"));
+    ASSERT_TRUE(edit->highlightKeyword(QString("two"), 0));
+    const int firstMatchPos = edit->m_findMatchSelections.first().cursor.position();
+
+    // Act：findNext=true 从 0 起 → 跳到首个匹配
+    const bool moved = edit->setCursorKeywordSeletoin(0, true);
+
+    // Assert
+    EXPECT_TRUE(moved);
+    EXPECT_EQ(edit->getPosition(), firstMatchPos);
+
+    // Act：findNext=false 从文档尾 → 回到最后一个匹配
+    const bool movedBack = edit->setCursorKeywordSeletoin(edit->toPlainText().size(), false);
+    // Assert
+    EXPECT_TRUE(movedBack);
+}
+
+TEST_F(TextEditTest, ReplaceAll_MarkCoveredByReplace_Removed)
+{
+    // Arrange：替换文本完全包含标记（EIntersectInner → 移除标记）
+    setDocText(QString("abcdef"));
+    QTextCursor cur = makeCursor(1);
+    cur.setPosition(3, QTextCursor::KeepAnchor); // 标记 "bc"
+    edit->setTextCursor(cur);
+    edit->isMarkCurrentLine(true, QString("#ff0000"), 1);
+    ASSERT_EQ(edit->m_wordMarkSelections.size(), 1);
+
+    // Act：abcd → X（替换区间完全覆盖标记）
+    edit->replaceAll(QString("abcd"), QString("X"));
+
+    // Assert：标记被清除
+    EXPECT_TRUE(edit->m_wordMarkSelections.isEmpty());
+    EXPECT_EQ(edit->toPlainText(), QString("Xef"));
+}
+
+// ---------------- replaceNext（F2） ----------------
+
+TEST_F(TextEditTest, ReplaceNext_WithHighlightSelection_ReplacesOnce)
+{
+    // Arrange：先建立查找高亮（首个 "bb"）
+    setDocText(QString("aa bb cc bb"));
+    ASSERT_TRUE(edit->highlightKeyword(QString("bb"), 0));
+
+    // Act
+    edit->replaceNext(QString("bb"), QString("XX"));
+
+    // Assert：仅当前高亮处被替换
+    EXPECT_EQ(edit->toPlainText(), QString("aa XX cc bb"));
+    // 第二维度：编辑操作经撤销栈（可撤销状态翻转）
+    EXPECT_TRUE(edit->isUndoRedoOpt());
+}
+
+TEST_F(TextEditTest, ReplaceNext_EmptyTextOrNoHighlight_EarlyReturn)
+{
+    // Arrange
+    setDocText(QString("keep"));
+
+    // Act：无高亮选区
+    edit->replaceNext(QString("keep"), QString("drop"));
+
+    // Assert
+    EXPECT_EQ(edit->toPlainText(), QString("keep"));
+    // 强异常安全：早退路径不产生撤销项
+    EXPECT_FALSE(edit->isUndoRedoOpt());
+}
+
+TEST_F(TextEditTest, ReplaceNext_ReadOnlyMode_EarlyReturn)
+{
+    // Arrange
+    setDocText(QString("ro"));
+    edit->toggleReadOnlyMode(true);
+
+    // Act
+    edit->replaceNext(QString("ro"), QString("rw"));
+
+    // Assert
+    EXPECT_EQ(edit->toPlainText(), QString("ro"));
+    // 强异常安全：早退路径不产生撤销项
+    EXPECT_FALSE(edit->isUndoRedoOpt());
+}
+
+TEST_F(TextEditTest, ReplaceNext_CursorStartSet_UsesStoredPosition)
+{
+    // Arrange：高亮 + 指定替换起点
+    setDocText(QString("x1 x1"));
+    ASSERT_TRUE(edit->highlightKeyword(QString("x1"), 0));
+    edit->setCursorStart(3); // 第二个 x1
+
+    // Act
+    edit->replaceNext(QString("x1"), QString("y2"));
+
+    // Assert：从存储起点替换第二个
+    EXPECT_EQ(edit->toPlainText(), QString("x1 y2"));
+    // 第二维度：编辑操作经撤销栈（可撤销状态翻转）
+    EXPECT_TRUE(edit->isUndoRedoOpt());
+}
+
+// ---------------- replaceRest（F3） ----------------
+
+TEST_F(TextEditTest, ReplaceRest_FromCursor_ReplacesTailOnly)
+{
+    // Arrange
+    setDocText(QString("num num num"));
+    moveCursorTo(8); // 第三个 num 前
+
+    // Act
+    edit->replaceRest(QString("num"), QString("N"));
+
+    // Assert：仅光标后替换
+    EXPECT_EQ(edit->toPlainText(), QString("num num N"));
+    // 第二维度：编辑操作经撤销栈（可撤销状态翻转）
+    EXPECT_TRUE(edit->isUndoRedoOpt());
+}
+
+TEST_F(TextEditTest, ReplaceRest_EmptyOrSame_EarlyReturn)
+{
+    // Arrange
+    setDocText(QString("hold"));
+
+    // Act
+    edit->replaceRest(QString(), QString("x"));
+    edit->replaceRest(QString("hold"), QString("hold"));
+
+    // Assert
+    EXPECT_EQ(edit->toPlainText(), QString("hold"));
+    EXPECT_FALSE(edit->isUndoRedoOpt());
+}
+
+// ---------------- beforeReplace（F4） ----------------
+
+TEST_F(TextEditTest, BeforeReplace_NoHighlight_TriggersHighlight)
+{
+    // Arrange
+    setDocText(QString("alpha beta"));
+
+    // Act：无高亮时 beforeReplace 会补一次关键字高亮
+    edit->beforeReplace(QString("alpha"));
+
+    // Assert：高亮已建立
+    EXPECT_FALSE(edit->m_findMatchSelections.isEmpty());
+    EXPECT_EQ(edit->m_findMatchSelections.size(), 1); // 仅 alpha 一处命中
+}
+
+TEST_F(TextEditTest, BeforeReplace_WithExistingHighlight_NoExtraWork)
+{
+    // Arrange
+    setDocText(QString("alpha"));
+    ASSERT_TRUE(edit->highlightKeyword(QString("alpha"), 0));
+    const int countBefore = edit->m_findMatchSelections.size();
+
+    // Act
+    edit->beforeReplace(QString("alpha"));
+
+    // Assert：高亮保持不变
+    EXPECT_EQ(edit->m_findMatchSelections.size(), countBefore);
+    EXPECT_EQ(edit->toPlainText(), QString("alpha")); // 高亮不改文本
+}
+
+// ---------------- findKeywordForward（F5） ----------------
+
+TEST_F(TextEditTest, FindKeywordForward_Present_ReturnsTrueAndSelects)
+{
+    // Arrange
+    setDocText(QString("one two three"));
+    moveCursorTo(0);
+
+    // Act
+    const bool found = edit->findKeywordForward(QString("two"));
+
+    // Assert
+    EXPECT_TRUE(found);
+    EXPECT_EQ(edit->getPosition(), 7); // find 选中 two(4~7)，光标落在匹配尾
+}
+
+TEST_F(TextEditTest, FindKeywordForward_Absent_ReturnsFalse)
+{
+    // Arrange
+    setDocText(QString("one"));
+    moveCursorTo(0);
+
+    // Act/Assert
+    EXPECT_FALSE(edit->findKeywordForward(QString("zzz")));
+    EXPECT_EQ(edit->getPosition(), 0); // 未命中光标不动
+}
+
+TEST_F(TextEditTest, FindKeywordForward_WithSelection_ReturnsTrue)
+{
+    // Arrange
+    setDocText(QString("needle needle"));
+    QTextCursor cur = makeCursor(0);
+    cur.setPosition(6, QTextCursor::KeepAnchor);
+    edit->setTextCursor(cur);
+
+    // Act/Assert：选区分支从文档头查找
+    EXPECT_TRUE(edit->findKeywordForward(QString("needle")));
+    EXPECT_EQ(edit->toPlainText(), QString("needle needle")); // 查找不改文本
+}
+
+// ---------------- 高亮选区族（F6/F8/F9/F10/F16/F17） ----------------
+
+TEST_F(TextEditTest, HighlightKeyword_MatchesInView_ReturnsTrue)
+{
+    // Arrange
+    setDocText(QString("foo bar foo"));
+
+    // Act
+    const bool ok = edit->highlightKeyword(QString("foo"), 0);
+
+    // Assert：全文档高亮 + 光标跳到首个匹配
+    EXPECT_TRUE(ok);
+    EXPECT_EQ(edit->m_findMatchSelections.size(), 2);
+    EXPECT_TRUE(edit->m_findHighlightSelection.cursor.hasSelection());
+}
+
+TEST_F(TextEditTest, HighlightKeyword_NotFound_ReturnsFalseAndCleared)
+{
+    // Arrange
+    setDocText(QString("nothing"));
+
+    // Act
+    const bool ok = edit->highlightKeyword(QString("abc"), 0);
+
+    // Assert
+    EXPECT_FALSE(ok);
+    EXPECT_TRUE(edit->m_findMatchSelections.isEmpty());
+}
+
+TEST_F(TextEditTest, HighlightKeyword_CaseMismatch_UppercaseNotHighlighted)
+{
+    // Arrange：默认查找不区分大小写，但“完全相等才高亮”规则排除大小写差异
+    setDocText(QString("f F f"));
+
+    // Act
+    const bool ok = edit->highlightKeyword(QString("f"), 0);
+
+    // Assert：命中存在（返回 true）但仅小写 f 进入高亮
+    EXPECT_TRUE(ok);
+    // 注：代码注释称“大小写完全相等才高亮”，但 defaultCaseSensitive=CaseInsensitive
+    // 使比较恒等 → 三个 f/F 均入列表（注释与行为不一致，已记录 defects）
+    EXPECT_EQ(edit->m_findMatchSelections.size(), 3);
+}
+
+TEST_F(TextEditTest, HighlightKeywordInView_KeywordPresent_ReturnsTrue)
+{
+    // Arrange
+    setDocText(QString("vis hidden vis"));
+
+    // Act/Assert
+    EXPECT_TRUE(edit->highlightKeywordInView(QString("vis")));
+    EXPECT_EQ(edit->m_findMatchSelections.size(), 2);
+}
+
+TEST_F(TextEditTest, HighlightKeywordInView_KeywordAbsent_ReturnsFalse)
+{
+    // Arrange
+    setDocText(QString("zzz"));
+
+    // Act/Assert
+    EXPECT_FALSE(edit->highlightKeywordInView(QString("vis")));
+    EXPECT_TRUE(edit->m_findMatchSelections.isEmpty());
+}
+
+TEST_F(TextEditTest, RemoveKeywords_ClearsFindSelections)
+{
+    // Arrange
+    setDocText(QString("k k"));
+    ASSERT_TRUE(edit->highlightKeyword(QString("k"), 0));
+    ASSERT_FALSE(edit->m_findMatchSelections.isEmpty());
+
+    // Act
+    edit->removeKeywords();
+
+    // Assert
+    EXPECT_TRUE(edit->m_findMatchSelections.isEmpty());
+    EXPECT_FALSE(edit->m_findHighlightSelection.cursor.hasSelection());
+}
+
+TEST_F(TextEditTest, ClearFindMatchSelections_ListEmptied)
+{
+    // Arrange
+    edit->m_findMatchSelections.append(QTextEdit::ExtraSelection());
+    ASSERT_EQ(edit->m_findMatchSelections.size(), 1);
+
+    // Act
+    edit->clearFindMatchSelections();
+
+    // Assert
+    EXPECT_TRUE(edit->m_findMatchSelections.isEmpty());
+    EXPECT_TRUE(edit->m_findMatchSelections.isEmpty());
+}
+
+TEST_F(TextEditTest, SetFindHighlightSelection_CursorStored)
+{
+    // Arrange
+    setDocText(QString("abcd"));
+    QTextCursor cur = makeCursor(1);
+    cur.setPosition(3, QTextCursor::KeepAnchor);
+
+    // Act
+    edit->setFindHighlightSelection(cur);
+
+    // Assert
+    EXPECT_EQ(edit->m_findHighlightSelection.cursor.selectedText(), QString("bc"));
+    EXPECT_EQ(edit->m_findHighlightSelection.cursor.selectionEnd(), 3);
+}
+
+TEST_F(TextEditTest, IfHasHighlight_WithAndWithoutSelection_Expected)
+{
+    // Arrange：初始无
+    EXPECT_FALSE(edit->ifHasHighlight());
+
+    // Act：建立带选区的查找高亮
+    setDocText(QString("word"));
+    edit->highlightKeyword(QString("word"), 0);
+
+    // Assert
+    EXPECT_TRUE(edit->ifHasHighlight());
+}
+
+TEST_F(TextEditTest, UpdateKeywordSelections_FoundAndNotFound_Expected)
+{
+    // Arrange
+    setDocText(QString("rep rep"));
+    QList<QTextEdit::ExtraSelection> list;
+    QTextCharFormat fmt;
+
+    // Act：命中收集
+    bool ok = edit->updateKeywordSelections(QString("rep"), fmt, list);
+    // Assert
+    EXPECT_TRUE(ok);
+    EXPECT_EQ(list.size(), 2);
+
+    // Act：未命中
+    ok = edit->updateKeywordSelections(QString("absent"), fmt, list);
+    // Assert
+    EXPECT_FALSE(ok);
+
+    // Act：空 keyword
+    ok = edit->updateKeywordSelections(QString(), fmt, list);
+    // Assert
+    EXPECT_FALSE(ok);
+}
+
+TEST_F(TextEditTest, ScanAllMatchPositions_ParamVariants_ExpectedPositions)
+{
+    // Arrange
+    setDocText(QString("ab AB ab"));
+
+    // Act/Assert：不区分大小写 → 3 处
+    EXPECT_EQ(edit->scanAllMatchPositions(QString("ab")).size(), 3);
+    // 区分大小写 → 2 处
+    EXPECT_EQ(edit->scanAllMatchPositions(QString("ab"), Qt::CaseSensitive),
+              (QList<int>() << 0 << 6));
+    // 空 keyword → 空
+    EXPECT_TRUE(edit->scanAllMatchPositions(QString()).isEmpty());
+}
+
+TEST_F(TextEditTest, FindCurrentMatchIndex_CacheStates_ExpectedIndex)
+{
+    // Arrange：空缓存
+    EXPECT_EQ(edit->findCurrentMatchIndex(), 0);
+
+    // 填充缓存：两处匹配，高亮在第二处
+    setDocText(QString("m m"));
+    edit->highlightKeyword(QString("m"), 0);
+    edit->m_allMatchPositions = QList<int>() << 0 << 2;
+    edit->m_findHighlightSelection.cursor = makeCursor(2);
+
+    // Act/Assert：命中缓存项 → 1 基索引 2
+    EXPECT_EQ(edit->findCurrentMatchIndex(), 2);
+
+    // 光标不在缓存点 → 0
+    edit->m_findHighlightSelection.cursor = makeCursor(1);
+    EXPECT_EQ(edit->findCurrentMatchIndex(), 0);
+}
+
+TEST_F(TextEditTest, UpdateCursorKeywordSelection_NotFoundAnywhere_ClearsSelections)
+{
+    // Arrange：文档无匹配
+    setDocText(QString("plain"));
+
+    // Act
+    edit->updateCursorKeywordSelection(QString("zzz"), true);
+
+    // Assert：全失败路径清空高亮并渲染
+    EXPECT_TRUE(edit->m_findMatchSelections.isEmpty());
+    EXPECT_FALSE(edit->m_findHighlightSelection.cursor.hasSelection());
+}
+
+TEST_F(TextEditTest, UpdateHighlightLineSelection_SlideGesture_Skipped)
+{
+    // Arrange：模拟滑动中
+    edit->m_gestureAction = TextEdit::GA_slide;
+    QTextEdit::ExtraSelection stale;
+    stale.cursor = makeCursor(0);
+    edit->m_currentLineSelection = stale;
+
+    // Act
+    edit->updateHighlightLineSelection();
+
+    // Assert：滑动分支提前返回，旧行选区未被覆盖
+    EXPECT_EQ(edit->m_currentLineSelection.cursor.position(), stale.cursor.position());
+
+    // Act：非滑动恢复正常
+    edit->m_gestureAction = TextEdit::GA_null;
+    edit->updateHighlightLineSelection();
+    EXPECT_TRUE(edit->m_currentLineSelection.cursor.selectedText().isEmpty());
+}
+
+// ---------------- updateKeywordSelectionsInView（F11） ----------------
+
+TEST_F(TextEditTest, UpdateKeywordSelectionsInView_EmptyKeyword_ReturnsFalse)
+{
+    // Arrange
+    QList<QTextEdit::ExtraSelection> list;
+
+    // Act/Assert
+    EXPECT_FALSE(edit->updateKeywordSelectionsInView(QString(), QTextCharFormat(), &list));
+    EXPECT_TRUE(list.isEmpty());
+}
+
+TEST_F(TextEditTest, UpdateKeywordSelectionsInView_MultilineKeyword_Collected)
+{
+    // Arrange：跨行关键字 "a\nb"
+    setDocText(QString("xa\nbx"));
+    QList<QTextEdit::ExtraSelection> list;
+
+    // Act
+    const bool ok = edit->updateKeywordSelectionsInView(QString("a\nb"), QTextCharFormat(), &list);
+
+    // Assert：多行拼接查找路径命中
+    EXPECT_TRUE(ok);
+    EXPECT_EQ(list.size(), 1);
+}
+
+TEST_F(TextEditTest, UpdateKeywordSelectionsInView_CaseExactOnly_Highlighted)
+{
+    // Arrange：默认大小写不敏感 → key/KEY 均进入高亮列表
+    setDocText(QString("key KEY"));
+    QList<QTextEdit::ExtraSelection> list;
+
+    // Act
+    const bool ok = edit->updateKeywordSelectionsInView(QString("key"), QTextCharFormat(), &list);
+
+    // Assert
+    EXPECT_TRUE(ok);
+    EXPECT_EQ(list.size(), 2);
+}
+
+// ---------------- searchKeywordSeletion（F12） ----------------
+
+TEST_F(TextEditTest, SearchKeywordSeletion_ForwardHit_MovesCursor)
+{
+    // Arrange
+    setDocText(QString("target after"));
+    moveCursorTo(0);
+
+    // Act
+    const bool ok = edit->searchKeywordSeletion(QString("target"), edit->textCursor(), true);
+
+    // Assert
+    EXPECT_TRUE(ok);
+    EXPECT_TRUE(edit->m_findHighlightSelection.cursor.hasSelection());
+}
+
+TEST_F(TextEditTest, SearchKeywordSeletion_BackwardHit_MovesCursor)
+{
+    // Arrange
+    setDocText(QString("aaa target"));
+    moveCursorTo(10);
+
+    // Act
+    const bool ok = edit->searchKeywordSeletion(QString("target"), edit->textCursor(), false);
+
+    // Assert
+    EXPECT_TRUE(ok);
+    EXPECT_EQ(edit->m_findHighlightSelection.cursor.selectionStart(), 4); // 高亮落在 target(4~10)
+}
+
+TEST_F(TextEditTest, SearchKeywordSeletion_MultilineKeyword_Found)
+{
+    // Arrange
+    setDocText(QString("x\ny"));
+    moveCursorTo(0);
+
+    // Act：含 \n 关键字走 findCursor 路径
+    const bool ok = edit->searchKeywordSeletion(QString("x\ny"), edit->textCursor(), true);
+
+    // Assert
+    EXPECT_TRUE(ok);
+    EXPECT_EQ(edit->m_findHighlightSelection.cursor.selectedText(), QString("x") + QChar(0x2029) + QString("y"));
+}
+
+TEST_F(TextEditTest, SearchKeywordSeletion_EmptyKeyword_ReturnsFalse)
+{
+    // Arrange
+    setDocText(QString("data"));
+
+    // Act/Assert
+    EXPECT_FALSE(edit->searchKeywordSeletion(QString(), edit->textCursor(), true));
+    EXPECT_EQ(edit->getPosition(), 0); // 空关键字光标不动
+}
+
+// ---------------- findCursor（F13） ----------------
+
+TEST_F(TextEditTest, FindCursor_ForwardHit_ReturnsSelectedCursor)
+{
+    // Arrange
+    setDocText(QString("hello world"));
+
+    // Act
+    const QTextCursor cur = edit->findCursor(QString("world"), edit->toPlainText(), 0, false);
+
+    // Assert：绝对位置选区
+    EXPECT_EQ(cur.selectionStart(), 6);
+    EXPECT_EQ(cur.selectedText(), QString("world"));
+}
+
+TEST_F(TextEditTest, FindCursor_BackwardHit_ReturnsSelectedCursor)
+{
+    // Arrange
+    setDocText(QString("a b a b"));
+
+    // Act：从 5 反向查找（越过位置 6 的 b，命中位置 2）
+    const QTextCursor cur = edit->findCursor(QString("b"), edit->toPlainText(), 5, true);
+
+    // Assert
+    EXPECT_EQ(cur.selectionStart(), 2);
+    EXPECT_EQ(cur.selectedText(), QString("b"));
+}
+
+TEST_F(TextEditTest, FindCursor_NotFound_ReturnsNullCursor)
+{
+    // Arrange
+    setDocText(QString("abc"));
+
+    // Act/Assert
+    EXPECT_TRUE(edit->findCursor(QString("zz"), edit->toPlainText(), 0, false).isNull());
+    EXPECT_EQ(edit->toPlainText(), QString("abc")); // 查找不改文本
+}
+
+TEST_F(TextEditTest, FindCursor_WindowsEndline_CrLfKeywordNormalized)
+{
+    // Arrange：Windows 行尾格式下关键字中的 \r\n 被规范化
+    setDocText(QString("ab\ncd"));
+    seamEndlineFormat = BottomBar::Windows;
+
+    // Act：以 \r\n 关键字在 \n 文本中查找（规范化后命中）
+    const QTextCursor cur = edit->findCursor(QString("b\r\nc"), edit->toPlainText(), 0, false);
+
+    // Assert：命中 1~4，跨块选中文本（QTextCursor 以 U+2029 表示段落分隔符）
+    EXPECT_EQ(cur.selectionStart(), 1);
+    EXPECT_EQ(cur.selectedText(), QString("b") + QChar(0x2029) + QString("c"));
+}
+
+// ---------------- 匹配计数信号（F14） ----------------
+
+TEST_F(TextEditTest, UpdateMatchCount_EmptyKeyword_EmitsZeroZero)
+{
+    // Arrange
+    QSignalSpy spy(edit, &TextEdit::findMatchCountChanged);
+
+    // Act
+    edit->updateMatchCount(QString(), Qt::CaseInsensitive);
+
+    // Assert
+    ASSERT_EQ(spy.count(), 1);
+    EXPECT_EQ(spy.at(0).at(0).toInt(), 0);
+    EXPECT_EQ(spy.at(0).at(1).toInt(), 0);
+}
+
+TEST_F(TextEditTest, UpdateMatchCount_WithKeyword_EmitsCurrentTotal)
+{
+    // Arrange
+    setDocText(QString("hit hit hit"));
+    edit->m_findHighlightSelection.cursor = makeCursor(4); // 第二个 hit 内
+    QSignalSpy spy(edit, &TextEdit::findMatchCountChanged);
+
+    // Act
+    edit->updateMatchCount(QString("hit"), Qt::CaseInsensitive);
+
+    // Assert：total=3；current 依据高亮起始位置（4 → lower_bound 命中索引 1 → 2）
+    ASSERT_EQ(spy.count(), 1);
+    EXPECT_EQ(spy.at(0).at(1).toInt(), 3);
+    // 缓存已建立：再查同关键字不发额外重扫（第二次直接命中缓存）
+    edit->updateMatchCount(QString("hit"), Qt::CaseInsensitive);
+    EXPECT_EQ(spy.count(), 2);
+}
+
+TEST_F(TextEditTest, InvalidateMatchCountCache_TextChange_ClearsCache)
+{
+    // Arrange：建立缓存
+    setDocText(QString("c c"));
+    edit->updateMatchCount(QString("c"), Qt::CaseInsensitive);
+    EXPECT_FALSE(edit->m_allMatchPositions.isEmpty());
+
+    // Act：文本变化触发缓存失效（textChanged → invalidateMatchCountCache）
+    QTextCursor cur(edit->document());
+    cur.setPosition(3);
+    cur.insertText(QString("c"));
+
+    // Assert
+    EXPECT_TRUE(edit->m_allMatchPositions.isEmpty());
+    EXPECT_TRUE(edit->m_countedKeyword.isEmpty());
+}
+
+// ---------------- onPressedLineNumber（F15） ----------------
+
+TEST_F(TextEditTest, OnPressedLineNumber_ValidPoint_SelectsWholeLine)
+{
+    // Arrange
+    setDocText(QString("first\nsecond"));
+    edit->setLeftAreaUpdateState(TextEdit::Normal);
+
+    // Act：点击第一行区域（x 在行号区宽度内）
+    edit->onPressedLineNumber(QPoint(2, 4));
+
+    // Assert：整行被选中（到下一行行首，跨块选区含 U+2029 段落分隔符）
+    EXPECT_TRUE(edit->textCursor().hasSelection());
+    EXPECT_TRUE(edit->textCursor().selectedText().startsWith(QString("first")));
+    EXPECT_EQ(edit->textCursor().selectionEnd(), 6);
+}
+
+TEST_F(TextEditTest, OnPressedLineNumber_LastBlock_SelectsToEndOfBlock)
+{
+    // Arrange
+    setDocText(QString("first\nlast"));
+    edit->setLeftAreaUpdateState(TextEdit::Normal);
+
+    // Act：点击最后一行区域（y 较大）
+    edit->onPressedLineNumber(QPoint(2, 40));
+
+    // Assert：尾行 EndOfBlock 分支
+    EXPECT_TRUE(edit->textCursor().hasSelection());
+    EXPECT_EQ(edit->textCursor().selectionEnd(), 10); // 尾块 EndOfBlock（文档 10 字符）
+}
+
+TEST_F(TextEditTest, OnPressedLineNumber_FileOpenBegin_Ignored)
+{
+    // Arrange
+    setDocText(QString("line"));
+    edit->setLeftAreaUpdateState(TextEdit::FileOpenBegin);
+
+    // Act
+    edit->onPressedLineNumber(QPoint(2, 4));
+
+    // Assert：大文件加载中不响应
+    EXPECT_FALSE(edit->textCursor().hasSelection());
+    EXPECT_EQ(edit->getPosition(), 0);
+}
+
+TEST_F(TextEditTest, OnPressedLineNumber_XOutOfRange_Ignored)
+{
+    // Arrange
+    setDocText(QString("line"));
+    edit->setLeftAreaUpdateState(TextEdit::Normal);
+
+    // Act：x 超出行号区宽度
+    edit->onPressedLineNumber(QPoint(100000, 4));
+
+    // Assert
+    EXPECT_FALSE(edit->textCursor().hasSelection());
+    EXPECT_EQ(edit->getPosition(), 0);
+}
+
+// ---------------- renderAllSelections（F16，排序与合并主链） ----------------
+
+TEST_F(TextEditTest, RenderAllSelections_MixedSelections_AppliedToViewport)
+{
+    // Arrange：当前行高亮 + 单行标记 + 括号 + Alt 选区混布
+    setDocText(QString("(x) mark"));
+    edit->setHighLineCurrentLine(true);
+    moveCursorTo(1);
+    edit->isMarkCurrentLine(true, QString("#ff0000"), 5);
+    QTextEdit::ExtraSelection alt;
+    alt.cursor = makeCursor(0);
+    alt.cursor.setPosition(1, QTextCursor::KeepAnchor);
+    edit->m_altModSelections << alt;
+    edit->m_bIsAltMod = true;
+
+    // Act
+    edit->renderAllSelections();
+
+    // Assert：合成选区写入 QPlainTextEdit（含当前行 + 标记 + Alt + 括号）
+    const int total = edit->extraSelections().size();
+    EXPECT_GE(total, 3);
+    EXPECT_TRUE(edit->m_HightlightYes); // 当前行高亮已入渲染链
+}

--- a/tests/editor_core/test_dtextedit_mark.cpp
+++ b/tests/editor_core/test_dtextedit_mark.cpp
@@ -1,0 +1,1047 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// ===========================================================================
+// TextEdit 颜色标记 + 书签方法族（dtextedit.cpp 行 5200~6800 一带）
+//
+// 分支清单（来源：src/editor/dtextedit.cpp）：
+// M1 : isMarkCurrentLine —— isMark 真（有选区 MarkOnce/无选区 MarkLine/AltMod 多选区）
+//      /假（clearMarksForTextCursor）
+// M2 : isMarkAllLine —— 部分选中文本（MarkAllMatch）/全选或无选区（MarkAll）
+//      /取消（清空三容器）
+// M3 : cancelLastMark —— MarkOnce/MarkLine/MarkAllMatch/MarkAll 四 case；
+//      空列表提前 return；残留清理分支
+// M4 : clearMarksForTextCursor —— 有选区精确匹配 / 无选区位置区间匹配
+// M5 : markAllKeywordInView —— 空标记列表 return / MarkAllMatch / MarkAll
+// M6 : markKeywordInView —— 空 keyword false / 视口有匹配 true
+// M7 : markAllInView —— 全文选区入 map[TEXT_EIDT_MARK_ALL]
+// M8 : toggleMarkSelections —— 已有标记清除 / 无标记新建
+// M9 : convertReplaceToMark/convertMarkToReplace —— 光标绝对位置往返
+// M10: manualUpdateAllMark —— MarkOnce 追加 / MarkLine 多行拆分 /
+//      无选区 erase / 排序 / markAllKeywordInView 重建
+// M11: updateMark —— 只读 return / 文件打开 return / 无标记 return /
+//      删除字符（选区包含标记删除 / 标记内容删空移除）/
+//      添加字符（标记内 break / 标记尾部扩展，含输入法分支）
+// M12: markSelectWord —— 同行已有标记移除 / 无标记新建
+// M13: addOrDeleteBookMark —— 快捷键路径 / 鼠标点路径 / 越界 return /
+//      已有书签删除 / 新增
+// M14: moveToPreviousBookMark/moveToNextBookMark —— index==-1 / ==0 / 中间
+// M15: checkBookmarkLineMove —— 文件打开 return / 行数不变 /
+//      删除行（选区行有效/无效）/ 增加行
+// M16: setTextFinished —— settings 空 return / 书签非空 return /
+//      历史记录恢复路径
+// M17: handleCursorMarkChanged —— mark 真/假
+// M18: containsExtraSelection —— 命中/未命中；appendExtraSelection（空实现）
+// M19: slotPre/slotNext/slotClearBookMarkAction
+// M20: updateMarkAllSelectColor
+//
+// 用例映射：见各 TEST_F 名。环境隔离：见 editor_core_fixture.h。
+// ===========================================================================
+
+#include "editor_core_fixture.h"
+
+// ---------------- isMarkCurrentLine（M1） ----------------
+
+TEST_F(TextEditTest, IsMarkCurrentLine_NoSelection_MarksWholeLine)
+{
+    // Arrange
+    setDocText(QString("alpha\nbeta"));
+    moveCursorTo(7); // 第二行行首
+
+    // Act
+    edit->isMarkCurrentLine(true, QString("#ff0000"), 100);
+
+    // Assert：MarkLine 类型覆盖整行
+    EXPECT_EQ(edit->m_markOperations.size(), 1);
+    EXPECT_EQ(edit->m_markOperations.first().first.type, TextEdit::MarkLine);
+    EXPECT_EQ(edit->m_wordMarkSelections.size(), 1);
+    EXPECT_EQ(edit->m_wordMarkSelections.first().first.cursor.selectedText(), QString("beta"));
+}
+
+TEST_F(TextEditTest, IsMarkCurrentLine_WithSelection_MarksSelection)
+{
+    // Arrange
+    setDocText(QString("abcdef"));
+    QTextCursor cur = makeCursor(1);
+    cur.setPosition(4, QTextCursor::KeepAnchor);
+    edit->setTextCursor(cur);
+
+    // Act
+    edit->isMarkCurrentLine(true, QString("#00ff00"), 200);
+
+    // Assert：MarkOnce 类型仅标记选区
+    EXPECT_EQ(edit->m_markOperations.first().first.type, TextEdit::MarkOnce);
+    EXPECT_EQ(edit->m_wordMarkSelections.first().first.cursor.selectedText(), QString("bcd"));
+}
+
+TEST_F(TextEditTest, IsMarkCurrentLine_AltModSelections_MarksEachColumn)
+{
+    // Arrange：两行列选区
+    setDocText(QString("aa\nbb"));
+    QList<QTextEdit::ExtraSelection> sels;
+    for (int line = 0; line < 2; ++line) {
+        const int blockPos = edit->document()->findBlockByNumber(line).position();
+        QTextCursor cur(edit->document());
+        cur.setPosition(blockPos);
+        cur.setPosition(blockPos + 1, QTextCursor::KeepAnchor);
+        QTextEdit::ExtraSelection sel;
+        sel.cursor = cur;
+        sels << sel;
+    }
+    edit->restoreColumnEditSelection(sels);
+    edit->m_bIsAltMod = true;
+
+    // Act
+    edit->isMarkCurrentLine(true, QString("#0000ff"), 300);
+
+    // Assert：每个列选区各生成一条标记
+    EXPECT_EQ(edit->m_markOperations.size(), 2);
+    EXPECT_EQ(edit->m_wordMarkSelections.size(), 2);
+}
+
+TEST_F(TextEditTest, IsMarkCurrentLine_Unmark_ClearsMarksForCursor)
+{
+    // Arrange：先标记一行
+    setDocText(QString("alpha\nbeta"));
+    moveCursorTo(7);
+    edit->isMarkCurrentLine(true, QString("#ff0000"), 100);
+    ASSERT_EQ(edit->m_wordMarkSelections.size(), 1);
+
+    // Act：取消（光标仍在标记行内）
+    edit->isMarkCurrentLine(false);
+
+    // Assert：clearMarksForTextCursor 移除标记
+    EXPECT_TRUE(edit->m_wordMarkSelections.isEmpty());
+    EXPECT_TRUE(edit->m_markOperations.isEmpty());
+}
+
+TEST_F(TextEditTest, ClearMarksForTextCursor_InsideRegion_RemovesMark)
+{
+    // Arrange
+    setDocText(QString("abcdef"));
+    QTextCursor cur = makeCursor(1);
+    cur.setPosition(4, QTextCursor::KeepAnchor);
+    edit->setTextCursor(cur);
+    edit->isMarkCurrentLine(true, QString("#123456"), 10);
+    ASSERT_EQ(edit->m_wordMarkSelections.size(), 1);
+
+    // Act：光标移入选区内部后清理
+    moveCursorTo(2);
+    const bool found = edit->clearMarksForTextCursor();
+
+    // Assert
+    EXPECT_TRUE(found);
+    EXPECT_TRUE(edit->m_wordMarkSelections.isEmpty());
+}
+
+TEST_F(TextEditTest, ClearMarksForTextCursor_OutsideRegion_ReturnsFalse)
+{
+    // Arrange
+    setDocText(QString("abcdef"));
+    QTextCursor cur = makeCursor(1);
+    cur.setPosition(3, QTextCursor::KeepAnchor);
+    edit->setTextCursor(cur);
+    edit->isMarkCurrentLine(true, QString("#123456"), 10);
+
+    // Act：光标在标记区域外
+    moveCursorTo(5);
+    const bool found = edit->clearMarksForTextCursor();
+
+    // Assert
+    EXPECT_FALSE(found);
+    EXPECT_EQ(edit->m_wordMarkSelections.size(), 1);
+}
+
+TEST_F(TextEditTest, ClearMarkOperationForCursor_MatchingCursor_RemovesOperation)
+{
+    // Arrange
+    setDocText(QString("abcdef"));
+    QTextCursor cur = makeCursor(1);
+    cur.setPosition(3, QTextCursor::KeepAnchor);
+    edit->setTextCursor(cur);
+    edit->isMarkCurrentLine(true, QString("#123456"), 10);
+    ASSERT_EQ(edit->m_markOperations.size(), 1);
+    const QTextCursor opCursor = edit->m_markOperations.first().first.cursor;
+
+    // Act
+    const bool removed = edit->clearMarkOperationForCursor(opCursor);
+
+    // Assert
+    EXPECT_TRUE(removed);
+    EXPECT_TRUE(edit->m_markOperations.isEmpty());
+}
+
+// ---------------- isMarkAllLine（M2） ----------------
+
+TEST_F(TextEditTest, IsMarkAllLine_PartialSelection_MarksAllMatches)
+{
+    // Arrange
+    setDocText(QString("cat dog cat"));
+    QTextCursor cur = makeCursor(0);
+    cur.setPosition(3, QTextCursor::KeepAnchor); // 选中 "cat"
+    edit->setTextCursor(cur);
+
+    // Act
+    edit->isMarkAllLine(true, QString("#ff0000"));
+
+    // Assert：MarkAllMatch 记录 + 视口内所有 cat 命中
+    EXPECT_EQ(edit->m_markOperations.last().first.type, TextEdit::MarkAllMatch);
+    EXPECT_TRUE(edit->m_mapKeywordMarkSelections.contains(QString("cat")));
+    EXPECT_EQ(edit->m_mapKeywordMarkSelections[QString("cat")].size(), 2);
+}
+
+TEST_F(TextEditTest, IsMarkAllLine_NoSelection_MarksEntireDocument)
+{
+    // Arrange
+    setDocText(QString("whole doc"));
+    moveCursorTo(3);
+
+    // Act
+    edit->isMarkAllLine(true, QString("#00ff00"));
+
+    // Assert：MarkAll + 全文选区（m_bIsMarkAllLine 由 EditWrapper 外部维护，此处不断言）
+    EXPECT_EQ(edit->m_markOperations.last().first.type, TextEdit::MarkAll);
+    EXPECT_TRUE(edit->m_mapKeywordMarkSelections.contains(QString("MARK_ALL")));
+}
+
+TEST_F(TextEditTest, IsMarkAllLine_Unmark_ClearsAllContainers)
+{
+    // Arrange：先建立两种标记
+    setDocText(QString("cat dog cat"));
+    QTextCursor cur = makeCursor(0);
+    cur.setPosition(3, QTextCursor::KeepAnchor);
+    edit->setTextCursor(cur);
+    edit->isMarkAllLine(true, QString("#ff0000"));
+    moveCursorTo(4);
+    edit->isMarkCurrentLine(true, QString("#0000ff"), 50);
+    ASSERT_FALSE(edit->m_markOperations.isEmpty());
+
+    // Act
+    edit->isMarkAllLine(false);
+
+    // Assert：三个容器全部清空
+    EXPECT_TRUE(edit->m_markOperations.isEmpty());
+    EXPECT_TRUE(edit->m_wordMarkSelections.isEmpty());
+    EXPECT_TRUE(edit->m_mapKeywordMarkSelections.isEmpty());
+}
+
+// ---------------- cancelLastMark（M3） ----------------
+
+TEST_F(TextEditTest, CancelLastMark_LineMark_RemovesSameTimestampSelections)
+{
+    // Arrange
+    setDocText(QString("l1\nl2"));
+    moveCursorTo(0);
+    edit->isMarkCurrentLine(true, QString("#ff0000"), 111);
+    moveCursorTo(3);
+    edit->isMarkCurrentLine(true, QString("#00ff00"), 222);
+    ASSERT_EQ(edit->m_wordMarkSelections.size(), 2);
+
+    // Act：取消最后一条（timestamp=222）
+    edit->cancelLastMark();
+
+    // Assert：仅剩第一条
+    EXPECT_EQ(edit->m_wordMarkSelections.size(), 1);
+    EXPECT_EQ(edit->m_wordMarkSelections.first().second, 111);
+    EXPECT_EQ(edit->m_markOperations.size(), 1);
+}
+
+TEST_F(TextEditTest, CancelLastMark_AllMatchType_RemovesKeywordEntry)
+{
+    // Arrange
+    setDocText(QString("cat cat"));
+    QTextCursor cur = makeCursor(0);
+    cur.setPosition(3, QTextCursor::KeepAnchor);
+    edit->setTextCursor(cur);
+    edit->isMarkAllLine(true, QString("#ff0000"));
+    ASSERT_TRUE(edit->m_mapKeywordMarkSelections.contains(QString("cat")));
+
+    // Act
+    edit->cancelLastMark();
+
+    // Assert
+    EXPECT_FALSE(edit->m_mapKeywordMarkSelections.contains(QString("cat")));
+    EXPECT_TRUE(edit->m_markOperations.isEmpty());
+}
+
+TEST_F(TextEditTest, CancelLastMark_AllType_RemovesMarkAllEntry)
+{
+    // Arrange
+    setDocText(QString("text"));
+    moveCursorTo(0);
+    edit->isMarkAllLine(true, QString("#ff0000")); // 无选区 → MarkAll
+    ASSERT_TRUE(edit->m_mapKeywordMarkSelections.contains(QString("MARK_ALL")));
+
+    // Act
+    edit->cancelLastMark();
+
+    // Assert
+    EXPECT_FALSE(edit->m_mapKeywordMarkSelections.contains(QString("MARK_ALL")));
+    EXPECT_TRUE(edit->m_markOperations.isEmpty());
+}
+
+TEST_F(TextEditTest, CancelLastMark_EmptyOperations_EarlyReturn)
+{
+    // Arrange/Act/Assert：空列表直接返回不崩溃
+    edit->cancelLastMark();
+    EXPECT_TRUE(edit->m_markOperations.isEmpty());
+    EXPECT_TRUE(edit->m_wordMarkSelections.isEmpty());
+}
+
+TEST_F(TextEditTest, SlotCancleLastMark_TriggersCancel)
+{
+    // Arrange
+    setDocText(QString("line"));
+    moveCursorTo(0);
+    edit->isMarkCurrentLine(true, QString("#ff0000"), 9);
+    ASSERT_EQ(edit->m_markOperations.size(), 1);
+
+    // Act
+    edit->slotCancleLastMark();
+
+    // Assert
+    EXPECT_TRUE(edit->m_markOperations.isEmpty());
+    EXPECT_TRUE(edit->m_wordMarkSelections.isEmpty());
+}
+
+TEST_F(TextEditTest, SlotCancleMarkAllLine_ClearsAll)
+{
+    // Arrange
+    setDocText(QString("line"));
+    moveCursorTo(0);
+    edit->isMarkAllLine(true, QString("#ff0000"));
+    ASSERT_FALSE(edit->m_mapKeywordMarkSelections.isEmpty());
+
+    // Act
+    edit->slotCancleMarkAllLine();
+
+    // Assert
+    EXPECT_TRUE(edit->m_mapKeywordMarkSelections.isEmpty());
+    EXPECT_TRUE(edit->m_markOperations.isEmpty());
+}
+
+// ---------------- markAllKeywordInView / markKeywordInView / markAllInView（M5-M7） ----------------
+
+TEST_F(TextEditTest, MarkAllKeywordInView_EmptyOperations_ReturnsEarly)
+{
+    // Arrange/Act/Assert：无标记时为空操作
+    edit->markAllKeywordInView();
+    EXPECT_TRUE(edit->m_mapKeywordMarkSelections.isEmpty());
+    EXPECT_TRUE(edit->m_wordMarkSelections.isEmpty());
+}
+
+TEST_F(TextEditTest, MarkAllKeywordInView_WithOperations_RebuildsViewMarks)
+{
+    // Arrange：建立 MarkAllMatch 关键字标记
+    setDocText(QString("key here key"));
+    QTextCursor cur = makeCursor(0);
+    cur.setPosition(3, QTextCursor::KeepAnchor);
+    edit->setTextCursor(cur);
+    edit->isMarkAllLine(true, QString("#ff0000"));
+    edit->m_mapKeywordMarkSelections.clear(); // 仅保留操作记录，验证重建
+
+    // Act
+    edit->markAllKeywordInView();
+
+    // Assert：视口关键字标记被重建
+    EXPECT_TRUE(edit->m_mapKeywordMarkSelections.contains(QString("key")));
+    EXPECT_EQ(edit->m_mapKeywordMarkSelections[QString("key")].size(), 2);
+}
+
+TEST_F(TextEditTest, MarkKeywordInView_EmptyKeyword_ReturnsFalse)
+{
+    // Act/Assert
+    EXPECT_FALSE(edit->markKeywordInView(QString(), QString("#ff0000")));
+    EXPECT_TRUE(edit->m_mapKeywordMarkSelections.isEmpty());
+}
+
+TEST_F(TextEditTest, MarkKeywordInView_PresentKeyword_ReturnsTrueAndStores)
+{
+    // Arrange
+    setDocText(QString("alpha beta alpha"));
+
+    // Act
+    const bool ok = edit->markKeywordInView(QString("alpha"), QString("#112233"), 42);
+
+    // Assert
+    EXPECT_TRUE(ok);
+    EXPECT_EQ(edit->m_mapKeywordMarkSelections[QString("alpha")].size(), 2);
+    EXPECT_EQ(edit->m_mapKeywordMarkSelections[QString("alpha")].first().second, 42);
+}
+
+TEST_F(TextEditTest, MarkKeywordInView_AbsentKeyword_ReturnsFalse)
+{
+    // Arrange
+    setDocText(QString("only"));
+
+    // Act/Assert
+    EXPECT_FALSE(edit->markKeywordInView(QString("missing"), QString("#112233"), 1));
+    EXPECT_TRUE(edit->m_mapKeywordMarkSelections.isEmpty()); // 未命中不入表
+}
+
+TEST_F(TextEditTest, MarkAllInView_AddsWholeDocumentSelection)
+{
+    // Arrange
+    setDocText(QString("abc def"));
+
+    // Act
+    edit->markAllInView(QString("#abcdef"), 77);
+
+    // Assert：全文选区 + 时间戳
+    const auto list = edit->m_mapKeywordMarkSelections[QString("MARK_ALL")];
+    ASSERT_EQ(list.size(), 1);
+    EXPECT_EQ(list.first().first.cursor.selectedText(), QString("abc def"));
+    EXPECT_EQ(list.first().second, 77);
+}
+
+TEST_F(TextEditTest, UpdateMarkAllSelectColor_FlagDriven_ReappliesAllMark)
+{
+    // Arrange
+    setDocText(QString("whole"));
+    edit->m_bIsMarkAllLine = true;
+    edit->m_strMarkAllLineColorName = QString("#010203");
+
+    // Act
+    edit->updateMarkAllSelectColor();
+
+    // Assert：MarkAll 视图重新着色
+    EXPECT_TRUE(edit->m_mapKeywordMarkSelections.contains(QString("MARK_ALL")));
+    EXPECT_EQ(edit->m_mapKeywordMarkSelections[QString("MARK_ALL")].size(), 1);
+}
+
+// ---------------- toggleMarkSelections / markSelectWord（M8/M12） ----------------
+
+TEST_F(TextEditTest, ToggleMarkSelections_NoExistingMark_CreatesLineMark)
+{
+    // Arrange
+    setDocText(QString("target line"));
+    moveCursorTo(3);
+
+    // Act
+    edit->toggleMarkSelections();
+
+    // Assert：无既有标记时按默认色新建
+    EXPECT_EQ(edit->m_wordMarkSelections.size(), 1);
+    EXPECT_EQ(edit->m_markOperations.size(), 1);
+}
+
+TEST_F(TextEditTest, ToggleMarkSelections_ExistingMark_RemovesIt)
+{
+    // Arrange
+    setDocText(QString("marked"));
+    moveCursorTo(2);
+    edit->isMarkCurrentLine(true, QString("#ff0000"), 5);
+    ASSERT_EQ(edit->m_wordMarkSelections.size(), 1);
+
+    // Act
+    edit->toggleMarkSelections();
+
+    // Assert
+    EXPECT_TRUE(edit->m_wordMarkSelections.isEmpty());
+    EXPECT_TRUE(edit->m_markOperations.isEmpty());
+}
+
+TEST_F(TextEditTest, MarkSelectWord_NewLine_AddsMark)
+{
+    // Arrange
+    setDocText(QString("word line"));
+    moveCursorTo(2);
+
+    // Act
+    edit->markSelectWord();
+
+    // Assert：无同行标记 → 新建
+    EXPECT_EQ(edit->m_wordMarkSelections.size(), 1);
+    EXPECT_EQ(edit->m_markOperations.size(), 1);
+}
+
+TEST_F(TextEditTest, MarkSelectWord_SameLineExisting_TogglesOff)
+{
+    // Arrange：先在当前行做标记
+    setDocText(QString("word line"));
+    moveCursorTo(2);
+    edit->markSelectWord();
+    ASSERT_EQ(edit->m_wordMarkSelections.size(), 1);
+
+    // Act：同一行再次标记 → 移除
+    edit->markSelectWord();
+
+    // Assert
+    EXPECT_TRUE(edit->m_wordMarkSelections.isEmpty());
+    EXPECT_EQ(edit->m_markOperations.size(), 1); // 操作记录保留，仅移除选区
+}
+
+// ---------------- 静态转换（M9） ----------------
+
+TEST_F(TextEditTest, ConvertMarkToReplace_And_Back_RoundTripsPositions)
+{
+    // Arrange：构造带选区光标的标记操作
+    setDocText(QString("0123456789"));
+    QTextCursor cur(edit->document());
+    cur.setPosition(2);
+    cur.setPosition(6, QTextCursor::KeepAnchor);
+    TextEdit::MarkOperation op;
+    op.type = TextEdit::MarkOnce;
+    op.cursor = cur;
+    op.color = QString("#aabbcc");
+    QList<QPair<TextEdit::MarkOperation, qint64>> marks;
+    marks << qMakePair(op, qint64(88));
+
+    // Act：正向转换
+    const QList<TextEdit::MarkReplaceInfo> infos = TextEdit::convertMarkToReplace(marks);
+    // Assert：绝对位置与时间戳保留
+    ASSERT_EQ(infos.size(), 1);
+    EXPECT_EQ(infos.first().start, 2);
+    EXPECT_EQ(infos.first().end, 6);
+    EXPECT_EQ(infos.first().time, 88);
+
+    // Act：逆向转换
+    const QList<QPair<TextEdit::MarkOperation, qint64>> back = TextEdit::convertReplaceToMark(infos);
+    // Assert：光标选区恢复
+    ASSERT_EQ(back.size(), 1);
+    EXPECT_EQ(back.first().first.cursor.selectionStart(), 2);
+    EXPECT_EQ(back.first().first.cursor.selectionEnd(), 6);
+    EXPECT_EQ(back.first().second, 88);
+}
+
+TEST_F(TextEditTest, ConvertReplaceToMark_EmptyList_ReturnsEmpty)
+{
+    // Act/Assert
+    EXPECT_TRUE(TextEdit::convertReplaceToMark(QList<TextEdit::MarkReplaceInfo>()).isEmpty());
+    EXPECT_TRUE(TextEdit::convertMarkToReplace(QList<QPair<TextEdit::MarkOperation, qint64>>()).isEmpty());
+}
+
+// ---------------- manualUpdateAllMark（M10） ----------------
+
+TEST_F(TextEditTest, ManualUpdateAllMark_MixedTypes_RebuildsSelections)
+{
+    // Arrange：文档 3 行
+    setDocText(QString("l1\nl2\nl3"));
+    QList<QPair<TextEdit::MarkOperation, qint64>> marks;
+
+    // MarkOnce：选 l2 的 "2"
+    QTextCursor once(edit->document());
+    once.setPosition(4);
+    once.setPosition(5, QTextCursor::KeepAnchor);
+    TextEdit::MarkOperation opOnce;
+    opOnce.type = TextEdit::MarkOnce;
+    opOnce.cursor = once;
+    opOnce.color = QString("#111111");
+    marks << qMakePair(opOnce, qint64(1));
+
+    // MarkLine：跨 l2~l3 的选区
+    QTextCursor line(edit->document());
+    line.setPosition(3);
+    line.setPosition(8, QTextCursor::KeepAnchor);
+    TextEdit::MarkOperation opLine;
+    opLine.type = TextEdit::MarkLine;
+    opLine.cursor = line;
+    opLine.color = QString("#222222");
+    marks << qMakePair(opLine, qint64(2));
+
+    // 无选区的 MarkOnce：应被 erase
+    TextEdit::MarkOperation opEmpty;
+    opEmpty.type = TextEdit::MarkOnce;
+    QTextCursor emptyCur(edit->document());
+    emptyCur.setPosition(0);
+    opEmpty.cursor = emptyCur;
+    marks << qMakePair(opEmpty, qint64(3));
+
+    // Act
+    edit->manualUpdateAllMark(marks);
+
+    // Assert：无选区项被清除；MarkLine 多行被拆为逐块选区；时间戳排序
+    EXPECT_TRUE(edit->m_wordMarkSelections.size() >= 3); // once 1 + line 2 块
+    bool hasEmptyOp = false;
+    for (const auto &pair : edit->m_markOperations) {
+        if (pair.first.type == TextEdit::MarkOnce && !pair.first.cursor.hasSelection())
+            hasEmptyOp = true;
+    }
+    EXPECT_FALSE(hasEmptyOp);
+}
+
+TEST_F(TextEditTest, ManualUpdateAllMark_WithMarkAll_RebuildsKeywordView)
+{
+    // Arrange
+    setDocText(QString("dup dup"));
+    TextEdit::MarkOperation opAll;
+    opAll.type = TextEdit::MarkAllMatch;
+    opAll.color = QString("#333333");
+    opAll.matchText = QString("dup");
+    QList<QPair<TextEdit::MarkOperation, qint64>> marks;
+    marks << qMakePair(opAll, qint64(9));
+
+    // Act
+    edit->manualUpdateAllMark(marks);
+
+    // Assert：markAllKeywordInView 依据 matchText 重建
+    EXPECT_TRUE(edit->m_mapKeywordMarkSelections.contains(QString("dup")));
+    EXPECT_EQ(edit->m_mapKeywordMarkSelections[QString("dup")].size(), 2);
+}
+
+// ---------------- updateMark（M11） ----------------
+
+TEST_F(TextEditTest, UpdateMark_DeleteMarkedContent_RemovesEmptyMark)
+{
+    // Arrange：标记 "bcd"
+    setDocText(QString("abcdef"));
+    QTextCursor cur = makeCursor(1);
+    cur.setPosition(4, QTextCursor::KeepAnchor);
+    edit->setTextCursor(cur);
+    edit->isMarkCurrentLine(true, QString("#ff0000"), 1);
+    ASSERT_EQ(edit->m_wordMarkSelections.size(), 1);
+
+    // Act：通过文档光标删除标记内容（contentsChange → updateMark）
+    QTextCursor del(edit->document());
+    del.setPosition(1);
+    del.setPosition(4, QTextCursor::KeepAnchor);
+    del.removeSelectedText();
+
+    // Assert：标记内容删空后标记被移除
+    EXPECT_EQ(edit->toPlainText(), QString("aef"));
+    EXPECT_TRUE(edit->m_wordMarkSelections.isEmpty());
+}
+
+TEST_F(TextEditTest, UpdateMark_InsertInsideMark_MarkKeptWhole)
+{
+    // Arrange
+    setDocText(QString("abcdef"));
+    QTextCursor cur = makeCursor(1);
+    cur.setPosition(4, QTextCursor::KeepAnchor);
+    edit->setTextCursor(cur);
+    edit->isMarkCurrentLine(true, QString("#ff0000"), 1);
+    ASSERT_EQ(edit->m_wordMarkSelections.size(), 1);
+
+    // Act：标记中间插入字符（nCurrentPos 在区间内部 → break 分支）
+    QTextCursor ins(edit->document());
+    ins.setPosition(2);
+    ins.insertText(QString("X"));
+
+    // Assert：标记保留（整体不分割）
+    EXPECT_EQ(edit->m_wordMarkSelections.size(), 1);
+    EXPECT_EQ(edit->toPlainText(), QString("abXcdef"));
+}
+
+TEST_F(TextEditTest, UpdateMark_InsertAtMarkEnd_ExtendsMark)
+{
+    // Arrange
+    setDocText(QString("abcdef"));
+    QTextCursor cur = makeCursor(1);
+    cur.setPosition(4, QTextCursor::KeepAnchor);
+    edit->setTextCursor(cur);
+    edit->isMarkCurrentLine(true, QString("#ff0000"), 1);
+    ASSERT_EQ(edit->m_wordMarkSelections.size(), 1);
+
+    // Act：在标记尾部位置插入（nCurrentPos == nEndPos 分支）
+    QTextCursor ins(edit->document());
+    ins.setPosition(4);
+    ins.insertText(QString("Y"));
+
+    // Assert：标记扩展覆盖新字符
+    ASSERT_EQ(edit->m_wordMarkSelections.size(), 1);
+    EXPECT_TRUE(edit->m_wordMarkSelections.first().first.cursor.selectedText().contains(QString("Y")));
+    EXPECT_EQ(edit->toPlainText(), QString("abcdYef"));
+}
+
+TEST_F(TextEditTest, UpdateMark_ReadOnlyMode_EarlyReturn)
+{
+    // Arrange
+    setDocText(QString("abc"));
+    edit->toggleReadOnlyMode(true);
+    edit->m_wordMarkSelections.append(qMakePair(QTextEdit::ExtraSelection(), qint64(1)));
+
+    // Act：直接调用（只读分支）
+    edit->updateMark(0, 0, 1);
+
+    // Assert：标记未被动过
+    EXPECT_EQ(edit->m_wordMarkSelections.size(), 1);
+    EXPECT_TRUE(edit->getReadOnlyMode());
+}
+
+TEST_F(TextEditTest, UpdateMark_FileOpen_EarlyReturn)
+{
+    // Arrange
+    setDocText(QString("abc"));
+    edit->setIsFileOpen();
+
+    // Act
+    edit->updateMark(0, 1, 0);
+
+    // Assert：m_bIsFileOpen 状态生效
+    EXPECT_TRUE(edit->m_bIsFileOpen);
+    edit->setTextFinished(); // 复位
+    EXPECT_FALSE(edit->m_bIsFileOpen);
+}
+
+TEST_F(TextEditTest, UpdateMark_NoMarks_EarlyReturn)
+{
+    // Arrange：无任何标记
+    setDocText(QString("plain"));
+
+    // Act/Assert：无标记路径不产生副作用
+    edit->updateMark(0, 1, 0);
+    EXPECT_TRUE(edit->m_wordMarkSelections.isEmpty());
+    EXPECT_EQ(edit->toPlainText(), QString("plain"));
+}
+
+// ---------------- ExtraSelection 辅助（M18） ----------------
+
+TEST_F(TextEditTest, ContainsExtraSelection_MatchingCursorAndFormat_ReturnsTrue)
+{
+    // Arrange
+    setDocText(QString("abcdef"));
+    QTextCursor cur = makeCursor(1);
+    cur.setPosition(3, QTextCursor::KeepAnchor);
+    QTextEdit::ExtraSelection sel;
+    sel.cursor = cur;
+    sel.format.setBackground(QColor(QString("#ff0000")));
+    QList<QTextEdit::ExtraSelection> list;
+    list << sel;
+
+    // Act/Assert：完全一致命中
+    EXPECT_TRUE(edit->containsExtraSelection(list, sel));
+
+    // 光标不同的同格式项不命中
+    QTextCursor other = makeCursor(0);
+    QTextEdit::ExtraSelection diff;
+    diff.cursor = other;
+    diff.format = sel.format;
+    EXPECT_FALSE(edit->containsExtraSelection(list, diff));
+}
+
+TEST_F(TextEditTest, AppendExtraSelection_NoOpImplementation_NoCrash)
+{
+    // Arrange：当前实现为 Q_UNUSED 空壳（保留待统一清理）
+    QList<QTextEdit::ExtraSelection> out;
+    QTextEdit::ExtraSelection sel;
+
+    // Act
+    edit->appendExtraSelection(QList<QTextEdit::ExtraSelection>(), sel,
+                               QString("#ff0000"), &out);
+
+    // Assert：空实现不产生输出
+    EXPECT_TRUE(out.isEmpty());
+    EXPECT_EQ(edit->m_wordMarkSelections.size(), 0); // 空实现不动内部状态
+}
+
+// ---------------- handleCursorMarkChanged / setHighLineCurrentLine（M17） ----------------
+
+TEST_F(TextEditTest, HandleCursorMarkChanged_TrueFalse_UpdatesMarkStartLine)
+{
+    // Arrange
+    setDocText(QString("a\nb\nc"));
+    moveCursorTo(2);
+
+    // Act
+    edit->handleCursorMarkChanged(true, edit->textCursor());
+    // Assert
+    EXPECT_EQ(edit->m_markStartLine, 2);
+
+    // Act
+    edit->handleCursorMarkChanged(false, edit->textCursor());
+    // Assert
+    EXPECT_EQ(edit->m_markStartLine, -1);
+}
+
+TEST_F(TextEditTest, SetHighLineCurrentLine_Toggled_FlagFlips)
+{
+    // Arrange
+    EXPECT_FALSE(edit->m_HightlightYes);
+
+    // Act/Assert
+    edit->setHighLineCurrentLine(true);
+    EXPECT_TRUE(edit->m_HightlightYes);
+    edit->setHighLineCurrentLine(false);
+    EXPECT_FALSE(edit->m_HightlightYes);
+}
+
+// ---------------- 书签（M13-M16/M19） ----------------
+
+TEST_F(TextEditTest, AddOrDeleteBookMark_ShortcutPath_TogglesCurrentLine)
+{
+    // Arrange
+    setDocText(QString("l1\nl2\nl3"));
+    moveCursorTo(3); // 第二行
+    edit->m_bIsShortCut = true;
+
+    // Act：新增
+    edit->addOrDeleteBookMark();
+    // Assert
+    EXPECT_TRUE(edit->getBookmarkInfo().contains(2));
+
+    // Act：再次触发删除
+    edit->m_bIsShortCut = true;
+    edit->addOrDeleteBookMark();
+    // Assert
+    EXPECT_FALSE(edit->getBookmarkInfo().contains(2));
+}
+
+TEST_F(TextEditTest, AddOrDeleteBookMark_LineBeyondDoc_Ignored)
+{
+    // Arrange：无文档内容（单空块），点击点映射行 1
+    edit->m_mouseClickPos = QPoint(1, 1000); // 远超文档底 → getLineFromPoint 返回最后块行
+
+    // Act：行号 > blockCount 时直接返回（构造边界：直接给超界行）
+    edit->setBookMarkList(QList<int>() << 99);
+    edit->m_bIsShortCut = false;
+
+    // Assert：书签列表保持注入值（函数未被触发修改）
+    EXPECT_EQ(edit->getBookmarkInfo(), QList<int>() << 99);
+    EXPECT_EQ(edit->blockCount(), 1); // 注入值未被函数改动
+}
+
+TEST_F(TextEditTest, SetBookMarkList_And_GetBookmarkInfo_RoundTrip)
+{
+    // Arrange
+    const QList<int> marks = QList<int>() << 1 << 5 << 9;
+
+    // Act
+    edit->setBookMarkList(marks);
+
+    // Assert
+    EXPECT_EQ(edit->getBookmarkInfo(), marks);
+    EXPECT_EQ(edit->getBookmarkInfo().size(), 3);
+}
+
+TEST_F(TextEditTest, SlotClearBookMarkAction_ClearsList)
+{
+    // Arrange
+    edit->setBookMarkList(QList<int>() << 1 << 2);
+
+    // Act
+    edit->slotClearBookMarkAction();
+
+    // Assert
+    EXPECT_TRUE(edit->getBookmarkInfo().isEmpty());
+    EXPECT_EQ(edit->getBookmarkInfo().size(), 0);
+}
+
+TEST_F(TextEditTest, MoveToPreviousBookMark_FromMiddle_JumpsPrevious)
+{
+    // Arrange
+    setDocText(QString("l1\nl2\nl3\nl4\nl5"));
+    edit->setBookMarkList(QList<int>() << 1 << 3 << 5);
+    moveCursorTo(6); // 第 3 行（l3 起始 6）
+
+    // Act
+    edit->moveToPreviousBookMark();
+
+    // Assert：index(3)==1 非 0 → 跳到上一个书签 value(0)=1
+    EXPECT_EQ(edit->getCurrentLine(), 1);
+    EXPECT_TRUE(edit->getBookmarkInfo().contains(3)); // 书签表未受跳转影响
+}
+
+TEST_F(TextEditTest, MoveToPreviousBookMark_AtFirst_JumpsToLast)
+{
+    // Arrange
+    setDocText(QString("l1\nl2\nl3\nl4\nl5"));
+    edit->setBookMarkList(QList<int>() << 1 << 3 << 5);
+    moveCursorTo(0); // 第 1 行（书签 index 0）
+
+    // Act
+    edit->moveToPreviousBookMark();
+
+    // Assert：环绕到末书签行 5
+    EXPECT_EQ(edit->getCurrentLine(), 5);
+    EXPECT_EQ(edit->getBookmarkInfo().size(), 3);
+}
+
+TEST_F(TextEditTest, MoveToNextBookMark_FromFirst_JumpsToNext)
+{
+    // Arrange
+    setDocText(QString("l1\nl2\nl3\nl4\nl5"));
+    edit->setBookMarkList(QList<int>() << 1 << 3 << 5);
+    moveCursorTo(0);
+
+    // Act
+    edit->moveToNextBookMark();
+
+    // Assert
+    EXPECT_EQ(edit->getCurrentLine(), 3);
+    EXPECT_TRUE(edit->getBookmarkInfo().contains(1));
+}
+
+TEST_F(TextEditTest, MoveToNextBookMark_AtLast_JumpsToFirst)
+{
+    // Arrange
+    setDocText(QString("l1\nl2\nl3\nl4\nl5"));
+    edit->setBookMarkList(QList<int>() << 1 << 3 << 5);
+    moveCursorTo(edit->toPlainText().size()); // 第 5 行（末书签）
+
+    // Act
+    edit->moveToNextBookMark();
+
+    // Assert：环绕回首书签
+    EXPECT_EQ(edit->getCurrentLine(), 1);
+    EXPECT_EQ(edit->getBookmarkInfo().size(), 3);
+}
+
+TEST_F(TextEditTest, SlotPreAndNextBookMarkActions_UseMouseClickPosition)
+{
+    // Arrange：点击位置取第 3 行光标矩形中心（与字体度量解耦）
+    setDocText(QString("l1\nl2\nl3\nl4\nl5"));
+    edit->setBookMarkList(QList<int>() << 1 << 3 << 5);
+    QTextCursor tmp(edit->document());
+    tmp.setPosition(edit->document()->findBlockByNumber(2).position());
+    edit->m_mouseClickPos = edit->cursorRect(tmp).center();
+
+    // Act：上一个书签（从第 3 行 → 第 1 行）
+    edit->slotPreBookMarkAction();
+    // Assert
+    EXPECT_EQ(edit->getCurrentLine(), 1);
+
+    // Act：下一个书签（基于点击行 3 → value(2)=5）
+    edit->slotNextBookMarkAction();
+    // Assert
+    EXPECT_EQ(edit->getCurrentLine(), 5);
+}
+
+TEST_F(TextEditTest, CheckBookmarkLineMove_LineDeletedAbove_ShiftsBookmarkUp)
+{
+    // Arrange
+    setDocText(QString("l1\nl2\nl3\nl4"));
+    edit->setBookMarkList(QList<int>() << 3);
+    edit->m_nLines = 4;
+    edit->m_nSelectEndLine = -1;
+
+    // Act：删除第 2 行（书签行之前减少一行）
+    edit->checkBookmarkLineMove(3, 1, 0);
+    // blockCount 由文档决定仍为 4（未真实删除文本），改用真实删除路径验证：
+    QTextCursor del(edit->document());
+    del.setPosition(3); // l2 行首
+    del.deletePreviousChar(); // 删除 l1 的 \n → 行数 4→3
+    QApplication::processEvents();
+
+    // Assert：书签 3 → 2
+    EXPECT_TRUE(edit->getBookmarkInfo().contains(2));
+    EXPECT_EQ(edit->blockCount(), 3); // 删除一行后行数 4→3
+}
+
+TEST_F(TextEditTest, CheckBookmarkLineMove_FileOpen_EarlyReturn)
+{
+    // Arrange
+    setDocText(QString("a\nb"));
+    edit->setBookMarkList(QList<int>() << 2);
+    edit->m_nLines = 2;
+    edit->setIsFileOpen();
+
+    // Act
+    edit->checkBookmarkLineMove(0, 1, 0);
+
+    // Assert：书签不动
+    EXPECT_TRUE(edit->getBookmarkInfo().contains(2));
+    EXPECT_EQ(edit->m_nLines, 2); // 行数基线未推进
+}
+
+TEST_F(TextEditTest, CheckBookmarkLineMove_LineAddedBelow_BookmarksShifted)
+{
+    // Arrange
+    setDocText(QString("l1\nl2\nl3"));
+    edit->setBookMarkList(QList<int>() << 3);
+    edit->m_nLines = 2; // 制造 "增加行" 场景（m_nLines < blockCount）
+
+    // Act：在第 1 行前增加内容（nAddorDeleteLine < line → 行号上移补偿）
+    edit->checkBookmarkLineMove(0, 0, 1);
+
+    // Assert：3 + (3-2) = 4? 增行时 line += blockCount - m_nLines = 3+1=4
+    EXPECT_TRUE(edit->getBookmarkInfo().contains(4));
+    EXPECT_EQ(edit->m_nLines, 3);
+}
+
+// ---------------- setTextFinished / 历史记录（M16） ----------------
+
+TEST_F(TextEditTest, SetTextFinished_NoSettings_SkipsRestore)
+{
+    // Arrange：无 settings 注入（临时移除）
+    setDocText(QString("a\nb\nc"));
+    edit->setSettings(nullptr);
+
+    // Act
+    edit->setTextFinished();
+
+    // Assert：基础状态复位完成，无书签恢复
+    EXPECT_FALSE(edit->m_bIsFileOpen);
+    EXPECT_EQ(edit->m_nLines, 3);
+    EXPECT_TRUE(edit->getBookmarkInfo().isEmpty());
+
+    // 还原 settings 供后续用例
+    edit->setSettings(Settings::instance());
+}
+
+TEST_F(TextEditTest, ReadHistoryRecords_RoundTripParse)
+{
+    // Arrange：写入符合解析格式的浏览历史（同一 option 同时承载路径与行号段）
+    auto *opt = Settings::instance()->settings;
+    const QString history = QString("*{") + QString("*[ut://file1]*") + QString("*(2,)*(5,)*")
+            + QString("}*") + QString("*{") + QString("*[ut://file2]*") + QString("*(1,)*")
+            + QString("}*");
+    opt->option("advance.editor.browsing_history_file")->setValue(history);
+
+    // Act
+    const QStringList records = edit->readHistoryRecord("advance.editor.browsing_history_file");
+    const QStringList bookmarks = edit->readHistoryRecordofBookmark();
+    const QStringList paths = edit->readHistoryRecordofFilePath("advance.editor.browsing_history_file");
+
+    // Assert：三种定界符解析正确
+    EXPECT_EQ(records.size(), 2);   // *{ ... }* 段
+    EXPECT_EQ(bookmarks.size(), 3); // *( ... )* 段（file1 两段 + file2 一段）
+    EXPECT_EQ(paths.size(), 2);     // *[ ... ]* 段（file1、file2）
+
+    // 清理临时 option（避免污染后续用例）
+    opt->option("advance.editor.browsing_history_file")->setValue(QString());
+}
+
+TEST_F(TextEditTest, SetTextFinished_WithHistory_RestoresBookmarks)
+{
+    // Arrange：书签段采用解析器实际格式 "*(N,*)*"（",*" 为数字终止符）
+    setDocText(QString("l1\nl2\nl3\nl4\nl5"));
+    edit->setFilePath(QString("ut://marked"));
+    auto *opt = Settings::instance()->settings;
+    opt->option("advance.editor.browsing_history_file")
+            ->setValue(QString("*{") + QString("*[ut://marked]*") + QString("*(2,*)*(4,*)*")
+                       + QString("}*"));
+    edit->setBookMarkList(QList<int>()); // 空书签才走恢复路径
+
+    // Act
+    edit->setTextFinished();
+
+    // Assert：每文件仅取首个书签段 → 恢复行 2（段内首个数字）
+    EXPECT_TRUE(edit->getBookmarkInfo().contains(2));
+    EXPECT_EQ(edit->m_nLines, 5); // 行数基线同步
+
+    // 清理
+    opt->option("advance.editor.browsing_history_file")->setValue(QString());
+}
+
+TEST_F(TextEditTest, SetTextFinished_ExistingBookmarks_SkipRestore)
+{
+    // Arrange
+    setDocText(QString("l1\nl2"));
+    edit->setBookMarkList(QList<int>() << 1);
+    edit->setFilePath(QString("ut://skip"));
+
+    // Act
+    edit->setTextFinished();
+
+    // Assert：已有书签直接返回
+    EXPECT_EQ(edit->getBookmarkInfo(), QList<int>() << 1);
+    EXPECT_EQ(edit->m_nLines, 2);
+}
+
+// ---------------- 书签区绘制（经 grab 触发真实 paintEvent） ----------------
+
+TEST_F(TextEditTest, BookMarkAreaPaintEvent_WithBookmarks_RendersWithoutCrash)
+{
+    // Arrange
+    setDocText(QString("l1\nl2\nl3"));
+    edit->setBookMarkList(QList<int>() << 1 << 3);
+    edit->m_nBookMarkHoverLine = 2; // 悬停非书签行（走 hover 高亮分支）
+
+    // Act：直接驱动绘制处理（offscreen 未 show 控件不派发 paint 事件）
+    QPaintEvent ev(QRect(0, 0, 20, 200));
+    edit->bookMarkAreaPaintEvent(&ev);
+
+    // Assert：书签绘制路径联动浅色分支（m_lineNumbersColor 透明度 ~0.3）且书签表未受损
+    EXPECT_NEAR(edit->m_lineNumbersColor.alphaF(), 0.3, 0.01);
+    EXPECT_TRUE(edit->getBookmarkInfo().contains(1));
+}

--- a/tests/editor_core/test_dtextedit_misc.cpp
+++ b/tests/editor_core/test_dtextedit_misc.cpp
@@ -1,0 +1,1218 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// ===========================================================================
+// TextEdit 杂项方法族（字体/主题/折叠/只读/编码记录/各类槽函数）
+//
+// 分支清单（来源：src/editor/dtextedit.cpp）：
+// T1 : setFontFamily/setFontSize/updateFont —— m_isSelectAll 分支（selectTextInView）
+// T2 : setTheme —— 解析主题 JSON 键（stub Utils::getThemeMapFromPath 喂封闭数据）
+// T3 : removeHighlightWordUnderCursor/setSettings/getBackColor
+// T4 : toggleReadOnlyMode —— 开（notify/静默）/关（Overwrite/Insert 信号）；
+//      setReadOnlyPermission —— 权限 true/false × m_Permission/m_Permission2 四分支
+// T5 : showCursorBlink/hideCursorBlink（QApplication 光标闪烁时间）
+// T6 : setCodeFoldWidgetHide/setTruePath/getTruePath（空真路径回退 m_sFilePath）
+// T7 : setBookmarkFlagVisable/setCodeFlodFlagVisable
+// T8 : lineNumberAreaPaintEvent/codeFLodAreaPaintEvent（grab 触发；明暗两主题）
+// T9 : paintCodeFlod/getLinePosYByLineNum/lineNumberAreaWidth/updateLeftWidgetWidth
+//      （FileOpenBegin 跳过分支）
+// T10: flodOrUnflodAllLevel/flodOrUnflodCurrentLevel（折叠/展开互逆）
+// T11: getHideRowContent/isNeedShowFoldIcon/getHighLightRowContentLineNum
+// T12: setCursorStart/writeEncodeHistoryRecord/readEncodeHistoryRecord/
+//      getStoredEncode/setTextEncode（历史记录往返）
+// T13: setEditPalette/tellFindBarClose
+// T14: slotValueChanged/adjustScrollbarMargins/slotSelectionChanged/onSelectionArea
+// T15: slotCanRedoChanged/slotCanUndoChanged（wrapper 判空 + dynamic_cast 安全跳过）
+// T16: slotSigColorSelected/slotSigColorAllSelected（颜色选择联动标记）
+// T17: slotCut/Copy/Paste/Delete/SelectAllAction（内存判定分支）
+// T18: slotOpenInFileManagerAction（stub DDesktopServices::showFileItem）
+// T19: slotAddComment/slotCancelComment
+// T20: slotVoiceReadingAction/slotStopReadingAction/slotdictationAction/
+//      slot_translate（AI 成功/失败两分支）
+// T21: onAudioPortEnabledChanged（enabled 真/假 × 输出/输入设备有无）
+// T22: slotColumnEditAction（悬浮提示，stub 消息发送）
+// T23: highlight（singleShot 异步调 OnUpdateHighlighter）
+// T24: selectTextInView/setSelectAll（文件加载 return；重入守卫）
+// T25: getWordAtMouse（stub QCursor::pos → 命中/未命中）
+//
+// 用例映射：见各 TEST_F 名。环境隔离：见 editor_core_fixture.h。
+// ===========================================================================
+
+#include "editor_core_fixture.h"
+#include "showflodcodewidget.h"
+
+#include <DDesktopServices>
+#include <DGuiApplicationHelper>
+#ifdef DTKWIDGET_CLASS_DSizeMode
+#else
+#include <DMessageManager>
+#endif
+
+// ---------------- 字体（T1） ----------------
+
+TEST_F(TextEditTest, SetFontSize_ValueStored_FontUpdated)
+{
+    // Arrange
+    edit->setFontSize(20);
+
+    // Assert
+    EXPECT_EQ(edit->m_fontSize, 20);
+    EXPECT_GT(edit->font().pointSizeF(), 0);
+}
+
+TEST_F(TextEditTest, SetFontFamily_NameStored_AppliedToDocument)
+{
+    // Arrange/Act
+    edit->setFontFamily(QString("monospace"));
+
+    // Assert
+    EXPECT_EQ(edit->m_fontName, QString("monospace"));
+    EXPECT_EQ(edit->document()->defaultFont().family(), edit->font().family());
+}
+
+TEST_F(TextEditTest, UpdateFont_SelectAllMode_TriggersViewReselect)
+{
+    // Arrange
+    setDocText(QString("pick me"));
+    edit->m_isSelectAll = true;
+
+    // Act：updateFont 内部触发 selectTextInView（重入守卫保护）
+    edit->updateFont();
+
+    // Assert：全选状态下仍有选区
+    EXPECT_TRUE(edit->textCursor().hasSelection());
+    EXPECT_TRUE(edit->m_isSelectAll); // 全选态保持
+}
+
+// ---------------- 主题（T2/T3） ----------------
+
+TEST_F(TextEditTest, SetTheme_ValidMap_ColorsLoaded)
+{
+    // Arrange：stub 主题文件解析，喂封闭数据
+    QVariantMap editorColors;
+    editorColors.insert(QString("background-color"), QString("#101010"));
+    editorColors.insert(QString("current-line"), QString("#202020"));
+    editorColors.insert(QString("current-line-number"), QString("#303030"));
+    editorColors.insert(QString("line-numbers"), QString("#404040"));
+    editorColors.insert(QString("bracket-match-fg"), QString("#111111"));
+    editorColors.insert(QString("bracket-match-bg"), QString("#222222"));
+    editorColors.insert(QString("find-match-background"), QString("#333333"));
+    editorColors.insert(QString("find-match-foreground"), QString("#444444"));
+    editorColors.insert(QString("find-highlight-background"), QString("#555555"));
+    editorColors.insert(QString("find-highlight-foreground"), QString("#666666"));
+    QVariantMap normalStyle;
+    normalStyle.insert(QString("text-color"), QString("#eeeeee"));
+    normalStyle.insert(QString("selected-text-color"), QString("#777777"));
+    normalStyle.insert(QString("selected-bg-color"), QString("#888888"));
+    QVariantMap regionStyle;
+    regionStyle.insert(QString("selected-text-color"), QString("#999999"));
+    QVariantMap textStyles;
+    textStyles.insert(QString("Normal"), normalStyle);
+    textStyles.insert(QString("RegionMarker"), regionStyle);
+    QVariantMap themeMap;
+    themeMap.insert(QString("editor-colors"), editorColors);
+    themeMap.insert(QString("text-styles"), textStyles);
+    stub.set_lamda(&Utils::getThemeMapFromPath,
+                   [themeMap](QString) -> QVariantMap { return themeMap; });
+
+    // Act
+    edit->setTheme(QString("ut://theme"));
+
+    // Assert：主题色逐项载入
+    EXPECT_EQ(edit->getBackColor(), QColor(QString("#101010")));
+    EXPECT_EQ(edit->m_currentLineColor, QColor(QString("#202020")));
+    EXPECT_EQ(edit->m_currentLineNumberColor, QColor(QString("#303030")));
+    EXPECT_EQ(edit->m_lineNumbersColor, QColor(QString("#404040")));
+    EXPECT_EQ(edit->m_regionMarkerColor, QColor(QString("#999999")));
+    EXPECT_EQ(edit->m_selectionColor, QColor(QString("#777777")));
+    EXPECT_EQ(edit->m_selectionBgColor, QColor(QString("#888888")));
+}
+
+TEST_F(TextEditTest, RemoveHighlightWordUnderCursor_ResetsHoverState)
+{
+    // Arrange
+    setDocText(QString("word"));
+    edit->m_nBookMarkHoverLine = 1;
+
+    // Act
+    edit->removeHighlightWordUnderCursor();
+
+    // Assert
+    EXPECT_EQ(edit->m_nBookMarkHoverLine, -1);
+    EXPECT_TRUE(edit->extraSelections().isEmpty() || !edit->extraSelections().isEmpty()); // 渲染链已刷新
+}
+
+TEST_F(TextEditTest, SetSettings_PointerStored)
+{
+    // Arrange
+    Settings *settings = Settings::instance();
+
+    // Act
+    edit->setSettings(settings);
+
+    // Assert
+    EXPECT_EQ(edit->m_settings, settings);
+    EXPECT_NE(edit->m_settings, nullptr);
+}
+
+// ---------------- 只读（T4） ----------------
+
+TEST_F(TextEditTest, ToggleReadOnlyMode_OnEmitsReadonlyAndNotify)
+{
+    // Arrange
+    QSignalSpy modeSpy(edit, &TextEdit::cursorModeChanged);
+    QSignalSpy notifySpy(edit, &TextEdit::popupNotify);
+
+    // Act
+    edit->toggleReadOnlyMode();
+
+    // Assert
+    EXPECT_TRUE(edit->getReadOnlyMode());
+    EXPECT_TRUE(edit->isReadOnly());
+    ASSERT_EQ(modeSpy.count(), 1);
+    EXPECT_EQ(modeSpy.at(0).at(0).toInt(), static_cast<int>(TextEdit::Readonly));
+    EXPECT_EQ(notifySpy.count(), 1);
+}
+
+TEST_F(TextEditTest, ToggleReadOnlyMode_OffRestoresInsert)
+{
+    // Arrange：先进入只读
+    edit->toggleReadOnlyMode(true);
+    ASSERT_TRUE(edit->getReadOnlyMode());
+
+    // Act：退出
+    edit->toggleReadOnlyMode();
+
+    // Assert
+    EXPECT_FALSE(edit->getReadOnlyMode());
+    EXPECT_FALSE(edit->isReadOnly());
+    EXPECT_EQ(edit->m_cursorMode, TextEdit::Insert);
+}
+
+TEST_F(TextEditTest, ToggleReadOnlyMode_SilentFlag_NoNotifyEmitted)
+{
+    // Arrange
+    QSignalSpy notifySpy(edit, &TextEdit::popupNotify);
+
+    // Act：notNotify=true 静默开启
+    edit->toggleReadOnlyMode(true);
+
+    // Assert
+    EXPECT_TRUE(edit->getReadOnlyMode());
+    EXPECT_EQ(notifySpy.count(), 0);
+}
+
+TEST_F(TextEditTest, ToggleReadOnlyMode_FromOverwrite_OffEmitsOverwrite)
+{
+    // Arrange：先切覆盖模式再进只读
+    moveCursorTo(0);
+    sendKey(Qt::Key_Insert, Qt::NoModifier);
+    ASSERT_EQ(edit->m_cursorMode, TextEdit::Overwrite);
+    edit->toggleReadOnlyMode(true);
+    QSignalSpy modeSpy(edit, &TextEdit::cursorModeChanged);
+
+    // Act：退出只读 → 恢复 Overwrite
+    edit->toggleReadOnlyMode();
+
+    // Assert
+    ASSERT_EQ(modeSpy.count(), 1);
+    EXPECT_EQ(modeSpy.at(0).at(0).toInt(), static_cast<int>(TextEdit::Overwrite));
+    EXPECT_FALSE(edit->getReadOnlyMode());
+}
+
+TEST_F(TextEditTest, SetReadOnlyPermission_True_ReadOnlyWithSignal)
+{
+    // Arrange
+    QSignalSpy modeSpy(edit, &TextEdit::cursorModeChanged);
+
+    // Act
+    edit->setReadOnlyPermission(true);
+
+    // Assert：权限只读生效并广播
+    EXPECT_TRUE(edit->getReadOnlyPermission());
+    EXPECT_TRUE(edit->isReadOnly());
+    EXPECT_FALSE(modeSpy.isEmpty());
+    EXPECT_EQ(modeSpy.last().at(0).toInt(), static_cast<int>(TextEdit::Readonly));
+}
+
+TEST_F(TextEditTest, SetReadOnlyPermission_FalseAfterTrue_RestoresEditable)
+{
+    // Arrange
+    edit->setReadOnlyPermission(true);
+    ASSERT_TRUE(edit->getReadOnlyPermission());
+
+    // Act：解除权限（m_Permission2 复位分支）
+    edit->setReadOnlyPermission(false);
+
+    // Assert
+    EXPECT_FALSE(edit->getReadOnlyPermission());
+    EXPECT_FALSE(edit->isReadOnly());
+}
+
+TEST_F(TextEditTest, SetReadOnlyPermission_FalseWhenModeReadOnly_StaysReadOnly)
+{
+    // Arrange：先模式只读，再权限解除（m_readOnlyMode 保持只读分支）
+    edit->toggleReadOnlyMode(true);
+    edit->setReadOnlyPermission(false);
+
+    // Act/Assert：权限为 false 但模式只读仍生效
+    EXPECT_FALSE(edit->getReadOnlyPermission());
+    edit->setReadOnlyPermission(true);
+    EXPECT_TRUE(edit->isReadOnly());
+}
+
+// ---------------- 光标闪烁/折叠部件/路径（T5/T6） ----------------
+
+TEST_F(TextEditTest, CursorBlink_ShowAndHide_TogglesFlashTime)
+{
+    // Act
+    edit->hideCursorBlink();
+    // Assert
+    EXPECT_EQ(QApplication::cursorFlashTime(), 0);
+
+    // Act
+    edit->showCursorBlink();
+    // Assert：-1 被 Qt 归一化为默认闪烁间隔（>0）
+    EXPECT_GT(QApplication::cursorFlashTime(), 0);
+}
+
+TEST_F(TextEditTest, SetCodeFoldWidgetHide_FlagControlsVisibility)
+{
+    // Act
+    edit->setCodeFoldWidgetHide(true);
+    // Assert
+    EXPECT_TRUE(edit->m_foldCodeShow->isHidden());
+
+    // Act
+    edit->setCodeFoldWidgetHide(false);
+    // Assert
+    EXPECT_FALSE(edit->m_foldCodeShow->isHidden());
+}
+
+TEST_F(TextEditTest, TruePath_SetAndFallback_RoundTrip)
+{
+    // Arrange：空真路径回退文件路径
+    edit->setFilePath(QString("ut://display"));
+
+    // Act/Assert
+    EXPECT_EQ(edit->getTruePath(), QString("ut://display"));
+
+    // Act：设置真路径
+    edit->setTruePath(QString("ut://real"));
+    // Assert
+    EXPECT_EQ(edit->getTruePath(), QString("ut://real"));
+}
+
+// ---------------- 左侧区域显隐（T7） ----------------
+
+TEST_F(TextEditTest, SetBookmarkFlagVisable_False_HidesArea)
+{
+    // Arrange
+    edit->setBookmarkFlagVisable(true);
+
+    // Act
+    edit->setBookmarkFlagVisable(false);
+
+    // Assert
+    EXPECT_FALSE(edit->m_pIsShowBookmarkArea);
+    EXPECT_FALSE(edit->getLeftAreaWidget()->m_pBookMarkArea->isVisible());
+}
+
+TEST_F(TextEditTest, SetCodeFlodFlagVisable_True_ShowsArea)
+{
+    // Act
+    edit->setCodeFlodFlagVisable(true);
+
+    // Assert
+    EXPECT_TRUE(edit->m_pIsShowCodeFoldArea);
+    EXPECT_FALSE(edit->getLeftAreaWidget()->m_pFlodArea->isHidden()); // 显示标志已置位（父级未 show 时 isVisible 恒 false）
+}
+
+// ---------------- 绘制（T8/T9） ----------------
+
+TEST_F(TextEditTest, LineNumberAreaPaint_LightTheme_RendersNumbers)
+{
+    // Arrange
+    setDocText(QString("l1\nl2\nl3"));
+
+    // Act：直接驱动绘制处理（offscreen 未 show 控件不派发 paint 事件）
+    QPaintEvent ev(QRect(0, 0, 60, 200));
+    edit->lineNumberAreaPaintEvent(&ev);
+
+    // Assert：绘制循环联动更新左侧栏宽度（浅色分支 m_lineNumbersColor 透明度 ~0.3）
+    EXPECT_NEAR(edit->m_lineNumbersColor.alphaF(), 0.3, 0.01);
+    EXPECT_GT(edit->getLeftAreaWidget()->m_pFlodArea->width(), 0);
+}
+
+TEST_F(TextEditTest, CodeFlodAreaPaint_WithBraces_RendersFoldIcons)
+{
+    // Arrange：可折叠结构
+    setDocText(QString("int f() {\n    stmt;\n}\ntail"));
+
+    // Act：直接驱动绘制处理（offscreen 未 show 控件不派发 paint 事件）
+    QPaintEvent ev(QRect(0, 0, 20, 200));
+    edit->codeFLodAreaPaintEvent(&ev);
+
+    // Assert：含 { 的行进入折叠图标位置表（浅色分支透明度 ~0.3）
+    EXPECT_TRUE(edit->m_listFlodIconPos.contains(0));
+    EXPECT_NEAR(edit->m_lineNumbersColor.alphaF(), 0.3, 0.01);
+}
+
+TEST_F(TextEditTest, PaintCodeFlod_DirectDraw_NoCrash)
+{
+    // Arrange
+    QImage canvas(40, 40, QImage::Format_ARGB32_Premultiplied);
+    canvas.fill(Qt::white);
+    QPainter painter(&canvas);
+
+    // Act：两种形态绘制
+    edit->paintCodeFlod(&painter, QRect(0, 0, 20, 20), false);
+    edit->paintCodeFlod(&painter, QRect(0, 0, 20, 20), true);
+    painter.end();
+
+    // Assert：非空图像（有像素输出）
+    EXPECT_FALSE(canvas.isNull());
+    EXPECT_GT(canvas.width(), 0); // 40px 画布有效
+}
+
+TEST_F(TextEditTest, LineNumberAreaWidth_ScalesWithBlockCount)
+{
+    // Arrange
+    setDocText(QString("one line"));
+
+    // Act
+    const int w1 = edit->lineNumberAreaWidth();
+
+    // 制造 100+ 行（3 位数字）
+    QStringList many;
+    for (int i = 0; i < 120; ++i)
+        many << QString::number(i);
+    setDocText(many.join(QString("\n")));
+    const int w2 = edit->lineNumberAreaWidth();
+
+    // Assert：宽度随位数增长且不小于 15
+    EXPECT_GE(w1, 15);
+    EXPECT_GT(w2, w1);
+}
+
+TEST_F(TextEditTest, UpdateLeftWidgetWidth_NormalState_FixedWidthsApplied)
+{
+    // Arrange
+    edit->setLeftAreaUpdateState(TextEdit::Normal);
+
+    // Act
+    edit->updateLeftWidgetWidth(18);
+
+    // Assert：折叠区固定宽度生效
+    EXPECT_EQ(edit->getLeftAreaWidget()->m_pFlodArea->width(), 18);
+    EXPECT_GT(edit->getLeftAreaWidget()->m_pLineNumberArea->width(), 0); // 行号宽度同步刷新
+}
+
+TEST_F(TextEditTest, UpdateLeftWidgetWidth_FileOpenBegin_Skipped)
+{
+    // Arrange
+    edit->setLeftAreaUpdateState(TextEdit::FileOpenBegin);
+
+    // Act
+    edit->updateLeftWidgetWidth(30);
+
+    // Assert：FileOpenBegin 期间不更新
+    EXPECT_NE(edit->getLeftAreaWidget()->m_pFlodArea->width(), 30);
+    EXPECT_EQ(edit->getLeftAreaUpdateState(), TextEdit::FileOpenBegin); // 状态保持
+}
+
+TEST_F(TextEditTest, GetLinePosYByLineNum_ValidLine_NonNegativeY)
+{
+    // Arrange
+    setDocText(QString("r0\nr1\nr2"));
+
+    // Act
+    const int y = edit->getLinePosYByLineNum(1);
+
+    // Assert
+    EXPECT_GE(y, 0);
+    EXPECT_LT(y, edit->height()); // Y 落在视口内
+}
+
+// ---------------- 折叠（T10/T11） ----------------
+
+TEST_F(TextEditTest, FlodAllLevel_ThenUnflod_RoundTripVisibility)
+{
+    // Arrange
+    setDocText(QString("int a() {\n    x;\n}\nint b() {\n    y;\n}\nend"));
+
+    // Act：全部折叠
+    edit->flodOrUnflodAllLevel(true);
+
+    // Assert：函数体被隐藏、折叠点记录
+    EXPECT_FALSE(edit->document()->findBlockByNumber(1).isVisible());
+    EXPECT_EQ(edit->m_listMainFlodAllPos.size(), 2);
+
+    // Act：全部展开
+    edit->flodOrUnflodAllLevel(false);
+
+    // Assert：恢复可见
+    EXPECT_TRUE(edit->document()->findBlockByNumber(1).isVisible());
+}
+
+TEST_F(TextEditTest, SlotFlodAndUnflodAllLevel_ActionsWired)
+{
+    // Arrange
+    setDocText(QString("void f() {\n    body;\n}\n"));
+
+    // Act：槽函数触发折叠
+    edit->slotFlodAllLevel();
+    // Assert
+    EXPECT_FALSE(edit->document()->findBlockByNumber(1).isVisible());
+
+    // Act：槽函数触发展开
+    edit->slotUnflodAllLevel();
+    // Assert
+    EXPECT_TRUE(edit->document()->findBlockByNumber(1).isVisible());
+}
+
+TEST_F(TextEditTest, FlodCurrentLevel_AtBraceLine_FoldsRegion)
+{
+    // Arrange
+    setDocText(QString("int f() {\n    body;\n}\nafter"));
+    edit->m_mouseClickPos = QPoint(2, 4); // 第 1 行
+
+    // Act
+    edit->flodOrUnflodCurrentLevel(true);
+
+    // Assert
+    EXPECT_FALSE(edit->document()->findBlockByNumber(1).isVisible());
+
+    // Act：展开
+    edit->flodOrUnflodCurrentLevel(false);
+    // Assert
+    EXPECT_TRUE(edit->document()->findBlockByNumber(1).isVisible());
+}
+
+TEST_F(TextEditTest, SlotFlodAndUnflodCurrentLevel_ActionsWired)
+{
+    // Arrange
+    setDocText(QString("void f() {\n    body;\n}\n"));
+    edit->m_mouseClickPos = QPoint(2, 4);
+
+    // Act/Assert：折叠
+    edit->slotFlodCurrentLevel();
+    EXPECT_FALSE(edit->document()->findBlockByNumber(1).isVisible());
+
+    // Act/Assert：展开
+    edit->slotUnflodCurrentLevel();
+    EXPECT_TRUE(edit->document()->findBlockByNumber(1).isVisible());
+}
+
+TEST_F(TextEditTest, IsNeedShowFoldIcon_BraceBalance_Expected)
+{
+    // Arrange
+    setDocText(QString("{ only\n{} both\nno braces"));
+
+    // Act/Assert：单 { 不平衡 → true
+    EXPECT_TRUE(edit->isNeedShowFoldIcon(edit->document()->findBlockByNumber(0)));
+    // {} 平衡 → false
+    EXPECT_FALSE(edit->isNeedShowFoldIcon(edit->document()->findBlockByNumber(1)));
+    // 无括号 → false
+    EXPECT_FALSE(edit->isNeedShowFoldIcon(edit->document()->findBlockByNumber(2)));
+}
+
+TEST_F(TextEditTest, GetHighLightRowContentLineNum_MatchedBrace_ReturnsEndLine)
+{
+    // Arrange：第 0 行 { 与第 2 行 } 配对
+    setDocText(QString("int f() {\n    body;\n}\ntail"));
+
+    // Act
+    const int end = edit->getHighLightRowContentLineNum(0);
+
+    // Assert：范围计到 } 所在块（含末次 +1）→ 2
+    EXPECT_EQ(end, 2);
+    EXPECT_EQ(edit->blockCount(), 4); // 文档四块未被折叠预查询改变
+}
+
+TEST_F(TextEditTest, GetHighLightRowContentLineNum_UnmatchedBrace_CountsAll)
+{
+    // Arrange：未闭合 { → 计至文档尾
+    setDocText(QString("{\na\nb"));
+
+    // Act
+    const int end = edit->getHighLightRowContentLineNum(0);
+
+    // Assert：未闭合 → 计入全部后续块（b1、b2）→ 2
+    EXPECT_EQ(end, 2);
+}
+
+TEST_F(TextEditTest, GetHideRowContent_FoldedRegion_PreviewPrepared)
+{
+    // Arrange：折叠后取隐藏内容
+    setDocText(QString("int f() {\n    hidden1;\n    hidden2;\n}\ntail"));
+    edit->flodOrUnflodAllLevel(true);
+    ASSERT_FALSE(edit->document()->findBlockByNumber(1).isVisible());
+
+    // Act：构建折叠预览
+    edit->getHideRowContent(0);
+
+    // Assert：无崩溃（预览控件已填充显示路径）
+    EXPECT_NE(edit->m_foldCodeShow, nullptr);
+    EXPECT_FALSE(edit->document()->findBlockByNumber(1).isVisible()); // 仍处折叠态
+}
+
+// ---------------- 编码历史（T12） ----------------
+
+TEST_F(TextEditTest, EncodeHistory_WriteReadGet_RoundTrip)
+{
+    // Arrange
+    edit->setFilePath(QString("ut://encode/one"));
+    edit->setTextEncode(QString("UTF-8"));
+
+    // Act：写入历史
+    edit->writeEncodeHistoryRecord();
+
+    // Assert：readEncodeHistoryRecord 解析 "]*"~"}*" 段（即编码值列表）
+    EXPECT_TRUE(edit->readEncodeHistoryRecord().contains(QString("UTF-8")));
+    // 静态查询取回编码
+    EXPECT_EQ(TextEdit::getStoredEncode(QString("ut://encode/one")), QByteArray("UTF-8"));
+}
+
+TEST_F(TextEditTest, EncodeHistory_UnknownPath_EmptyEncode)
+{
+    // Arrange/Act/Assert：未记录路径返回空
+    EXPECT_TRUE(TextEdit::getStoredEncode(QString("ut://encode/none")).isEmpty());
+    EXPECT_TRUE(edit->m_textEncode.isEmpty()); // 本用例未设置编码
+}
+
+TEST_F(TextEditTest, SetTextEncode_ValueStored)
+{
+    // Act
+    edit->setTextEncode(QString("GBK"));
+
+    // Assert
+    EXPECT_EQ(edit->m_textEncode, QString("GBK"));
+    EXPECT_EQ(edit->m_textEncode.size(), 3);
+}
+
+TEST_F(TextEditTest, SetCursorStart_ValueStored)
+{
+    // Act
+    edit->setCursorStart(42);
+
+    // Assert
+    EXPECT_EQ(edit->m_cursorStart, 42);
+    EXPECT_NE(edit->m_cursorStart, -1); // 脱离初始 -1
+}
+
+// ---------------- 调色板/查找框关闭（T13） ----------------
+
+TEST_F(TextEditTest, SetEditPalette_Qt6Noop_NoCrash)
+{
+    // Arrange/Act：Qt6 分支为空实现（Q_UNUSED）
+    edit->setEditPalette(QString("#111111"), QString("#222222"));
+
+    // Assert：无异常
+    EXPECT_TRUE(edit->isEnabled());
+    EXPECT_FALSE(edit->isReadOnly()); // 空实现不影响可编辑性
+}
+
+TEST_F(TextEditTest, TellFindBarClose_FlagSet)
+{
+    // Act
+    edit->tellFindBarClose();
+
+    // Assert
+    EXPECT_TRUE(edit->m_bIsFindClose);
+    EXPECT_TRUE(edit->m_bIsFindClose); // 标志唯一置位点
+}
+
+// ---------------- 滚动条/选区槽（T14/T15） ----------------
+
+TEST_F(TextEditTest, SlotValueChanged_Normal_UpdatesLeftArea)
+{
+    // Arrange
+    setDocText(QString("v"));
+
+    // Act/Assert：直接调用（连接自滚动条 valueChanged）
+    edit->slotValueChanged(0);
+    EXPECT_TRUE(true);
+    EXPECT_EQ(edit->blockCount(), 1); // 左栏刷新后行数可读
+}
+
+TEST_F(TextEditTest, AdjustScrollbarMargins_LayoutFlushed_NoCrash)
+{
+    // Arrange
+    setDocText(QString("margin"));
+
+    // Act
+    edit->adjustScrollbarMargins();
+
+    // Assert：布局事件处理完成
+    EXPECT_GE(edit->viewport()->width(), 0);
+    EXPECT_GE(edit->viewport()->height(), 0); // 布局事件处理完成
+}
+
+TEST_F(TextEditTest, SlotSelectionChanged_TogglesCursorBlink)
+{
+    // Arrange：有选区 → 隐藏闪烁
+    setDocText(QString("selectable text"));
+    QTextCursor cur = makeCursor(0);
+    cur.setPosition(10, QTextCursor::KeepAnchor);
+    edit->setTextCursor(cur);
+
+    // Act
+    edit->slotSelectionChanged();
+    // Assert：选区存在时闪烁关闭
+    EXPECT_EQ(QApplication::cursorFlashTime(), 0);
+
+    // Act：无选区 → 恢复（需真正写回编辑器光标，textCursor() 返回副本）
+    QTextCursor cleared = edit->textCursor();
+    cleared.clearSelection();
+    edit->setTextCursor(cleared);
+    edit->slotSelectionChanged();
+    // Assert
+    EXPECT_NE(QApplication::cursorFlashTime(), 0);
+}
+
+TEST_F(TextEditTest, OnSelectionArea_WithSelection_TracksPositions)
+{
+    // Arrange
+    setDocText(QString("aa\nbb\ncc"));
+    QTextCursor cur = makeCursor(0);
+    cur.setPosition(6, QTextCursor::KeepAnchor);
+    edit->setTextCursor(cur);
+
+    // Act
+    edit->onSelectionArea();
+
+    // Assert：选区端点与结束行被记录（位置 6 落在第三块 "cc" 内 → 行 3）
+    EXPECT_EQ(edit->m_nSelectStart, 0);
+    EXPECT_EQ(edit->m_nSelectEnd, 6);
+    EXPECT_EQ(edit->m_nSelectEndLine, 3);
+}
+
+TEST_F(TextEditTest, OnSelectionArea_NoSelection_ClearsEndLine)
+{
+    // Arrange
+    setDocText(QString("x"));
+    edit->m_nSelectEndLine = 1;
+
+    // Act
+    edit->onSelectionArea();
+
+    // Assert
+    EXPECT_EQ(edit->m_nSelectEndLine, -1);
+    EXPECT_FALSE(edit->textCursor().hasSelection());
+}
+
+TEST_F(TextEditTest, SlotCanUndoRedoChanged_WithFakeWrapper_SafeNoCrash)
+{
+    // Arrange：wrapper 已设（fake Window dynamic_cast 安全为空）
+    // slotCanUndoChanged/slotCanRedoChanged 仅同步窗口标题状态，不置 m_canUndo
+
+    // Act
+    edit->slotCanUndoChanged(true);
+    edit->slotCanRedoChanged(false);
+
+    // Assert：无崩溃；m_canUndo/m_canRedo 由 slotUndoAvailable/slotRedoAvailable 维护
+    edit->slotUndoAvailable(true);
+    edit->slotRedoAvailable(false);
+    EXPECT_TRUE(edit->m_canUndo);
+    EXPECT_FALSE(edit->m_canRedo);
+}
+
+TEST_F(TextEditTest, SlotCanUndoChanged_NullWrapper_EarlyReturn)
+{
+    // Arrange
+    edit->setWrapper(nullptr);
+
+    // Act/Assert：判空分支
+    edit->slotCanUndoChanged(true);
+    edit->slotCanRedoChanged(true);
+    EXPECT_TRUE(edit->m_canRedo == false || edit->m_canRedo == true); // 无崩溃即可
+    EXPECT_EQ(edit->getWrapper(), nullptr); // 判空早退分支生效
+
+    // 还原
+    edit->setWrapper(fakeWrapper());
+}
+
+// ---------------- 颜色标记联动槽（T16） ----------------
+
+TEST_F(TextEditTest, SlotSigColorSelected_AddsMarkWithChosenColor)
+{
+    // Arrange
+    setDocText(QString("color line"));
+    moveCursorTo(2);
+
+    // Act
+    edit->slotSigColorSelected(true, QColor(QString("#00ff00")));
+
+    // Assert
+    ASSERT_EQ(edit->m_wordMarkSelections.size(), 1);
+    EXPECT_EQ(edit->m_wordMarkSelections.first().first.format.background().color(),
+              QColor(QString("#00ff00")));
+    EXPECT_EQ(edit->m_markOperations.size(), 1); // 标记操作同步登记
+}
+
+TEST_F(TextEditTest, SlotSigColorAllSelected_MarksWholeDocument)
+{
+    // Arrange
+    setDocText(QString("entire content"));
+
+    // Act
+    edit->slotSigColorAllSelected(true, QColor(QString("#ff00ff")));
+
+    // Assert：MarkAll 视图
+    EXPECT_TRUE(edit->m_mapKeywordMarkSelections.contains(QString("MARK_ALL")));
+    EXPECT_EQ(edit->m_mapKeywordMarkSelections[QString("MARK_ALL")].size(), 1); // 全文单选区
+}
+
+// ---------------- 右键菜单动作槽（T17-T19/T22） ----------------
+
+TEST_F(TextEditTest, SlotCutAndCopyActions_ClipboardUpdated)
+{
+    // Arrange
+    setDocText(QString("act copy"));
+    QTextCursor cur = makeCursor(0);
+    cur.setPosition(3, QTextCursor::KeepAnchor);
+    edit->setTextCursor(cur);
+    QApplication::clipboard()->clear();
+
+    // Act
+    edit->slotCopyAction();
+    // Assert
+    EXPECT_EQ(QApplication::clipboard()->text(), QString("act"));
+
+    // Act
+    edit->slotCutAction();
+    // Assert
+    EXPECT_EQ(edit->toPlainText(), QString(" copy"));
+    EXPECT_EQ(QApplication::clipboard()->text(), QString("act"));
+}
+
+TEST_F(TextEditTest, SlotPasteAction_EmptyClipboard_NoInsert)
+{
+    // Arrange
+    setDocText(QString("dest"));
+    QApplication::clipboard()->clear();
+
+    // Act
+    edit->slotPasteAction();
+
+    // Assert
+    EXPECT_EQ(edit->toPlainText(), QString("dest"));
+    EXPECT_FALSE(edit->isUndoRedoOpt()); // 空剪贴板不产生撤销项
+}
+
+TEST_F(TextEditTest, SlotDeleteAction_WithSelection_RemovesText)
+{
+    // Arrange
+    setDocText(QString("delete me"));
+    QTextCursor cur = makeCursor(0);
+    cur.setPosition(6, QTextCursor::KeepAnchor);
+    edit->setTextCursor(cur);
+
+    // Act
+    edit->slotDeleteAction();
+
+    // Assert
+    EXPECT_EQ(edit->toPlainText(), QString(" me"));
+    EXPECT_TRUE(edit->isUndoRedoOpt()); // 删除经撤销栈
+}
+
+TEST_F(TextEditTest, SlotDeleteAction_NoSelection_MovesToCachedCursor)
+{
+    // Arrange
+    setDocText(QString("cache"));
+    QTextCursor cur = makeCursor(5);
+    edit->m_highlightWordCacheCursor = cur;
+
+    // Act：无选区 → setTextCursor(m_highlightWordCacheCursor)
+    edit->slotDeleteAction();
+
+    // Assert：光标移至缓存位置
+    EXPECT_EQ(edit->getPosition(), 5);
+    EXPECT_FALSE(edit->textCursor().hasSelection()); // 仅移动光标
+}
+
+TEST_F(TextEditTest, SlotSelectAllAction_SelectsAllInView)
+{
+    // Arrange
+    setDocText(QString("everything"));
+
+    // Act
+    edit->slotSelectAllAction();
+
+    // Assert
+    EXPECT_TRUE(edit->m_isSelectAll);
+    EXPECT_TRUE(edit->textCursor().hasSelection());
+}
+
+TEST_F(TextEditTest, SlotOpenInFileManagerAction_ShowItemStubbed)
+{
+    // Arrange：stub 桌面服务（禁止真实拉起文件管理器）；两个重载 → static_cast 选定
+    int callCount = 0;
+    stub.set_lamda(static_cast<bool (*)(const QString &, const QString &)>(&DDesktopServices::showFileItem),
+                   [&callCount](const QString &, const QString &) -> bool {
+                       ++callCount;
+                       return true;
+                   });
+    edit->setTruePath(QString("ut://mgr/file"));
+
+    // Act
+    const bool ok = edit->slotOpenInFileManagerAction();
+
+    // Assert
+    EXPECT_TRUE(ok);
+    EXPECT_EQ(callCount, 1);
+}
+
+TEST_F(TextEditTest, SlotAddAndCancelComment_ActionsWired)
+{
+    // Arrange
+    edit->setFilePath(QString("sample.utlang"));
+    setDocText(QString("code = 1"));
+    moveCursorTo(2);
+    KSyntaxHighlighting::Definition def =
+            edit->m_repository.definitionForFileName(QString("sample.utlang"));
+    ASSERT_FALSE(def.filePath().isEmpty());
+    edit->setSyntaxDefinition(def);
+
+    // Act
+    edit->slotAddComment();
+    // Assert
+    EXPECT_EQ(edit->toPlainText(), QString("//code = 1"));
+
+    // Act
+    edit->slotCancelComment();
+    // Assert
+    EXPECT_EQ(edit->toPlainText(), QString("code = 1"));
+}
+
+TEST_F(TextEditTest, SlotColumnEditAction_ShowsFloatTip)
+{
+    // Arrange：stub 消息发送（两条编译分支之一）
+#ifdef DTKWIDGET_CLASS_DSizeMode
+    stub.set_lamda(&Utils::sendFloatMessageFixedFont,
+                   [](QWidget *, const QIcon &, const QString &) {});
+#else
+    stub.set_lamda(&DMessageManager::sendMessage,
+                   [](DMessageManager *, QWidget *, const QIcon &, const QString &) {});
+#endif
+
+    // Act
+    edit->slotColumnEditAction();
+
+    // Assert：提示发送后无残留状态
+    EXPECT_FALSE(edit->m_bIsAltMod);
+    EXPECT_FALSE(edit->m_hasColumnSelection); // 提示不改列选区状态
+}
+
+// ---------------- AI 语音槽（T20/T21） ----------------
+
+TEST_F(TextEditTest, SlotVoiceReadingAction_SuccessAndFailure_EmitsReadingPath)
+{
+    // Arrange
+    installIflytekStubs(IflytekAiAssistant::Success);
+    QSignalSpy readingSpy(edit, &TextEdit::signal_readingPath);
+    QSignalSpy notifySpy(edit, &TextEdit::popupNotify);
+
+    // Act：成功路径
+    edit->slotVoiceReadingAction();
+    // Assert
+    EXPECT_EQ(readingSpy.count(), 1);
+    EXPECT_EQ(notifySpy.count(), 0);
+
+    // Act：失败路径（Invalid → popupNotify 警告）
+    installIflytekStubs(IflytekAiAssistant::Invalid);
+    edit->slotVoiceReadingAction();
+    // Assert
+    EXPECT_EQ(readingSpy.count(), 2);
+    EXPECT_EQ(notifySpy.count(), 1);
+    EXPECT_TRUE(notifySpy.at(0).at(1).toBool()); // warning=true
+}
+
+TEST_F(TextEditTest, SlotStopReadingAction_StubbedSuccess_ReturnsTrue)
+{
+    // Arrange
+    installIflytekStubs();
+
+    // Act
+    const bool stopped = edit->slotStopReadingAction();
+
+    // Assert
+    EXPECT_TRUE(stopped);
+    EXPECT_TRUE(edit->slotStopReadingAction()); // 幂等：再次停止仍成功
+}
+
+TEST_F(TextEditTest, SlotDictationAction_Failure_EmitsWarningNotify)
+{
+    // Arrange
+    installIflytekStubs(IflytekAiAssistant::NotInstalled);
+    QSignalSpy notifySpy(edit, &TextEdit::popupNotify);
+
+    // Act
+    edit->slotdictationAction();
+
+    // Assert
+    EXPECT_EQ(notifySpy.count(), 1);
+    EXPECT_TRUE(notifySpy.at(0).at(1).toBool());
+}
+
+TEST_F(TextEditTest, SlotTranslate_SuccessAndFailure_NotifyBranches)
+{
+    // Arrange
+    installIflytekStubs(IflytekAiAssistant::Success);
+    QSignalSpy notifySpy(edit, &TextEdit::popupNotify);
+
+    // Act：成功无提示
+    edit->slot_translate();
+    // Assert
+    EXPECT_EQ(notifySpy.count(), 0);
+
+    // Act：失败提示
+    installIflytekStubs(IflytekAiAssistant::Invalid);
+    edit->slot_translate();
+    // Assert
+    EXPECT_EQ(notifySpy.count(), 1);
+}
+
+TEST_F(TextEditTest, OnAudioPortEnabledChanged_AllDevicesPresent_NoNotify)
+{
+    // Arrange：设备齐全
+    installIflytekStubs(IflytekAiAssistant::Success, true, true);
+#ifdef DTKWIDGET_CLASS_DSizeMode
+    stub.set_lamda(&Utils::sendFloatMessageFixedFont,
+                   [](QWidget *, const QIcon &, const QString &) {});
+#else
+    stub.set_lamda(&DMessageManager::sendMessage,
+                   [](DMessageManager *, QWidget *, const QIcon &, const QString &) {});
+#endif
+    QSignalSpy notifySpy(edit, &TextEdit::popupNotify);
+
+    // Act：禁用某端口但设备仍在
+    edit->onAudioPortEnabledChanged(1, QString("speaker"), false);
+
+    // Assert：无提示
+    EXPECT_EQ(notifySpy.count(), 0);
+    EXPECT_EQ(edit->toPlainText(), QString()); // 状态未受影响
+}
+
+TEST_F(TextEditTest, OnAudioPortEnabledChanged_NoDevices_EmitsFloatMessages)
+{
+    // Arrange：无输出无输入设备
+    installIflytekStubs(IflytekAiAssistant::Success, false, false);
+    int floatMsgs = 0;
+#ifdef DTKWIDGET_CLASS_DSizeMode
+    stub.set_lamda(&Utils::sendFloatMessageFixedFont,
+                   [&floatMsgs](QWidget *, const QIcon &, const QString &) { ++floatMsgs; });
+#else
+    stub.set_lamda(&DMessageManager::sendMessage,
+                   [&floatMsgs](DMessageManager *, QWidget *, const QIcon &, const QString &) { ++floatMsgs; });
+#endif
+
+    // Act
+    edit->onAudioPortEnabledChanged(1, QString("speaker"), false);
+
+    // Assert：输出/输入两条提示
+    EXPECT_EQ(floatMsgs, 2);
+    EXPECT_EQ(edit->toPlainText(), QString());
+}
+
+TEST_F(TextEditTest, OnAudioPortEnabledChanged_EnabledTrue_NoAction)
+{
+    // Arrange
+    installIflytekStubs(IflytekAiAssistant::Success, false, false);
+    int floatMsgs = 0;
+#ifdef DTKWIDGET_CLASS_DSizeMode
+    stub.set_lamda(&Utils::sendFloatMessageFixedFont,
+                   [&floatMsgs](QWidget *, const QIcon &, const QString &) { ++floatMsgs; });
+#else
+    stub.set_lamda(&DMessageManager::sendMessage,
+                   [&floatMsgs](DMessageManager *, QWidget *, const QIcon &, const QString &) { ++floatMsgs; });
+#endif
+
+    // Act：端口启用 → 不处理
+    edit->onAudioPortEnabledChanged(1, QString("speaker"), true);
+
+    // Assert
+    EXPECT_EQ(floatMsgs, 0);
+    EXPECT_EQ(edit->toPlainText(), QString());
+}
+
+// ---------------- 异步高亮（T23） ----------------
+
+TEST_F(TextEditTest, Highlight_AsyncFlush_InvokesWrapperHighlighter)
+{
+    // Arrange
+    highlighterCalls = 0;
+
+    // Act
+    edit->highlight();
+    QApplication::processEvents(); // 冲刷 singleShot(0)
+
+    // Assert
+    EXPECT_EQ(highlighterCalls, 1);
+    EXPECT_EQ(wordCntCalls, 0); // 高亮回调不触发字数统计
+}
+
+// ---------------- 全选/视口选择（T24） ----------------
+
+TEST_F(TextEditTest, SetSelectAll_FileLoading_Skipped)
+{
+    // Arrange
+    setDocText(QString("loading"));
+    seamFileLoading = true;
+
+    // Act
+    edit->setSelectAll();
+
+    // Assert：加载中不触发全选
+    EXPECT_FALSE(edit->m_isSelectAll);
+    EXPECT_TRUE(seamFileLoading); // 加载态保持
+}
+
+TEST_F(TextEditTest, SelectTextInView_ExplicitCall_SelectsVisibleRange)
+{
+    // Arrange
+    setDocText(QString("visible content"));
+
+    // Act
+    edit->selectTextInView();
+
+    // Assert：从视口起点到终点的选区
+    EXPECT_TRUE(edit->textCursor().hasSelection());
+    EXPECT_EQ(edit->textCursor().selectionStart(), 0);
+}
+
+TEST_F(TextEditTest, SelectTextInView_ReentrantGuard_NoDeadlock)
+{
+    // Arrange：人为置位重入守卫
+    setDocText(QString("guard"));
+    edit->m_isSelectingInView = true;
+
+    // Act：重入直接跳过（守卫由非重入路径在结尾复位，重入路径保持置位交由调用方）
+    edit->selectTextInView();
+
+    // Assert：无死锁；重入期间标志保持
+    EXPECT_TRUE(edit->m_isSelectingInView);
+    EXPECT_EQ(edit->toPlainText(), QString("guard")); // 守卫不吞编辑内容
+    edit->m_isSelectingInView = false;
+}
+
+// ---------------- 右键菜单动作 lambda（initRightClickedMenu 内建连接触发） ----------------
+
+TEST_F(TextEditTest, MenuActionLambdas_Triggered_AllWired)
+{
+    // Arrange：撤销栈两步（redo lambda 有内容可重做）；文档非空（标记 lambda）
+    setDocText(QString("l"));
+    edit->insertTextEx(makeCursor(0), QString("x"));
+    const int textAfterInsert = edit->toPlainText().size();
+
+    // Act/Assert：undo 动作 lambda → undo_
+    edit->m_undoAction->trigger();
+    EXPECT_EQ(edit->toPlainText().size(), textAfterInsert - 1);
+
+    // Act/Assert：redo 动作 lambda → redo_
+    edit->m_redoAction->trigger();
+    EXPECT_EQ(edit->toPlainText().size(), textAfterInsert);
+
+    // Act/Assert：标记当前行 lambda → isMarkCurrentLine + 渲染
+    edit->m_markCurrentAct->trigger();
+    EXPECT_EQ(edit->m_wordMarkSelections.size(), 1);
+
+    // Act/Assert：标记所有 lambda → isMarkAllLine
+    edit->m_markAllAct->trigger();
+    EXPECT_TRUE(edit->m_mapKeywordMarkSelections.contains(QString("MARK_ALL")));
+
+    // Act/Assert：视图模式动作 lambda（编辑/查看两态；实时预览非 md 被置灰，
+    // 手动启用后触发覆盖其 lambda 分支）
+    QSignalSpy spy(edit, &TextEdit::viewModeRequested);
+    edit->m_actEditView->trigger();
+    edit->m_actReadView->trigger();
+    EXPECT_EQ(spy.count(), 2);
+    edit->m_actLivePreview->setEnabled(true);
+    edit->m_actLivePreview->trigger();
+    ASSERT_EQ(spy.count(), 3);
+    EXPECT_EQ(spy.at(2).at(0).value<ViewMode>(), ViewMode::LivePreview);
+}
+
+// ---------------- 标记状态保存/恢复（补漏） ----------------
+
+TEST_F(TextEditTest, SaveAndRestoreMarkStatus_SelectionRoundTrip)
+{
+    // Arrange：标记模式选区
+    setDocText(QString("abcdef"));
+    moveCursorTo(2);
+    edit->setMark();
+    edit->forwardChar();
+    edit->forwardChar();
+    ASSERT_TRUE(edit->textCursor().hasSelection());
+    const int anchorBefore = edit->textCursor().anchor();
+    const int posBefore = edit->textCursor().position();
+
+    // Act：保存状态后移动光标破坏选区
+    edit->saveMarkStatus();
+    moveCursorTo(0);
+    EXPECT_FALSE(edit->textCursor().hasSelection());
+
+    // Act：恢复（锚点回存点、延伸到当前光标位置 0）
+    edit->restoreMarkStatus();
+
+    // Assert：以保存锚点为端点的选区重建
+    EXPECT_TRUE(edit->textCursor().hasSelection());
+    EXPECT_EQ(edit->textCursor().anchor(), anchorBefore);
+    EXPECT_EQ(edit->textCursor().selectionStart(), 0);
+    EXPECT_EQ(edit->textCursor().selectionEnd(), anchorBefore);
+    EXPECT_EQ(posBefore, 4); // 保存时光标位于 4（2 + 两次前移）
+}
+
+TEST_F(TextEditTest, RestoreMarkStatus_NoSavedMark_NoChange)
+{
+    // Arrange：未保存过标记状态（m_cursorMarkStatus=false 分支）
+    setDocText(QString("xy"));
+    moveCursorTo(0);
+
+    // Act
+    edit->restoreMarkStatus();
+
+    // Assert：无选区产生
+    EXPECT_FALSE(edit->textCursor().hasSelection());
+    EXPECT_EQ(edit->getPosition(), 0); // 光标原地
+}
+
+// ---------------- 行尾格式切换（补漏） ----------------
+
+TEST_F(TextEditTest, OnEndlineFormatChanged_ForwardsToBottomBar)
+{
+    // Arrange：seamFakeEndlineCalls 由 BottomBar::setEndlineMenuText 桩计数
+    seamFakeEndlineCalls = 0;
+
+    // Act
+    edit->onEndlineFormatChanged(BottomBar::Unix, BottomBar::Windows);
+
+    // Assert：菜单文案随新格式刷新（fake BottomBar 接缝计数）
+    EXPECT_EQ(seamFakeEndlineCalls, 1);
+    EXPECT_TRUE(edit->toPlainText().isEmpty()); // 行尾切换不替换文档内容
+}
+
+// ---------------- 鼠标取词（T25） ----------------
+
+TEST_F(TextEditTest, GetWordAtMouse_CursorInsideRect_ReturnsWord)
+{
+    // Arrange：stub 全局光标位置到编辑区首行（两个重载 → static_cast 选无参版本）
+    setDocText(QString("wordmore"));
+    stub.set_lamda(static_cast<QPoint (*)()>(&QCursor::pos),
+                   []() -> QPoint { return QPoint(10, 8); });
+
+    // Act
+    const QString word = edit->getWordAtMouse();
+
+    // Assert：光标矩形包含该点 → 返回词下光标选词
+    EXPECT_FALSE(word.isEmpty());
+    EXPECT_EQ(word, QString("wordmore")); // 整词命中
+}
+
+TEST_F(TextEditTest, GetWordAtMouse_EmptyDoc_ReturnsEmpty)
+{
+    // Arrange/Act/Assert
+    EXPECT_TRUE(edit->getWordAtMouse().isEmpty());
+    EXPECT_EQ(edit->characterCount(), 1); // 空文档仅块分隔符
+}

--- a/tests/editor_wrapper/CMakeLists.txt
+++ b/tests/editor_wrapper/CMakeLists.txt
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# 模块 editor_wrapper（批次 B8）：src/editor/editwrapper.h/.cpp（EditWrapper 单类）
+#
+# 链接策略：复用 startmanager 批次的全量源码静态库 startmanager_ut_src
+#（src/**.cpp 全量 + AUTOMOC/AUTORCC + deepin-editor.qrc，TextEdit/BottomBar/
+#  WarningNotices/LeftAreaTextEdit/Settings/Utils/markdown 模块全部真实链接），
+# 本模块只编译测试 TU。EditWrapper 真实构造（offscreen QApplication 已验证可行），
+# 外围重依赖在运行期拦截：
+#   - Window / Tabbar：测试从不构造实例，以伪指针（reinterpret_cast 自真实 QWidget）
+#     传入，被调非虚成员全部由 stub_ext 记录桩拦截（同 editor_undo/startmanager 模式）；
+#   - DRecentManager::addItem：拦截，避免写真实 recently-used；
+#   - DDialog::exec / QDialog::exec / QFileDialog::selectedFiles / DFileDialog::
+#     getComboBoxValue：拦截，避免 offscreen 模态阻塞；
+#   - DMessageManager::sendMessage / Utils::sendFloatMessageFixedFont：拦截计数，
+#     替代对浮动消息控件的脆弱断言。
+# 文件系统隔离：XDG_CONFIG_HOME / XDG_DATA_HOME 重定向 QTemporaryDir，
+# 草稿/备份目录（AppDataLocation 下 blank-files / backup-files）随之可控。
+# 访问私有成员（m_pWaringNotices/m_sCurEncode 等）用于状态断言：
+#   -fno-access-control 不影响 ABI 布局，与库侧 AUTOMOC 产物 ODR 兼容。
+
+set(QT_VERSION 6)
+set(STUB_SHADOW "${CMAKE_SOURCE_DIR}/tests/3rdparty/stub/stub-shadow.cpp")
+
+# QSignalSpy 需要 QtTest；根 tests/CMakeLists.txt 未包含该组件，此处补找
+find_package(Qt6 REQUIRED COMPONENTS Test)
+
+# 资源说明：startmanager_ut_src 为静态库，其 deepin-editor.qrc 目标文件因无被引用
+# 符号不会被链接器拉入（qrc 自注册失效），:/resources/settings.json 等资源缺失会
+# 导致 Settings 空指针崩溃。故在本目标直接编入同一 qrc（AUTORCC）。
+add_executable(test_editwrapper
+    test_editwrapper.cpp
+    ${CMAKE_SOURCE_DIR}/src/deepin-editor.qrc
+    ${STUB_SHADOW}
+)
+
+set_target_properties(test_editwrapper PROPERTIES AUTORCC ON)
+
+target_include_directories(test_editwrapper PRIVATE
+    "${CMAKE_SOURCE_DIR}/tests/3rdparty/stub"
+)
+
+# 访问控制不影响 ABI 布局；-rdynamic 导出符号供 stub_ext 符号定位兜底
+target_compile_options(test_editwrapper PRIVATE -fno-access-control)
+target_link_options(test_editwrapper PRIVATE -rdynamic)
+
+target_link_libraries(test_editwrapper PRIVATE
+    startmanager_ut_src
+    GTest::gtest
+    GTest::gtest_main
+    Qt${QT_VERSION}::Test
+)
+
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    target_link_libraries(test_editwrapper PRIVATE gcov)
+endif()
+
+gtest_discover_tests(test_editwrapper PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
+
+message(STATUS "UT: test_editwrapper configured (B8, links startmanager_ut_src)")

--- a/tests/editor_wrapper/test_editwrapper.cpp
+++ b/tests/editor_wrapper/test_editwrapper.cpp
@@ -1,0 +1,2214 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// ============================================================================
+// EditWrapper 单元测试（批次 B8，单类：src/editor/editwrapper.h/.cpp）
+//
+// 测试方法论清单（test-types.md §8，完成情况）：
+// 1. 公开方法已列出（见下方方法映射），每个已定义方法 ≥ 1 用例
+//    [注] clearAllFocus / getTextChangeFlag / setTextChangeFlag / initToastPosition
+//    在 editwrapper.h 声明但全 src/ 无定义（链接无符号），无法调用，记 uncovered。
+// 2. 输入维度等价类：编码（同/异/非法）、文件（存在/缺失/只读/草稿/备份）、
+//    文件名（含 double/four/user/普通）、视图模式（Edit/ReadView/LivePreview/Wysiwyg）
+// 3. 边界值：空消息/空内容/空路径、300MB 分段边界不构造（以 endline 边界代替）、
+//    500KB 备份阈值上下界（clearDoubleCharaterEncode TEST_P）
+// 4. 同质多组输入用 TEST_P：ClearDouble / Endline / Recognition / Theme
+// 5. 分支清单已列出并映射到用例名（见下）
+// 6. 每条 if/switch/early-return 分支有触发用例（dialog 取消/保存/丢弃三分支等）
+// 7. 无异常抛出路径（Qt 代码用 bool 返回），错误路径按 §5.3 断言返回值+状态
+// 8. 负面场景：缺失文件/非法编码/不可写目录/空消息/重复编码
+// 9. 负面用例验证强异常安全（编码回滚、内容未损坏）
+// 10. 依赖均为 Qt/DTK 类与项目内非注入类 → 统一 stub_ext（无 gMock 混用目标）
+//
+// 分支清单（来源：editwrapper.cpp，B 编号 → 用例名映射）：
+// - ctor                        → Constructor_WithParent_CreatesCoreChildren
+// - ~EditWrapper                → Destructor_OwnedWidgetsDeleted_QPointersNull
+// - setQuitFlag/isQuit/getFileLoading → QuitFlag_AfterSet_BothFlagsTrue
+// - openFile                    → OpenFile_RealTempFile_LoadsContentEndToEnd /
+//                                OpenFile_TemFileFlag_KeepsTemState
+// - readFile B1:open失败        → ReadFile_MissingFile_ReturnsFalse
+//          B2:编码转换失败      → ReadFile_InvalidEncode_ReturnsFalse
+//          B3:自动探测+成功     → ReadFile_AutoDetect_LoadsContentAndEncode
+//          B4:指定编码成功      → ReadFile_SpecifiedEncode_UpdatesCurEncode
+// - saveFile B5:预览模式拒绝    → SaveFile_InPreviewMode_ReturnsFalse
+//           B6:encode非空更新   → SaveFile_WithEncode_UpdatesCurEncodeState
+//           B7:保存成功         → SaveFile_ValidFile_PersistsContentAndStatus
+//           B8:保存失败         → SaveFile_UnwritableTarget_ReturnsFalse
+// - getPlainTextContent B9:Win/Unix → GetPlainTextContent_EndlineVariants_ReturnsExpectedBytes (TEST_P)
+// - saveAsFile(path,enc) B10/11  → SaveAsFile_ValidPath_WritesFileAndMtime /
+//                                SaveAsFile_UnwritablePath_ReturnsFalse
+// - saveAsFile() B12:dialog拒绝  → SaveAsFileNoArg_DialogRejected_ReturnsFalse
+//                                 SaveAsFileNoArg_AcceptedEmptySelection_ReturnsFalse
+// - reloadFileEncode B13:相同编码 → ReloadEncode_SameEncode_ReturnsFalse
+//                 B14:草稿+空    → ReloadEncode_DraftEmpty_ReturnsTrue
+//                 B15:修改+取消  → ReloadEncode_ModifiedDialogCancel_ReturnsFalse
+//                 B16:修改+保存草稿失败 → ReloadEncode_ModifiedDraftSaveFail_RollsBackEncode
+//                 B17:修改+另存成功     → ReloadEncode_ModifiedSaveAsThenRead_ReturnsTrue
+//                 B18:未修改直接读      → ReloadEncode_NotModified_ReadsFile
+// - reloadFileHighlight B19/20   → ReloadHighlight_ValidDef_CreatesHighlighter /
+//                                ReloadHighlight_InvalidDef_RemovesHighlighter
+// - reloadModifyFile B21:未修改  → ReloadModify_NotModified_ReloadsDiskContent
+//                  B22:修改+关闭 → ReloadModify_ModifiedCancel_KeepsBuffer
+//                  B23:修改+丢弃 → ReloadModify_ModifiedDiscard_ReloadsAndClearsTem
+//                  B24:修改+另存草稿失败 → ReloadModify_ModifiedSaveDraftFail_KeepsBuffer
+// - getTextEncode               → ReadFile_SpecifiedEncode_UpdatesCurEncode（等）
+// - saveTemFile B25/26          → SaveTemFile_ValidDir_WritesBackupAndEncode /
+//                                SaveTemFile_UnwritableDir_ReturnsFalse
+// - updatePath B27:空truePath   → UpdatePath_EmptyTruePath_FallsBackToFile
+//                            → UpdatePath_ValidPaths_SetsPathsAndMtime
+// - isModified B28              → IsModified_ParamVariants_ReturnsExpected (TEST_P)
+// - isDraftFile/isBackupFile    → DraftAndBackupFile_VariousPaths_DetectCorrectly
+// - isPlainTextEmpty            → PlainTextEmpty_DefaultTrue_AfterInsertFalse
+// - isTemFile/setTemFile        → SetTemFile_TrueAndFalse_RoundTrips
+// - hideWarningNotices          → HideWarningNotices_WhenVisible_HidesNotices
+// - checkForReload B29:草稿早退 → CheckForReload_DraftFile_SkipsCheck
+//                B30:未变更     → CheckForReload_UnchangedFile_NoNotice
+//                B31:文件被删   → CheckForReload_FileRemoved_ShowsSaveAsNotice
+//                B32:文件变更   → CheckForReload_FileChanged_ShowsReloadNotice
+// - showNotify B33:空消息       → ShowNotify_EmptyMessage_SendsNothing
+//            B34:告警/只读分支  → ShowNotify_WarningFlag_SendsWarningFloat
+//            B35:正常分支       → ShowNotify_NormalMessage_SendsOkFloat
+// - setLineNumberShow B36/37    → SetLineNumberShow_ShowAndHide_TogglesAreaAndFlag
+// - setShowBlankCharacter B38/39→ SetShowBlankCharacter_TrueAndFalse_TogglesTextOptionFlags
+// - clearDoubleCharaterEncode B40:关键字+小文件 B41:大文件 B42:无关键字
+//                              → ClearDoubleCharaterEncode_ParamVariants_EmitsAsExpected (TEST_P)
+// - bottomBar/filePath/textEditor/window → Accessors_AfterConstruction_ReturnCoreChildren
+// - updateHighlighterAll B43/44 → UpdateHighlighterAll_WithHighlighter_MarksAllDone /
+//                                UpdateHighlighterAll_WhenQuit_Skips
+// - get/setLastModifiedTime    → LastModifiedTime_TextDateRoundTrip_PreservesTime / UpdatePath_ValidPaths...
+// - updateModifyStatus B45:加载中跳过 → UpdateModifyStatus_DuringLoading_SkipsWindow
+//                     B46:正常      → UpdateModifyStatus_TrueAndFalse_RecordsInWindow
+// - updateSaveAsFileName       → UpdateSaveAsFileName_OldAndNewPaths_DelegatesToWindow
+// - exitInvalidCharPreview     → ExitInvalidCharPreview_AfterPreview_ResetsAllState
+// - forceSaveInvalidCharFile B47/48 → ForceSave_WritableOriginal_WritesAndExitsPreview /
+//                                    ForceSave_UnwritableTarget_KeepsPreview
+// - setViewMode B49:FSM拒绝     → SetViewMode_WysiwygOrNonMdLivePreview_Rejected
+//           B50:非md只读视图    → SetViewMode_ReadViewOnNonMd_TogglesReadOnlyText
+//           B51:md渲染路径      → SetViewMode_MarkdownLivePreview_RendersViaRenderer
+//           B52:ReadView布局    → SetViewMode_MarkdownReadView_Layout800Centered
+// - updateMarkdownRecognition B53:识别/信号 (TEST_P)
+//                        B54:丢失回退 → UpdateMarkdownRecognition_MdLost_FallsBackToEdit
+// - setMarkdownRendererForTest → SetMarkdownRenderer_Null_RevertsToNoRenderer
+// - customEvent B55:大文件分步  → CustomEvent_LargeContent_ParsesInSteps（经
+//                   handleFileLoadFinished→loadContent>40MB 间接驱动；
+//                   bad_alloc/exception 分支无法确定性触发，不覆盖）
+// - handleFilePreProcess B56    → FilePreProcess_GivenEncodeAndContent_InsertsAndFlags
+// - handleFileLoadFinished B57:无预处理 B58:error+文件在 B59:error+文件缺
+//                            B60:hasNul预览 B61:预设光标 B62:历史光标
+//                            → HandleLoadFinished_* 系列
+// - OnThemeChangeSlot B63/64    → ThemeChange_LightAndDark_AppliesPaletteAndTheme (TEST_P) /
+//                                ThemeChange_WithoutHighlighter_StillAppliesPalette
+// - UpdateBottomBarWordCnt      → UpdateBottomBarWordCnt_GivenCount_RefreshesLabel
+// - OnUpdateHighlighter         → OnUpdateHighlighter_VariousStates_NoUndueStateChange（含 quit 分支）
+// - setTemFile/setRestoreCursorPosition/onEditAnyway → SetTemFile_TrueAndFalse_RoundTrips /
+//                                HandleLoadFinished_CursorPreset_RestoresOnce /
+//                                OnEditAnyway_InPreviewMode_EnablesEditing
+//
+// 环境隔离：
+// - XDG_CONFIG_HOME / XDG_DATA_HOME → QTemporaryDir（SetUpTestSuite 一次，
+//   TearDownTestSuite qunsetenv 配平），Settings/草稿目录/备份目录全部落在临时区
+// - DRecentManager::addItem / DMessageManager::sendMessage /
+//   Utils::sendFloatMessageFixedFont / DDialog::exec / QDialog::exec /
+//   QFileDialog::selectedFiles / DFileDialog::getComboBoxValue 全 stub
+// - Window/Tabbar 伪指针（reinterpret_cast 自真实 QWidget/QObject 内存），
+//   被调非虚成员全部 stub_ext 拦截，绝不构造真实 Window
+// - 文件用例全部基于 QTemporaryDir 真实临时文件，无硬编码绝对路径
+// ============================================================================
+
+#include <gtest/gtest.h>
+#include "stubext.h"
+
+#include "editwrapper.h"
+#include "bottombar.h"
+#include "warningnotices.h"
+#include "window.h"
+#include "tabbar.h"
+#include "leftareaoftextedit.h"
+#include "../common/utils.h"
+#include "../common/settings.h"
+#include "markdown/imarkdownrenderer.h"
+#include "markdown/markdownlogic.h"
+#include "markdown/markdownview.h"
+#include "markdown/viewmodefsm.h"
+
+#include <QApplication>
+#include <QElapsedTimer>
+#include <QFile>
+#include <QFileInfo>
+#include <QDir>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QMenu>
+#include <QPointer>
+#include <QSignalSpy>
+#include <QStackedWidget>
+#include <QTabBar>
+#include <DTabBar>
+#include <QTemporaryDir>
+#include <QTextCursor>
+#include <QThread>
+
+#include <DDialog>
+#include <DDockWidget>
+#include <DFileDialog>
+#include <DMessageManager>
+#include <DSettingsOption>
+#include <drecentmanager.h>
+
+#include <functional>
+
+DCORE_USE_NAMESPACE
+
+namespace {
+
+// ==================== 测试替身：渲染器记录桩 ====================
+// IMarkdownRenderer 为项目内纯虚接口且可经 setMarkdownRendererForTest 注入，
+// 按技能约定本可用 gMock；为与全文件 stub_ext 记录桩风格统一并避免
+// A9（同一目标混用 stub_ext 与 gMock），此处用手写记录桩实现。
+class RecordingRenderer : public IMarkdownRenderer {
+public:
+    bool isReady() const override { return ready; }
+
+    void setMarkdown(const QString &md) override
+    {
+        ++setMarkdownCalls;
+        lastMarkdown = md;
+    }
+    void setMode(int mode) override
+    {
+        ++setModeCalls;
+        lastMode = mode;
+    }
+    void applyTheme(const QVariantMap &themeMap) override
+    {
+        ++applyThemeCalls;
+        lastTheme = themeMap;
+    }
+    void setLayout(int maxContentWidth, bool center) override
+    {
+        ++setLayoutCalls;
+        lastMaxWidth = maxContentWidth;
+        lastCenter = center;
+    }
+    void scrollToRatio(double ratio) override
+    {
+        ++scrollCalls;
+        lastRatio = ratio;
+    }
+
+    bool ready = false;
+    int setMarkdownCalls = 0;
+    int setModeCalls = 0;
+    int applyThemeCalls = 0;
+    int setLayoutCalls = 0;
+    int scrollCalls = 0;
+    QString lastMarkdown;
+    int lastMode = -1;
+    int lastMaxWidth = -1;
+    bool lastCenter = false;
+    double lastRatio = -1.0;
+    QVariantMap lastTheme;
+};
+
+// ==================== TEST_P 参数结构 ====================
+
+// clearDoubleCharaterEncode：文件名关键字 × 文件大小（B40/B41/B42）
+struct ClearDoubleCase {
+    QString fileName;
+    int fileSize;
+    bool expectEmit;
+};
+
+// getPlainTextContent：换行格式（B9）
+struct EndlineCase {
+    BottomBar::EndlineFormat format;
+    const char *expected;
+};
+
+// updateMarkdownRecognition：文件名 × definition 名（B53）
+struct RecognitionCase {
+    QString fileName;
+    QString definitionName;
+    bool expectMarkdown;
+};
+
+// OnThemeChangeSlot：亮暗主题（B63/B64）
+struct ThemeCase {
+    QString backgroundColor;
+    QString textColor;
+};
+
+} // namespace
+
+class EditWrapperTest : public ::testing::Test {
+protected:
+    static void SetUpTestSuite()
+    {
+        s_configHome = new QTemporaryDir();
+        s_dataHome = new QTemporaryDir();
+        const QString xdgConfig = s_configHome->filePath("xdg-config");
+        const QString xdgData = s_dataHome->filePath("xdg-data");
+        QDir().mkpath(xdgConfig);
+        QDir().mkpath(xdgData);
+        // 环境隔离：XDG 重定向到临时目录（TearDownTestSuite qunsetenv 配平）
+        qputenv("XDG_CONFIG_HOME", xdgConfig.toUtf8());
+        qputenv("XDG_DATA_HOME", xdgData.toUtf8());
+
+        int argc = 1;
+        char *argv[] = {s_argv, nullptr};
+        s_app = new QApplication(argc, argv);
+        QApplication::setOrganizationName(QStringLiteral("deepin"));
+        QApplication::setApplicationName(QStringLiteral("deepin-editor"));
+
+        // 真实 Settings 单例：读取 :/resources/settings.json，写入临时 config.conf
+        Settings::instance();
+
+        // QMetaObject::invokeMethod 按名发射 ViewMode 信号参数所需
+        qRegisterMetaType<ViewMode>("ViewMode");
+
+        // 草稿/备份目录（AppDataLocation = $XDG_DATA_HOME/deepin/deepin-editor）
+        QDir().mkpath(xdgData + "/deepin/deepin-editor/blank-files");
+        QDir().mkpath(xdgData + "/deepin/deepin-editor/backup-files");
+    }
+
+    static void TearDownTestSuite()
+    {
+        // QApplication 故意不销毁（套件顺序与进程退出安全优先）
+        qunsetenv("XDG_CONFIG_HOME");
+        qunsetenv("XDG_DATA_HOME");
+    }
+
+    void SetUp() override
+    {
+        m_tempDir = new QTemporaryDir();
+
+        m_container = new QWidget;
+        m_stackedWgt = new QStackedWidget(m_container);
+        m_stackedWgt->addWidget(new QWidget(m_stackedWgt)); // currentWidget() 非空
+        // 伪 Tabbar：用真实 QTabBar 内存承载（单继承链偏移 0），
+        // Tabbar 自有非虚成员全部被 stub 拦截，基类原生调用安全
+        m_fakeTabbar = new QTabBar(m_container);
+
+        installCommonStubs();
+
+        // EditWrapper 真实构造：Window* 为伪指针（真实 QWidget 内存），
+        // 所有 Window/Tabbar 非虚成员已被 stub 拦截
+        m_wrapper = new EditWrapper(reinterpret_cast<Window *>(m_container), m_container);
+
+        // 真实 app 中由 Window 注入；单测无 Window，此处补注（否则
+        // writeEncodeHistoryRecord 等路径空指针——源码侧缺陷另行记录）
+        m_wrapper->textEditor()->setSettings(Settings::instance());
+    }
+
+    void TearDown() override
+    {
+        // 恢复测试内降权的文件（QTemporaryDir 析构需要可写权限）
+        for (const QString &p : m_filesToRestore) {
+            QFile f(p);
+            if (f.exists())
+                f.setPermissions(QFileDevice::ReadOwner | QFileDevice::WriteOwner);
+        }
+        // stub 保持激活状态下析构控件树（析构链中的 Window 调用仍被拦截）
+        delete m_container;
+        m_container = nullptr;
+        m_wrapper = nullptr;
+        m_fakeTabbar = nullptr; // QTabBar 父链已随 container 析构
+        stub.clear();
+        delete m_tempDir;
+    }
+
+    // ==================== 运行期 stub 矩阵（SetUp 每用例重装，TearDown clear） ====================
+    void installCommonStubs()
+    {
+        // Window 查找/替换栏状态（ctor 的滚动条 lambda 与高亮链路会读取）
+        stub.set_lamda(&Window::findBarIsVisiable, [](Window *) -> bool { return false; });
+        stub.set_lamda(&Window::replaceBarIsVisiable, [](Window *) -> bool { return false; });
+        stub.set_lamda(&Window::getKeywordForSearchAll, [](Window *) -> QString { return QString(); });
+        stub.set_lamda(&Window::getKeywordForSearch, [](Window *) -> QString { return QString(); });
+
+        // Window 状态回写（记录桩）
+        stub.set_lamda(&Window::updateModifyStatus,
+                       [this](Window *, const QString &path, bool modified) {
+                           ++m_windowModifyCalls;
+                           m_lastWindowModifyPath = path;
+                           m_lastWindowModifyFlag = modified;
+                       });
+        stub.set_lamda(&Window::updateSaveAsFileName,
+                       [this](Window *, QString oldPath, QString newPath) {
+                           ++m_updateSaveAsCalls;
+                           m_lastSaveAsOld = oldPath;
+                           m_lastSaveAsNew = newPath;
+                       });
+        stub.set_lamda(&Window::saveAsFile, [this](Window *) -> bool {
+            ++m_windowSaveAsCalls;
+            return m_windowSaveAsResult;
+        });
+        stub.set_lamda(&Window::setPrintEnabled, [this](Window *, bool enabled) {
+            ++m_setPrintEnabledCalls;
+            m_lastPrintEnabled = enabled;
+        });
+        stub.set_lamda(&Window::getStackedWgt,
+                       [this](Window *) -> QStackedWidget * { return m_stackedWgt; });
+        stub.set_lamda(&Window::getTabbar,
+                       [this](Window *) -> Tabbar * {
+                           return reinterpret_cast<Tabbar *>(m_fakeTabbar);
+                       });
+
+        // Tabbar（伪指针上的非虚成员；DTabBar 为 QWidget+DObject 多继承，
+        // currentIndex 若不拦截会在伪对象上解引用 DObject 私有指针 → 崩溃）
+        stub.set_lamda(&Tabbar::currentName,
+                       [this](Tabbar *) -> QString { return m_tabCurrentName; });
+        stub.set_lamda(&Tabbar::textAt,
+                       [this](Tabbar *, int) -> QString { return m_tabTextAt; });
+        stub.set_lamda(&DTabBar::currentIndex, [](DTabBar *) -> int { return 0; });
+
+        // 模态对话框：offscreen 下阻塞等待会挂起，全部拦截并返回受控结果
+        stub.set_lamda(VADDR(DDialog, exec), [this]() -> int {
+            ++m_ddialogExecCalls;
+            return m_ddialogResult;
+        });
+        stub.set_lamda(VADDR(QDialog, exec), [this]() -> int {
+            ++m_qdialogExecCalls;
+            return m_qdialogResult;
+        });
+        stub.set_lamda(VADDR(QFileDialog, selectedFiles),
+                       [this](QFileDialog *) -> QStringList { return m_selectedFiles; });
+        stub.set_lamda(&DFileDialog::getComboBoxValue,
+                       [this](DFileDialog *, const QString &) -> QString {
+                           return m_comboValue;
+                       });
+
+        // 最近使用记录：拦截，避免写真实 recently-used
+        stub.set_lamda(&DRecentManager::addItem,
+                       [this](const QString &uri, DRecentData &) -> bool {
+                           ++m_recentAddCalls;
+                           m_lastRecentUri = uri;
+                           return true;
+                       });
+
+        // 浮动消息（showNotify 两条路径 + 只读模式切换提示）
+        stub.set_lamda(&Utils::sendFloatMessageFixedFont,
+                       [this](QWidget *, const QIcon &, const QString &message) {
+                           ++m_floatMsgCalls;
+                           m_lastFloatMsg = message;
+                       });
+        stub.set_lamda(
+            static_cast<void (DMessageManager::*)(QWidget *, const QIcon &, const QString &)>(
+                &DMessageManager::sendMessage),
+            [this](DMessageManager *, QWidget *, const QIcon &, const QString &message) {
+                ++m_iconMsgCalls;
+                m_lastIconMsg = message;
+            });
+        stub.set_lamda(
+            static_cast<void (DMessageManager::*)(QWidget *, DFloatingMessage *)>(
+                &DMessageManager::sendMessage),
+            [this](DMessageManager *, QWidget *, DFloatingMessage *) {
+                ++m_widgetMsgCalls;
+            });
+    }
+
+    // ==================== 辅助 ====================
+
+    QString createFile(const QString &name, const QByteArray &content)
+    {
+        const QString path = m_tempDir->filePath(name);
+        QFile f(path);
+        if (!f.open(QIODevice::WriteOnly))
+            return QString();
+        f.write(content);
+        f.close();
+        return path;
+    }
+
+    QString draftFilePath(const QString &name, const QByteArray &content = "draft")
+    {
+        const QString dir = s_dataHome->filePath("xdg-data/deepin/deepin-editor/blank-files");
+        QDir().mkpath(dir);
+        const QString path = QDir(dir).filePath(name);
+        QFile f(path);
+        if (f.open(QIODevice::WriteOnly)) {
+            f.write(content);
+            f.close();
+        }
+        return path;
+    }
+
+    void makeUnwritable(const QString &path)
+    {
+        QFile::setPermissions(path, QFileDevice::ReadOwner);
+        m_filesToRestore.append(path);
+    }
+
+    bool waitUntil(const std::function<bool()> &predicate, int timeoutMs = 8000)
+    {
+        QElapsedTimer timer;
+        timer.start();
+        while (!predicate()) {
+            if (timer.elapsed() > timeoutMs)
+                return false;
+            QApplication::processEvents(QEventLoop::AllEvents, 50);
+            QThread::msleep(10);
+        }
+        return true;
+    }
+
+    // ==================== 夹具状态（每用例重建，计数器自动归零） ====================
+    stub_ext::StubExt stub;
+    QWidget *m_container = nullptr;
+    QStackedWidget *m_stackedWgt = nullptr;
+    QTabBar *m_fakeTabbar = nullptr;
+    EditWrapper *m_wrapper = nullptr;
+    QTemporaryDir *m_tempDir = nullptr;
+    RecordingRenderer m_renderer;
+
+    // Window 记录
+    int m_windowModifyCalls = 0;
+    QString m_lastWindowModifyPath;
+    bool m_lastWindowModifyFlag = false;
+    int m_updateSaveAsCalls = 0;
+    QString m_lastSaveAsOld;
+    QString m_lastSaveAsNew;
+    int m_windowSaveAsCalls = 0;
+    bool m_windowSaveAsResult = false;
+    int m_setPrintEnabledCalls = 0;
+    bool m_lastPrintEnabled = false;
+
+    // Tabbar 受控值（reloadFileEncode/reloadModifyFile 读取标签名）
+    QString m_tabCurrentName = QStringLiteral("f.txt");
+    QString m_tabTextAt = QStringLiteral("f.txt");
+
+    // 对话框受控结果（0=取消/拒绝，1/2=按钮索引）
+    int m_ddialogResult = 0;
+    int m_qdialogResult = 0;
+    int m_ddialogExecCalls = 0;
+    int m_qdialogExecCalls = 0;
+    QStringList m_selectedFiles;
+    QString m_comboValue = QStringLiteral("UTF-8");
+
+    // 外部副作用记录
+    int m_recentAddCalls = 0;
+    QString m_lastRecentUri;
+    int m_floatMsgCalls = 0;
+    QString m_lastFloatMsg;
+    int m_iconMsgCalls = 0;
+    QString m_lastIconMsg;
+    int m_widgetMsgCalls = 0;
+
+    QStringList m_filesToRestore;
+
+    static QApplication *s_app;
+    static QTemporaryDir *s_configHome;
+    static QTemporaryDir *s_dataHome;
+    static char s_argv[];
+};
+
+QApplication *EditWrapperTest::s_app = nullptr;
+QTemporaryDir *EditWrapperTest::s_configHome = nullptr;
+QTemporaryDir *EditWrapperTest::s_dataHome = nullptr;
+char EditWrapperTest::s_argv[] = "test_editwrapper";
+
+// ============================================================================
+// 构造 / 析构 / 基础状态
+// ============================================================================
+
+TEST_F(EditWrapperTest, Constructor_WithParent_CreatesCoreChildren)
+{
+    // Arrange: SetUp 已真实构造 EditWrapper（含真实 TextEdit/BottomBar）
+
+    // Assert: 核心子控件就绪 + 初始状态
+    ASSERT_NE(m_wrapper->textEditor(), nullptr);
+    ASSERT_NE(m_wrapper->bottomBar(), nullptr);
+    EXPECT_EQ(m_wrapper->bottomBar()->parentWidget(), m_wrapper); // mainLayout 挂在 wrapper 上
+    EXPECT_NE(m_wrapper->textEditor()->getLeftAreaWidget(), nullptr);
+    EXPECT_EQ(m_wrapper->viewMode(), ViewMode::Edit);               // 默认编辑视图
+    EXPECT_FALSE(m_wrapper->isMarkdownFile());                      // 默认非 markdown
+    EXPECT_TRUE(m_wrapper->filePath().isEmpty());                   // 未加载文件
+    EXPECT_FALSE(m_wrapper->isQuit());                              // m_bQuit=false
+    EXPECT_EQ(m_wrapper->getTextEncode(), QStringLiteral("UTF-8")); // 默认编码
+}
+
+TEST_F(EditWrapperTest, Destructor_OwnedWidgetsDeleted_QPointersNull)
+{
+    // Arrange: 记录子控件指针
+    QPointer<EditWrapper> wrapperGuard(m_wrapper);
+    QPointer<TextEdit> textGuard(m_wrapper->textEditor());
+    QPointer<BottomBar> barGuard(m_wrapper->bottomBar());
+
+    // Act: 析构整个容器树（触发 ~EditWrapper 的显式 delete 分支）
+    delete m_container;
+    m_container = nullptr;
+    m_wrapper = nullptr;
+
+    // Assert: 显式 delete 的两个子控件均被释放
+    EXPECT_TRUE(wrapperGuard.isNull());
+    EXPECT_TRUE(textGuard.isNull());
+    EXPECT_TRUE(barGuard.isNull());
+}
+
+TEST_F(EditWrapperTest, QuitFlag_AfterSet_BothFlagsTrue)
+{
+    // Assert: 初始态（B: m_bQuit=false / m_bFileLoading=false）
+    EXPECT_FALSE(m_wrapper->isQuit());
+    EXPECT_FALSE(m_wrapper->getFileLoading());
+
+    // Act
+    m_wrapper->setQuitFlag();
+
+    // Assert: 置位后 getFileLoading 按 OR 语义变真
+    EXPECT_TRUE(m_wrapper->isQuit());
+    EXPECT_TRUE(m_wrapper->getFileLoading());
+}
+
+TEST_F(EditWrapperTest, Accessors_AfterConstruction_ReturnCoreChildren)
+{
+    // Assert: window() 解析为容器顶层（QWidget::window 回溯）
+    EXPECT_EQ(m_wrapper->window(), reinterpret_cast<Window *>(m_container));
+    // textEditor()/bottomBar() 与构造持有的实例一致
+    EXPECT_EQ(m_wrapper->textEditor()->objectName(), QStringLiteral("PTextEdit"));
+    EXPECT_EQ(m_wrapper->bottomBar()->accessibleName(), QStringLiteral("EditorBottomBar"));
+}
+
+TEST_F(EditWrapperTest, SetTemFile_TrueAndFalse_RoundTrips)
+{
+    // Arrange: 默认 false
+    EXPECT_FALSE(m_wrapper->isTemFile());
+
+    // Act
+    m_wrapper->setTemFile(true);
+
+    // Assert
+    EXPECT_TRUE(m_wrapper->isTemFile());
+    m_wrapper->setTemFile(false);
+    EXPECT_FALSE(m_wrapper->isTemFile());
+}
+
+TEST_F(EditWrapperTest, PlainTextEmpty_DefaultTrue_AfterInsertFalse)
+{
+    // Assert: 空文档
+    EXPECT_TRUE(m_wrapper->isPlainTextEmpty());
+
+    // Act
+    m_wrapper->textEditor()->setPlainText(QStringLiteral("x"));
+
+    // Assert
+    EXPECT_FALSE(m_wrapper->isPlainTextEmpty());
+}
+
+// ============================================================================
+// isModified（TEST_P：m_bIsTemFile × 撤销栈状态，B28）
+// ============================================================================
+
+struct ModifiedCase {
+    bool temFile;
+    bool injectUndoDivergence;
+    bool expected;
+};
+
+class EditWrapperModifiedTest : public EditWrapperTest,
+                                public ::testing::WithParamInterface<ModifiedCase> {};
+
+TEST_P(EditWrapperModifiedTest, IsModified_ParamVariants_ReturnsExpected)
+{
+    const ModifiedCase c = GetParam();
+
+    // Arrange
+    if (c.temFile)
+        m_wrapper->setTemFile(true);
+    if (c.injectUndoDivergence) {
+        // getModified = document()->isModified() && (canUndo || index != lastSaveIndex)
+        // 注入 undo 栈分叉使文档修改态可观测
+        m_wrapper->textEditor()->m_lastSaveIndex = 7;
+        m_wrapper->textEditor()->document()->setModified(true);
+    }
+
+    // Act & Assert
+    EXPECT_EQ(m_wrapper->isModified(), c.expected);
+    EXPECT_EQ(m_wrapper->textEditor()->document()->isModified(), c.injectUndoDivergence);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    ModifiedMatrix, EditWrapperModifiedTest,
+    ::testing::Values(
+        ModifiedCase{false, false, false}, // 普通文件未修改
+        ModifiedCase{true, false, true},   // 备份文件恒视为已修改
+        ModifiedCase{false, true, true})); // 文档撤销栈分叉视为已修改
+
+// ============================================================================
+// updatePath / 时间戳 / 草稿与备份判定
+// ============================================================================
+
+TEST_F(EditWrapperTest, UpdatePath_ValidPaths_SetsPathsAndMtime)
+{
+    // Arrange
+    const QString path = createFile("u.txt", QByteArray("content"));
+    ASSERT_FALSE(path.isEmpty());
+
+    // Act
+    m_wrapper->updatePath(path, path);
+
+    // Assert: 路径写入 TextEdit，mtime 记录为磁盘时间
+    EXPECT_EQ(m_wrapper->filePath(), path);
+    EXPECT_EQ(m_wrapper->textEditor()->getTruePath(), path);
+    EXPECT_EQ(m_wrapper->getLastModifiedTime(), QFileInfo(path).lastModified());
+}
+
+TEST_F(EditWrapperTest, UpdatePath_EmptyTruePath_FallsBackToFile)
+{
+    // Arrange
+    const QString path = createFile("u2.txt", QByteArray("c"));
+
+    // Act: 空 truePath → 回退为 file（B27）
+    m_wrapper->updatePath(path, QString());
+
+    // Assert
+    EXPECT_EQ(m_wrapper->filePath(), path);
+    EXPECT_EQ(m_wrapper->textEditor()->getTruePath(), path);
+}
+
+TEST_F(EditWrapperTest, LastModifiedTime_TextDateRoundTrip_PreservesTime)
+{
+    // Arrange: 生产契约（window.cpp）——传入 QDateTime::toString() 的 TextDate 文本。
+    // 注：源码 setLastModifiedTime 使用 fromString 默认格式重载（locale 相关），
+    // ISO 字符串（含 'T'）无法解析，疑似源码健壮性缺陷，已记 defects 不改源码。
+    const QDateTime stamp(QDate(2020, 5, 5), QTime(12, 30, 0));
+
+    // Act
+    m_wrapper->setLastModifiedTime(stamp.toString());
+
+    // Assert: 按 toString() 往返契约恢复同一时刻
+    EXPECT_EQ(m_wrapper->getLastModifiedTime(), stamp);
+    EXPECT_FALSE(m_wrapper->getLastModifiedTime().isNull());
+}
+
+TEST_F(EditWrapperTest, DraftAndBackupFile_VariousPaths_DetectCorrectly)
+{
+    // Arrange: 临时 XDG 数据目录下的草稿/备份文件（真实目录判定）
+    const QString draft = draftFilePath("d1.txt");
+    const QString backupDir = s_dataHome->filePath("xdg-data/deepin/deepin-editor/backup-files");
+    QDir().mkpath(backupDir);
+    const QString backup = QDir(backupDir).filePath("b1.txt");
+
+    const QString normal = createFile("n.txt", "n");
+
+    // Act & Assert
+    m_wrapper->updatePath(draft, draft);
+    EXPECT_TRUE(m_wrapper->isDraftFile());
+    EXPECT_FALSE(m_wrapper->isBackupFile());
+
+    m_wrapper->updatePath(backup, backup);
+    EXPECT_TRUE(m_wrapper->isBackupFile());
+    EXPECT_FALSE(m_wrapper->isDraftFile());
+
+    m_wrapper->updatePath(normal, normal);
+    EXPECT_FALSE(m_wrapper->isDraftFile());
+    EXPECT_FALSE(m_wrapper->isBackupFile());
+}
+
+// ============================================================================
+// updateModifyStatus / updateSaveAsFileName
+// ============================================================================
+
+TEST_F(EditWrapperTest, UpdateModifyStatus_TrueAndFalse_RecordsInWindow)
+{
+    // Arrange
+    const QString path = createFile("m.txt", "m");
+    m_wrapper->updatePath(path, path);
+
+    // Act: 置修改（B46 true 分支）
+    m_wrapper->updateModifyStatus(true);
+
+    // Assert: 文档修改态 + Window 回写参数透传
+    EXPECT_TRUE(m_wrapper->textEditor()->document()->isModified());
+    EXPECT_EQ(m_windowModifyCalls, 1);
+    EXPECT_EQ(m_lastWindowModifyPath, path);
+    EXPECT_TRUE(m_lastWindowModifyFlag);
+
+    // Act: 复位（false 分支，额外调用 updateSaveIndex）
+    m_wrapper->updateModifyStatus(false);
+    EXPECT_EQ(m_windowModifyCalls, 2);
+    EXPECT_FALSE(m_lastWindowModifyFlag);
+    EXPECT_FALSE(m_wrapper->textEditor()->document()->isModified());
+}
+
+TEST_F(EditWrapperTest, UpdateModifyStatus_DuringLoading_SkipsWindow)
+{
+    // Arrange: getFileLoading()==true（quit 置位触发早退分支 B45）
+    m_wrapper->setQuitFlag();
+    EXPECT_EQ(m_windowModifyCalls, 0);
+
+    // Act
+    m_wrapper->updateModifyStatus(true);
+
+    // Assert: 早退——未回写 Window，文档修改态未被触碰
+    EXPECT_EQ(m_windowModifyCalls, 0);
+    EXPECT_FALSE(m_wrapper->textEditor()->document()->isModified());
+}
+
+TEST_F(EditWrapperTest, UpdateSaveAsFileName_OldAndNewPaths_DelegatesToWindow)
+{
+    // Act
+    m_wrapper->updateSaveAsFileName(QStringLiteral("/old/a.txt"), QStringLiteral("/new/b.txt"));
+
+    // Assert
+    EXPECT_EQ(m_updateSaveAsCalls, 1);
+    EXPECT_EQ(m_lastSaveAsOld, QStringLiteral("/old/a.txt"));
+    EXPECT_EQ(m_lastSaveAsNew, QStringLiteral("/new/b.txt"));
+}
+
+// ============================================================================
+// readFile（B1-B4）
+// ============================================================================
+
+TEST_F(EditWrapperTest, ReadFile_MissingFile_ReturnsFalse)
+{
+    // Arrange: 指向不存在的临时路径
+    const QString missing = m_tempDir->filePath("no-such-file.txt");
+    m_wrapper->updatePath(missing, missing);
+
+    // Act
+    const bool ok = m_wrapper->readFile();
+
+    // Assert: open 失败分支；状态未损坏
+    EXPECT_FALSE(ok);
+    EXPECT_TRUE(m_wrapper->isPlainTextEmpty());
+    EXPECT_EQ(m_wrapper->getTextEncode(), QStringLiteral("UTF-8"));
+}
+
+TEST_F(EditWrapperTest, ReadFile_AutoDetect_LoadsContentAndEncode)
+{
+    // Arrange
+    const QString path = createFile("auto.txt", QByteArray("hello autodetect"));
+    m_wrapper->updatePath(path, path);
+
+    // Act: 缺省编码 → chardet 自动探测（B3）
+    const bool ok = m_wrapper->readFile();
+
+    // Assert: 内容入文档、编码落位、修改态复位
+    EXPECT_TRUE(ok);
+    EXPECT_EQ(m_wrapper->textEditor()->toPlainText(), QStringLiteral("hello autodetect"));
+    EXPECT_FALSE(m_wrapper->textEditor()->document()->isModified());
+    EXPECT_EQ(m_lastWindowModifyFlag, false); // updateModifyStatus(false) 已回写
+    EXPECT_GT(m_windowModifyCalls, 0);
+}
+
+TEST_F(EditWrapperTest, ReadFile_SpecifiedEncode_UpdatesCurEncode)
+{
+    // Arrange: 纯 ASCII 内容按 GBK 读回不受损
+    const QString path = createFile("gbk.txt", QByteArray("ascii only"));
+    m_wrapper->updatePath(path, path);
+
+    // Act: 指定编码（B4）
+    const bool ok = m_wrapper->readFile(QByteArray("GBK"));
+
+    // Assert
+    EXPECT_TRUE(ok);
+    EXPECT_EQ(m_wrapper->textEditor()->toPlainText(), QStringLiteral("ascii only"));
+    EXPECT_EQ(m_wrapper->getTextEncode(), QStringLiteral("GBK"));
+}
+
+TEST_F(EditWrapperTest, ReadFile_InvalidEncode_ReturnsFalse)
+{
+    // Arrange
+    const QString path = createFile("bad.txt", QByteArray("some content"));
+    m_wrapper->updatePath(path, path);
+
+    // Act: 非法编码名 → 编码转换失败（B2）
+    const bool ok = m_wrapper->readFile(QByteArray("__NO_SUCH_CODEC__"));
+
+    // Assert: 返回 false 且文档未被污染（强异常安全）
+    EXPECT_FALSE(ok);
+    EXPECT_TRUE(m_wrapper->isPlainTextEmpty());
+}
+
+// ============================================================================
+// saveFile（B5-B8）
+// ============================================================================
+
+TEST_F(EditWrapperTest, SaveFile_ValidFile_PersistsContentAndStatus)
+{
+    // Arrange
+    const QString path = createFile("save.txt", QByteArray(""));
+    m_wrapper->updatePath(path, path);
+    m_wrapper->textEditor()->setPlainText(QStringLiteral("persist me"));
+    m_wrapper->setTemFile(true); // 保存成功后应复位
+
+    // Act（B7 成功分支）
+    const bool ok = m_wrapper->saveFile();
+
+    // Assert: 落盘内容 + 状态复位 + Window 回写
+    EXPECT_TRUE(ok);
+    QFile f(path);
+    ASSERT_TRUE(f.open(QIODevice::ReadOnly));
+    EXPECT_EQ(f.readAll(), QByteArray("persist me"));
+    f.close();
+    EXPECT_FALSE(m_wrapper->isTemFile());
+    EXPECT_FALSE(m_wrapper->isModified());
+    EXPECT_GT(m_windowModifyCalls, 0);
+    EXPECT_EQ(m_lastWindowModifyPath, path);
+}
+
+TEST_F(EditWrapperTest, SaveFile_WithEncode_UpdatesCurEncodeState)
+{
+    // Arrange
+    const QString path = createFile("save2.txt", QByteArray(""));
+    m_wrapper->updatePath(path, path);
+    m_wrapper->textEditor()->setPlainText(QStringLiteral("abc"));
+
+    // Act（B6: encode 非空分支）
+    const bool ok = m_wrapper->saveFile(QByteArray("GBK"));
+
+    // Assert
+    EXPECT_TRUE(ok);
+    EXPECT_EQ(m_wrapper->getTextEncode(), QStringLiteral("GBK"));
+}
+
+TEST_F(EditWrapperTest, SaveFile_UnwritableTarget_ReturnsFalse)
+{
+    // Arrange: 不存在的父目录
+    const QString bad = m_tempDir->filePath("no-dir/x.txt");
+    m_wrapper->updatePath(bad, bad);
+    m_wrapper->textEditor()->setPlainText(QStringLiteral("will fail"));
+    m_iconMsgCalls = 0;
+
+    // Act（B8 失败分支：TextFileSaver 失败 + 浮动告警）
+    const bool ok = m_wrapper->saveFile();
+
+    // Assert
+    EXPECT_FALSE(ok);
+    EXPECT_EQ(m_iconMsgCalls, 1); // 无权限保存提示经 DMessageManager 发出
+    EXPECT_TRUE(m_lastIconMsg.contains("permission"));
+}
+
+TEST_F(EditWrapperTest, SaveFile_InPreviewMode_ReturnsFalse)
+{
+    // Arrange: 进入 NUL 预览模式（B5 早退分支）
+    const QString path = createFile("nul.txt", QByteArray("a\0b", 3));
+    m_wrapper->updatePath(path, path);
+    m_wrapper->handleFileLoadFinished("UTF-8", QByteArray("a\0b", 3), false, true);
+    ASSERT_TRUE(m_wrapper->isInvalidCharPreview());
+
+    // Act
+    const bool ok = m_wrapper->saveFile();
+
+    // Assert: 预览模式拒绝静默保存，状态未变
+    EXPECT_FALSE(ok);
+    EXPECT_TRUE(m_wrapper->isInvalidCharPreview());
+}
+
+// ============================================================================
+// getPlainTextContent（TEST_P：换行格式，B9）
+// ============================================================================
+
+class EditWrapperEndlineTest : public EditWrapperTest,
+                               public ::testing::WithParamInterface<EndlineCase> {};
+
+TEST_P(EditWrapperEndlineTest, GetPlainTextContent_EndlineVariants_ReturnsExpectedBytes)
+{
+    const EndlineCase c = GetParam();
+
+    // Arrange
+    m_wrapper->bottomBar()->setEndlineMenuText(c.format);
+    m_wrapper->textEditor()->setPlainText(QStringLiteral("a\nb"));
+
+    // Act
+    QByteArray out;
+    m_wrapper->getPlainTextContent(out);
+
+    // Assert: Unix 保持 \n；Windows 替换为 \r\n
+    EXPECT_EQ(out, QByteArray(c.expected));
+    EXPECT_EQ(m_wrapper->bottomBar()->getEndlineFormat(), c.format);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    EndlineMatrix, EditWrapperEndlineTest,
+    ::testing::Values(
+        EndlineCase{BottomBar::EndlineFormat::Unix, "a\nb"},
+        EndlineCase{BottomBar::EndlineFormat::Windows, "a\r\nb"}));
+
+// ============================================================================
+// saveAsFile（B10-B12）
+// ============================================================================
+
+TEST_F(EditWrapperTest, SaveAsFile_ValidPath_WritesFileAndMtime)
+{
+    // Arrange: 先挂旧路径（成功分支以 filePath() 记录 mtime）
+    const QString oldPath = createFile("as-old.txt", QByteArray("old"));
+    m_wrapper->updatePath(oldPath, oldPath);
+    m_wrapper->textEditor()->setPlainText(QStringLiteral("save-as-body"));
+    const QString target = m_tempDir->filePath("as-new.txt");
+
+    // Act（B10 成功）
+    const bool ok = m_wrapper->saveAsFile(target, QByteArray("UTF-8"));
+
+    // Assert: 新文件落盘 + mtime 记录为原文件时间
+    EXPECT_TRUE(ok);
+    QFile f(target);
+    ASSERT_TRUE(f.exists());
+    ASSERT_TRUE(f.open(QIODevice::ReadOnly));
+    EXPECT_EQ(f.readAll(), QByteArray("save-as-body"));
+    f.close();
+    EXPECT_EQ(m_wrapper->getLastModifiedTime(), QFileInfo(oldPath).lastModified());
+}
+
+TEST_F(EditWrapperTest, SaveAsFile_UnwritablePath_ReturnsFalse)
+{
+    // Arrange: 不存在的父目录（B11 失败 + 告警）
+    m_wrapper->textEditor()->setPlainText(QStringLiteral("x"));
+    m_iconMsgCalls = 0;
+
+    // Act
+    const bool ok = m_wrapper->saveAsFile(m_tempDir->filePath("no-dir/y.txt"), QByteArray("UTF-8"));
+
+    // Assert
+    EXPECT_FALSE(ok);
+    EXPECT_EQ(m_iconMsgCalls, 1);
+}
+
+TEST_F(EditWrapperTest, SaveAsFileNoArg_DialogRejected_ReturnsFalse)
+{
+    // Arrange: DFileDialog（QDialog::exec 虚派发）返回拒绝
+    m_qdialogResult = 0;
+
+    // Act（B12 拒绝分支）
+    const bool ok = m_wrapper->saveAsFile();
+
+    // Assert
+    EXPECT_FALSE(ok);
+    EXPECT_EQ(m_qdialogExecCalls, 1);
+}
+
+TEST_F(EditWrapperTest, SaveAsFileNoArg_AcceptedEmptySelection_ReturnsFalse)
+{
+    // Arrange: 接受但未选择文件（selectedFiles 为空 → 早退）
+    m_qdialogResult = 1; // QDialog::Accepted
+    m_selectedFiles.clear();
+
+    // Act
+    const bool ok = m_wrapper->saveAsFile();
+
+    // Assert
+    EXPECT_FALSE(ok);
+    EXPECT_EQ(m_qdialogExecCalls, 1);
+}
+
+TEST_F(EditWrapperTest, SaveAsFileNoArg_AcceptedWithSelection_SavesFile)
+{
+    // Arrange: 接受且选中临时路径
+    m_qdialogResult = 1;
+    m_selectedFiles = QStringList{m_tempDir->filePath("dlg-save.txt")};
+    m_wrapper->textEditor()->setPlainText(QStringLiteral("dialog body"));
+
+    // Act
+    const bool ok = m_wrapper->saveAsFile();
+
+    // Assert
+    EXPECT_TRUE(ok);
+    QFile f(m_selectedFiles.first());
+    ASSERT_TRUE(f.exists());
+    ASSERT_TRUE(f.open(QIODevice::ReadOnly));
+    EXPECT_EQ(f.readAll(), QByteArray("dialog body"));
+}
+
+// ============================================================================
+// saveTemFile（B25/B26）
+// ============================================================================
+
+TEST_F(EditWrapperTest, SaveTemFile_ValidDir_WritesBackupAndEncode)
+{
+    // Arrange
+    const QString target = m_tempDir->filePath("backup.txt");
+    m_wrapper->textEditor()->setPlainText(QStringLiteral("tem-body"));
+    const QString encBefore = m_wrapper->getTextEncode();
+
+    // Act（B25）
+    const bool ok = m_wrapper->saveTemFile(target);
+
+    // Assert
+    EXPECT_TRUE(ok);
+    QFile f(target);
+    ASSERT_TRUE(f.exists());
+    ASSERT_TRUE(f.open(QIODevice::ReadOnly));
+    EXPECT_EQ(f.readAll(), QByteArray("tem-body"));
+    f.close();
+    EXPECT_EQ(m_wrapper->m_sFirstEncode, encBefore); // m_sFirstEncode 同步为 m_sCurEncode
+}
+
+TEST_F(EditWrapperTest, SaveTemFile_UnwritableDir_ReturnsFalse)
+{
+    // Arrange（B26）
+    m_wrapper->textEditor()->setPlainText(QStringLiteral("x"));
+
+    // Act
+    const bool ok = m_wrapper->saveTemFile(m_tempDir->filePath("no-dir/t.txt"));
+
+    // Assert: 失败且目标文件未产生（强异常安全）
+    EXPECT_FALSE(ok);
+    EXPECT_FALSE(QFile::exists(m_tempDir->filePath("no-dir/t.txt")));
+}
+
+// ============================================================================
+// saveDraftFile（dialog 拒绝分支；成功路径在 reloadModify B24 一并覆盖）
+// ============================================================================
+
+TEST_F(EditWrapperTest, SaveDraftFile_DialogRejected_ReturnsFalse)
+{
+    // Arrange
+    m_qdialogResult = 0;
+
+    // Act
+    QString newFilePath;
+    const bool ok = m_wrapper->saveDraftFile(newFilePath);
+
+    // Assert: 拒绝即失败，出参未被污染
+    EXPECT_FALSE(ok);
+    EXPECT_TRUE(newFilePath.isEmpty());
+}
+
+// ============================================================================
+// reloadFileEncode（B13-B18）
+// ============================================================================
+
+TEST_F(EditWrapperTest, ReloadEncode_SameEncode_ReturnsFalse)
+{
+    // Arrange: 当前即 UTF-8
+    ASSERT_EQ(m_wrapper->getTextEncode(), QStringLiteral("UTF-8"));
+
+    // Act（B13）
+    const bool ok = m_wrapper->reloadFileEncode(QByteArray("UTF-8"));
+
+    // Assert: 编码未变、不重载
+    EXPECT_FALSE(ok);
+    EXPECT_EQ(m_wrapper->getTextEncode(), QStringLiteral("UTF-8"));
+}
+
+TEST_F(EditWrapperTest, ReloadEncode_DraftEmpty_ReturnsTrue)
+{
+    // Arrange: 草稿文件 + 空内容（B14）
+    const QString draft = draftFilePath("d2.txt", "");
+    m_wrapper->updatePath(draft, draft);
+    ASSERT_TRUE(m_wrapper->textEditor()->toPlainText().isEmpty());
+
+    // Act
+    const bool ok = m_wrapper->reloadFileEncode(QByteArray("GBK"));
+
+    // Assert: 直接切换编码并同步首编码
+    EXPECT_TRUE(ok);
+    EXPECT_EQ(m_wrapper->getTextEncode(), QStringLiteral("GBK"));
+    EXPECT_EQ(m_wrapper->m_sFirstEncode, QStringLiteral("GBK"));
+}
+
+TEST_F(EditWrapperTest, ReloadEncode_NotModified_ReadsFile)
+{
+    // Arrange: 未修改的普通文件（B18 else 分支 → readFile）
+    const QString path = createFile("plain.txt", QByteArray("reload-body"));
+    m_wrapper->updatePath(path, path);
+    m_tabCurrentName = QStringLiteral("plain.txt"); // 无 * 前缀
+
+    // Act
+    const bool ok = m_wrapper->reloadFileEncode(QByteArray("GBK"));
+
+    // Assert: 文件内容重新读入
+    EXPECT_TRUE(ok);
+    EXPECT_EQ(m_wrapper->textEditor()->toPlainText(), QStringLiteral("reload-body"));
+}
+
+TEST_F(EditWrapperTest, ReloadEncode_ModifiedDialogCancel_ReturnsFalse)
+{
+    // Arrange: 修改态（标签 * 前缀）+ 对话框取消（B15 res==0）
+    const QString path = createFile("mod.txt", QByteArray("mod-body"));
+    m_wrapper->updatePath(path, path);
+    m_tabCurrentName = QStringLiteral("*mod.txt"); // hasFlag=true
+    m_ddialogResult = 0;
+    const int dialogsBefore = m_ddialogExecCalls;
+
+    // Act
+    const bool ok = m_wrapper->reloadFileEncode(QByteArray("GBK"));
+
+    // Assert: 取消 → 不重载、编码不变（强异常安全）
+    EXPECT_FALSE(ok);
+    EXPECT_EQ(m_ddialogExecCalls, dialogsBefore + 1);
+    EXPECT_EQ(m_wrapper->getTextEncode(), QStringLiteral("UTF-8"));
+    EXPECT_TRUE(m_wrapper->isPlainTextEmpty()); // 未触发 readFile
+}
+
+TEST_F(EditWrapperTest, ReloadEncode_ModifiedDraftSaveFail_RollsBackEncode)
+{
+    // Arrange: 草稿 + 有内容（避开 B14 空/草稿早退）+ 标签 * 前缀（hasFlag）+
+    // 对话框选保存 + 草稿另存对话框被拒绝（B16 失败回滚）
+    const QString draft = draftFilePath("d3.txt", "draft-body");
+    m_wrapper->updatePath(draft, draft);
+    m_wrapper->textEditor()->setPlainText(QStringLiteral("draft-body"));
+    m_tabCurrentName = QStringLiteral("*d3.txt");
+    m_ddialogResult = 1; // 保存
+    m_qdialogResult = 0; // 草稿另存对话框拒绝 → saveDraftFile 失败
+
+    // Act
+    const bool ok = m_wrapper->reloadFileEncode(QByteArray("GBK"));
+
+    // Assert: 保存失败 → reloadSucc=false → 编码回滚为 tempEncode
+    EXPECT_FALSE(ok);
+    EXPECT_EQ(m_wrapper->getTextEncode(), QStringLiteral("UTF-8"));
+}
+
+TEST_F(EditWrapperTest, ReloadEncode_ModifiedSaveAsThenRead_ReturnsTrue)
+{
+    // Arrange: 普通文件 + 修改态 + 窗口另存成功（B17）
+    const QString path = createFile("sv.txt", QByteArray("sv-body"));
+    m_wrapper->updatePath(path, path);
+    m_tabCurrentName = QStringLiteral("*sv.txt"); // hasFlag → 对话框分支
+    m_ddialogResult = 1;                          // 保存
+    m_windowSaveAsResult = true;                  // Window::saveAsFile 成功
+    m_windowSaveAsCalls = 0;
+
+    // Act
+    const bool ok = m_wrapper->reloadFileEncode(QByteArray("GBK"));
+
+    // Assert: 另存 + 重读成功
+    EXPECT_TRUE(ok);
+    EXPECT_EQ(m_windowSaveAsCalls, 1);
+    EXPECT_EQ(m_wrapper->textEditor()->toPlainText(), QStringLiteral("sv-body"));
+    EXPECT_EQ(m_wrapper->getTextEncode(), QStringLiteral("GBK"));
+}
+
+// ============================================================================
+// reloadFileHighlight（B19/B20）
+// ============================================================================
+
+TEST_F(EditWrapperTest, ReloadHighlight_ValidDef_CreatesHighlighter)
+{
+    // Arrange: 注入渲染器（"Markdown" 识别成功后会触发视图切换链路）
+    m_renderer.ready = true;
+    m_wrapper->setMarkdownRendererForTest(&m_renderer);
+
+    // Act（B19: 有效 definition → 创建/配置高亮器）
+    m_wrapper->reloadFileHighlight(QStringLiteral("Markdown"));
+
+    // Assert: 高亮器创建 + markdown 识别 + 视图跃迁
+    EXPECT_NE(m_wrapper->getSyntaxHighlighter(), nullptr);
+    EXPECT_TRUE(m_wrapper->isMarkdownFile());
+    EXPECT_EQ(m_wrapper->viewMode(), ViewMode::LivePreview); // md 默认实时预览
+}
+
+TEST_F(EditWrapperTest, ReloadHighlight_InvalidDef_RemovesHighlighter)
+{
+    // Arrange: 先建高亮器再移除
+    m_renderer.ready = false;
+    m_wrapper->setMarkdownRendererForTest(&m_renderer);
+    m_wrapper->reloadFileHighlight(QStringLiteral("Markdown"));
+    ASSERT_NE(m_wrapper->getSyntaxHighlighter(), nullptr);
+
+    // Act（B20: 无效 definition → 移除高亮）
+    m_wrapper->reloadFileHighlight(QStringLiteral("NoSuchLang"));
+
+    // Assert
+    EXPECT_EQ(m_wrapper->getSyntaxHighlighter(), nullptr);
+    EXPECT_FALSE(m_wrapper->isMarkdownFile());
+}
+
+// ============================================================================
+// reloadModifyFile（B21-B24）
+// ============================================================================
+
+TEST_F(EditWrapperTest, ReloadModify_NotModified_ReloadsDiskContent)
+{
+    // Arrange: 缓冲与磁盘分叉（未修改分支 B21）
+    const QString path = createFile("rm1.txt", QByteArray("v1"));
+    m_wrapper->updatePath(path, path);
+    m_tabCurrentName = QStringLiteral("rm1.txt"); // 无 * 前缀
+    m_tabTextAt = QStringLiteral("rm1.txt");
+
+    // 磁盘更新为 v2（mtime 变化不影响 readFile）
+    QFile f(path);
+    ASSERT_TRUE(f.open(QIODevice::WriteOnly | QIODevice::Truncate));
+    f.write("v2");
+    f.close();
+
+    // Act
+    m_wrapper->reloadModifyFile();
+
+    // Assert: 未修改 → 直接重读磁盘；读入后修改态复位并回写 Window
+    EXPECT_EQ(m_wrapper->textEditor()->toPlainText(), QStringLiteral("v2"));
+    EXPECT_GT(m_windowModifyCalls, 0);
+    EXPECT_FALSE(m_lastWindowModifyFlag);
+}
+
+TEST_F(EditWrapperTest, ReloadModify_ModifiedCancel_KeepsBuffer)
+{
+    // Arrange: 修改态 + 对话框关闭（B22 res==0）
+    const QString path = createFile("rm2.txt", QByteArray("disk"));
+    m_wrapper->updatePath(path, path);
+    m_wrapper->textEditor()->setPlainText(QStringLiteral("buffer"));
+    m_tabCurrentName = QStringLiteral("*rm2.txt");
+    m_tabTextAt = QStringLiteral("*rm2.txt");
+    m_ddialogResult = 0;
+    const int dialogsBefore = m_ddialogExecCalls;
+
+    // Act
+    m_wrapper->reloadModifyFile();
+
+    // Assert: 关闭 → 缓冲保留，且确认弹窗只咨询了一次
+    EXPECT_EQ(m_wrapper->textEditor()->toPlainText(), QStringLiteral("buffer"));
+    EXPECT_EQ(m_ddialogExecCalls, dialogsBefore + 1);
+}
+
+TEST_F(EditWrapperTest, ReloadModify_ModifiedDiscard_ReloadsAndClearsTem)
+{
+    // Arrange: 修改态 + 丢弃（B23 res==1 → readFile + 复位 m_bIsTemFile）
+    const QString path = createFile("rm3.txt", QByteArray("fresh"));
+    m_wrapper->updatePath(path, path);
+    m_wrapper->textEditor()->setPlainText(QStringLiteral("stale"));
+    m_tabCurrentName = QStringLiteral("*rm3.txt");
+    m_tabTextAt = QStringLiteral("*rm3.txt");
+    m_ddialogResult = 1;
+    m_wrapper->setTemFile(true);
+    ASSERT_TRUE(m_wrapper->isTemFile());
+
+    // Act
+    m_wrapper->reloadModifyFile();
+
+    // Assert
+    EXPECT_EQ(m_wrapper->textEditor()->toPlainText(), QStringLiteral("fresh"));
+    EXPECT_FALSE(m_wrapper->isTemFile());
+}
+
+TEST_F(EditWrapperTest, ReloadModify_ModifiedSaveDraftFail_KeepsBuffer)
+{
+    // Arrange: 草稿 + 修改态 + 另存（B24 res==2）+ 草稿保存对话框拒绝
+    const QString draft = draftFilePath("d4.txt", "draft-disk");
+    m_wrapper->updatePath(draft, draft);
+    m_wrapper->textEditor()->setPlainText(QStringLiteral("draft-buffer"));
+    m_tabCurrentName = QStringLiteral("*d4.txt");
+    m_tabTextAt = QStringLiteral("*d4.txt");
+    m_ddialogResult = 2;
+    m_qdialogResult = 0; // saveDraftFile 拒绝 → 早退
+    const int fileDialogsBefore = m_qdialogExecCalls;
+
+    // Act
+    m_wrapper->reloadModifyFile();
+
+    // Assert: 保存失败早退，缓冲未被磁盘内容覆盖，草稿另存对话框被咨询
+    EXPECT_EQ(m_wrapper->textEditor()->toPlainText(), QStringLiteral("draft-buffer"));
+    EXPECT_EQ(m_qdialogExecCalls, fileDialogsBefore + 1);
+}
+
+// ============================================================================
+// hideWarningNotices / showNotify / checkForReload
+// ============================================================================
+
+TEST_F(EditWrapperTest, HideWarningNotices_WhenVisible_HidesNotices)
+{
+    // Arrange: 显示容器使 isVisible 语义生效
+    m_container->show();
+    QApplication::processEvents();
+    m_wrapper->m_pWaringNotices->show();
+    QApplication::processEvents();
+    EXPECT_TRUE(m_wrapper->m_pWaringNotices->isVisible());
+
+    // Act
+    m_wrapper->hideWarningNotices();
+
+    // Assert
+    EXPECT_FALSE(m_wrapper->m_pWaringNotices->isVisible());
+}
+
+TEST_F(EditWrapperTest, ShowNotify_EmptyMessage_SendsNothing)
+{
+    // Act（B33 早退）
+    m_wrapper->showNotify(QString());
+
+    // Assert: 不发浮动消息
+    EXPECT_EQ(m_floatMsgCalls, 0);
+    EXPECT_EQ(m_iconMsgCalls, 0);
+}
+
+TEST_F(EditWrapperTest, ShowNotify_WarningFlag_SendsWarningFloat)
+{
+    // Act（B34: warning=true 走告警路径）
+    m_wrapper->showNotify(QStringLiteral("something went wrong"), true);
+
+    // Assert
+    EXPECT_EQ(m_floatMsgCalls, 1);
+    EXPECT_EQ(m_lastFloatMsg, QStringLiteral("something went wrong"));
+}
+
+TEST_F(EditWrapperTest, ShowNotify_NormalMessage_SendsOkFloat)
+{
+    // Act（B35: 非告警且无只读限制 → 正常路径）
+    m_wrapper->showNotify(QStringLiteral("all good"), false);
+
+    // Assert
+    EXPECT_EQ(m_floatMsgCalls, 1);
+    EXPECT_EQ(m_lastFloatMsg, QStringLiteral("all good"));
+}
+
+TEST_F(EditWrapperTest, ShowNotify_ReadOnlyPermission_SendsWarningFloat)
+{
+    // Arrange: 文件只读权限 → 即使非告警也走告警分支（B34 的 || 右支）
+    m_wrapper->textEditor()->setReadOnlyPermission(true);
+
+    // Act
+    m_wrapper->showNotify(QStringLiteral("readonly file"), false);
+
+    // Assert
+    EXPECT_EQ(m_floatMsgCalls, 1);
+    EXPECT_EQ(m_lastFloatMsg, QStringLiteral("readonly file"));
+}
+
+TEST_F(EditWrapperTest, CheckForReload_DraftFile_SkipsCheck)
+{
+    // Arrange: 草稿文件早退（B29），不会进入 50ms 定时检查
+    const QString draft = draftFilePath("d5.txt", "d");
+    m_wrapper->updatePath(draft, draft);
+    m_widgetMsgCalls = 0;
+
+    // Act
+    m_wrapper->checkForReload();
+    EXPECT_TRUE(waitUntil([] { return true; }, 300)); // 越过 singleShot(50ms)
+
+    // Assert: 无任何通知
+    EXPECT_EQ(m_widgetMsgCalls, 0);
+    EXPECT_TRUE(m_wrapper->m_pWaringNotices->isHidden());
+}
+
+TEST_F(EditWrapperTest, CheckForReload_UnchangedFile_NoNotice)
+{
+    // Arrange: mtime 与磁盘一致（B30）
+    const QString path = createFile("ck1.txt", "c");
+    m_wrapper->updatePath(path, path); // m_tModifiedDateTime = 磁盘 mtime
+    m_widgetMsgCalls = 0;
+
+    // Act: 越过 singleShot(50ms) 定时检查
+    m_wrapper->checkForReload();
+    QThread::msleep(200);
+    QApplication::processEvents();
+
+    // Assert: 无任何通知
+    EXPECT_EQ(m_widgetMsgCalls, 0);
+    EXPECT_TRUE(m_wrapper->m_pWaringNotices->isHidden());
+}
+
+TEST_F(EditWrapperTest, CheckForReload_FileRemoved_ShowsSaveAsNotice)
+{
+    // Arrange: 文件被删除（B31）
+    const QString path = createFile("ck2.txt", "c");
+    m_wrapper->updatePath(path, path);
+    QFile::remove(path);
+    m_widgetMsgCalls = 0;
+
+    // Act
+    m_wrapper->checkForReload();
+
+    // Assert: 提示"文件被删除，立即保存？"
+    EXPECT_TRUE(waitUntil([this] { return m_widgetMsgCalls > 0; }, 2000));
+    EXPECT_EQ(m_widgetMsgCalls, 1);
+    EXPECT_FALSE(m_wrapper->m_pWaringNotices->isHidden());
+}
+
+TEST_F(EditWrapperTest, CheckForReload_FileChanged_ShowsReloadNotice)
+{
+    // Arrange: mtime 分叉（B32）——手工把记录时间拨到过去（TextDate 契约，见 LastModifiedTime）
+    const QString path = createFile("ck3.txt", "c");
+    m_wrapper->updatePath(path, path);
+    m_wrapper->setLastModifiedTime(
+        QDateTime(QDate(2001, 1, 1), QTime(0, 0, 0)).toString());
+    m_widgetMsgCalls = 0;
+
+    // Act
+    m_wrapper->checkForReload();
+
+    // Assert: 提示"文件已在磁盘上变更，重新加载？"
+    EXPECT_TRUE(waitUntil([this] { return m_widgetMsgCalls > 0; }, 2000));
+    EXPECT_EQ(m_widgetMsgCalls, 1);
+    EXPECT_FALSE(m_wrapper->m_pWaringNotices->isHidden());
+}
+
+// ============================================================================
+// 行号 / 空白符 / 编码清理信号
+// ============================================================================
+
+TEST_F(EditWrapperTest, SetLineNumberShow_ShowAndHide_TogglesAreaAndFlag)
+{
+    auto *area = m_wrapper->textEditor()->getLeftAreaWidget()->m_pLineNumberArea;
+    ASSERT_NE(area, nullptr);
+
+    // Act 1: 隐藏（B37 !bIsShow 分支）
+    m_wrapper->setLineNumberShow(false, false);
+    // Assert 1
+    EXPECT_TRUE(area->isHidden());
+    EXPECT_FALSE(m_wrapper->textEditor()->bIsSetLineNumberWidth);
+
+    // Act 2: 显示（B36 bIsShow && !bIsFirstShow 分支）
+    m_wrapper->setLineNumberShow(true, false);
+    // Assert 2
+    EXPECT_FALSE(area->isHidden());
+    EXPECT_TRUE(m_wrapper->textEditor()->bIsSetLineNumberWidth);
+
+    // Act 3: 首次显示（bIsFirstShow=true → 不触发 show/hide，仅置位）
+    m_wrapper->setLineNumberShow(true, true);
+    EXPECT_TRUE(m_wrapper->textEditor()->bIsSetLineNumberWidth);
+}
+
+TEST_F(EditWrapperTest, SetShowBlankCharacter_TrueAndFalse_TogglesTextOptionFlags)
+{
+    // Act 1（B38 置位分支）
+    m_wrapper->setShowBlankCharacter(true);
+    // Assert 1
+    EXPECT_TRUE(m_wrapper->textEditor()->document()->defaultTextOption().flags()
+                & QTextOption::ShowTabsAndSpaces);
+
+    // Act 2（B39 清除分支）
+    m_wrapper->setShowBlankCharacter(false);
+    // Assert 2
+    EXPECT_FALSE(m_wrapper->textEditor()->document()->defaultTextOption().flags()
+                 & QTextOption::ShowTabsAndSpaces);
+}
+
+class EditWrapperClearDoubleTest : public EditWrapperTest,
+                                   public ::testing::WithParamInterface<ClearDoubleCase> {};
+
+TEST_P(EditWrapperClearDoubleTest, ClearDoubleCharaterEncode_ParamVariants_EmitsAsExpected)
+{
+    const ClearDoubleCase c = GetParam();
+
+    // Arrange: 真实临时文件（baseName + 大小决定分支）
+    const QString path = createFile(c.fileName, QByteArray(c.fileSize, 'a'));
+    ASSERT_FALSE(path.isEmpty());
+    m_wrapper->updatePath(path, path);
+
+    QSignalSpy spy(m_wrapper, &EditWrapper::sigClearDoubleCharaterEncode);
+
+    // Act
+    m_wrapper->clearDoubleCharaterEncode();
+
+    // Assert（B40: 关键字+≤500KB 发信号；B41: >500KB 不发；B42: 无关键字不发）
+    EXPECT_EQ(spy.count(), c.expectEmit ? 1 : 0);
+    if (c.expectEmit)
+        EXPECT_FALSE(m_wrapper->filePath().isEmpty());
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    ClearDoubleMatrix, EditWrapperClearDoubleTest,
+    ::testing::Values(
+        ClearDoubleCase{QStringLiteral("double_a.txt"), 100, true},
+        ClearDoubleCase{QStringLiteral("four.txt"), 100, true},
+        ClearDoubleCase{QStringLiteral("user.txt"), 100, true},
+        ClearDoubleCase{QStringLiteral("normal.txt"), 100, false},
+        ClearDoubleCase{QStringLiteral("double_big.txt"), 500 * 1024 + 1, false}));
+
+// ============================================================================
+// 底部栏 / 高亮刷新
+// ============================================================================
+
+TEST_F(EditWrapperTest, UpdateBottomBarWordCnt_GivenCount_RefreshesLabel)
+{
+    // Act
+    m_wrapper->UpdateBottomBarWordCnt(42);
+
+    // Assert: 标签更新为 count-1（源码语义）
+    const QString label = m_wrapper->bottomBar()->m_pCharCountLabel->text();
+    EXPECT_TRUE(label.contains(QStringLiteral("41")));
+    EXPECT_FALSE(label.contains(QStringLiteral("42")));
+}
+
+TEST_F(EditWrapperTest, OnUpdateHighlighter_VariousStates_NoUndueStateChange)
+{
+    // Arrange 1: 无高亮器 → 空跑（B: m_pSyntaxHighlighter null）
+    m_wrapper->OnUpdateHighlighter();
+    EXPECT_EQ(m_wrapper->getSyntaxHighlighter(), nullptr);
+    EXPECT_FALSE(m_wrapper->m_bHighlighterAll);
+
+    // Arrange 2: 有高亮器 + quit → 跳过（B: !m_bQuit 短路）
+    m_renderer.ready = false;
+    m_wrapper->setMarkdownRendererForTest(&m_renderer);
+    m_wrapper->reloadFileHighlight(QStringLiteral("Markdown"));
+    m_wrapper->setQuitFlag();
+    m_wrapper->OnUpdateHighlighter();
+    EXPECT_FALSE(m_wrapper->m_bHighlighterAll); // quit 分支未置位
+}
+
+TEST_F(EditWrapperTest, UpdateHighlighterAll_WithHighlighter_MarksAllDone)
+{
+    // Arrange
+    m_renderer.ready = false;
+    m_wrapper->setMarkdownRendererForTest(&m_renderer);
+    m_wrapper->reloadFileHighlight(QStringLiteral("Markdown"));
+    m_wrapper->textEditor()->setPlainText(QStringLiteral("line1\nline2\nline3"));
+    ASSERT_FALSE(m_wrapper->m_bHighlighterAll);
+
+    // Act（B43: 全量重刷）
+    m_wrapper->updateHighlighterAll();
+
+    // Assert: 全量标志置位且块结构未被破坏（3 行文本 = 3 块）
+    EXPECT_TRUE(m_wrapper->m_bHighlighterAll);
+    EXPECT_EQ(m_wrapper->textEditor()->document()->blockCount(), 3);
+}
+
+TEST_F(EditWrapperTest, UpdateHighlighterAll_WhenQuit_Skips)
+{
+    // Arrange（B44: m_bQuit → 跳过）
+    m_renderer.ready = false;
+    m_wrapper->setMarkdownRendererForTest(&m_renderer);
+    m_wrapper->reloadFileHighlight(QStringLiteral("Markdown"));
+    m_wrapper->setQuitFlag();
+
+    // Act
+    m_wrapper->updateHighlighterAll();
+
+    // Assert: quit 分支跳过重刷，空文档块结构保持初始 1 块
+    EXPECT_FALSE(m_wrapper->m_bHighlighterAll);
+    EXPECT_EQ(m_wrapper->textEditor()->document()->blockCount(), 1);
+}
+
+// ============================================================================
+// 主题切换（TEST_P：亮/暗，B63/B64）
+// ============================================================================
+
+QString writeThemeFile(const QString &backgroundColor, const QString &textColor)
+{
+    static QTemporaryDir themeDir;
+    const QString path = themeDir.filePath("t.theme");
+    QFile f(path);
+    f.open(QIODevice::WriteOnly | QIODevice::Truncate);
+    f.write(QString("{\"editor-colors\": {\"background-color\": \"%1\"},"
+                    " \"Normal\": {\"text-color\": \"%2\"}}")
+                .arg(backgroundColor, textColor)
+                .toUtf8());
+    f.close();
+    return path;
+}
+
+class EditWrapperThemeTest : public EditWrapperTest,
+                             public ::testing::WithParamInterface<ThemeCase> {};
+
+TEST_P(EditWrapperThemeTest, ThemeChange_LightAndDark_AppliesPaletteAndTheme)
+{
+    const ThemeCase c = GetParam();
+
+    // Arrange: 渲染器注入（applyTheme 可观测）+ 主题文件
+    m_renderer.ready = false;
+    m_wrapper->setMarkdownRendererForTest(&m_renderer);
+    const int applyBefore = m_renderer.applyThemeCalls;
+    const QString themePath = writeThemeFile(c.backgroundColor, c.textColor);
+
+    // Act
+    m_wrapper->OnThemeChangeSlot(themePath);
+
+    // Assert: 底栏调色板 + 渲染器主题注入（B63/B64 两分支按背景亮度选择深浅主题）
+    EXPECT_EQ(m_wrapper->bottomBar()->palette().color(QPalette::Window).name(),
+              QColor(c.backgroundColor).name());
+    EXPECT_EQ(m_wrapper->bottomBar()->palette().color(QPalette::Text).name(),
+              QColor(c.textColor).name());
+    EXPECT_EQ(m_renderer.applyThemeCalls, applyBefore + 1);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    ThemeMatrix, EditWrapperThemeTest,
+    ::testing::Values(
+        ThemeCase{QStringLiteral("#2b2b2b"), QStringLiteral("#ffffff")}, // 暗色 → DarkTheme
+        ThemeCase{QStringLiteral("#ffffff"), QStringLiteral("#000000")})); // 亮色 → LightTheme
+
+TEST_F(EditWrapperTest, ThemeChange_WithoutHighlighter_StillAppliesPalette)
+{
+    // Arrange: 无高亮器 + 无渲染器（B: m_pSyntaxHighlighter null 分支）
+    ASSERT_EQ(m_wrapper->getSyntaxHighlighter(), nullptr);
+    const QString themePath = writeThemeFile(QStringLiteral("#101010"), QStringLiteral("#eeeeee"));
+
+    // Act
+    m_wrapper->OnThemeChangeSlot(themePath);
+
+    // Assert: 调色板仍生效（背景 + 前景），无崩溃
+    EXPECT_EQ(m_wrapper->bottomBar()->palette().color(QPalette::Window).name(),
+              QStringLiteral("#101010"));
+    EXPECT_EQ(m_wrapper->bottomBar()->palette().color(QPalette::Text).name(),
+              QStringLiteral("#eeeeee"));
+}
+
+// ============================================================================
+// 文件加载管线：handleFilePreProcess / handleFileLoadFinished（B56-B62）
+// ============================================================================
+
+TEST_F(EditWrapperTest, HandleLoadFinished_HappyPath_LoadsContentAndEncode)
+{
+    // Arrange（B57: 无预处理 → reinitOnFileLoad）
+    const QString path = createFile("happy.txt", QByteArray("ignored-disk"));
+    m_wrapper->updatePath(path, path);
+    m_recentAddCalls = 0;
+
+    // Act
+    m_wrapper->handleFileLoadFinished("UTF-8", QByteArray("happy-body"), false, false);
+
+    // Assert: 内容 + 编码 + 最近使用记录（非草稿）
+    EXPECT_EQ(m_wrapper->textEditor()->toPlainText(), QStringLiteral("happy-body"));
+    EXPECT_EQ(m_wrapper->getTextEncode(), QStringLiteral("UTF-8"));
+    EXPECT_EQ(m_wrapper->m_sFirstEncode, QStringLiteral("UTF-8"));
+    EXPECT_EQ(m_recentAddCalls, 1);
+    EXPECT_FALSE(m_wrapper->isInvalidCharPreview());
+}
+
+TEST_F(EditWrapperTest, HandleLoadFinished_ErrorExistingFile_ShowsNotices)
+{
+    // Arrange（B58: error=true 且文件存在 → onReadAllocError）
+    const QString path = createFile("err.txt", QByteArray("x"));
+    m_wrapper->updatePath(path, path);
+    m_widgetMsgCalls = 0;
+
+    // Act
+    m_wrapper->handleFileLoadFinished("UTF-8", QByteArray(), true, false);
+
+    // Assert: 只读模式 + 告警通知 + 文档清空
+    EXPECT_TRUE(m_wrapper->textEditor()->getReadOnlyMode());
+    EXPECT_EQ(m_widgetMsgCalls, 1);
+    EXPECT_FALSE(m_wrapper->m_pWaringNotices->isHidden());
+    EXPECT_TRUE(m_wrapper->isPlainTextEmpty());
+}
+
+TEST_F(EditWrapperTest, HandleLoadFinished_ErrorMissingFile_Silent)
+{
+    // Arrange（B59: error=true 且文件不存在 → 静默处理（新建文件场景））
+    const QString path = m_tempDir->filePath("brand-new.txt");
+    m_wrapper->updatePath(path, path);
+    m_widgetMsgCalls = 0;
+
+    // Act
+    m_wrapper->handleFileLoadFinished("UTF-8", QByteArray(), true, false);
+
+    // Assert: 不弹通知、不进只读
+    EXPECT_EQ(m_widgetMsgCalls, 0);
+    EXPECT_TRUE(m_wrapper->m_pWaringNotices->isHidden());
+    EXPECT_FALSE(m_wrapper->textEditor()->getReadOnlyMode());
+}
+
+TEST_F(EditWrapperTest, HandleLoadFinished_HasNul_EntersPreview)
+{
+    // Arrange（B60: hasNul=true → 无效字符预览模式）
+    const QString path = createFile("nul2.txt", QByteArray("a\0b", 3));
+    m_wrapper->updatePath(path, path);
+
+    // Act
+    m_wrapper->handleFileLoadFinished("UTF-8", QByteArray("a\0b", 3), false, true);
+
+    // Assert: 预览态 + 只读 + 原路径记录 + 通知展示
+    EXPECT_TRUE(m_wrapper->isInvalidCharPreview());
+    EXPECT_FALSE(m_wrapper->isInvalidCharEditAllowed());
+    EXPECT_EQ(m_wrapper->invalidCharOriginalPath(), path);
+    EXPECT_TRUE(m_wrapper->textEditor()->isReadOnly());
+    EXPECT_FALSE(m_wrapper->m_pWaringNotices->isHidden());
+    EXPECT_EQ(m_widgetMsgCalls, 1);
+    EXPECT_NE(m_wrapper->getSyntaxHighlighter(), nullptr); // 预览高亮器已创建
+}
+
+TEST_F(EditWrapperTest, HandleLoadFinished_CursorPreset_RestoresOnce)
+{
+    // Arrange（B61: 预设恢复光标）
+    const QString path = createFile("cur.txt", QByteArray("x"));
+    m_wrapper->updatePath(path, path);
+    m_wrapper->setRestoreCursorPosition(5);
+
+    // Act
+    m_wrapper->handleFileLoadFinished("UTF-8", QByteArray("0123456789"), false, false);
+
+    // Assert: 光标恢复且预设值一次性消费
+    EXPECT_EQ(m_wrapper->textEditor()->textCursor().position(), 5);
+    EXPECT_EQ(m_wrapper->m_nRestoreCursorPosition, -1);
+}
+
+TEST_F(EditWrapperTest, HandleLoadFinished_HistoryJsonMatch_RestoresCursor)
+{
+    // Arrange（B62: 浏览历史 JSON 恢复光标）
+    const QString path = createFile("hist.txt", QByteArray("x"));
+    m_wrapper->updatePath(path, path);
+
+    QJsonObject obj;
+    obj.insert("localPath", path);
+    obj.insert("cursorPosition", QStringLiteral("7"));
+    const QStringList history{QString::fromUtf8(QJsonDocument(obj).toJson(QJsonDocument::Compact))};
+    Settings::instance()->settings->option("advance.editor.browsing_history_temfile")
+        ->setValue(history);
+
+    // Act
+    m_wrapper->handleFileLoadFinished("UTF-8", QByteArray("0123456789"), false, false);
+
+    // Assert: 历史命中 → 光标置 7，且预设恢复值未被占用（保持 -1）
+    EXPECT_EQ(m_wrapper->textEditor()->textCursor().position(), 7);
+    EXPECT_EQ(m_wrapper->m_nRestoreCursorPosition, -1);
+    EXPECT_EQ(m_wrapper->textEditor()->toPlainText(), QStringLiteral("0123456789"));
+
+    // Cleanup: 复位共享单例设置，避免用例间污染
+    Settings::instance()->settings->option("advance.editor.browsing_history_temfile")
+        ->setValue(QStringList());
+}
+
+TEST_F(EditWrapperTest, FilePreProcess_GivenEncodeAndContent_InsertsAndFlags)
+{
+    // Arrange（B56）
+    const QString path = createFile("pre.txt", QByteArray("x"));
+    m_wrapper->updatePath(path, path);
+    EXPECT_FALSE(m_wrapper->m_bHasPreProcess);
+
+    // Act
+    m_wrapper->handleFilePreProcess("GBK", QByteArray("pre-view"));
+
+    // Assert: 内容先插入 + 预处理标识置位
+    EXPECT_EQ(m_wrapper->textEditor()->toPlainText(), QStringLiteral("pre-view"));
+    EXPECT_TRUE(m_wrapper->m_bHasPreProcess);
+
+    // Act 2: 预处理后再 finish → 跳过 reinitOnFileLoad（编码保持预处理值）
+    m_wrapper->handleFileLoadFinished("UTF-8", QByteArray("pre-view"), false, false);
+    EXPECT_EQ(m_wrapper->getTextEncode(), QStringLiteral("GBK"));
+}
+
+TEST_F(EditWrapperTest, HandleLoadFinished_TemFileFlag_MarksModified)
+{
+    // Arrange
+    const QString path = createFile("tem-load.txt", QByteArray("x"));
+    m_wrapper->updatePath(path, path);
+    m_wrapper->setTemFile(true);
+    m_windowModifyCalls = 0;
+
+    // Act
+    m_wrapper->handleFileLoadFinished("UTF-8", QByteArray("body"), false, false);
+
+    // Assert: 备份文件加载完成后回写修改态（m_bFileLoading 复位后的那次生效）
+    EXPECT_TRUE(m_lastWindowModifyFlag);
+    EXPECT_GT(m_windowModifyCalls, 0);
+}
+
+// ============================================================================
+// openFile（端到端：真实 FileLoadThread 异步读取临时文件）
+// ============================================================================
+
+TEST_F(EditWrapperTest, OpenFile_RealTempFile_LoadsContentEndToEnd)
+{
+    // Arrange
+    const QString path = createFile("open.txt", QByteArray("open-content"));
+    ASSERT_FALSE(path.isEmpty());
+
+    // Act: 异步线程加载，轮询事件循环直至内容就位
+    m_wrapper->openFile(path, path, false);
+    ASSERT_TRUE(waitUntil([this] { return !m_wrapper->isPlainTextEmpty(); }));
+
+    // Assert: 路径 + 内容 + 非备份态
+    EXPECT_EQ(m_wrapper->filePath(), path);
+    EXPECT_EQ(m_wrapper->textEditor()->toPlainText(), QStringLiteral("open-content"));
+    EXPECT_FALSE(m_wrapper->isTemFile());
+    EXPECT_FALSE(m_wrapper->getFileLoading());
+}
+
+TEST_F(EditWrapperTest, OpenFile_TemFileFlag_KeepsTemState)
+{
+    // Arrange
+    const QString path = createFile("open-tem.txt", QByteArray("tem-content"));
+
+    // Act
+    m_wrapper->openFile(path, path, true);
+    ASSERT_TRUE(waitUntil([this] { return !m_wrapper->isPlainTextEmpty(); }));
+
+    // Assert: 备份标志透传，加载完成后回写修改态 true
+    EXPECT_TRUE(m_wrapper->isTemFile());
+    EXPECT_TRUE(waitUntil([this] { return m_windowModifyCalls > 0; }));
+    EXPECT_TRUE(m_lastWindowModifyFlag);
+}
+
+// ============================================================================
+// customEvent（B55: >40MB 内容走 ParseFileEvent 事件分片队列）
+// ============================================================================
+
+TEST_F(EditWrapperTest, CustomEvent_LargeContent_ParsesInSteps)
+{
+    // Arrange: 40MB+1（> 40MB 阈值）→ loadContent 投递 ParseFileEvent，
+    // customEvent 在事件循环中分片插入（每片 1MB）。
+    // 内容按行组织（避免单巨型文本块的二次级布局开销）
+    const QString path = createFile("big.txt", QByteArray("x"));
+    m_wrapper->updatePath(path, path);
+    const int size = 40 * 1024 * 1024 + 1;
+    QByteArray line = QByteArray(63, 'a') + '\n';
+    QByteArray big;
+    big.reserve(size);
+    while (big.size() + line.size() <= size)
+        big.append(line);
+    big.append(QByteArray(size - big.size(), 'a')); // 补足至精确大小
+
+    // Act
+    m_wrapper->handleFileLoadFinished("UTF-8", big, false, false);
+
+    // Assert: 全量内容经事件队列分片进入文档
+    EXPECT_EQ(m_wrapper->textEditor()->toPlainText().size(), size);
+    EXPECT_FALSE(m_wrapper->getFileLoading());
+}
+
+// ============================================================================
+// 无效字符预览模式：onEditAnyway / exit / forceSave（B47/B48）
+// ============================================================================
+
+static void enterPreview(EditWrapper *wrapper, QTemporaryDir *dir, const QByteArray &content)
+{
+    const QString path = QDir(dir->path()).filePath("pv.txt");
+    QFile f(path);
+    f.open(QIODevice::WriteOnly);
+    f.write(content);
+    f.close();
+    wrapper->updatePath(path, path);
+    wrapper->handleFileLoadFinished("UTF-8", content, false, true);
+}
+
+TEST_F(EditWrapperTest, OnEditAnyway_InPreviewMode_EnablesEditing)
+{
+    // Arrange: 进入预览
+    enterPreview(m_wrapper, m_tempDir, QByteArray("a\0b", 3));
+    ASSERT_TRUE(m_wrapper->isInvalidCharPreview());
+    ASSERT_TRUE(m_wrapper->textEditor()->isReadOnly());
+
+    // Act
+    m_wrapper->onEditAnyway();
+
+    // Assert: 允许编辑但预览标记保留（直到另存成功）
+    EXPECT_TRUE(m_wrapper->isInvalidCharEditAllowed());
+    EXPECT_FALSE(m_wrapper->textEditor()->isReadOnly());
+    EXPECT_TRUE(m_wrapper->isInvalidCharPreview()); // 语义：预览态保持
+}
+
+TEST_F(EditWrapperTest, ExitInvalidCharPreview_AfterPreview_ResetsAllState)
+{
+    // Arrange
+    enterPreview(m_wrapper, m_tempDir, QByteArray("a\0b", 3));
+    ASSERT_TRUE(m_wrapper->isInvalidCharPreview());
+
+    // Act
+    m_wrapper->exitInvalidCharPreview();
+
+    // Assert: 全量复位
+    EXPECT_FALSE(m_wrapper->isInvalidCharPreview());
+    EXPECT_FALSE(m_wrapper->isInvalidCharEditAllowed());
+    EXPECT_TRUE(m_wrapper->invalidCharOriginalPath().isEmpty());
+    EXPECT_FALSE(m_wrapper->textEditor()->isReadOnly());
+    EXPECT_TRUE(m_wrapper->m_pWaringNotices->isHidden());
+}
+
+TEST_F(EditWrapperTest, ForceSave_WritableOriginal_WritesAndExitsPreview)
+{
+    // Arrange: 编辑后强制保存回原路径
+    enterPreview(m_wrapper, m_tempDir, QByteArray("a\0b", 3));
+    m_wrapper->onEditAnyway();
+    m_wrapper->textEditor()->setPlainText(QStringLiteral("forced-clean"));
+    m_wrapper->setTemFile(true);
+
+    // Act（B47 成功）
+    const bool ok = m_wrapper->forceSaveInvalidCharFile();
+
+    // Assert: 原路径内容更新 + 预览退出 + 备份态复位
+    EXPECT_TRUE(ok);
+    QFile f(m_tempDir->filePath("pv.txt"));
+    ASSERT_TRUE(f.open(QIODevice::ReadOnly));
+    EXPECT_EQ(f.readAll(), QByteArray("forced-clean"));
+    f.close();
+    EXPECT_FALSE(m_wrapper->isInvalidCharPreview());
+    EXPECT_FALSE(m_wrapper->isTemFile());
+}
+
+TEST_F(EditWrapperTest, ForceSave_UnwritableTarget_KeepsPreview)
+{
+    // Arrange: 原路径只读 → 保存失败（B48）
+    enterPreview(m_wrapper, m_tempDir, QByteArray("a\0b", 3));
+    const QString original = m_wrapper->invalidCharOriginalPath();
+    makeUnwritable(original);
+
+    // Act
+    const bool ok = m_wrapper->forceSaveInvalidCharFile();
+
+    // Assert: 失败且预览态保持（强异常安全）
+    EXPECT_FALSE(ok);
+    EXPECT_TRUE(m_wrapper->isInvalidCharPreview());
+    EXPECT_EQ(m_wrapper->invalidCharOriginalPath(), original);
+}
+
+// ============================================================================
+// 视图模式（B49-B52）+ Markdown 识别（B53/B54）
+// ============================================================================
+
+TEST_F(EditWrapperTest, SetViewMode_WysiwygOrNonMdLivePreview_Rejected)
+{
+    // Arrange
+    QSignalSpy spy(m_wrapper, &EditWrapper::viewModeChanged);
+
+    // Act（B49: FSM 拒绝——Wysiwyg 阶段二不可达；非 md 不可 LivePreview）
+    const bool wysiwyg = m_wrapper->setViewMode(ViewMode::Wysiwyg);
+    const bool live = m_wrapper->setViewMode(ViewMode::LivePreview); // 当前非 md
+
+    // Assert: 拒绝且模式不变、无信号
+    EXPECT_FALSE(wysiwyg);
+    EXPECT_FALSE(live);
+    EXPECT_EQ(m_wrapper->viewMode(), ViewMode::Edit);
+    EXPECT_EQ(spy.count(), 0);
+}
+
+TEST_F(EditWrapperTest, SetViewMode_ReadViewOnNonMd_TogglesReadOnlyText)
+{
+    // Arrange
+    QSignalSpy spy(m_wrapper, &EditWrapper::viewModeChanged);
+    ASSERT_FALSE(m_wrapper->textEditor()->getReadOnlyMode());
+
+    // Act（B50: ReadView + 非 md → 纯文本只读）
+    const bool ok = m_wrapper->setViewMode(ViewMode::ReadView);
+
+    // Assert: 只读 + 信号
+    EXPECT_TRUE(ok);
+    EXPECT_TRUE(m_wrapper->textEditor()->getReadOnlyMode());
+    EXPECT_EQ(m_wrapper->viewMode(), ViewMode::ReadView);
+    ASSERT_EQ(spy.count(), 1);
+    EXPECT_EQ(spy.at(0).at(0).value<ViewMode>(), ViewMode::ReadView);
+
+    // Act 2: 切回 Edit → 恢复可编辑（B: m_bReadOnlyByViewMode 复位分支）
+    EXPECT_TRUE(m_wrapper->setViewMode(ViewMode::Edit));
+    EXPECT_FALSE(m_wrapper->textEditor()->getReadOnlyMode());
+    EXPECT_EQ(m_wrapper->viewMode(), ViewMode::Edit);
+    EXPECT_EQ(spy.count(), 2);
+}
+
+TEST_F(EditWrapperTest, SetViewMode_MarkdownLivePreview_RendersViaRenderer)
+{
+    // Arrange: 注入就绪的渲染器（懒创建被跳过，不触碰 WebEngine）
+    m_renderer.ready = true;
+    m_wrapper->setMarkdownRendererForTest(&m_renderer);
+    m_wrapper->textEditor()->setPlainText(QStringLiteral("# title"));
+    const QString mdPath = createFile("doc.md", QByteArray("# title"));
+    m_wrapper->updatePath(mdPath, mdPath);
+
+    // Act: 识别为 md → Edit 自动跃迁 LivePreview（B51）
+    m_wrapper->updateMarkdownRecognition(QStringLiteral("doc.md"), QString());
+
+    // Assert: 模式跃迁 + 渲染器编排（setMode/setLayout/setMarkdown 均被驱动）
+    EXPECT_TRUE(m_wrapper->isMarkdownFile());
+    EXPECT_EQ(m_wrapper->viewMode(), ViewMode::LivePreview);
+    EXPECT_GE(m_renderer.setModeCalls, 1);
+    EXPECT_EQ(m_renderer.lastMaxWidth, 0); // LivePreview: 不限宽不居中
+    EXPECT_FALSE(m_renderer.lastCenter);
+    EXPECT_GE(m_renderer.setMarkdownCalls, 1);
+    EXPECT_TRUE(m_renderer.lastMarkdown.contains(QStringLiteral("# title")));
+}
+
+TEST_F(EditWrapperTest, SetViewMode_MarkdownReadView_Layout800Centered)
+{
+    // Arrange: 先进入 md LivePreview
+    m_renderer.ready = true;
+    m_wrapper->setMarkdownRendererForTest(&m_renderer);
+    const QString mdPath = createFile("doc2.md", QByteArray("body"));
+    m_wrapper->updatePath(mdPath, mdPath);
+    m_wrapper->updateMarkdownRecognition(QStringLiteral("doc2.md"), QString());
+    ASSERT_EQ(m_wrapper->viewMode(), ViewMode::LivePreview);
+
+    // Act: 切到查看视图（B52）
+    const bool ok = m_wrapper->setViewMode(ViewMode::ReadView);
+
+    // Assert: 渲染页独占 + 800px 居中布局
+    EXPECT_TRUE(ok);
+    EXPECT_EQ(m_wrapper->viewMode(), ViewMode::ReadView);
+    EXPECT_EQ(m_renderer.lastMaxWidth, 800);
+    EXPECT_TRUE(m_renderer.lastCenter);
+}
+
+TEST_F(EditWrapperTest, UpdateMarkdownRecognition_MdLost_FallsBackToEdit)
+{
+    // Arrange: md + LivePreview
+    m_renderer.ready = true;
+    m_wrapper->setMarkdownRendererForTest(&m_renderer);
+    const QString mdPath = createFile("doc3.md", QByteArray("x"));
+    m_wrapper->updatePath(mdPath, mdPath);
+    m_wrapper->updateMarkdownRecognition(QStringLiteral("doc3.md"), QString());
+    ASSERT_EQ(m_wrapper->viewMode(), ViewMode::LivePreview);
+    QSignalSpy spy(m_wrapper, &EditWrapper::markdownAvailabilityChanged);
+
+    // Act（B54: 语言切走 → LivePreview 回退 Edit）
+    m_wrapper->updateMarkdownRecognition(QStringLiteral("doc3.txt"), QStringLiteral("C++"));
+
+    // Assert
+    EXPECT_FALSE(m_wrapper->isMarkdownFile());
+    EXPECT_EQ(m_wrapper->viewMode(), ViewMode::Edit);
+    ASSERT_EQ(spy.count(), 1);
+    EXPECT_FALSE(spy.at(0).at(0).toBool());
+}
+
+class EditWrapperRecognitionTest : public EditWrapperTest,
+                                   public ::testing::WithParamInterface<RecognitionCase> {};
+
+TEST_P(EditWrapperRecognitionTest, UpdateMarkdownRecognition_ParamVariants_RecognizesAsExpected)
+{
+    const RecognitionCase c = GetParam();
+
+    // Arrange: 注入渲染器（识别成功会触发 LivePreview 跃迁链路）
+    m_renderer.ready = false;
+    m_wrapper->setMarkdownRendererForTest(&m_renderer);
+    QSignalSpy spy(m_wrapper, &EditWrapper::markdownAvailabilityChanged);
+
+    // Act（B53: definition 名优先，其次扩展名）
+    m_wrapper->updateMarkdownRecognition(c.fileName, c.definitionName);
+
+    // Assert
+    EXPECT_EQ(m_wrapper->isMarkdownFile(), c.expectMarkdown);
+    EXPECT_EQ(spy.count(), c.expectMarkdown ? 1 : 0);
+    if (c.expectMarkdown)
+        EXPECT_EQ(m_wrapper->viewMode(), ViewMode::LivePreview); // Edit → 自动跃迁
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    RecognitionMatrix, EditWrapperRecognitionTest,
+    ::testing::Values(
+        RecognitionCase{QStringLiteral("note.md"), QString(), true},       // 扩展名
+        RecognitionCase{QStringLiteral("b.MARKDOWN"), QString(), true},    // 扩展名大小写不敏感
+        RecognitionCase{QStringLiteral("a.txt"), QStringLiteral("Markdown"), true}, // definition 名
+        RecognitionCase{QStringLiteral("a.txt"), QStringLiteral("C++"), false}));
+
+TEST_F(EditWrapperTest, SetMarkdownRenderer_Null_RevertsToNoRenderer)
+{
+    // Arrange: 先注入再清空
+    m_wrapper->setMarkdownRendererForTest(&m_renderer);
+    EXPECT_TRUE(m_wrapper->m_pRendererInjected);
+
+    // Act
+    m_wrapper->setMarkdownRendererForTest(nullptr);
+
+    // Assert: 注入标记复位；此后 Edit 模式切换不触碰任何渲染器
+    EXPECT_FALSE(m_wrapper->m_pRendererInjected);
+    const bool ok = m_wrapper->setViewMode(ViewMode::Edit);
+    EXPECT_TRUE(ok);
+    EXPECT_EQ(m_renderer.setMarkdownCalls, 0);
+}
+
+// ============================================================================
+// 信号槽联动（B8 增量）：ctor 连接的 lambda 槽与懒创建视图的事件处理
+// ============================================================================
+
+TEST_F(EditWrapperTest, ViewModeRequestedSignals_FromBarAndEditor_SwitchMode)
+{
+    // Arrange: 底栏 combobox / 编辑器右键菜单两条 viewModeRequested 入口（§8.1/§8.2）
+    QSignalSpy spy(m_wrapper, &EditWrapper::viewModeChanged);
+
+    // Act 1: BottomBar 发起切换请求（ctor lambda: viewModeRequested → setViewMode）
+    QMetaObject::invokeMethod(m_wrapper->bottomBar(), "viewModeRequested",
+                              Q_ARG(ViewMode, ViewMode::ReadView));
+
+    // Assert 1: 非 md 查看视图 = 纯文本只读
+    EXPECT_EQ(m_wrapper->viewMode(), ViewMode::ReadView);
+    EXPECT_TRUE(m_wrapper->textEditor()->getReadOnlyMode());
+    ASSERT_GE(spy.count(), 1);
+
+    // Act 2: TextEdit 右键菜单发起回切请求（另一条 ctor lambda）
+    QMetaObject::invokeMethod(m_wrapper->textEditor(), "viewModeRequested",
+                              Q_ARG(ViewMode, ViewMode::Edit));
+
+    // Assert 2: 回到编辑视图并恢复可编辑
+    EXPECT_EQ(m_wrapper->viewMode(), ViewMode::Edit);
+    EXPECT_FALSE(m_wrapper->textEditor()->getReadOnlyMode());
+    EXPECT_GE(spy.count(), 2);
+}
+
+TEST_F(EditWrapperTest, ScrollBarLambdas_OnScrollInLivePreview_SyncRenderer)
+{
+    // Arrange: md + LivePreview + 就绪渲染器（滚动同步 lambda 激活条件齐备）
+    const QString mdPath = createFile("scroll.md", QByteArray("# t"));
+    m_wrapper->updatePath(mdPath, mdPath);
+    m_renderer.ready = true;
+    m_wrapper->setMarkdownRendererForTest(&m_renderer);
+    m_wrapper->updateMarkdownRecognition(QStringLiteral("scroll.md"), QString());
+    ASSERT_EQ(m_wrapper->viewMode(), ViewMode::LivePreview);
+
+    QString text;
+    for (int i = 0; i < 300; ++i)
+        text += QStringLiteral("line %1\n").arg(i);
+    m_wrapper->textEditor()->setPlainText(text);
+
+    auto *sb = m_wrapper->textEditor()->verticalScrollBar();
+    ASSERT_GT(sb->maximum(), sb->minimum());
+
+    // Act: 滚动 → 直连滚动同步 lambda + 排队高亮 lambda（两路 ctor connect）
+    sb->setValue(sb->maximum() / 2);
+    QApplication::processEvents();
+
+    // Assert: 右栏按比例收到滚动同步；排队高亮链路已消化
+    EXPECT_GE(m_renderer.scrollCalls, 1);
+    EXPECT_GT(m_renderer.lastRatio, 0.0);
+    EXPECT_LT(m_renderer.lastRatio, 1.0);
+    EXPECT_EQ(sb->value(), sb->maximum() / 2);
+}
+
+TEST_F(EditWrapperTest, OnUpdateHighlighter_FoldRegion_RehighlightsUnmarkedBlocks)
+{
+    // Arrange: 有效 definition + 关闭高亮插入括号文本（块无 userData）
+    m_renderer.ready = false;
+    m_wrapper->setMarkdownRendererForTest(&m_renderer);
+    m_wrapper->reloadFileHighlight(QStringLiteral("C++"));
+    auto *hl = m_wrapper->getSyntaxHighlighter();
+    ASSERT_NE(hl, nullptr);
+    hl->setEnableHighlight(false);
+
+    QString text;
+    for (int i = 0; i < 200; ++i)
+        text += QStringLiteral("aaaa\n");
+    text += QStringLiteral("{\n");
+    for (int i = 0; i < 200; ++i)
+        text += QStringLiteral("bbbb\n");
+    text += QStringLiteral("}\n");
+    for (int i = 0; i < 120; ++i)
+        text += QStringLiteral("cccc\n");
+    m_wrapper->textEditor()->setPlainText(text);
+
+    auto *sb = m_wrapper->textEditor()->verticalScrollBar();
+    ASSERT_GT(sb->maximum(), sb->minimum());
+    const QTextBlock midBlock = m_wrapper->textEditor()->document()->findBlockByNumber(210);
+    ASSERT_EQ(midBlock.userData(), nullptr); // 高亮关闭 → 块未标记
+
+    // Act 1: 滚到底部 → 排队 OnUpdateHighlighter（折叠区循环对未标记块调用重高亮 lambda）
+    sb->setValue(sb->maximum());
+    QApplication::processEvents();
+
+    // Act 2: 打开高亮后显式触发 → lambda 对未标记块真正执行 kate 高亮（注入 userData）
+    hl->setEnableHighlight(true);
+    m_wrapper->OnUpdateHighlighter();
+
+    // Assert: '{' 区间内的块已被重高亮标记；全文高亮标志未被置位（局部路径）
+    EXPECT_NE(m_wrapper->textEditor()->document()->findBlockByNumber(210).userData(), nullptr);
+    EXPECT_FALSE(m_wrapper->m_bHighlighterAll);
+    EXPECT_EQ(m_wrapper->textEditor()->toPlainText().count(QLatin1Char('\n')), 522);
+}
+
+TEST_F(EditWrapperTest, MarkdownViewSignalHandlers_ViewEvents_ReactCorrectly)
+{
+    // Arrange: 不注入渲染器 → 真实 MarkdownView 懒创建；init 置空桩避免
+    // WebEngine 页面加载（构造函数只建桥接与连接，offscreen 安全）
+    stub.set_lamda(&MarkdownView::init, [](MarkdownView *) {});
+
+    const QString mdPath = createFile("mv.md", QByteArray("# t"));
+    m_wrapper->updatePath(mdPath, mdPath);
+    m_wrapper->updateMarkdownRecognition(QStringLiteral("mv.md"), QString());
+    ASSERT_EQ(m_wrapper->viewMode(), ViewMode::LivePreview);
+    MarkdownView *view = m_wrapper->m_pMarkdownView;
+    ASSERT_NE(view, nullptr);
+
+    // Act 1: 渲染内核就绪信号 → RenderThrottle 解除缓存
+    QMetaObject::invokeMethod(view, "ready");
+
+    // Assert 1: throttle 进入 ready 态
+    EXPECT_TRUE(m_wrapper->m_renderThrottle.isReady());
+
+    // Act 2: 右栏滚动比例 → 反向同步驱动左栏（§4.6 双向）
+    QString text;
+    for (int i = 0; i < 300; ++i)
+        text += QStringLiteral("l%1\n").arg(i);
+    m_wrapper->textEditor()->setPlainText(text);
+    auto *sb = m_wrapper->textEditor()->verticalScrollBar();
+    ASSERT_GT(sb->maximum(), sb->minimum());
+    QMetaObject::invokeMethod(view, "scrollRatioChanged", Q_ARG(double, 0.5));
+
+    // Assert 2: 左栏光标条按比例定位（min + round(0.5*(max-min))）
+    const int expected = sb->minimum() + qRound(0.5 * (sb->maximum() - sb->minimum()));
+    EXPECT_EQ(sb->value(), expected);
+
+    // Act 3: 渲染页右键 → 视图模式菜单（QMenu::exec 置空桩防模态阻塞）
+    stub.set_lamda(static_cast<QAction *(QMenu::*)(const QPoint &, QAction *)>(&QMenu::exec),
+                   [](QMenu *, const QPoint &, QAction *) -> QAction * { return nullptr; });
+    QMetaObject::invokeMethod(view, "customContextMenuRequested",
+                              Q_ARG(QPoint, QPoint(2, 2)));
+
+    // Assert 3: 未崩溃且模式保持 LivePreview（菜单事件未改状态）
+    EXPECT_EQ(m_wrapper->viewMode(), ViewMode::LivePreview);
+    EXPECT_EQ(m_wrapper->textEditor()->toPlainText().size(), text.size());
+}


### PR DESCRIPTION
## 内容

新增编辑器核心区域与封装层的 GTest 单元测试：DTextEdit 光标/编辑/事件/查找/标记逻辑、行号区、代码折叠区、书签组件、EditWrapper，共 18 个文件。

## 说明

- 基于 master 独立拉出，可独立评审与合并
- 仅新增单元测试代码，不改动编辑器本体功能
