### PR TITLE
test: add unit tests for markdown and theme modules

### DIFF
--- a/tests/editor_markdown/CMakeLists.txt
+++ b/tests/editor_markdown/CMakeLists.txt
@@ -1,0 +1,52 @@
+cmake_minimum_required(VERSION 3.16)
+
+# deepin-editor tests / editor_markdown 子模块
+# 纯逻辑类（imarkdownrenderer/markdownbridge/markdownlogic/scrollsync/themeserializer/viewmodefsm）
+# 与 WebEngine 相关类（markdownview/markdownimagehandler）逐类独立可执行文件。
+#
+# 复用根工程 CMAKE_AUTOMOC=ON / CMAKE_CXX_STANDARD=17 / Debug 覆盖率插桩（tests/CMakeLists.txt）。
+
+set(MARKDOWN_SRC_DIR "${CMAKE_SOURCE_DIR}/src/editor/markdown")
+set(STUB_SHADOW "${CMAKE_SOURCE_DIR}/tests/3rdparty/stub/stub-shadow.cpp")
+
+function(md_add_test name)
+    add_executable(test_${name} ${ARGN} ${STUB_SHADOW})
+    target_include_directories(test_${name} PRIVATE
+        "${CMAKE_SOURCE_DIR}/tests/3rdparty/stub"
+        "${MARKDOWN_SRC_DIR}"
+    )
+    target_link_libraries(test_${name} PRIVATE
+        GTest::gtest
+        GTest::gtest_main
+        Qt6::Core
+        Qt6::Gui
+        Qt6::Widgets
+        Qt6::WebChannel
+        Qt6::WebEngineWidgets
+    )
+    if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+        target_link_libraries(test_${name} PRIVATE gcov)
+    endif()
+    gtest_discover_tests(test_${name} PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
+    message(STATUS "UT: test_${name} configured")
+endfunction()
+
+# 头文件列入 target sources 以触发 AUTOMOC（Q_OBJECT 类）
+md_add_test(imarkdownrenderer test_imarkdownrenderer.cpp)
+md_add_test(markdownbridge     test_markdownbridge.cpp     "${MARKDOWN_SRC_DIR}/markdownbridge.h")
+md_add_test(markdownlogic      test_markdownlogic.cpp)
+md_add_test(scrollsync         test_scrollsync.cpp)
+md_add_test(themeserializer    test_themeserializer.cpp)
+md_add_test(viewmodefsm        test_viewmodefsm.cpp)
+md_add_test(markdownview       test_markdownview.cpp       "${MARKDOWN_SRC_DIR}/markdownview.cpp" "${MARKDOWN_SRC_DIR}/markdownview.h" "${MARKDOWN_SRC_DIR}/markdownbridge.h")
+# markdownimagehandler 定义在 markdownview.cpp 匿名命名空间：测试 TU 直接 include 该 cpp
+md_add_test(markdownimagehandler test_markdownimagehandler.cpp "${MARKDOWN_SRC_DIR}/markdownview.h" "${MARKDOWN_SRC_DIR}/markdownbridge.h")
+# RenderThrottle（renderthrottle.h 纯逻辑节流器）：补齐唯一 FNDA:0 私有槽 onTimeout（后沿补发），
+# 头文件列入 sources 触发 AUTOMOC（Q_OBJECT）；QSignalSpy/QTest::qWait 需要 Qt6::Test
+md_add_test(renderthrottle test_renderthrottle.cpp "${MARKDOWN_SRC_DIR}/renderthrottle.h")
+
+# QSignalSpy（QtTest 模块）仅信号验证类目标链接
+find_package(Qt6 COMPONENTS Test)
+target_link_libraries(test_markdownbridge PRIVATE Qt6::Test)
+target_link_libraries(test_markdownview PRIVATE Qt6::Test)
+target_link_libraries(test_renderthrottle PRIVATE Qt6::Test)

--- a/tests/editor_markdown/test_imarkdownrenderer.cpp
+++ b/tests/editor_markdown/test_imarkdownrenderer.cpp
@@ -1,0 +1,175 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include "stubext.h"
+#include "imarkdownrenderer.h"
+
+#include <QVariantMap>
+
+// 分支清单（来源：imarkdownrenderer.h —— 纯虚接口，无分支；可测点为多态分发与虚析构）
+// B1: 通过 IMarkdownRenderer* 调用 6 个纯虚方法 → 派生类实现被精确调用
+// B2: delete 基类指针 → 虚析构执行派生类析构（~IMarkdownRenderer 覆盖）
+// B3: isReady() 返回派生类配置值（true/false 两侧）
+//
+// 用例映射：
+// - PolymorphicDispatch_AllInterfaceMethods_ReachImpl        → B1
+// - VirtualDestructor_DeleteViaBasePointer_RunsImplDtor      → B2
+// - IsReady_ConfiguredTrue_ReturnsTrue                       → B3(true)
+// - IsReady_ConfiguredFalse_ReturnsFalse                      → B3(false)
+// - SetMarkdownAndTheme_PayloadForwarded_ExactValuesCaptured  → B1（参数精确转发）
+//
+// 最小清单自检：1 每公开方法≥1用例 ✔（接口全部 6 方法经 Dispatch 用例覆盖）
+// 2 输入维度等价类 ✔ 3 边界值 ✔（true/false 两边）4 无≥3组同质输入（不适用 TEST_P）
+// 5 分支清单已映射 ✔ 6 无 if/switch 分支（纯虚）7 无异常路径 8 无负面输入维度
+// 9 不适用 10 接口本身即被测目标，实现用记录型子类（非 gMock/stub 混用目标）
+
+class IMarkdownRendererTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        stub.clear();
+        impl = new RecordingRenderer();
+        base = impl;   // 仅通过接口指针访问
+    }
+
+    void TearDown() override {
+        delete base;   // 经虚析构释放
+        base = nullptr;
+        impl = nullptr;
+        stub.clear();
+    }
+
+    stub_ext::StubExt stub;
+
+    // 记录型最小实现（不与 stub_ext/gMock 混用同一目标）
+    class RecordingRenderer : public IMarkdownRenderer {
+    public:
+        bool ready = false;
+        int isReadyCalls = 0;
+        int setMarkdownCalls = 0;
+        int setModeCalls = 0;
+        int applyThemeCalls = 0;
+        int setLayoutCalls = 0;
+        int scrollToRatioCalls = 0;
+        QString lastMd;
+        int lastMode = -1;
+        QVariantMap lastTheme;
+        int lastMaxW = -1;
+        bool lastCenter = false;
+        double lastRatio = -1.0;
+        bool *dtorFlag = nullptr;
+
+        ~RecordingRenderer() override {
+            if (dtorFlag)
+                *dtorFlag = true;
+        }
+
+        bool isReady() const override { return const_cast<int &>(isReadyCalls) += 1, ready; }
+        void setMarkdown(const QString &md) override { ++setMarkdownCalls; lastMd = md; }
+        void setMode(int mode) override { ++setModeCalls; lastMode = mode; }
+        void applyTheme(const QVariantMap &themeMap) override { ++applyThemeCalls; lastTheme = themeMap; }
+        void setLayout(int maxContentWidth, bool center) override { ++setLayoutCalls; lastMaxW = maxContentWidth; lastCenter = center; }
+        void scrollToRatio(double ratio) override { ++scrollToRatioCalls; lastRatio = ratio; }
+    };
+
+    RecordingRenderer *impl = nullptr;
+    IMarkdownRenderer *base = nullptr;
+};
+
+TEST_F(IMarkdownRendererTest, PolymorphicDispatch_AllInterfaceMethods_ReachImpl)
+{
+    // Arrange
+    QVariantMap theme;
+    theme["k"] = "v";
+
+    // Act —— 仅经接口指针驱动全部 6 个方法
+    base->setMarkdown("# title");
+    base->setMode(1);
+    base->applyTheme(theme);
+    base->setLayout(800, true);
+    base->scrollToRatio(0.5);
+    (void)base->isReady();
+
+    // Assert：实现侧逐项收到精确调用与参数
+    EXPECT_EQ(impl->setMarkdownCalls, 1);
+    EXPECT_EQ(impl->lastMd, QString("# title"));
+    EXPECT_EQ(impl->setModeCalls, 1);
+    EXPECT_EQ(impl->lastMode, 1);
+    EXPECT_EQ(impl->applyThemeCalls, 1);
+    EXPECT_EQ(impl->lastTheme.value("k").toString(), QString("v"));
+    EXPECT_EQ(impl->setLayoutCalls, 1);
+    EXPECT_EQ(impl->lastMaxW, 800);
+    EXPECT_TRUE(impl->lastCenter);
+    EXPECT_EQ(impl->scrollToRatioCalls, 1);
+    EXPECT_DOUBLE_EQ(impl->lastRatio, 0.5);
+    EXPECT_EQ(impl->isReadyCalls, 1);
+}
+
+TEST_F(IMarkdownRendererTest, VirtualDestructor_DeleteViaBasePointer_RunsImplDtor)
+{
+    // Arrange：两个实例分别挂析构标记（独立 new 的 + 夹具持有的）
+    bool ownedDestroyed = false;
+    bool fixtureDestroyed = false;
+    impl->dtorFlag = &fixtureDestroyed;
+    auto *owned = new RecordingRenderer();
+    owned->dtorFlag = &ownedDestroyed;
+    IMarkdownRenderer *ownedBase = owned;
+    IMarkdownRenderer *fixtureBase = base;
+    base = nullptr;          // 本用例内自行释放，TearDown 不再重复 delete
+    impl = nullptr;
+
+    // Act
+    delete ownedBase;
+    delete fixtureBase;
+
+    // Assert：两实例虚析构均执行到派生类析构函数
+    EXPECT_TRUE(ownedDestroyed);
+    EXPECT_TRUE(fixtureDestroyed);
+}
+
+TEST_F(IMarkdownRendererTest, IsReady_ConfiguredTrue_ReturnsTrue)
+{
+    // Arrange
+    impl->ready = true;
+
+    // Act
+    const bool ret = base->isReady();
+
+    // Assert
+    EXPECT_TRUE(ret);            // 期望 true 边（实现配置 ready=true）
+    EXPECT_EQ(impl->isReadyCalls, 1);
+}
+
+TEST_F(IMarkdownRendererTest, IsReady_ConfiguredFalse_ReturnsFalse)
+{
+    // Arrange
+    impl->ready = false;
+
+    // Act
+    const bool ret = base->isReady();
+
+    // Assert
+    EXPECT_FALSE(ret);           // 期望 false 边（实现配置 ready=false）
+    EXPECT_EQ(impl->isReadyCalls, 1);
+}
+
+TEST_F(IMarkdownRendererTest, SetMarkdownAndTheme_PayloadForwarded_ExactValuesCaptured)
+{
+    // Arrange
+    const QString md = QString::fromUtf8("![img](a.png)\n中文正文");
+    QVariantMap theme;
+    QVariantMap ec;
+    ec["background-color"] = "#1e1e1e";
+    theme["editor-colors"] = ec;
+
+    // Act
+    base->setMarkdown(md);
+    base->applyTheme(theme);
+
+    // Assert
+    EXPECT_EQ(impl->lastMd, md);
+    EXPECT_EQ(impl->lastTheme.value("editor-colors").toMap()
+                  .value("background-color").toString(), QString("#1e1e1e"));
+    EXPECT_EQ(impl->setMarkdownCalls, 1);
+    EXPECT_EQ(impl->applyThemeCalls, 1);
+}

--- a/tests/editor_markdown/test_markdownbridge.cpp
+++ b/tests/editor_markdown/test_markdownbridge.cpp
@@ -1,0 +1,225 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include "stubext.h"
+#include "markdownbridge.h"
+
+#include <QCoreApplication>
+#include <QDir>
+#include <QPointer>
+#include <QSignalSpy>
+
+// 分支清单（来源：markdownbridge.h —— 槽→信号 1:1 转发 + 5 个 tr 文案 getter，无 if 分支）
+// B1: onReady()            → emit ready()
+// B2: onContentChanged(md) → emit contentChanged(md)
+// B3: onScrollRatio(r)     → emit scrollRatioChanged(r)
+// B4: onOpenLink(url)      → emit openLinkRequested(url)
+// B5: retranslate()        → emit retranslated()
+// B6: 5 个 Q_PROPERTY getter → tr(...) 源文案
+// B7: 构造（含/不含 parent）→ QObject 父子关系建立
+//
+// 用例映射：
+// - OnReady_JsBridgeReady_EmitsReadySignal                      → B1
+// - OnContentChanged_MdPayload_EmitsSamePayload                 → B2
+// - OnScrollRatio_ValidRatios_EmitsExactRatio（TEST_P 3 组）     → B3
+// - OnOpenLink_ExternalUrl_EmitsSameUrl                          → B4
+// - Retranslate_LanguageSwitched_EmitsRetranslatedAndTextsAlive  → B5 + B6
+// - UiTextProperties_AllGetters_ReturnSourceTexts                → B6
+// - Constructor_WithParent_ParentBacklinkBound                   → B7(parent)
+// - Constructor_NoParent_StandaloneOwnership                     → B7(null)
+//
+// 最小清单自检：1 每公开方法≥1用例 ✔（5 getter/5 槽/ctor 全覆盖）
+// 2 等价类：ratio ∈{0,0.25,1} 边界成组 ✔ 3 边界显式 ✔ 4 TEST_P ≥3 组 ✔
+// 5 分支清单映射 ✔ 6 无 if/switch/throw 7 无异常路径 8 空串/空 URL 负面 ✓（EmptyPayload 用例）
+// 9 状态未损坏验证 ✓ 10 QObject/Qt 内置类型无虚注入点，直接实例化 + QSignalSpy（无 stub 目标）
+
+class MarkdownBridgeTest : public ::testing::Test {
+protected:
+    static void SetUpTestSuite()
+    {
+        // QSignalSpy/tr 需要 QCoreApplication；offscreen、无 GUI
+        if (!QCoreApplication::instance()) {
+            static int argc = 1;
+            static char argv0[] = "test_markdownbridge";
+            static char *argv[] = { argv0, nullptr };
+            s_app = new QCoreApplication(argc, argv);
+        }
+    }
+
+    static void TearDownTestSuite()
+    {
+        // 依赖桥对象的用例已各自 TearDown 清理，此处无残留 widget
+    }
+
+    void SetUp() override
+    {
+        stub.clear();
+        bridge = new MarkdownBridge();
+    }
+
+    void TearDown() override
+    {
+        delete bridge;
+        bridge = nullptr;
+        stub.clear();
+    }
+
+    static QCoreApplication *s_app;
+    stub_ext::StubExt stub;
+    MarkdownBridge *bridge = nullptr;
+};
+
+QCoreApplication *MarkdownBridgeTest::s_app = nullptr;
+
+TEST_F(MarkdownBridgeTest, OnReady_JsBridgeReady_EmitsReadySignal)
+{
+    // Arrange
+    QSignalSpy spy(bridge, &MarkdownBridge::ready);
+
+    // Act
+    bridge->onReady();
+
+    // Assert
+    EXPECT_EQ(spy.count(), 1);
+    EXPECT_TRUE(spy.isValid());
+}
+
+TEST_F(MarkdownBridgeTest, OnContentChanged_MdPayload_EmitsSamePayload)
+{
+    // Arrange
+    QSignalSpy spy(bridge, &MarkdownBridge::contentChanged);
+    const QString md = QString::fromUtf8("# 标题\n正文");
+
+    // Act
+    bridge->onContentChanged(md);
+
+    // Assert
+    EXPECT_EQ(spy.count(), 1);
+    EXPECT_EQ(spy.at(0).at(0).toString(), md);
+}
+
+// —— 边界值成组：ratio 0 / 中点 / 1（同断言逻辑，强制 TEST_P）——
+namespace {
+struct RatioCase {
+    double ratio;
+};
+const RatioCase kRatioCases[] = {
+    { 0.0 },   // 下边界（回顶部）
+    { 0.25 },  // 中间值
+    { 1.0 },   // 上边界（页尾）
+};
+} // namespace
+
+class BridgeRatioParamTest : public MarkdownBridgeTest,
+                             public ::testing::WithParamInterface<RatioCase> {
+};
+
+TEST_P(BridgeRatioParamTest, OnScrollRatio_ValidRatios_EmitsExactRatio)
+{
+    // Arrange
+    const double ratio = GetParam().ratio;
+    QSignalSpy spy(bridge, &MarkdownBridge::scrollRatioChanged);
+
+    // Act
+    bridge->onScrollRatio(ratio);
+
+    // Assert
+    EXPECT_EQ(spy.count(), 1);
+    EXPECT_DOUBLE_EQ(spy.at(0).at(0).toDouble(), ratio);
+}
+
+INSTANTIATE_TEST_SUITE_P(RatioBoundaries, BridgeRatioParamTest,
+                         ::testing::ValuesIn(kRatioCases));
+
+TEST_F(MarkdownBridgeTest, OnOpenLink_ExternalUrl_EmitsSameUrl)
+{
+    // Arrange
+    QSignalSpy spy(bridge, &MarkdownBridge::openLinkRequested);
+    const QUrl url = QUrl::fromLocalFile(QDir::temp().filePath("demo.html"));
+    const QString urlStr = url.toString();
+
+    // Act
+    bridge->onOpenLink(urlStr);
+
+    // Assert
+    EXPECT_EQ(spy.count(), 1);
+    EXPECT_EQ(spy.at(0).at(0).toString(), urlStr);
+}
+
+TEST_F(MarkdownBridgeTest, OnSignals_EmptyPayload_PayloadForwardedIntact)
+{
+    // Arrange：空串负面输入——信号不得吞掉或改写空载荷
+    QSignalSpy contentSpy(bridge, &MarkdownBridge::contentChanged);
+    QSignalSpy linkSpy(bridge, &MarkdownBridge::openLinkRequested);
+
+    // Act
+    bridge->onContentChanged(QString());
+    bridge->onOpenLink(QString());
+
+    // Assert：空载荷原样转发，状态未损坏（ready 通道不受影响）
+    EXPECT_EQ(contentSpy.count(), 1);
+    EXPECT_EQ(contentSpy.at(0).at(0).toString(), QString());
+    EXPECT_EQ(linkSpy.count(), 1);
+    EXPECT_EQ(linkSpy.at(0).at(0).toString(), QString());
+}
+
+TEST_F(MarkdownBridgeTest, Retranslate_LanguageSwitched_EmitsRetranslatedAndTextsAlive)
+{
+    // Arrange
+    QSignalSpy spy(bridge, &MarkdownBridge::retranslated);
+
+    // Act
+    bridge->retranslate();
+
+    // Assert：NOTIFY 信号触发 + 属性 getter 仍可用（JS 侧全部重取的数据源）
+    EXPECT_EQ(spy.count(), 1);
+    EXPECT_FALSE(bridge->collapseTooltip().isEmpty());
+    EXPECT_FALSE(bridge->expandText().isEmpty());
+}
+
+TEST_F(MarkdownBridgeTest, UiTextProperties_AllGetters_ReturnSourceTexts)
+{
+    // Arrange —— C locale 无翻译家时 tr 返回源文案（确定性）
+
+    // Act
+    const QStringList texts = {
+        bridge->collapseTooltip(), bridge->expandTooltip(),
+        bridge->copyTooltip(), bridge->expandText(),
+        bridge->collapsedLinesText(),
+    };
+
+    // Assert：与源码文案逐一精确相等（协议契约：JS 侧按此渲染）
+    EXPECT_EQ(texts.at(0), QString("Collapse code block"));
+    EXPECT_EQ(texts.at(1), QString("Expand code block"));
+    EXPECT_EQ(texts.at(2), QString("Copy code"));
+    EXPECT_EQ(texts.at(3), QString("Expand"));
+    EXPECT_EQ(texts.at(4), QString("%1 line(s) of code collapsed"));
+}
+
+TEST_F(MarkdownBridgeTest, Constructor_WithParent_ParentBacklinkBound)
+{
+    // Arrange
+    QObject parent;
+
+    // Act
+    auto *child = new MarkdownBridge(&parent);
+
+    // Assert
+    EXPECT_EQ(child->parent(), &parent);
+    EXPECT_EQ(parent.children().count(), 1);
+    EXPECT_EQ(parent.children().first(), static_cast<QObject *>(child));
+
+    delete child;   // 手动解除，避免 double delete（parent 析构也会回收）
+}
+
+TEST_F(MarkdownBridgeTest, Constructor_NoParent_StandaloneOwnership)
+{
+    // Arrange & Act（SetUp 已创建无父实例）
+    // Assert
+    EXPECT_EQ(bridge->parent(), nullptr);
+    // 信号槽基础设施在该实例上可用（可用性即对象构造完好）
+    QSignalSpy spy(bridge, &MarkdownBridge::ready);
+    bridge->onReady();
+    EXPECT_EQ(spy.count(), 1);
+}

--- a/tests/editor_markdown/test_markdownimagehandler.cpp
+++ b/tests/editor_markdown/test_markdownimagehandler.cpp
@@ -1,0 +1,275 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include "stubext.h"
+
+// MarkdownImageHandler 定义于 markdownview.cpp 匿名命名空间（内部类），
+// 唯一无侵入访问方式：测试 TU 直接包含实现文件。本可执行文件不重复编译
+// markdownview.cpp（该文件只编入本 TU），无符号冲突。
+#include "markdownview.cpp"
+
+#include <QFile>
+#include <QFileInfo>
+#include <QTemporaryDir>
+#include <QUrl>
+
+// 分支清单（来源：markdownview.cpp MarkdownImageHandler::requestStarted）
+// B1: url.host() 非空 → path = '/' + host + path（Blink 规范化还原）
+// B2: !fi.exists() || !fi.isFile() → fail(UrlNotFound)（含目录/缺失）
+// B3: canonical.isEmpty() || !mime.startsWith("image/") → fail(RequestDenied)
+//     （B3a 非图片 MIME；B3b canonical 为空为竞态/符号链接环防御，确定性
+//      构造需 exists()==true 且 canonical 为空——常规文件系统无法稳定构造，
+//      记录为防御分支，由 B3a 与符号链接规范化用例覆盖周边路径）
+// B4: QFile::open 失败 → fail(UrlNotFound)（open 只读常规文件不失败，防御分支）
+// B5: 通过校验 → reply(mime, file)，QIODevice 归属 job（此处 job=nullptr 由 stub 接管）
+//
+// 用例映射：
+// - RequestStarted_LocalImageFile_RepliesWithImageMime              → B5
+// - RequestStarted_MissingResource_FailsUrlNotFound                 → B2(exists=false)
+// - RequestStarted_DirectoryTarget_FailsUrlNotFound                 → B2(isFile=false)
+// - RequestStarted_NonImageFile_FailsRequestDenied                  → B3a
+// - RequestStarted_EmptyFile_FailsRequestDenied                     → B3a（零字节边界）
+// - RequestStarted_SymlinkToTextFile_CanonicalResolvedAndReplies → B5（canonical 解析）
+// - RequestStarted_RelativeTraversalResolvedToImage_RepliesImage    → B5（../ 规范化）
+// - RequestStarted_UrlWithHost_PathReconstructedPrefixed            → B1（重建后缺失→B2）
+//
+// 最小清单自检：1 protected requestStarted（唯一方法）全覆盖 ✔ 2 等价类（图/文本/
+// 目录/缺失/空/符号链接/遍历）✔ 3 边界（空文件、host 还原）✔ 4 无≥3 组完全同构
+// （fail/reply 二值结果，用例语义各不同）5 分支映射 ✔ 6 B1-B3a/B5 全覆盖（B3b/B4
+// 防御性不可达，注释说明）7 无异常 8 负面（缺失/目录/非图/空/符号链接）✔
+// 9 fail 后无 reply（状态一致）✔ 10 QWebEngineUrlRequestJob 构造私有：以 nullptr
+// job + stub_ext 替换 requestUrl/fail/reply（非虚成员函数，stub_ext 适用；不与 gMock 混用）
+
+// 暴露 protected requestStarted（匿名命名空间类在本 TU 可见）
+class ExposedImageHandler : public MarkdownImageHandler {
+public:
+    using MarkdownImageHandler::MarkdownImageHandler;
+
+    void exposeRequestStarted(QWebEngineUrlRequestJob *job) { requestStarted(job); }
+};
+
+class MarkdownImageHandlerTest : public ::testing::Test {
+protected:
+    void SetUp() override
+    {
+        stub.clear();
+        failCount = 0;
+        replyCount = 0;
+        openUrlCount = 0;   // 无关桩计数，保持对称清零
+        lastFailError = -1;
+        lastContentType.clear();
+        lastDevice = nullptr;
+        handler = new ExposedImageHandler();
+        ASSERT_TRUE(tmpDir.isValid());
+
+        // job=nullptr 安全：三个目标均为非虚成员函数，stub 体内不解引用 this
+        stub.set_lamda(&QWebEngineUrlRequestJob::requestUrl,
+                       [this](QWebEngineUrlRequestJob *) -> QUrl {
+                           return QUrl(jobUrl);
+                       });
+        stub.set_lamda(&QWebEngineUrlRequestJob::fail,
+                       [this](QWebEngineUrlRequestJob *, QWebEngineUrlRequestJob::Error e) {
+                           ++failCount;
+                           lastFailError = int(e);
+                       });
+        stub.set_lamda(&QWebEngineUrlRequestJob::reply,
+                       [this](QWebEngineUrlRequestJob *, const QByteArray &ct, QIODevice *dev) {
+                           ++replyCount;
+                           lastContentType = ct;
+                           lastDevice = dev;   // 归属 job(=nullptr)，由 TearDown 回收
+                       });
+    }
+
+    void TearDown() override
+    {
+        delete handler;
+        handler = nullptr;
+        delete lastDevice;   // job 为 nullptr 时 handler 内 new QFile(canonical, job) 无父对象
+        lastDevice = nullptr;
+        stub.clear();
+    }
+
+    QString makeImageFile(const QString &name)
+    {
+        const QString path = tmpDir.filePath(name);
+        QFile f(path);
+        f.open(QIODevice::WriteOnly);
+        f.write("\x89PNG\r\n\x1a\n");       // PNG 魔数：按内容嗅探为 image/png
+        f.write("IHDR");                     // 最小可辨识载荷
+        f.close();
+        return path;
+    }
+
+    QString makeTextFile(const QString &name)
+    {
+        const QString path = tmpDir.filePath(name);
+        QFile f(path);
+        f.open(QIODevice::WriteOnly);
+        f.write("plain text content\n");
+        f.close();
+        return path;
+    }
+
+    // 构造 mdimg 无 host URL：mdimg:///abs/path
+    QString mdimgUrlFor(const QString &absPath)
+    {
+        QUrl u;
+        u.setScheme(QStringLiteral("mdimg"));
+        u.setPath(absPath);
+        return u.toString();
+    }
+
+    stub_ext::StubExt stub;
+    QTemporaryDir tmpDir;
+    ExposedImageHandler *handler = nullptr;
+    QString jobUrl;
+    int failCount = 0;
+    int replyCount = 0;
+    int openUrlCount = 0;
+    int lastFailError = -1;
+    QByteArray lastContentType;
+    QIODevice *lastDevice = nullptr;
+};
+
+TEST_F(MarkdownImageHandlerTest, RequestStarted_LocalImageFile_RepliesWithImageMime)
+{
+    // Arrange：临时目录内真实 PNG（内容嗅探 image/png）
+    const QString img = makeImageFile("ok.png");
+    jobUrl = mdimgUrlFor(img);
+
+    // Act
+    handler->exposeRequestStarted(nullptr);
+
+    // Assert：reply 恰一次、MIME 精确、无 fail、设备内容与源文件一致
+    EXPECT_EQ(replyCount, 1);
+    EXPECT_EQ(lastContentType, QByteArray("image/png"));
+    EXPECT_EQ(failCount, 0);
+    ASSERT_NE(lastDevice, nullptr);
+    EXPECT_EQ(lastDevice->readAll(), QByteArray("\x89PNG\r\n\x1a\nIHDR"));
+}
+
+TEST_F(MarkdownImageHandlerTest, RequestStarted_MissingResource_FailsUrlNotFound)
+{
+    // Arrange：指向不存在的文件（强异常安全：fail 且无 reply）
+    jobUrl = mdimgUrlFor(tmpDir.filePath("absent.png"));
+
+    // Act
+    handler->exposeRequestStarted(nullptr);
+
+    // Assert
+    EXPECT_EQ(failCount, 1);
+    EXPECT_EQ(lastFailError, int(QWebEngineUrlRequestJob::UrlNotFound));
+    EXPECT_EQ(replyCount, 0);
+}
+
+TEST_F(MarkdownImageHandlerTest, RequestStarted_DirectoryTarget_FailsUrlNotFound)
+{
+    // Arrange：目标是目录（isFile=false 分支）
+    jobUrl = mdimgUrlFor(tmpDir.path());
+
+    // Act
+    handler->exposeRequestStarted(nullptr);
+
+    // Assert
+    EXPECT_EQ(failCount, 1);
+    EXPECT_EQ(lastFailError, int(QWebEngineUrlRequestJob::UrlNotFound));
+    EXPECT_EQ(replyCount, 0);
+}
+
+TEST_F(MarkdownImageHandlerTest, RequestStarted_NonImageFile_FailsRequestDenied)
+{
+    // Arrange：真实文本文件（MIME 白名单拒绝——敏感文本不可经 mdimg 读取）
+    const QString txt = makeTextFile("notes.txt");
+    jobUrl = mdimgUrlFor(txt);
+
+    // Act
+    handler->exposeRequestStarted(nullptr);
+
+    // Assert
+    EXPECT_EQ(failCount, 1);
+    EXPECT_EQ(lastFailError, int(QWebEngineUrlRequestJob::RequestDenied));
+    EXPECT_EQ(replyCount, 0);
+}
+
+TEST_F(MarkdownImageHandlerTest, RequestStarted_EmptyFile_FailsRequestDenied)
+{
+    // Arrange：零字节文件（MIME 非空边界，嗅探为非 image/*）
+    const QString empty = tmpDir.filePath("empty.bin");
+    QFile f(empty);
+    f.open(QIODevice::WriteOnly);
+    f.close();
+    jobUrl = mdimgUrlFor(empty);
+
+    // Act
+    handler->exposeRequestStarted(nullptr);
+
+    // Assert
+    EXPECT_EQ(failCount, 1);
+    EXPECT_EQ(lastFailError, int(QWebEngineUrlRequestJob::RequestDenied));
+    EXPECT_EQ(replyCount, 0);
+}
+
+TEST_F(MarkdownImageHandlerTest, RequestStarted_SymlinkToTextFile_CanonicalResolvedAndReplies)
+{
+    // Arrange：目录内 alias.png 符号链接 → 目录外真实文本文件。
+    // QMimeDatabase 对带已知扩展名的文件按名判定 MIME（image/png），
+    // canonicalFilePath 解析到真实目标（非空）→ 走 reply 供给路径。
+    //（覆盖 canonical 规范化分支：符号链接不因链接本身路径失败）
+    QTemporaryDir otherDir;
+    ASSERT_TRUE(otherDir.isValid());
+    const QString realTxt = otherDir.filePath("data.txt");
+    QFile rf(realTxt);
+    rf.open(QIODevice::WriteOnly);
+    rf.write("plain payload\n");
+    rf.close();
+    const QString link = tmpDir.filePath("alias.png");
+    ASSERT_TRUE(QFile::link(realTxt, link));
+    jobUrl = mdimgUrlFor(link);
+
+    // Act
+    handler->exposeRequestStarted(nullptr);
+
+    // Assert：canonical 解析成功 + 按扩展名 MIME 供给（真实行为契约）
+    EXPECT_EQ(replyCount, 1);
+    EXPECT_EQ(lastContentType, QByteArray("image/png"));
+    EXPECT_EQ(failCount, 0);
+}
+
+TEST_F(MarkdownImageHandlerTest, RequestStarted_RelativeTraversalResolvedToImage_RepliesImage)
+{
+    // Arrange：路径含 sub/../（规范化后仍指向合法图片——合法相对写法不误杀）
+    const QString img = makeImageFile("real.png");
+    QDir(tmpDir.path()).mkpath(QStringLiteral("sub"));
+    const QString withDotDot = tmpDir.path() + QStringLiteral("/sub/../real.png");
+    jobUrl = mdimgUrlFor(withDotDot);
+
+    // Act
+    handler->exposeRequestStarted(nullptr);
+
+    // Assert：canonicalFilePath 规范化成功 + 图片 MIME → 正常供给
+    EXPECT_EQ(replyCount, 1);
+    EXPECT_EQ(lastContentType, QByteArray("image/png"));
+    EXPECT_EQ(failCount, 0);
+}
+
+TEST_F(MarkdownImageHandlerTest, RequestStarted_UrlWithHost_PathReconstructedPrefixed)
+{
+    // Arrange：Blink 把 mdimg:///abs 规范化为 mdimg://abs/…，handler 需还原
+    // 用"host=缺失段 + path=真实文件"构造：重建出的 /host/abs 不存在 → UrlNotFound。
+    // 若还原逻辑缺失（bug），path 命中真实文件会 reply——断言可区分两种实现。
+    const QString img = makeImageFile("h.png");
+    QUrl u;
+    u.setScheme(QStringLiteral("mdimg"));
+    u.setHost(QStringLiteral("missingseg"));
+    u.setPath(img);
+    jobUrl = u.toString();
+
+    // Act
+    handler->exposeRequestStarted(nullptr);
+
+    // Assert：重建路径 /missingseg/<abs> 不存在 → fail（B1 执行 + B2 兜底）
+    EXPECT_EQ(failCount, 1);
+    EXPECT_EQ(lastFailError, int(QWebEngineUrlRequestJob::UrlNotFound));
+    EXPECT_EQ(replyCount, 0);
+}

--- a/tests/editor_markdown/test_markdownlogic.cpp
+++ b/tests/editor_markdown/test_markdownlogic.cpp
@@ -1,0 +1,331 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include "stubext.h"
+#include "markdownlogic.h"
+
+#include <QDir>
+#include <QTemporaryDir>
+#include <QUrl>
+
+// 分支清单（来源：markdownlogic.h）
+// isMarkdownByDefinitionName:
+//   D1: definitionName == "Markdown"（大小写敏感精确）→ true
+//   D2: 其他（小写/空/带后缀）→ false
+// isMarkdownByFileName:
+//   F1: fileName.isEmpty() → false（提前 return）
+//   F2: lower endsWith .md/.markdown/.mdown → true
+//   F3: 其他扩展 → false
+// isMarkdown:
+//   M1: definition 命中 → true（优先）
+//   M2: definition 未命中但扩展命中 → true
+//   M3: 两者都未命中 → false
+// resolveImagePaths:
+//   R1: md.isEmpty() || baseDir.isEmpty() → 原样返回（提前 return）
+//   R2: path 为 http:/https:/data:/mdimg: → 原样保留（4 个 || 短路条件）
+//   R3: 本地相对/绝对路径 → 改写 mdimg://<percent-encode(abs)>
+//   R4: 带 title 的图片语法 → title 原样保留
+//   R5: 无图片 → 文本原样返回（循环 0 次）
+//   R6: 多图片/中间文本 → 拼接正确（循环 N 次 + last 尾段）
+//   R7: 路径带空白 → QString(path).trimmed()
+//
+// 用例映射：
+// - IsMarkdownByDefinitionName_ExactAndCaseVariants_ReturnsExpected（TEST_P 6 组）  → D1/D2
+// - IsMarkdownByFileName_ExtensionVariants_ReturnsExpected（TEST_P 8 组）           → F1/F2/F3
+// - IsMarkdown_DefinitionPriorityOverExtension_ReturnsExpected（TEST_P 5 组）        → M1/M2/M3
+// - ResolveImagePaths_EmptyMdOrBaseDir_ReturnsInputUnchanged（TEST_P 3 组）          → R1
+// - ResolveImagePaths_NetworkAndDataSchemes_PreservedAsIs（TEST_P 4 组）             → R2
+// - ResolveImagePaths_RelativeLocalPath_RewrittenToMdimgUrl                          → R3
+// - ResolveImagePaths_AbsoluteLocalPath_RewrittenToMdimgUrl                           → R3
+// - ResolveImagePaths_TitleSuffix_PreservedInRebuild                                 → R4
+// - ResolveImagePaths_NoImageSyntax_TextUnchanged                                    → R5
+// - ResolveImagePaths_MultipleImagesWithText_InterleavedCorrectly                    → R6
+// - ResolveImagePaths_PathWithSurroundingSpaces_TrimmedBeforeResolve                 → R7
+//
+// 最小清单自检：1 每公开方法≥1用例 ✔（4 个静态方法全覆盖，private 无）
+// 2 等价类划分 ✔ 3 边界（空串/大小写/多图/尾段）✔ 4 TEST_P ×4（各≥3 组）✔
+// 5 分支清单映射 ✔ 6 全部分支有用例 ✔ 7 无 throw 8 空输入负面 ✔ 9 纯函数无状态损坏 ✔
+// 10 Qt 静态工具类直接调用 + QTemporaryDir 隔离文件系统 ✔（无 stub 目标）
+
+// —— 等价类/边界成组：definition 名 ——
+namespace {
+struct NameCase {
+    QString name;
+    bool expected;
+};
+const NameCase kDefCases[] = {
+    { QStringLiteral("Markdown"), true },            // 唯一有效等价类
+    { QStringLiteral("markdown"), false },           // 大小写敏感：小写拒绝
+    { QStringLiteral("MARKDOWN"), false },           // 大写拒绝
+    { QStringLiteral("Markdown Extra"), false },      // 非精确匹配
+    { QStringLiteral(""), false },                    // 空串边界
+    { QStringLiteral("Markdowns"), false },           // 前缀+后缀近似
+};
+} // namespace
+
+class DefNameParamTest : public ::testing::TestWithParam<NameCase> {
+};
+
+TEST_P(DefNameParamTest, IsMarkdownByDefinitionName_ExactAndCaseVariants_ReturnsExpected)
+{
+    // Arrange
+    const auto &c = GetParam();
+
+    // Act
+    const bool ret = MarkdownLogic::isMarkdownByDefinitionName(c.name);
+
+    // Assert
+    EXPECT_EQ(ret, c.expected);   // 期望值见参数表注释
+    EXPECT_EQ(ret, c.name == QStringLiteral("Markdown"));
+}
+
+INSTANTIATE_TEST_SUITE_P(DefinitionNames, DefNameParamTest,
+                         ::testing::ValuesIn(kDefCases));
+
+// —— 等价类/边界成组：文件名扩展 ——
+namespace {
+const NameCase kFileCases[] = {
+    { QStringLiteral("README.md"), true },
+    { QStringLiteral("note.MARKDOWN"), true },        // 扩展名不区分大小写
+    { QStringLiteral("a.MdOwN"), true },
+    { QStringLiteral("b.mdown"), true },
+    { QStringLiteral("c.txt"), false },
+    { QStringLiteral("d.md5"), false },               // 近似扩展非 .md
+    { QStringLiteral("md"), false },                   // 无点边界
+    { QStringLiteral(""), false },                     // 空串提前 return
+};
+} // namespace
+
+class FileNameParamTest : public ::testing::TestWithParam<NameCase> {
+};
+
+TEST_P(FileNameParamTest, IsMarkdownByFileName_ExtensionVariants_ReturnsExpected)
+{
+    // Arrange
+    const auto &c = GetParam();
+
+    // Act
+    const bool ret = MarkdownLogic::isMarkdownByFileName(c.name);
+
+    // Assert
+    EXPECT_EQ(ret, c.expected);
+    // 与底层 toLower+endsWith 行为一致性（第二条独立断言）
+    const QString lower = c.name.toLower();
+    EXPECT_EQ(ret, lower.endsWith(".md") || lower.endsWith(".markdown") || lower.endsWith(".mdown"));
+}
+
+INSTANTIATE_TEST_SUITE_P(FileNames, FileNameParamTest,
+                         ::testing::ValuesIn(kFileCases));
+
+// —— 综合：definition 优先于扩展 ——
+namespace {
+struct ComboCase {
+    QString fileName;
+    QString definitionName;
+    bool expected;
+};
+const ComboCase kComboCases[] = {
+    { QStringLiteral("x.txt"), QStringLiteral("Markdown"), true },    // definition 优先
+    { QStringLiteral("x.md"), QStringLiteral("C++"), true },          // 扩展兜底
+    { QStringLiteral("x.txt"), QStringLiteral("C++"), false },        // 双未命中
+    { QStringLiteral(""), QStringLiteral(""), false },                 // 双空边界
+    { QStringLiteral("y.md"), QStringLiteral("Markdown"), true },      // 双命中
+};
+} // namespace
+
+class ComboParamTest : public ::testing::TestWithParam<ComboCase> {
+};
+
+TEST_P(ComboParamTest, IsMarkdown_DefinitionPriorityOverExtension_ReturnsExpected)
+{
+    // Arrange
+    const auto &c = GetParam();
+
+    // Act
+    const bool ret = MarkdownLogic::isMarkdown(c.fileName, c.definitionName);
+
+    // Assert
+    EXPECT_EQ(ret, c.expected);
+    // definition 命中时与文件名无关（优先级验证）
+    if (c.definitionName == QStringLiteral("Markdown"))
+        EXPECT_TRUE(ret);
+}
+
+INSTANTIATE_TEST_SUITE_P(Combinations, ComboParamTest,
+                         ::testing::ValuesIn(kComboCases));
+
+// —— R1：空输入提前返回 ——
+namespace {
+struct EmptyCase {
+    QString md;
+    QString baseDir;
+};
+const EmptyCase kEmptyCases[] = {
+    { QString(), QStringLiteral("/any/dir") },   // 空 md
+    { QStringLiteral("# t"), QString() },        // 空 baseDir
+    { QString(), QString() },                    // 双空边界
+};
+} // namespace
+
+class EmptyInputParamTest : public ::testing::TestWithParam<EmptyCase> {
+};
+
+TEST_P(EmptyInputParamTest, ResolveImagePaths_EmptyMdOrBaseDir_ReturnsInputUnchanged)
+{
+    // Arrange
+    const auto &c = GetParam();
+
+    // Act
+    const QString out = MarkdownLogic::resolveImagePaths(c.md, c.baseDir);
+
+    // Assert：提前 return，原样返回（不得产生 mdimg:// 改写）
+    EXPECT_EQ(out, c.md);
+    EXPECT_FALSE(out.contains(QStringLiteral("mdimg://")));
+}
+
+INSTANTIATE_TEST_SUITE_P(EmptyInputs, EmptyInputParamTest,
+                         ::testing::ValuesIn(kEmptyCases));
+
+// —— R2：保留 scheme（4 组同质）——
+namespace {
+struct SchemeCase {
+    QString path;
+};
+const SchemeCase kSchemeCases[] = {
+    { QStringLiteral("http://example.org/a.png") },
+    { QStringLiteral("https://example.org/b.png") },
+    { QStringLiteral("data:image/png;base64,iVBORw0KGgo=") },
+    { QStringLiteral("mdimg:///already/resolved.png") },
+};
+} // namespace
+
+class SchemeParamTest : public ::testing::TestWithParam<SchemeCase> {
+};
+
+TEST_P(SchemeParamTest, ResolveImagePaths_NetworkAndDataSchemes_PreservedAsIs)
+{
+    // Arrange
+    const auto &c = GetParam();
+    const QString md = QStringLiteral("![alt](") + c.path + QStringLiteral(")");
+    QTemporaryDir dir;
+    ASSERT_TRUE(dir.isValid());
+
+    // Act
+    const QString out = MarkdownLogic::resolveImagePaths(md, dir.path());
+
+    // Assert：原样保留，不重写、不 percent-encode
+    EXPECT_EQ(out, md);
+    EXPECT_EQ(out.count(QStringLiteral("mdimg://")), c.path.startsWith(QStringLiteral("mdimg:")) ? 1 : 0);
+}
+
+INSTANTIATE_TEST_SUITE_P(PreservedSchemes, SchemeParamTest,
+                         ::testing::ValuesIn(kSchemeCases));
+
+TEST(MarkdownLogicTest, ResolveImagePaths_RelativeLocalPath_RewrittenToMdimgUrl)
+{
+    // Arrange
+    QTemporaryDir dir;
+    ASSERT_TRUE(dir.isValid());
+    const QString md = QStringLiteral("![logo](img/logo.png)");
+    const QString abs = QDir(dir.path()).absoluteFilePath(QStringLiteral("img/logo.png"));
+
+    // Act
+    const QString out = MarkdownLogic::resolveImagePaths(md, dir.path());
+
+    // Assert：改写为 mdimg:// + percent-encoding(abs)（'/' 保留，恰三个斜杠）
+    const QString expected = QStringLiteral("mdimg://")
+                             + QString::fromUtf8(QUrl::toPercentEncoding(abs, "/"));
+    EXPECT_EQ(out, QStringLiteral("![logo](") + expected + QStringLiteral(")"));
+    EXPECT_TRUE(out.startsWith(QStringLiteral("![logo](mdimg:///")));
+    EXPECT_TRUE(out.contains(QStringLiteral("img/logo.png")));
+}
+
+TEST(MarkdownLogicTest, ResolveImagePaths_AbsoluteLocalPath_RewrittenToMdimgUrl)
+{
+    // Arrange
+    QTemporaryDir dir;
+    ASSERT_TRUE(dir.isValid());
+    const QString abs = dir.filePath(QStringLiteral("pic.png"));   // 绝对路径输入
+    const QString md = QStringLiteral("![](") + abs + QStringLiteral(")");
+
+    // Act
+    const QString out = MarkdownLogic::resolveImagePaths(md, dir.path() + QStringLiteral("/nested"));
+
+    // Assert：absoluteFilePath 对绝对入参原样返回，仍改写为 mdimg
+    const QString expected = QStringLiteral("mdimg://")
+                             + QString::fromUtf8(QUrl::toPercentEncoding(abs, "/"));
+    EXPECT_EQ(out, QStringLiteral("![](") + expected + QStringLiteral(")"));
+    EXPECT_TRUE(out.contains(QStringLiteral("mdimg:///")));
+}
+
+TEST(MarkdownLogicTest, ResolveImagePaths_TitleSuffix_PreservedInRebuild)
+{
+    // Arrange
+    QTemporaryDir dir;
+    ASSERT_TRUE(dir.isValid());
+    const QString md = QStringLiteral("![cap]( shot.png \"截图\")");
+
+    // Act
+    const QString out = MarkdownLogic::resolveImagePaths(md, dir.path());
+
+    // Assert：路径 trimmed + title（含引号与空格）原样保留
+    const QString abs = QDir(dir.path()).absoluteFilePath(QStringLiteral("shot.png"));
+    const QString expected = QStringLiteral("mdimg://")
+                             + QString::fromUtf8(QUrl::toPercentEncoding(abs, "/"));
+    EXPECT_EQ(out, QStringLiteral("![cap](") + expected + QStringLiteral(" \"截图\")"));
+    EXPECT_TRUE(out.contains(QStringLiteral("\"截图\"")));
+}
+
+TEST(MarkdownLogicTest, ResolveImagePaths_NoImageSyntax_TextUnchanged)
+{
+    // Arrange
+    const QString md = QString::fromUtf8("# 标题\n[链接](http://example.org)\n正文无图");
+    QTemporaryDir dir;
+    ASSERT_TRUE(dir.isValid());
+
+    // Act
+    const QString out = MarkdownLogic::resolveImagePaths(md, dir.path());
+
+    // Assert：循环 0 次，全文原样（普通链接不误伤）
+    EXPECT_EQ(out, md);
+    EXPECT_FALSE(out.contains(QStringLiteral("mdimg")));
+}
+
+TEST(MarkdownLogicTest, ResolveImagePaths_MultipleImagesWithText_InterleavedCorrectly)
+{
+    // Arrange
+    QTemporaryDir dir;
+    ASSERT_TRUE(dir.isValid());
+    const QString md = QStringLiteral("pre ![a](a.png) mid ![b](sub/b.png) tail");
+
+    // Act
+    const QString out = MarkdownLogic::resolveImagePaths(md, dir.path());
+
+    // Assert：两图均改写，中间/首尾文本保留（尾段 last 拼接）
+    const QString absA = QDir(dir.path()).absoluteFilePath(QStringLiteral("a.png"));
+    const QString absB = QDir(dir.path()).absoluteFilePath(QStringLiteral("sub/b.png"));
+    const QString urlA = QString::fromUtf8(QUrl::toPercentEncoding(absA, "/"));
+    const QString urlB = QString::fromUtf8(QUrl::toPercentEncoding(absB, "/"));
+    EXPECT_EQ(out, QStringLiteral("pre ![a](mdimg://") + urlA
+                    + QStringLiteral(") mid ![b](mdimg://") + urlB
+                    + QStringLiteral(") tail"));
+    EXPECT_EQ(out.count(QStringLiteral("mdimg://")), 2);
+}
+
+TEST(MarkdownLogicTest, ResolveImagePaths_PathWithSurroundingSpaces_TrimmedBeforeResolve)
+{
+    // Arrange
+    QTemporaryDir dir;
+    ASSERT_TRUE(dir.isValid());
+    const QString md = QStringLiteral("![x](   space.png   )");
+
+    // Act
+    const QString out = MarkdownLogic::resolveImagePaths(md, dir.path());
+
+    // Assert：trimmed 后按 baseDir 解析（URL 不含空格与 %20 以外的空白）
+    const QString abs = QDir(dir.path()).absoluteFilePath(QStringLiteral("space.png"));
+    const QString expected = QString::fromUtf8(QUrl::toPercentEncoding(abs, "/"));
+    EXPECT_EQ(out, QStringLiteral("![x](mdimg://") + expected + QStringLiteral(")"));
+    EXPECT_FALSE(out.contains(QStringLiteral(" space")));
+}

--- a/tests/editor_markdown/test_markdownview.cpp
+++ b/tests/editor_markdown/test_markdownview.cpp
@@ -1,0 +1,577 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include "stubext.h"
+#include "markdownview.h"
+#include "themeserializer.h"
+
+#include <QApplication>
+#include <QDesktopServices>
+#include <QElapsedTimer>
+#include <QEventLoop>
+#include <QMetaEnum>
+#include <QMetaType>
+#include <QSignalSpy>
+#include <QTemporaryDir>
+#include <QTimer>
+#include <QWebEnginePage>
+#include <QWebEngineProfile>
+#include <QWebEngineSettings>
+
+// 分支清单（来源：markdownview.cpp）
+// ctor: 连接 bridge 四信号 + renderProcessTerminated（无分支）
+// init():
+//   I1: profile 无 mdimgHandlerInstalled 属性 → installUrlSchemeHandler + setProperty
+//   I2: 属性已为 true（同 profile 第二个视图）→ 跳过安装
+//   I3: load(qrc:/editor/markdown/web/milkdown.html)
+//   I4: page urlChanged → http/https → openUrl + load(qrc)；其他 scheme → 仅告警
+// onBridgeReady():
+//   R1: m_hasPendingMd → 补发内容并清标记
+//   R2: m_hasLayout → 补发布局
+//   R3: m_hasTheme → 补发主题
+//   R4: m_hasScroll（含 0.0 有效）→ 补发滚动
+//   R5: emit ready()
+// setMarkdown/setLayout/applyTheme/scrollToRatio: 缓存 + 即时 emit（无分支，参数与标记）
+// setMode: mode==Editable → true，否则 false（含越界值）
+// openLinkRequested lambda: scheme http/https → QDesktopServices::openUrl；否则拦截
+// renderProcessTerminated lambda: m_ready=false + 300ms 后 Reload
+// scrollRatio(): h<=0 → 0.0；h>0 → clampRatio(scrollY/h)
+//
+// 用例映射：
+// - Constructor_BareCreation_BridgeChildNotReady                       → ctor
+// - BridgeSignals_ForwardedToViewSignals_PayloadIntact                  → ctor 连接
+// - SetMarkdown_BeforeReady_EmitsAndCachesForReplay                    → setMarkdown/R1
+// - SetMode_ReadOnlyEditableAndInvalid_EmitsMappedFlag                  → setMode 分支
+// - ApplyTheme_DarkAndLightMaps_EmitsSerializedJsonAndFlag（TEST_P 2）  → applyTheme
+// - SetLayout_MaxWidthAndCenter_EmitsExactParams                        → setLayout/R2
+// - ScrollToRatio_BoundaryValues_EmitsExactRatio（TEST_P 3）             → scrollToRatio/R4
+// - OnBridgeReady_FullCache_ReplaysAllAndEmitsReady                     → R1-R5
+// - OnBridgeReady_ZeroRatioValid_ReplaysZeroScroll                      → R4（0.0 边界）
+// - OnBridgeReady_NoCache_EmitsOnlyReady                                 → R1-R4 反例
+// - ScrollRatio_EmptyContents_ReturnsZero                                → h<=0
+// - ScrollRatio_NonEmptyContents_ReturnsClampedRatio                     → h>0 + clamp
+// - OpenLink_HttpAndHttpsSchemes_DelegatedToDesktopServices             → 白名单
+// - OpenLink_NonHttpScheme_BlockedWithoutDelegation                      → 拦截
+// - RenderProcessTerminated_AliveView_MarksUnreadyAndReloads            → 恢复 lambda
+// - Init_FreshProfile_InstallsHandlerRegistersChannelLoadsQrc           → I1/I3
+// - Init_SecondViewSameProfile_SkipsHandlerReinstall                     → I2
+// - UrlChanged_ExternalHttp_DelegatesToBrowserAndReloadsRenderPage       → I4 白名单
+// - UrlChanged_NonHttpScheme_StaysInRenderPage                            → I4 反例
+//
+// 最小清单自检：1 公开方法全覆盖（ctor/dtor/init/bridge/isReady/setMarkdown/setMode/
+// applyTheme/setLayout/scrollToRatio/scrollRatio；onBridgeReady private 经 bridge 公开槽触发）
+// ✔ 2 等价类 ✔ 3 边界（ratio 0/1、mode 越界、空缓存）✔ 4 TEST_P ×2（≥3 组）✔
+// 5 分支映射 ✔ 6 I1-I4/R1-R5/模式分支全覆盖 ✔ 7 无异常路径 8 越界/拦截负面 ✔
+// 9 fail/拦截后状态一致 ✔ 10 QDesktopServices/openUrl、QWebChannel::registerObject、
+// QWebEngineView::load、QWebEnginePage::contentsSize/scrollPosition、profile 安装等
+// 外部依赖一律 stub_ext（虚函数 triggerAction 用 VADDR）；QSignalSpy 验信号；不与 gMock 混用
+
+class MarkdownViewTest : public ::testing::Test {
+protected:
+    static void SetUpTestSuite()
+    {
+        // QWidget 派生类必须 QApplication；offscreen 平台不产生真实窗口
+        if (!QApplication::instance()) {
+            static int argc = 1;
+            static char argv0[] = "test_markdownview";
+            static char *argv[] = { argv0, nullptr };
+            s_app = new QApplication(argc, argv);
+        }
+        // renderProcessTerminated 信号参数类型（直接调用需注册）
+        qRegisterMetaType<QWebEnginePage::RenderProcessTerminationStatus>(
+            "QWebEnginePage::RenderProcessTerminationStatus");
+    }
+
+    static void TearDownTestSuite()
+    {
+        // 各用例 TearDown 已删除视图；销毁应用保证 WebEngine 干净退出码
+        if (s_app) {
+            s_app->processEvents(QEventLoop::AllEvents, 100);
+            delete s_app;
+            s_app = nullptr;
+        }
+    }
+
+    void SetUp() override
+    {
+        stub.clear();
+        openUrlCount = 0;
+        loadCount = 0;
+        registerCount = 0;
+        installCount = 0;
+        reloadCount = 0;
+        lastOpenedUrl.clear();
+        lastLoadedUrl.clear();
+
+        // QDesktopServices::openUrl 静态：禁止真实调起系统浏览器
+        stub.set_lamda(&QDesktopServices::openUrl,
+                       [this](const QUrl &url) -> bool {
+                           ++openUrlCount;
+                           lastOpenedUrl = url;
+                           return true;
+                       });
+        // load 重载：精确 static_cast 到 QUrl 版本
+        stub.set_lamda(static_cast<void (QWebEngineView::*)(const QUrl &)>(&QWebEngineView::load),
+                       [this](QWebEngineView *, const QUrl &url) {
+                           ++loadCount;
+                           lastLoadedUrl = url;
+                       });
+        // WebChannel 注册（避免真实 JS 侧握手状态）
+        stub.set_lamda(&QWebChannel::registerObject,
+                       [this](QWebChannel *, const QString &id, QObject *) {
+                           ++registerCount;
+                           lastRegisteredId = id;
+                       });
+        // mdimg handler 安装（真实安装无必要，计数区分 I1/I2）
+        stub.set_lamda(&QWebEngineProfile::installUrlSchemeHandler,
+                       [this](QWebEngineProfile *, const QByteArray &, QWebEngineUrlSchemeHandler *) {
+                           ++installCount;
+                       });
+        // 崩溃恢复 Reload（虚函数 → VADDR）
+        stub.set_lamda(VADDR(QWebEnginePage, triggerAction),
+                       [this](QWebEnginePage *, QWebEnginePage::WebAction action, bool) {
+                           if (action == QWebEnginePage::Reload)
+                               ++reloadCount;
+                       });
+
+        obj = new MarkdownView();
+    }
+
+    void TearDown() override
+    {
+        delete obj;   // 触发析构函数覆盖；QWebEngineView/页面递归删除
+        obj = nullptr;
+        stub.clear();
+    }
+
+    static QApplication *s_app;
+    stub_ext::StubExt stub;
+    MarkdownView *obj = nullptr;
+    int openUrlCount = 0;
+    int loadCount = 0;
+    int registerCount = 0;
+    int installCount = 0;
+    int reloadCount = 0;
+    QUrl lastOpenedUrl;
+    QUrl lastLoadedUrl;
+    QString lastRegisteredId;
+};
+
+QApplication *MarkdownViewTest::s_app = nullptr;
+
+TEST_F(MarkdownViewTest, Constructor_BareCreation_BridgeChildNotReady)
+{
+    // Arrange & Act（SetUp 已构造，未 init）
+
+    // Assert：bridge 为子对象且未就绪（构造分离契约：不启动 WebEngine 渲染）
+    EXPECT_NE(obj->bridge(), nullptr);
+    EXPECT_EQ(obj->bridge()->parent(), obj);
+    EXPECT_FALSE(obj->isReady());   // 期望 false 边：ready 仅在 onBridgeReady 后
+}
+
+TEST_F(MarkdownViewTest, ModeEnum_MetaObjectRegistration_KeysAndValuesMapped)
+{
+    // Arrange：Q_ENUM(Mode) 生成的元信息（QMetaEnum/QMetaType 注册路径）
+
+    // Act
+    const QMetaEnum me = QMetaEnum::fromType<MarkdownView::Mode>();
+    const QMetaType mt = QMetaType::fromType<MarkdownView::Mode>();
+
+    // Assert：枚举↔字符串双向映射与所属元对象
+    EXPECT_EQ(me.keyCount(), 2);
+    EXPECT_STREQ(me.valueToKey(MarkdownView::ReadOnly), "ReadOnly");
+    EXPECT_STREQ(me.valueToKey(MarkdownView::Editable), "Editable");
+    EXPECT_EQ(me.keyToValue("Editable"), int(MarkdownView::Editable));
+    EXPECT_EQ(mt.metaObject(), &MarkdownView::staticMetaObject);
+
+    // QVariant 打包/解包枚举（QMetaType 名称注册路径）
+    const QVariant packed = QVariant::fromValue(MarkdownView::Editable);
+    EXPECT_EQ(packed.userType(), mt.id());
+    EXPECT_EQ(packed.value<MarkdownView::Mode>(), MarkdownView::Editable);
+    EXPECT_EQ(mt.name(), QByteArray("MarkdownView::Mode"));
+
+    // Q_ENUM 生成的 friend 辅助函数（ADL 可达；constexpr 常规路径编译期折叠，
+    // 显式调用保证运行时执行覆盖）
+    EXPECT_STREQ(qt_getEnumName(MarkdownView::ReadOnly), "Mode");
+    EXPECT_EQ(qt_getEnumMetaObject(MarkdownView::Editable), &MarkdownView::staticMetaObject);
+}
+
+TEST_F(MarkdownViewTest, BridgeSignals_ForwardedToViewSignals_PayloadIntact)
+{
+    // Arrange：ctor 中 bridge→view 的 contentChanged/scrollRatioChanged 转发
+    QSignalSpy contentSpy(obj, &MarkdownView::contentChanged);
+    QSignalSpy scrollSpy(obj, &MarkdownView::scrollRatioChanged);
+
+    // Act：经 bridge 公开槽注入（JS 侧来源等价路径）
+    obj->bridge()->onContentChanged(QStringLiteral("# live"));
+    obj->bridge()->onScrollRatio(0.4);
+
+    // Assert
+    ASSERT_EQ(contentSpy.count(), 1);
+    EXPECT_EQ(contentSpy.at(0).at(0).toString(), QString("# live"));
+    ASSERT_EQ(scrollSpy.count(), 1);
+    EXPECT_DOUBLE_EQ(scrollSpy.at(0).at(0).toDouble(), 0.4);
+}
+
+TEST_F(MarkdownViewTest, SetMarkdown_BeforeReady_EmitsAndCachesForReplay)
+{
+    // Arrange
+    QSignalSpy mdSpy(obj->bridge(), &MarkdownBridge::setMarkdownRequested);
+
+    // Act：ready 前推送（JS 未接线，协议层双保险缓存）
+    obj->setMarkdown(QStringLiteral("# cached"));
+
+    // Assert：即时 emit 一次 + 未就绪（缓存待补发）
+    EXPECT_EQ(mdSpy.count(), 1);
+    EXPECT_EQ(mdSpy.at(0).at(0).toString(), QString("# cached"));
+    EXPECT_FALSE(obj->isReady());
+
+    // Act 2：内核就绪 → 补发缓存内容
+    QSignalSpy readySpy(obj, &MarkdownView::ready);
+    obj->bridge()->onReady();
+
+    // Assert 2：累计两次（即时+补发）且 ready
+    EXPECT_EQ(mdSpy.count(), 2);
+    EXPECT_EQ(mdSpy.at(1).at(0).toString(), QString("# cached"));
+    EXPECT_EQ(readySpy.count(), 1);
+    EXPECT_TRUE(obj->isReady());   // 期望 true 边：onBridgeReady 置位
+}
+
+TEST_F(MarkdownViewTest, SetMode_ReadOnlyEditableAndInvalid_EmitsMappedFlag)
+{
+    // Arrange
+    QSignalSpy modeSpy(obj->bridge(), &MarkdownBridge::setModeRequested);
+
+    // Act：ReadOnly(0) / Editable(1) / 越界值(99)
+    obj->setMode(MarkdownView::ReadOnly);
+    obj->setMode(MarkdownView::Editable);
+    obj->setMode(99);
+
+    // Assert：映射为 editable 布尔，仅 Editable(1) 为 true
+    ASSERT_EQ(modeSpy.count(), 3);
+    EXPECT_FALSE(modeSpy.at(0).at(0).toBool());
+    EXPECT_TRUE(modeSpy.at(1).at(0).toBool());
+    EXPECT_FALSE(modeSpy.at(2).at(0).toBool());   // 越界按非 Editable 处理
+}
+
+// —— applyTheme 深浅两态（同断言逻辑成组）——
+namespace {
+struct ThemeCase {
+    QString bg;
+    QString fg;
+    bool expectedDark;
+};
+const ThemeCase kThemeCases[] = {
+    { "#1e1e1e", "#eeeeee", true },
+    { "#ffffff", "#1f1f1f", false },
+    { "#252525", "#d0d0d0", true },
+};
+} // namespace
+
+class ViewThemeParamTest : public MarkdownViewTest,
+                           public ::testing::WithParamInterface<ThemeCase> {
+};
+
+TEST_P(ViewThemeParamTest, ApplyTheme_DarkAndLightMaps_EmitsSerializedJsonAndFlag)
+{
+    // Arrange
+    const auto &c = GetParam();
+    QVariantMap theme;
+    QVariantMap ec;
+    ec["background-color"] = c.bg;
+    ec["text-color"] = c.fg;
+    theme["editor-colors"] = ec;
+    const QString expectedJson = ThemeSerializer::serialize(theme);
+    QSignalSpy themeSpy(obj->bridge(), &MarkdownBridge::applyThemeRequested);
+
+    // Act
+    obj->applyTheme(theme);
+
+    // Assert：序列化 JSON 与深浅标志精确（阶段 3 ThemeSerializer 集成契约）
+    EXPECT_EQ(themeSpy.count(), 1);
+    EXPECT_EQ(themeSpy.at(0).at(0).toString(), expectedJson);
+    EXPECT_EQ(themeSpy.at(0).at(1).toBool(), c.expectedDark);
+    EXPECT_EQ(ThemeSerializer::isDark(theme), c.expectedDark);
+}
+
+INSTANTIATE_TEST_SUITE_P(ViewThemes, ViewThemeParamTest,
+                         ::testing::ValuesIn(kThemeCases));
+
+TEST_F(MarkdownViewTest, SetLayout_MaxWidthAndCenter_EmitsExactParams)
+{
+    // Arrange
+    QSignalSpy layoutSpy(obj->bridge(), &MarkdownBridge::setLayoutRequested);
+
+    // Act：居中约束与半幅无限宽两种布局
+    obj->setLayout(800, true);
+    obj->setLayout(0, false);
+
+    // Assert
+    ASSERT_EQ(layoutSpy.count(), 2);
+    EXPECT_EQ(layoutSpy.at(0).at(0).toInt(), 800);
+    EXPECT_TRUE(layoutSpy.at(0).at(1).toBool());
+    EXPECT_EQ(layoutSpy.at(1).at(0).toInt(), 0);   // 0=不限最大宽边界
+    EXPECT_FALSE(layoutSpy.at(1).at(1).toBool());
+}
+
+// —— scrollToRatio 边界值成组（0/中点/1）——
+namespace {
+struct ViewRatioCase {
+    double ratio;
+};
+const ViewRatioCase kViewRatioCases[] = {
+    { 0.0 },
+    { 0.5 },
+    { 1.0 },
+};
+} // namespace
+
+class ViewRatioParamTest : public MarkdownViewTest,
+                           public ::testing::WithParamInterface<ViewRatioCase> {
+};
+
+TEST_P(ViewRatioParamTest, ScrollToRatio_BoundaryValues_EmitsExactRatio)
+{
+    // Arrange
+    const double ratio = GetParam().ratio;
+    QSignalSpy scrollSpy(obj->bridge(), &MarkdownBridge::scrollToRatioRequested);
+
+    // Act
+    obj->scrollToRatio(ratio);
+
+    // Assert
+    EXPECT_EQ(scrollSpy.count(), 1);
+    EXPECT_DOUBLE_EQ(scrollSpy.at(0).at(0).toDouble(), ratio);
+}
+
+INSTANTIATE_TEST_SUITE_P(ViewRatioBoundaries, ViewRatioParamTest,
+                         ::testing::ValuesIn(kViewRatioCases));
+
+TEST_F(MarkdownViewTest, OnBridgeReady_FullCache_ReplaysAllAndEmitsReady)
+{
+    // Arrange：ready 前塞满四类缓存（内容/布局/主题/滚动）
+    QSignalSpy mdSpy(obj->bridge(), &MarkdownBridge::setMarkdownRequested);
+    QSignalSpy layoutSpy(obj->bridge(), &MarkdownBridge::setLayoutRequested);
+    QSignalSpy themeSpy(obj->bridge(), &MarkdownBridge::applyThemeRequested);
+    QSignalSpy scrollSpy(obj->bridge(), &MarkdownBridge::scrollToRatioRequested);
+    QSignalSpy readySpy(obj, &MarkdownView::ready);
+    QVariantMap theme;
+    QVariantMap ec;
+    ec["background-color"] = "#1e1e1e";
+    theme["editor-colors"] = ec;
+    obj->setMarkdown(QStringLiteral("body"));
+    obj->setLayout(800, true);
+    obj->applyTheme(theme);
+    obj->scrollToRatio(0.25);
+    EXPECT_EQ(mdSpy.count(), 1);   // 前置即时 emit
+
+    // Act：内核就绪
+    obj->bridge()->onReady();
+
+    // Assert：四类全部补发（即时 1 次 + 补发 1 次 = 2）+ ready 恰一次
+    EXPECT_EQ(mdSpy.count(), 2);
+    EXPECT_EQ(mdSpy.at(1).at(0).toString(), QString("body"));
+    EXPECT_EQ(layoutSpy.count(), 2);
+    EXPECT_EQ(layoutSpy.at(1).at(0).toInt(), 800);
+    EXPECT_TRUE(layoutSpy.at(1).at(1).toBool());
+    EXPECT_EQ(themeSpy.count(), 2);
+    EXPECT_EQ(themeSpy.at(1).at(1).toBool(), true);
+    EXPECT_EQ(scrollSpy.count(), 2);
+    EXPECT_DOUBLE_EQ(scrollSpy.at(1).at(0).toDouble(), 0.25);
+    EXPECT_EQ(readySpy.count(), 1);
+    EXPECT_TRUE(obj->isReady());
+}
+
+TEST_F(MarkdownViewTest, OnBridgeReady_ZeroRatioValid_ReplaysZeroScroll)
+{
+    // Arrange：0.0（回顶部）是有效状态，以独立标记而非值判断
+    QSignalSpy scrollSpy(obj->bridge(), &MarkdownBridge::scrollToRatioRequested);
+    QSignalSpy readySpy(obj, &MarkdownView::ready);
+    obj->scrollToRatio(0.0);
+
+    // Act
+    obj->bridge()->onReady();
+
+    // Assert：0.0 未被吞掉（即时 1 次 + 补发 1 次）
+    EXPECT_EQ(scrollSpy.count(), 2);
+    EXPECT_DOUBLE_EQ(scrollSpy.at(1).at(0).toDouble(), 0.0);
+    EXPECT_EQ(readySpy.count(), 1);
+}
+
+TEST_F(MarkdownViewTest, OnBridgeReady_NoCache_EmitsOnlyReady)
+{
+    // Arrange：从未 set 过任何状态
+    QSignalSpy mdSpy(obj->bridge(), &MarkdownBridge::setMarkdownRequested);
+    QSignalSpy layoutSpy(obj->bridge(), &MarkdownBridge::setLayoutRequested);
+    QSignalSpy themeSpy(obj->bridge(), &MarkdownBridge::applyThemeRequested);
+    QSignalSpy scrollSpy(obj->bridge(), &MarkdownBridge::scrollToRatioRequested);
+    QSignalSpy readySpy(obj, &MarkdownView::ready);
+
+    // Act
+    obj->bridge()->onReady();
+
+    // Assert：只发 ready，不补发任何缓存
+    EXPECT_EQ(readySpy.count(), 1);
+    EXPECT_EQ(mdSpy.count(), 0);
+    EXPECT_EQ(layoutSpy.count(), 0);
+    EXPECT_EQ(themeSpy.count(), 0);
+    EXPECT_EQ(scrollSpy.count(), 0);
+    EXPECT_TRUE(obj->isReady());
+}
+
+TEST_F(MarkdownViewTest, ScrollRatio_EmptyContents_ReturnsZero)
+{
+    // Arrange：未 load 任何内容（contentsSize 无效/负，h<=0 分支）
+
+    // Act
+    const double ratio = obj->scrollRatio();
+
+    // Assert：除零保护 → 0.0（期望精确值）
+    EXPECT_DOUBLE_EQ(ratio, 0.0);
+    EXPECT_GE(ratio, 0.0);
+}
+
+TEST_F(MarkdownViewTest, ScrollRatio_NonEmptyContents_ReturnsClampedRatio)
+{
+    // Arrange：stub 页面几何（contentsSize/scrollPosition 均非虚属性 getter）
+    stub.set_lamda(&QWebEnginePage::contentsSize,
+                   [](QWebEnginePage *) -> QSizeF { return QSizeF(0, 1000); });
+    stub.set_lamda(&QWebEnginePage::scrollPosition,
+                   [](QWebEnginePage *) -> QPointF { return QPointF(0, 250); });
+
+    // Act
+    const double ratio = obj->scrollRatio();
+
+    // Assert：250/1000
+    EXPECT_NEAR(ratio, 0.25, 1e-12);
+
+    // Arrange 2：越界滚动位置 → 钳制
+    stub.set_lamda(&QWebEnginePage::scrollPosition,
+                   [](QWebEnginePage *) -> QPointF { return QPointF(0, 1500); });
+
+    // Act 2 & Assert 2：1500/1000=1.5 → clamp 1.0
+    EXPECT_NEAR(obj->scrollRatio(), 1.0, 1e-12);
+}
+
+TEST_F(MarkdownViewTest, OpenLink_HttpAndHttpsSchemes_DelegatedToDesktopServices)
+{
+    // Arrange：JS 点击拦截主路径 → bridge openLinkRequested → 系统浏览器（已 stub）
+
+    // Act
+    obj->bridge()->onOpenLink(QStringLiteral("https://example.org/doc"));
+    obj->bridge()->onOpenLink(QStringLiteral("http://example.org/other"));
+
+    // Assert：白名单内两 scheme 均转交且 URL 原样
+    EXPECT_EQ(openUrlCount, 2);
+    EXPECT_EQ(lastOpenedUrl.toString(), QString("http://example.org/other"));
+}
+
+TEST_F(MarkdownViewTest, OpenLink_NonHttpScheme_BlockedWithoutDelegation)
+{
+    // Arrange：安全审查——任意协议处理程序风险，非白名单一律拦截
+    QTemporaryDir dir;
+    ASSERT_TRUE(dir.isValid());
+    const QString fileUrl = QUrl::fromLocalFile(dir.filePath("x.html")).toString();
+
+    // Act
+    obj->bridge()->onOpenLink(fileUrl);
+    obj->bridge()->onOpenLink(QStringLiteral("javascript:alert(1)"));
+
+    // Assert：无转交、无崩溃、就绪状态未受影响（强安全不变式）
+    EXPECT_EQ(openUrlCount, 0);
+    EXPECT_FALSE(obj->isReady());
+}
+
+TEST_F(MarkdownViewTest, RenderProcessTerminated_AliveView_MarksUnreadyAndReloads)
+{
+    // Arrange：先就绪，再模拟渲染进程终止
+    obj->bridge()->onReady();
+    ASSERT_TRUE(obj->isReady());
+
+    // Act：发出 renderProcessTerminated（异步恢复经 300ms singleShot）
+    QMetaObject::invokeMethod(obj, "renderProcessTerminated",
+                              Q_ARG(QWebEnginePage::RenderProcessTerminationStatus,
+                                    QWebEnginePage::NormalTerminationStatus),
+                              Q_ARG(int, 0));
+    EXPECT_FALSE(obj->isReady());   // 同步置位：期望 false 边
+
+    // Arrange 2：等待 300ms 定时器触发（页面仍在，事件循环驱动）
+    QElapsedTimer elapsed;
+    elapsed.start();
+    while (elapsed.elapsed() < 700 && reloadCount == 0)
+        QApplication::processEvents(QEventLoop::AllEvents, 50);
+
+    // Assert：恢复路径执行了页面 Reload
+    EXPECT_EQ(reloadCount, 1);
+    EXPECT_EQ(openUrlCount, 0);   // 恢复不触外部浏览器
+}
+
+TEST_F(MarkdownViewTest, Init_FreshProfile_InstallsHandlerRegistersChannelLoadsQrc)
+{
+    // Arrange：默认 profile 尚未安装标记（进程内首视图；若先前用例已装则走 I2 用例断言）
+    QWebEngineProfile *profile = obj->page()->profile();
+    profile->setProperty("mdimgHandlerInstalled", QVariant());   // 重置为无效，确保 I1 路径
+
+    // Act
+    obj->init();
+
+    // Assert：I1 安装 + 属性置位 + 通道注册 + 加载渲染页
+    EXPECT_EQ(installCount, 1);
+    EXPECT_EQ(profile->property("mdimgHandlerInstalled").toBool(), true);
+    EXPECT_EQ(registerCount, 1);
+    EXPECT_EQ(lastRegisteredId, QString("bridge"));
+    EXPECT_EQ(loadCount, 1);
+    EXPECT_EQ(lastLoadedUrl.toString(), QString("qrc:/editor/markdown/web/milkdown.html"));
+}
+
+TEST_F(MarkdownViewTest, Init_SecondViewSameProfile_SkipsHandlerReinstall)
+{
+    // Arrange：首个视图已完成安装（属性置位）
+    QWebEngineProfile *profile = obj->page()->profile();
+    profile->setProperty("mdimgHandlerInstalled", true);
+    MarkdownView second;
+
+    // Act
+    second.init();
+
+    // Assert：I2 分支——不再安装，但通道注册与页面加载照常
+    EXPECT_EQ(installCount, 0);
+    EXPECT_EQ(registerCount, 1);
+    EXPECT_EQ(loadCount, 1);
+    EXPECT_EQ(profile->property("mdimgHandlerInstalled").toBool(), true);
+}
+
+TEST_F(MarkdownViewTest, UrlChanged_ExternalHttp_DelegatesToBrowserAndReloadsRenderPage)
+{
+    // Arrange：init（load 已 stub，不会真实导航）
+    obj->init();
+    const int loadBefore = loadCount;
+
+    // Act：页面若导航到外部地址（兜底路径）
+    QMetaObject::invokeMethod(obj->page(), "urlChanged",
+                              Q_ARG(QUrl, QUrl(QStringLiteral("https://example.org/away"))));
+
+    // Assert：转系统浏览器 + reload 回渲染页
+    EXPECT_EQ(openUrlCount, 1);
+    EXPECT_EQ(lastOpenedUrl.toString(), QString("https://example.org/away"));
+    EXPECT_EQ(loadCount, loadBefore + 1);
+    EXPECT_EQ(lastLoadedUrl.toString(), QString("qrc:/editor/markdown/web/milkdown.html"));
+}
+
+TEST_F(MarkdownViewTest, UrlChanged_NonHttpScheme_StaysInRenderPage)
+{
+    // Arrange
+    obj->init();
+    const int loadBefore = loadCount;
+    QTemporaryDir dir;
+    ASSERT_TRUE(dir.isValid());
+
+    // Act：file 导航（非白名单 scheme）
+    QMetaObject::invokeMethod(obj->page(), "urlChanged",
+                              Q_ARG(QUrl, QUrl::fromLocalFile(dir.path())));
+
+    // Assert：既不转浏览器也不 reload（保持当前渲染页）
+    EXPECT_EQ(openUrlCount, 0);
+    EXPECT_EQ(loadCount, loadBefore);
+}

--- a/tests/editor_markdown/test_renderthrottle.cpp
+++ b/tests/editor_markdown/test_renderthrottle.cpp
@@ -1,0 +1,130 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// ============================================================================
+// RenderThrottle 单元测试（src/editor/markdown/renderthrottle.h）
+//
+// 覆盖现状：renderthrottle.h 已由 markdownview/editwrapper TU 间接覆盖
+// ctor/interval/setInterval/isReady/setReady/noteContent 前沿/flushNow/
+// flushPending（lcov 6/7），唯一 FNDA:0 为私有槽 onTimeout（后沿补发）。
+//
+// 分支清单 → 用例映射（onTimeout，renderthrottle.h:88）：
+//   B1 onTimeout: m_pending != m_lastEmitted && flushPending()==true
+//      → 补发最新 pending 并 m_timer.start() 续期下一周期
+//      → NoteContent_ContinuousInput_TimeoutEmitsAndRenewsCycle
+//        / NoteContent_DuringCooldown_TimeoutEmitsLatestThenStops
+//   B2 onTimeout: 条件不满足（pending==lastEmitted 或 flush false）
+//      → 不补发、不续期，定时器自然停止
+//      → NoteContent_DuringCooldown_TimeoutEmitsLatestThenStops（收敛段）
+//
+// 实现要点：真实 QTimer 事件循环驱动（QTest::qWait 交付 timeout），
+// setInterval(50) 缩短节流周期保证用例速度，节流语义与默认 300ms 同构。
+// ============================================================================
+
+#include <gtest/gtest.h>
+#include "stubext.h"
+
+#include <QCoreApplication>
+#include <QSignalSpy>
+#include <QtTest>
+
+#include "renderthrottle.h"
+
+class RenderThrottleTest : public ::testing::Test {
+protected:
+    static void SetUpTestSuite()
+    {
+        if (QCoreApplication::instance() == nullptr) {
+            static int argc = 1;
+            static char appName[] = "test_renderthrottle";
+            static char *argv[] = { appName, nullptr };
+            s_app = new QCoreApplication(argc, argv);
+        }
+    }
+
+    static void TearDownTestSuite()
+    {
+        // QCoreApplication 保留至进程退出（RenderThrottle 为纯 QObject 逻辑）
+    }
+
+    static QCoreApplication *s_app;
+};
+
+QCoreApplication *RenderThrottleTest::s_app = nullptr;
+
+// B1+B2：冷却期内累积的变更由 onTimeout 补发最新内容；补发后静默，
+// 下一周期无新内容则不续期、定时器自然停止（任何变更可见延迟有上界）
+TEST_F(RenderThrottleTest, NoteContent_DuringCooldown_TimeoutEmitsLatestThenStops)
+{
+    // Arrange
+    RenderThrottle throttle;
+    throttle.setInterval(50);
+    QSignalSpy spy(&throttle, &RenderThrottle::renderRequested);
+    throttle.setReady(true);
+
+    // Act 1：前沿立即渲染（冷却期外首次变更）
+    throttle.noteContent(QStringLiteral("a"));
+    ASSERT_EQ(spy.count(), 1) << "front-edge change must render immediately";
+
+    // Act 2：冷却期内第二笔变更 → pending 累积，onTimeout 后沿补发
+    throttle.noteContent(QStringLiteral("b"));
+    QTest::qWait(180);   // > interval(50) + 调度缓冲，确保 timeout 已交付
+
+    // Assert：后沿补发最新内容
+    EXPECT_EQ(spy.count(), 2);
+    EXPECT_EQ(spy.at(1).at(0).toString(), QStringLiteral("b"));
+
+    // Act 3：静默两个周期 → pending==lastEmitted，onTimeout 不再补发/续期
+    QTest::qWait(200);
+
+    // Assert：无任何额外发射（定时器自然停止）
+    EXPECT_EQ(spy.count(), 2);
+}
+
+// B1：连续输入期间每个节流周期最多渲染一次；周期内新内容由下一个
+// onTimeout 补发并续期（第二周期），renderRequested 恒为最新 pending
+TEST_F(RenderThrottleTest, NoteContent_ContinuousInput_TimeoutEmitsAndRenewsCycle)
+{
+    // Arrange
+    RenderThrottle throttle;
+    throttle.setInterval(50);
+    QSignalSpy spy(&throttle, &RenderThrottle::renderRequested);
+    throttle.setReady(true);
+
+    // Act：第 1 周期（前沿 + 冷却期内变更）
+    throttle.noteContent(QStringLiteral("a"));
+    ASSERT_EQ(spy.count(), 1);
+    throttle.noteContent(QStringLiteral("b"));
+    QTest::qWait(90);   // onTimeout #1 → emit b，续期
+    ASSERT_EQ(spy.count(), 2) << "trailing edge must emit latest pending";
+
+    // Act：第 2 周期（续期冷却期内又有新变更）
+    throttle.noteContent(QStringLiteral("c"));
+    QTest::qWait(90);   // onTimeout #2 → emit c
+
+    // Assert
+    EXPECT_EQ(spy.count(), 3);
+    EXPECT_EQ(spy.at(2).at(0).toString(), QStringLiteral("c"));
+    EXPECT_EQ(spy.at(1).at(0).toString(), QStringLiteral("b"));
+}
+
+// B2 补充：默认 interval(300) 语义下的后沿补发（不缩短周期，验证出厂值）
+TEST_F(RenderThrottleTest, NoteContent_DefaultInterval_TrailingEdgeEmitsAfterCooldown)
+{
+    // Arrange
+    RenderThrottle throttle;
+    ASSERT_EQ(throttle.interval(), 300) << "spec: 300ms throttle window";
+    QSignalSpy spy(&throttle, &RenderThrottle::renderRequested);
+    throttle.setReady(true);
+
+    // Act
+    throttle.noteContent(QStringLiteral("first"));
+    ASSERT_EQ(spy.count(), 1);
+    throttle.noteContent(QStringLiteral("second"));
+    QTest::qWait(420);   // > 300ms 冷却 + 调度缓冲
+
+    // Assert
+    EXPECT_EQ(spy.count(), 2);
+    EXPECT_EQ(spy.at(1).at(0).toString(), QStringLiteral("second"));
+}

--- a/tests/editor_markdown/test_scrollsync.cpp
+++ b/tests/editor_markdown/test_scrollsync.cpp
@@ -1,0 +1,166 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include "stubext.h"
+#include "scrollsync.h"
+
+#include <climits>
+
+// 分支清单（来源：scrollsync.h）
+// clampRatio:
+//   C1: ratio < 0.0 → 0.0
+//   C2: ratio > 1.0 → 1.0
+//   C3: [0,1] 区间 → 原值
+// ratioFromScrollBar:
+//   S1: max <= min → 0.0（除零保护，含 max<min 与相等）
+//   S2: 正常 (value-min)/(max-min) → 钳制后值
+//   S3: value 越出 [min,max] → 钳制到 0/1
+//   S4: min 非 0（负 min 边界）
+//
+// 用例映射：
+// - ClampRatio_BoundaryValues_ClampsToUnitInterval（TEST_P 7 组）      → C1/C2/C3
+// - RatioFromScrollBar_DegenerateRange_ReturnsZero（TEST_P 3 组）      → S1
+// - RatioFromScrollBar_NormalRanges_ReturnsNormalized（TEST_P 5 组）   → S2/S4
+// - RatioFromScrollBar_ValueOutOfRange_ClampedToUnitInterval（TEST_P 3 组）→ S3
+//
+// 最小清单自检：1 每公开方法≥1用例 ✔（2 方法全覆盖）2 等价类 ✔ 3 边界值显式成组 ✔
+// 4 TEST_P ×3（各≥3 组）✔ 5 分支映射 ✔ 6 全分支覆盖 ✔ 7 无异常 8 负面（退化区间/越界）✔
+// 9 纯函数无状态 ✔ 10 无外部依赖，无需 stub ✔
+
+// —— C1/C2/C3：[0,1] 钳制边界值成组 ——
+namespace {
+struct ClampCase {
+    double input;
+    double expected;
+};
+const ClampCase kClampCases[] = {
+    { -0.5, 0.0 },     // 下越界
+    { -0.001, 0.0 },   // 贴近下界的负值
+    { 0.0, 0.0 },      // 下边界
+    { 0.3, 0.3 },      // 区间内
+    { 1.0, 1.0 },      // 上边界
+    { 1.0001, 1.0 },   // 贴近上界的越界
+    { 2.5, 1.0 },      // 上越界
+};
+} // namespace
+
+class ClampRatioParamTest : public ::testing::TestWithParam<ClampCase> {
+};
+
+TEST_P(ClampRatioParamTest, ClampRatio_BoundaryValues_ClampsToUnitInterval)
+{
+    // Arrange
+    const auto &c = GetParam();
+
+    // Act
+    const double out = ScrollSync::clampRatio(c.input);
+
+    // Assert
+    EXPECT_NEAR(out, c.expected, 1e-12);   // 期望值见参数表
+    EXPECT_GE(out, 0.0);                   // 恒 >= 0
+    EXPECT_LE(out, 1.0);                   // 恒 <= 1
+}
+
+INSTANTIATE_TEST_SUITE_P(ClampBoundaries, ClampRatioParamTest,
+                         ::testing::ValuesIn(kClampCases));
+
+// —— S1：退化区间（max<=min，除零保护）——
+namespace {
+struct BarCase {
+    int value;
+    int min;
+    int max;
+};
+const BarCase kDegenerateCases[] = {
+    { 0, 10, 10 },    // max == min
+    { 5, 10, 5 },     // max < min
+    { 7, 0, -3 },     // max 为负
+};
+} // namespace
+
+class DegenerateBarParamTest : public ::testing::TestWithParam<BarCase> {
+};
+
+TEST_P(DegenerateBarParamTest, RatioFromScrollBar_DegenerateRange_ReturnsZero)
+{
+    // Arrange
+    const auto &c = GetParam();
+
+    // Act
+    const double out = ScrollSync::ratioFromScrollBar(c.value, c.min, c.max);
+
+    // Assert：除零保护路径恒 0（期望 0.0 边）
+    EXPECT_DOUBLE_EQ(out, 0.0);
+    EXPECT_GE(out, 0.0);
+}
+
+INSTANTIATE_TEST_SUITE_P(DegenerateRanges, DegenerateBarParamTest,
+                         ::testing::ValuesIn(kDegenerateCases));
+
+// —— S2/S4：正常区间（含非零 min）——
+namespace {
+struct RatioCase {
+    int value;
+    int min;
+    int max;
+    double expected;
+};
+const RatioCase kNormalCases[] = {
+    { 0, 0, 100, 0.0 },     // 顶边界
+    { 50, 0, 100, 0.5 },    // 中点
+    { 100, 0, 100, 1.0 },   // 底边界
+    { 10, 10, 110, 0.0 },   // 非零 min：value==min
+    { 60, 10, 110, 0.5 },   // 非零 min：中点
+};
+} // namespace
+
+class NormalBarParamTest : public ::testing::TestWithParam<RatioCase> {
+};
+
+TEST_P(NormalBarParamTest, RatioFromScrollBar_NormalRanges_ReturnsNormalized)
+{
+    // Arrange
+    const auto &c = GetParam();
+
+    // Act
+    const double out = ScrollSync::ratioFromScrollBar(c.value, c.min, c.max);
+
+    // Assert
+    EXPECT_NEAR(out, c.expected, 1e-12);
+    // 与 clampRatio 组合语义一致（独立公式复核）
+    const double raw = double(c.value - c.min) / double(c.max - c.min);
+    EXPECT_NEAR(out, ScrollSync::clampRatio(raw), 1e-12);
+}
+
+INSTANTIATE_TEST_SUITE_P(NormalRanges, NormalBarParamTest,
+                         ::testing::ValuesIn(kNormalCases));
+
+// —— S3：value 越出区间 → 钳制 ——
+namespace {
+const RatioCase kOutOfRangeCases[] = {
+    { -50, 0, 100, 0.0 },    // 下越界
+    { 200, 0, 100, 1.0 },    // 上越界
+    { INT_MIN, 0, 100, 0.0 },// 极小值边界
+};
+} // namespace
+
+class OutOfRangeBarParamTest : public ::testing::TestWithParam<RatioCase> {
+};
+
+TEST_P(OutOfRangeBarParamTest, RatioFromScrollBar_ValueOutOfRange_ClampedToUnitInterval)
+{
+    // Arrange
+    const auto &c = GetParam();
+
+    // Act
+    const double out = ScrollSync::ratioFromScrollBar(c.value, c.min, c.max);
+
+    // Assert
+    EXPECT_NEAR(out, c.expected, 1e-12);
+    EXPECT_LE(out, 1.0);
+    EXPECT_GE(out, 0.0);
+}
+
+INSTANTIATE_TEST_SUITE_P(OutOfRangeValues, OutOfRangeBarParamTest,
+                         ::testing::ValuesIn(kOutOfRangeCases));

--- a/tests/editor_markdown/test_themeserializer.cpp
+++ b/tests/editor_markdown/test_themeserializer.cpp
@@ -1,0 +1,255 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include "stubext.h"
+#include "themeserializer.h"
+
+#include <QColor>
+#include <QJsonDocument>
+#include <QJsonObject>
+
+// 分支清单（来源：themeserializer.h）
+// isDark:
+//   K1: 背景色缺失/非法 → false（!bg.isValid()）
+//   K2: bg.lightness() < 128 → true（深色）
+//   K3: bg.lightness() >= 128 → false（浅色）
+// serialize（bg/fg 各自 valid 与否 × 深浅色回退，三态组合）:
+//   T1: bg+fg 均 valid（浅）→ 各键由真实色派生（darker 分支）
+//   T2: bg+fg 均 valid（深）→ lighter 分支
+//   T3: bg valid、fg 缺失（深）→ --fg/--fg-secondary/--code-fg 走深色回退常量
+//   T4: bg valid、fg 缺失（浅）→ 浅色回退常量
+//   T5: bg 缺失（空 map）→ --bg/--code-bg/--border 回退常量（dark=false）
+// foregroundColor(private，经 serialize 间接):
+//   P1: editor-colors.text-color 有效 → 直接用
+//   P2: 缺失/非法 → 回退 text-styles.Normal.text-color
+// backgroundColor(private，经 isDark/serialize 间接):
+//   Q1: editor-colors 存在 → 取 background-color
+//   Q2: 不存在 → 无效色
+//
+// 用例映射：
+// - IsDark_BackgroundLightness_ReturnsExpected（TEST_P 4 组）                       → K1/K2/K3
+// - Serialize_FullySpecifiedThemes_DerivesAllCssVars（TEST_P 3 组：浅/深/中亮度）    → T1/T2
+// - Serialize_MissingForeground_FallsBackByDarkness（TEST_P 3 组）                   → T3/T4
+// - Serialize_EmptyOrBrokenMap_UsesLightDefaults                                     → T5 + Q2 + P2 回退链
+// - Serialize_ForegroundFromTextStyleNormal_UsedWhenEditorColorMissing               → P2 命中
+// - Serialize_OutputIsCompactJson_AllKeysPresent                                      → 结构契约
+//
+// 最小清单自检：1 公开方法≥1用例 ✔（isDark/serialize；private 两个经公开方法间接全覆盖分支）
+// 2 等价类（bg/fg × 深/浅/缺失）✔ 3 边界（lightness 127/128 邻界）✔ 4 TEST_P ×3 ✔
+// 5 分支映射 ✔ 6 全分支 ✔ 7 无异常 8 破损/空 map 负面 ✔ 9 纯函数 ✔ 10 无依赖直接调用 ✔
+
+namespace {
+QVariantMap makeTheme(const QString &bg, const QString &fg)
+{
+    QVariantMap theme;
+    QVariantMap ec;
+    if (!bg.isEmpty())
+        ec["background-color"] = bg;
+    if (!fg.isEmpty())
+        ec["text-color"] = fg;
+    if (!ec.isEmpty())
+        theme["editor-colors"] = ec;
+    return theme;
+}
+} // namespace
+
+// —— K1/K2/K3：深浅判定等价类（含 127/128 邻界）——
+namespace {
+struct DarkCase {
+    QString bg;
+    bool expected;
+    const char *note;
+};
+const DarkCase kDarkCases[] = {
+    { "#1e1e1e", true,  "典型深色底" },          // lightness=30 < 128
+    { "#000000", true,  "纯黑边界（0）" },
+    { "#ffffff", false, "纯白边界（255）" },
+    { "#808080", false, "邻界（lightness=128，不小于 128 → 浅）" },
+};
+} // namespace
+
+class IsDarkParamTest : public ::testing::TestWithParam<DarkCase> {
+};
+
+TEST_P(IsDarkParamTest, IsDark_BackgroundLightness_ReturnsExpected)
+{
+    // Arrange
+    const auto &c = GetParam();
+    const QVariantMap theme = makeTheme(c.bg, "#ffffff");
+
+    // Act
+    const bool dark = ThemeSerializer::isDark(theme);
+
+    // Assert
+    EXPECT_EQ(dark, c.expected);   // 期望值依据：c.note 描述的 lightness 分支
+    EXPECT_EQ(QColor(c.bg).lightness() < 128, dark);   // 与 QColor lightness 独立复核
+}
+
+INSTANTIATE_TEST_SUITE_P(Darkness, IsDarkParamTest,
+                         ::testing::ValuesIn(kDarkCases));
+
+TEST(MarkdownThemeSerializerTest, IsDark_MissingOrInvalidBackground_ReturnsFalse)
+{
+    // Arrange：负面——空 map / 缺 editor-colors / 非法色串
+    const QVariantMap empty;
+    const QVariantMap broken = makeTheme("not-a-color", "#ffffff");
+    QVariantMap noKey;
+    noKey["other"] = 42;
+
+    // Act & Assert：无效背景一律按浅色处理（期望 false 边）
+    EXPECT_FALSE(ThemeSerializer::isDark(empty));
+    EXPECT_FALSE(ThemeSerializer::isDark(broken));
+    EXPECT_FALSE(ThemeSerializer::isDark(noKey));
+}
+
+// —— T1/T2：bg+fg 齐备时派生全部 CSS 变量（QColor darker/lighter 为确定性算法）——
+namespace {
+struct FullCase {
+    QString bg;
+    QString fg;
+};
+const FullCase kFullCases[] = {
+    { "#ffffff", "#1f1f1f" },   // 浅色主题
+    { "#1e1e1e", "#eeeeee" },   // 深色主题
+    { "#f0f0f0", "#333333" },   // 中间亮度浅色
+};
+} // namespace
+
+class FullThemeParamTest : public ::testing::TestWithParam<FullCase> {
+};
+
+TEST_P(FullThemeParamTest, Serialize_FullySpecifiedThemes_DerivesAllCssVars)
+{
+    // Arrange
+    const auto &c = GetParam();
+    const QVariantMap theme = makeTheme(c.bg, c.fg);
+    const QColor bg(c.bg);
+    const QColor fg(c.fg);
+    const bool dark = bg.lightness() < 128;
+
+    // Act
+    const QString json = ThemeSerializer::serialize(theme);
+
+    // Assert：六个 CSS 变量全部按源规则派生
+    const QJsonObject obj = QJsonDocument::fromJson(json.toUtf8()).object();
+    EXPECT_EQ(obj["--bg"].toString(), bg.name());
+    EXPECT_EQ(obj["--fg"].toString(), fg.name());
+    EXPECT_EQ(obj["--fg-secondary"].toString(),
+              dark ? fg.darker(150).name() : fg.darker(180).name());
+    EXPECT_EQ(obj["--code-fg"].toString(), fg.name());
+    EXPECT_EQ(obj["--code-bg"].toString(),
+              dark ? bg.lighter(130).name() : bg.darker(110).name());
+    EXPECT_EQ(obj["--border"].toString(),
+              dark ? bg.lighter(150).name() : bg.darker(130).name());
+    // isDark 与 serialize 内部判定一致（副作用交叉验证）
+    EXPECT_EQ(ThemeSerializer::isDark(theme), dark);
+}
+
+INSTANTIATE_TEST_SUITE_P(FullThemes, FullThemeParamTest,
+                         ::testing::ValuesIn(kFullCases));
+
+// —— T3/T4：fg 缺失时前景三键按深浅回退常量（bg 仍真实派生 code-bg/border）——
+namespace {
+struct FallbackCase {
+    QString bg;
+    QString expectedFg;
+    QString expectedFgSecondary;
+};
+const FallbackCase kFallbackCases[] = {
+    { "#1e1e1e", "#ffffff", "#a6a6a6" },   // 深色回退
+    { "#ffffff", "#1f1f1f", "#595959" },   // 浅色回退
+    { "#f5f5f5", "#1f1f1f", "#595959" },   // 中间亮度浅色回退
+};
+} // namespace
+
+class FallbackThemeParamTest : public ::testing::TestWithParam<FallbackCase> {
+};
+
+TEST_P(FallbackThemeParamTest, Serialize_MissingForeground_FallsBackByDarkness)
+{
+    // Arrange：仅有背景色（deepin/deepin_dark 等主题文本键缺失的真实形态）
+    const auto &c = GetParam();
+    const QVariantMap theme = makeTheme(c.bg, QString());
+    const QColor bg(c.bg);
+    const bool dark = bg.lightness() < 128;
+
+    // Act
+    const QString json = ThemeSerializer::serialize(theme);
+
+    // Assert：bg 真实、fg 三键走深浅回退常量、code-bg/border 从真实 bg 派生
+    const QJsonObject obj = QJsonDocument::fromJson(json.toUtf8()).object();
+    EXPECT_EQ(obj["--bg"].toString(), bg.name());
+    EXPECT_EQ(obj["--fg"].toString(), c.expectedFg);
+    EXPECT_EQ(obj["--fg-secondary"].toString(), c.expectedFgSecondary);
+    EXPECT_EQ(obj["--code-fg"].toString(), c.expectedFg);
+    EXPECT_EQ(obj["--code-bg"].toString(),
+              dark ? bg.lighter(130).name() : bg.darker(110).name());
+    EXPECT_EQ(obj["--border"].toString(),
+              dark ? bg.lighter(150).name() : bg.darker(130).name());
+}
+
+INSTANTIATE_TEST_SUITE_P(ForegroundFallbacks, FallbackThemeParamTest,
+                         ::testing::ValuesIn(kFallbackCases));
+
+TEST(MarkdownThemeSerializerTest, Serialize_EmptyOrBrokenMap_UsesLightDefaults)
+{
+    // Arrange：负面——完全空 map / 非法背景
+    const QVariantMap empty;
+    const QVariantMap broken = makeTheme("not-a-color", QString());
+
+    // Act
+    const QString jsonEmpty = ThemeSerializer::serialize(empty);
+    const QString jsonBroken = ThemeSerializer::serialize(broken);
+
+    // Assert：全部键回退浅色默认（bg 缺失分支 T5）
+    const QJsonObject obj = QJsonDocument::fromJson(jsonEmpty.toUtf8()).object();
+    EXPECT_EQ(obj["--bg"].toString(), "#ffffff");
+    EXPECT_EQ(obj["--fg"].toString(), "#1f1f1f");
+    EXPECT_EQ(obj["--fg-secondary"].toString(), "#595959");
+    EXPECT_EQ(obj["--code-fg"].toString(), "#1f1f1f");
+    EXPECT_EQ(obj["--code-bg"].toString(), "#f5f5f5");
+    EXPECT_EQ(obj["--border"].toString(), "#e0e0e0");
+    // 非法背景与空 map 输出一致（强一致性：破损输入不产生半派生状态）
+    EXPECT_EQ(jsonBroken, jsonEmpty);
+    EXPECT_FALSE(ThemeSerializer::isDark(empty));
+}
+
+TEST(MarkdownThemeSerializerTest, Serialize_ForegroundFromTextStyleNormal_UsedWhenEditorColorMissing)
+{
+    // Arrange：editor-colors.text-color 缺失，文本色存于 text-styles.Normal（private 前景回退链 P2）
+    QVariantMap theme;
+    QVariantMap ec;
+    ec["background-color"] = "#252525";
+    theme["editor-colors"] = ec;
+    QVariantMap ts, normal;
+    normal["text-color"] = "#d0d0d0";
+    ts["Normal"] = normal;
+    theme["text-styles"] = ts;
+
+    // Act
+    const QString json = ThemeSerializer::serialize(theme);
+
+    // Assert：前景取自 Normal 而非回退常量
+    const QJsonObject obj = QJsonDocument::fromJson(json.toUtf8()).object();
+    EXPECT_EQ(obj["--fg"].toString(), "#d0d0d0");
+    EXPECT_EQ(obj["--code-fg"].toString(), "#d0d0d0");
+    EXPECT_EQ(obj["--fg-secondary"].toString(), QColor("#d0d0d0").darker(150).name());
+    EXPECT_TRUE(ThemeSerializer::isDark(theme));   // #252525 → 深色
+}
+
+TEST(MarkdownThemeSerializerTest, Serialize_OutputIsCompactJson_AllKeysPresent)
+{
+    // Arrange
+    const QVariantMap theme = makeTheme("#1e1e1e", "#eeeeee");
+
+    // Act
+    const QString json = ThemeSerializer::serialize(theme);
+
+    // Assert：Compact JSON（无空白换行）且恰含 6 个键
+    const QJsonObject obj = QJsonDocument::fromJson(json.toUtf8()).object();
+    EXPECT_EQ(obj.size(), 6);
+    EXPECT_EQ(obj.keys().count(), 6);
+    EXPECT_FALSE(json.contains('\n'));
+    EXPECT_FALSE(json.contains(' '));   // Compact 模式无空格分隔符
+}

--- a/tests/editor_markdown/test_viewmodefsm.cpp
+++ b/tests/editor_markdown/test_viewmodefsm.cpp
@@ -1,0 +1,263 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include "stubext.h"
+#include "viewmodefsm.h"
+
+// 分支清单（来源：viewmodefsm.h）
+// resolveDefaultMode:
+//   A1: isMarkdown → LivePreview；A2: 非 → Edit
+// isLivePreviewAvailable: L1: isMarkdown 直通
+// isEditViewAvailable / isReadViewAvailable: 恒 true（入口始终显示）
+// canSwitchTo switch:
+//   C1: Edit → true；C2: ReadView → true；C3: LivePreview → isMarkdown；C4: Wysiwyg → false
+// fallbackWhenMarkdownLost:
+//   F1: LivePreview → Edit；F2: 其他保持
+// elevateWhenMarkdownGained:
+//   E1: Edit → LivePreview；E2: 其他保持
+// isReadOnlyTextMode:
+//   R1: ReadView && !isMarkdown → true；R2: 其他 → false
+//
+// 用例映射：
+// - ResolveDefaultMode_MarkdownOrNot_ReturnsExpected（TEST_P 2 组，双色分支各一侧）→ A1/A2
+// - IsLivePreviewAvailable_MarkdownOrNot_ReturnsIsMarkdown（TEST_P 2 组）           → L1
+// - EditAndReadViewEntries_AnyFileKind_AlwaysAvailable（TEST_P 4 组）                → 恒真分支
+// - CanSwitchTo_AllModeFileCombinations_ReturnsExpected（TEST_P 8 组）               → C1-C4 + default
+// - FallbackWhenMarkdownLost_AllModes_ReturnsExpected（TEST_P 4 组）                 → F1/F2
+// - ElevateWhenMarkdownGained_AllModes_ReturnsExpected（TEST_P 4 组）                → E1/E2
+// - IsReadOnlyTextMode_ModeFileCombinations_ReturnsExpected（TEST_P 4 组）           → R1/R2
+//
+// 最小清单自检：1 每公开方法≥1用例 ✔（8 方法全覆盖）2 等价类（模式×是否md 全网格）✔
+// 3 边界（Wysiwyg 预留态）✔ 4 TEST_P ×6（≥3 组）✔ 5 分支映射 ✔ 6 全分支 ✔
+// 7 无异常 8 无效/预留模式负面 ✔ 9 纯函数 ✔ 10 无外部依赖 ✔
+
+// —— A1/A2 ——
+namespace {
+struct BoolCase {
+    bool isMarkdown;
+};
+const BoolCase kBoolCases[] = {
+    { true },
+    { false },
+};
+} // namespace
+
+class DefaultModeParamTest : public ::testing::TestWithParam<BoolCase> {
+};
+
+TEST_P(DefaultModeParamTest, ResolveDefaultMode_MarkdownOrNot_ReturnsExpected)
+{
+    // Arrange
+    const bool isMarkdown = GetParam().isMarkdown;
+
+    // Act
+    const ViewMode mode = ViewModeFsm::resolveDefaultMode(isMarkdown);
+
+    // Assert
+    EXPECT_EQ(mode, isMarkdown ? ViewMode::LivePreview : ViewMode::Edit);
+    // 与置灰规则一致性：默认模式必为可切换目标（不变式）
+    EXPECT_TRUE(ViewModeFsm::canSwitchTo(mode, isMarkdown));
+}
+
+INSTANTIATE_TEST_SUITE_P(DefaultModes, DefaultModeParamTest,
+                         ::testing::ValuesIn(kBoolCases));
+
+// —— L1 ——
+class LivePreviewAvailParamTest : public ::testing::TestWithParam<BoolCase> {
+};
+
+TEST_P(LivePreviewAvailParamTest, IsLivePreviewAvailable_MarkdownOrNot_ReturnsIsMarkdown)
+{
+    // Arrange
+    const bool isMarkdown = GetParam().isMarkdown;
+
+    // Act
+    const bool ret = ViewModeFsm::isLivePreviewAvailable(isMarkdown);
+
+    // Assert：md 专属入口（非 md 置灰）
+    EXPECT_EQ(ret, isMarkdown);
+    if (isMarkdown)
+        EXPECT_TRUE(ret);   // md → 可用边
+    else
+        EXPECT_FALSE(ret);  // 非 md → 置灰边
+}
+
+INSTANTIATE_TEST_SUITE_P(LivePreviewAvailability, LivePreviewAvailParamTest,
+                         ::testing::ValuesIn(kBoolCases));
+
+// —— 恒真入口 ——
+namespace {
+struct ModeBoolCase {
+    ViewMode mode;
+    bool isMarkdown;
+};
+const ModeBoolCase kEntryCases[] = {
+    { ViewMode::Edit, true },
+    { ViewMode::Edit, false },
+    { ViewMode::ReadView, true },
+    { ViewMode::ReadView, false },
+};
+} // namespace
+
+class EntryAvailParamTest : public ::testing::TestWithParam<ModeBoolCase> {
+};
+
+TEST_P(EntryAvailParamTest, EditAndReadViewEntries_AnyFileKind_AlwaysAvailable)
+{
+    // Arrange
+    const auto &c = GetParam();
+
+    // Act
+    const bool edit = ViewModeFsm::isEditViewAvailable(c.isMarkdown);
+    const bool read = ViewModeFsm::isReadViewAvailable(c.isMarkdown);
+
+    // Assert：入口始终显示（含新建 .txt），与文件类型无关
+    EXPECT_TRUE(edit);
+    EXPECT_TRUE(read);
+}
+
+INSTANTIATE_TEST_SUITE_P(AlwaysAvailableEntries, EntryAvailParamTest,
+                         ::testing::ValuesIn(kEntryCases));
+
+// —— C1-C4（模式 × 文件类型全网格）——
+namespace {
+struct SwitchCase {
+    ViewMode target;
+    bool isMarkdown;
+    bool expected;
+    const char *note;
+};
+const SwitchCase kSwitchCases[] = {
+    { ViewMode::Edit, true, true, "任意文件可切编辑" },
+    { ViewMode::Edit, false, true, "非 md 也可切编辑" },
+    { ViewMode::ReadView, true, true, "md 查看走渲染" },
+    { ViewMode::ReadView, false, true, "非 md 查看走纯文本只读" },
+    { ViewMode::LivePreview, true, true, "仅 md 可切实时预览" },
+    { ViewMode::LivePreview, false, false, "非 md 实时预览置灰" },
+    { ViewMode::Wysiwyg, true, false, "阶段二预留不可达" },
+    { ViewMode::Wysiwyg, false, false, "阶段二预留不可达（非 md）" },
+};
+} // namespace
+
+class CanSwitchParamTest : public ::testing::TestWithParam<SwitchCase> {
+};
+
+TEST_P(CanSwitchParamTest, CanSwitchTo_AllModeFileCombinations_ReturnsExpected)
+{
+    // Arrange
+    const auto &c = GetParam();
+
+    // Act
+    const bool ret = ViewModeFsm::canSwitchTo(c.target, c.isMarkdown);
+
+    // Assert
+    EXPECT_EQ(ret, c.expected);   // 期望值见参数表 note
+    // 与置灰规则一致性（LivePreview 唯一受文件类型约束的入口）
+    EXPECT_EQ(ret, c.target == ViewMode::LivePreview
+                        ? c.isMarkdown
+                        : c.target != ViewMode::Wysiwyg);
+}
+
+INSTANTIATE_TEST_SUITE_P(SwitchMatrix, CanSwitchParamTest,
+                         ::testing::ValuesIn(kSwitchCases));
+
+// —— F1/F2 ——
+namespace {
+struct TransitionCase {
+    ViewMode current;
+    ViewMode expected;
+};
+const TransitionCase kFallbackCases[] = {
+    { ViewMode::LivePreview, ViewMode::Edit },   // 唯一回退
+    { ViewMode::Edit, ViewMode::Edit },          // 保持
+    { ViewMode::ReadView, ViewMode::ReadView },  // 保持（纯文本只读语义）
+    { ViewMode::Wysiwyg, ViewMode::Wysiwyg },    // 保持
+};
+} // namespace
+
+class FallbackParamTest : public ::testing::TestWithParam<TransitionCase> {
+};
+
+TEST_P(FallbackParamTest, FallbackWhenMarkdownLost_AllModes_ReturnsExpected)
+{
+    // Arrange
+    const auto &c = GetParam();
+
+    // Act
+    const ViewMode out = ViewModeFsm::fallbackWhenMarkdownLost(c.current);
+
+    // Assert
+    EXPECT_EQ(out, c.expected);
+    // 回退结果在非 md 下必须合法可切换（Wysiwyg 为阶段二预留态，按设计不可达，豁免）
+    if (out != ViewMode::Wysiwyg)
+        EXPECT_TRUE(ViewModeFsm::canSwitchTo(out, false));
+}
+
+INSTANTIATE_TEST_SUITE_P(MarkdownLost, FallbackParamTest,
+                         ::testing::ValuesIn(kFallbackCases));
+
+// —— E1/E2 ——
+namespace {
+const TransitionCase kElevateCases[] = {
+    { ViewMode::Edit, ViewMode::LivePreview },   // 唯一跃迁
+    { ViewMode::LivePreview, ViewMode::LivePreview },
+    { ViewMode::ReadView, ViewMode::ReadView },
+    { ViewMode::Wysiwyg, ViewMode::Wysiwyg },
+};
+} // namespace
+
+class ElevateParamTest : public ::testing::TestWithParam<TransitionCase> {
+};
+
+TEST_P(ElevateParamTest, ElevateWhenMarkdownGained_AllModes_ReturnsExpected)
+{
+    // Arrange
+    const auto &c = GetParam();
+
+    // Act
+    const ViewMode out = ViewModeFsm::elevateWhenMarkdownGained(c.current);
+
+    // Assert
+    EXPECT_EQ(out, c.expected);
+    // md 下结果合法（Wysiwyg 阶段二预留态按设计不可达，豁免）
+    if (out != ViewMode::Wysiwyg)
+        EXPECT_TRUE(ViewModeFsm::canSwitchTo(out, true));
+}
+
+INSTANTIATE_TEST_SUITE_P(MarkdownGained, ElevateParamTest,
+                         ::testing::ValuesIn(kElevateCases));
+
+// —— R1/R2 ——
+namespace {
+struct ReadOnlyCase {
+    ViewMode mode;
+    bool isMarkdown;
+    bool expected;
+};
+const ReadOnlyCase kReadOnlyCases[] = {
+    { ViewMode::ReadView, false, true },   // 唯一纯文本只读组合
+    { ViewMode::ReadView, true, false },   // md 查看走渲染页
+    { ViewMode::Edit, false, false },
+    { ViewMode::LivePreview, true, false },
+};
+} // namespace
+
+class ReadOnlyParamTest : public ::testing::TestWithParam<ReadOnlyCase> {
+};
+
+TEST_P(ReadOnlyParamTest, IsReadOnlyTextMode_ModeFileCombinations_ReturnsExpected)
+{
+    // Arrange
+    const auto &c = GetParam();
+
+    // Act
+    const bool ret = ViewModeFsm::isReadOnlyTextMode(c.mode, c.isMarkdown);
+
+    // Assert
+    EXPECT_EQ(ret, c.expected);
+    EXPECT_EQ(ret, c.mode == ViewMode::ReadView && !c.isMarkdown);   // 公式独立复核
+}
+
+INSTANTIATE_TEST_SUITE_P(ReadOnlyTextModes, ReadOnlyParamTest,
+                         ::testing::ValuesIn(kReadOnlyCases));

--- a/tests/thememodule/CMakeLists.txt
+++ b/tests/thememodule/CMakeLists.txt
@@ -1,0 +1,54 @@
+cmake_minimum_required(VERSION 3.16)
+
+# B9 模块：thememodule（ThemeListModel / ThemeListView / ThemeItemDelegate / ThemePanel）
+# 策略：复用 startmanager 子目录的全量源码静态库 startmanager_ut_src（含 AUTOMOC 产物，
+# themepanel.cpp 相对包含的真实 ../widgets/window.h 无法用 -I 遮蔽，故链接真实源码库；
+# 运行期绝不实例化 Window：popup/hide 仅经 m_window->geometry()（QWidget 单继承链
+# 非虚方法）读取父窗口几何，测试传普通 QWidget 父对象）。
+# 运行期外部交互全部由 stub_ext 拦截：
+#   - QDir::entryInfoList（主题目录扫描）与 Utils::getThemeMapFromPath（JSON 解析）
+#     → 受控假数据，不触真实文件系统
+#   - QApplication::sendEvent（LayoutRequest 计数）、QPainter::fillPath（paintEvent 落笔断言）
+#   - QPropertyAnimation 动画真实运行（offscreen 定时器驱动，事件循环收尾）
+# QT_QPA_PLATFORM=offscreen 无头运行。
+
+set(QT_VERSION 6)
+
+# QSignalSpy 需要 Qt6 Test 组件
+find_package(Qt6 REQUIRED COMPONENTS Test)
+
+set(STUB_SHADOW "${CMAKE_SOURCE_DIR}/tests/3rdparty/stub/stub-shadow.cpp")
+
+file(GLOB TEST_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/test_*.cpp")
+
+add_executable(test_thememodule
+    ${TEST_SOURCES}
+    ${STUB_SHADOW})
+
+target_include_directories(test_thememodule
+    PRIVATE
+    ${CMAKE_SOURCE_DIR}/tests/3rdparty/stub
+    ${CMAKE_SOURCE_DIR}/src
+    ${CMAKE_SOURCE_DIR}/src/common
+    ${CMAKE_SOURCE_DIR}/src/thememodule)
+
+# 访问 protected/private 成员（paint/sizeHint/eventFilter/selectionChanged/paintEvent、
+# m_themes/m_themeView/m_themeModel/m_frameColor 等）；不改变 ABI 布局，与库侧 AUTOMOC 产物 ODR 兼容
+target_compile_options(test_thememodule PRIVATE -fno-access-control)
+# 导出符号到动态符号表（stub_ext 函数入口 patch）
+target_link_options(test_thememodule PRIVATE -rdynamic)
+
+target_link_libraries(test_thememodule PRIVATE
+    startmanager_ut_src
+    GTest::gtest
+    GTest::gtest_main
+    Qt6::Test)  # QSignalSpy
+
+# 覆盖率库（Debug 模式下）
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    target_link_libraries(test_thememodule PRIVATE gcov)
+endif()
+
+gtest_discover_tests(test_thememodule PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
+
+message(STATUS "UT: thememodule configured with ${TEST_SOURCES}")

--- a/tests/thememodule/test_env.h
+++ b/tests/thememodule/test_env.h
@@ -1,0 +1,85 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+// thememodule 测试共享环境：
+// - 一个测试二进制承载 4 个套件，QApplication(offscreen) 全进程仅构造一次
+// - 主题目录扫描隔离：拦截 QDir::entryInfoList + Utils::getThemeMapFromPath，
+//   以受控假数据驱动 ThemeListModel::initThemes，不读写真实文件系统
+
+#include <QApplication>
+#include <QColor>
+#include <QDir>
+#include <QFileInfo>
+#include <QList>
+#include <QPair>
+#include <QString>
+#include <QVariantMap>
+
+#include "stubext.h"
+#include "utils.h"
+
+// 共享 QApplication（offscreen）：4 个套件复用同一实例，进程退出时统一释放
+inline QApplication *thememoduleEnsureApp()
+{
+    if (QApplication::instance() == nullptr) {
+        static int argc = 1;
+        static char appName[] = "test_thememodule";
+        static char *argv[] = { appName, nullptr };
+        (void)new QApplication(argc, argv);
+    }
+    return static_cast<QApplication *>(QApplication::instance());
+}
+
+// 一份受控主题数据：first = 主题文件路径，second = getThemeMapFromPath 应返回的 JSON 映射
+using FakeThemeSource = QList<QPair<QString, QVariantMap>>;
+
+// 构造标准主题映射（name / background-color / text-styles 全套颜色）
+inline QVariantMap makeThemeMap(const QString &name, const QString &bgColorHex,
+                                const QString &textColorHex = "#101010")
+{
+    QVariantMap textStyles;
+    for (const char *key : { "Import", "String", "BuiltIn", "Keyword",
+                             "Comment", "Function", "Normal", "Others" }) {
+        QVariantMap style;
+        style.insert("text-color", textColorHex);
+        textStyles.insert(QLatin1String(key), style);
+    }
+
+    QVariantMap editorColors;
+    editorColors.insert("background-color", bgColorHex);
+
+    QVariantMap metadata;
+    metadata.insert("name", name);
+
+    QVariantMap map;
+    map.insert("text-styles", textStyles);
+    map.insert("editor-colors", editorColors);
+    map.insert("metadata", metadata);
+    return map;
+}
+
+// 拦截主题数据源（必须在 ThemeListModel 构造前安装）：
+// 1) QDir::entryInfoList(QDir::Filters, QDir::SortFlags) const → 返回假主题文件清单
+// 2) Utils::getThemeMapFromPath → 按路径查表返回假 JSON 映射（未登记路径返回空映射）
+inline void installThemeSourceStubs(stub_ext::StubExt &stub, const FakeThemeSource &themes)
+{
+    stub.set_lamda(
+        static_cast<QFileInfoList (QDir::*)(QDir::Filters, QDir::SortFlags) const>(
+            &QDir::entryInfoList),
+        [themes](QDir *, QDir::Filters, QDir::SortFlags) -> QFileInfoList {
+            QFileInfoList list;
+            for (const auto &theme : themes)
+                list << QFileInfo(theme.first);
+            return list;
+        });
+
+    stub.set_lamda(&Utils::getThemeMapFromPath,
+                   [themes](const QString &filepath) -> QVariantMap {
+                       for (const auto &theme : themes)
+                           if (theme.first == filepath)
+                               return theme.second;
+                       return QVariantMap();
+                   });
+}

--- a/tests/thememodule/test_themeitemdelegate.cpp
+++ b/tests/thememodule/test_themeitemdelegate.cpp
@@ -1,0 +1,169 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// ThemeItemDelegate（src/thememodule/themeitemdelegate.cpp）单元测试
+//
+// 类特征：QStyledItemDelegate 系（QAbstractItemDelegate 子类），paint/sizeHint 为
+// protected override；paint 为纯绘制逻辑，经 -fno-access-control 直接调用，
+// 以 QImage+QPainter 离屏渲染落笔验证 + stub 计数交叉断言（Wave1 已验证 offscreen 可行）。
+//
+// 分支清单 → 用例映射：
+// - ThemeItemDelegate::ThemeItemDelegate → 各用例 SetUp 构造
+// - paint: option.state & State_Selected（if 分支，选中画笔宽 2） → Paint_SelectedState_DrawsOnImage（stub 计数）
+// - paint: else 分支（未选中画笔宽 1） → Paint_UnselectedState_DrawsOnImage（像素验证）
+// - sizeHint → SizeHint_AnyIndex_ReturnsFixedHeight
+//
+// 最小清单完成情况：
+// | 1 | 每个公开/保护方法 ≥1 用例 | 完成（ctor/dtor/paint/sizeHint） |
+// | 2 | 等价类划分（选中态/非选中态） | 完成 |
+// | 3 | 边界值（默认 option / 默认索引形态） | 完成 |
+// | 4 | TEST_P | N/A（两态已由独立用例精确断言，无 ≥3 组同断言逻辑） |
+// | 5 | 分支清单映射 | 见上方 |
+// | 6 | if 分支两侧全覆盖 | 完成 |
+// | 7 | 异常路径 EXPECT_THROW | N/A（纯绘制无 throw） |
+// | 8 | 负面场景（空主题映射仍可绘制） | 完成（getThemeMapFromPath 未登记路径返回空映射） |
+// | 9 | 强异常安全（绘制前后模型行数不变） | 完成 |
+// | 10 | stub_ext（Utils::getThemeMapFromPath / QPainter::drawText 计数） | 完成 |
+
+#include <gtest/gtest.h>
+
+#include <QColor>
+#include <QImage>
+#include <QModelIndex>
+#include <QPainter>
+#include <QRect>
+#include <QSize>
+#include <QStyleOptionViewItem>
+#include <QVariant>
+
+#include "test_env.h"
+#include "themeitemdelegate.h"
+#include "themelistmodel.h"
+
+namespace {
+
+class ThemeItemDelegateTest : public ::testing::Test {
+protected:
+    static void SetUpTestSuite() { thememoduleEnsureApp(); }
+
+    void SetUp() override
+    {
+        stub.clear();
+        themeMapCallCount = 0;
+        installThemeSourceStubs(stub, {
+            { QStringLiteral("/ut-fake-themes/dark.theme"), makeThemeMap("Dark", "#222222", "#EEEEEE") },
+        });
+        model = new ThemeListModel();
+        delegate = new ThemeItemDelegate();
+    }
+
+    void TearDown() override
+    {
+        delete delegate;  // 覆盖 ~ThemeItemDelegate
+        delete model;
+        delegate = nullptr;
+        model = nullptr;
+        stub.clear();
+    }
+
+    // 统计 Utils::getThemeMapFromPath 被真实调用的次数（在既有主题源 stub 上叠加计数）
+    void instrumentThemeMapCalls()
+    {
+        // 重新安装带计数的 stub（set_lamda 对同一地址重复设置会自动 reset 旧值）
+        stub.set_lamda(&Utils::getThemeMapFromPath,
+                       [this](const QString &) -> QVariantMap {
+                           ++themeMapCallCount;
+                           return makeThemeMap("Dark", "#222222", "#EEEEEE");
+                       });
+    }
+
+    QStyleOptionViewItem makeOption(QStyle::State extraState)
+    {
+        QStyleOptionViewItem option;
+        option.rect = QRect(0, 0, 300, 130);
+        option.state |= QStyle::State_Enabled | extraState;
+        return option;
+    }
+
+    stub_ext::StubExt stub;
+    int themeMapCallCount = 0;
+    ThemeListModel *model = nullptr;
+    ThemeItemDelegate *delegate = nullptr;
+};
+
+// ---- sizeHint ----
+
+TEST_F(ThemeItemDelegateTest, SizeHint_AnyIndex_ReturnsFixedHeight)
+{
+    // Arrange：默认构造的 option/index（边界形态）
+    QStyleOptionViewItem option;
+    QModelIndex index;
+
+    // Act
+    const QSize hint = delegate->sizeHint(option, index);  // protected 经 -fno-access-control
+
+    // Assert：固定返回宽 -1 高 130（未启用则 131）
+    EXPECT_EQ(hint.width(), -1);
+    EXPECT_EQ(hint.height(), 130);
+}
+
+// ---- paint：真实离屏渲染（else 分支：未选中画笔）----
+
+TEST_F(ThemeItemDelegateTest, Paint_UnselectedState_DrawsOnImage)
+{
+    // Arrange
+    instrumentThemeMapCalls();
+    QImage image(300, 130, QImage::Format_ARGB32_Premultiplied);
+    image.fill(Qt::transparent);
+    QPainter painter(&image);
+    ASSERT_TRUE(painter.isActive());
+    const QModelIndex idx = model->index(0, 0);
+    const QStyleOptionViewItem option = makeOption(QStyle::State_None);
+
+    // Act
+    delegate->paint(&painter, option, idx);
+    painter.end();
+
+    // Assert：完整语法高亮样例绘制落笔（10 段文本 + 背景 + 边框），图片出现非透明像素
+    int paintedPixels = 0;
+    for (int y = 0; y < image.height(); ++y) {
+        for (int x = 0; x < image.width(); ++x) {
+            if (qAlpha(image.pixel(x, y)) != 0)
+                ++paintedPixels;
+        }
+    }
+    EXPECT_GT(paintedPixels, 0);
+    EXPECT_EQ(themeMapCallCount, 1);  // 恰好解析一次主题 JSON
+    EXPECT_EQ(model->rowCount(QModelIndex()), 1);  // 绘制不破坏模型（强异常安全）
+}
+
+// ---- paint：选中态（if 分支）+ drawText 计数 ----
+
+TEST_F(ThemeItemDelegateTest, Paint_SelectedState_DrawsAllSyntaxSegments)
+{
+    // Arrange：拦截 QRect 版 drawText 统计文本绘制次数（真实落笔由上一用例验证）
+    instrumentThemeMapCalls();
+    int drawTextCount = 0;
+    stub.set_lamda(
+        static_cast<void (QPainter::*)(const QRect &, int, const QString &, QRect *)>(
+            &QPainter::drawText),
+        [&drawTextCount](QPainter *, const QRect &, int, const QString &, QRect *) {
+            ++drawTextCount;
+        });
+    QImage image(300, 130, QImage::Format_ARGB32_Premultiplied);
+    image.fill(Qt::transparent);
+    QPainter painter(&image);
+    const QModelIndex idx = model->index(0, 0);
+    const QStyleOptionViewItem option = makeOption(QStyle::State_Selected);
+
+    // Act
+    delegate->paint(&painter, option, idx);
+    painter.end();
+
+    // Assert：语法高亮样例全部 10 段文本都请求绘制；主题 JSON 恰好解析一次
+    //（源码固定绘制：#include/"deepin.h"/QString/theme/() {//Return/return/"Dark"/;/}）
+    EXPECT_EQ(drawTextCount, 10);
+    EXPECT_EQ(themeMapCallCount, 1);
+}
+
+}  // namespace

--- a/tests/thememodule/test_themelistmodel.cpp
+++ b/tests/thememodule/test_themelistmodel.cpp
@@ -1,0 +1,215 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// ThemeListModel（src/thememodule/themelistmodel.cpp）单元测试
+//
+// 类特征：QAbstractListModel 子类（非直接 GUI 绘制），主题清单来源于
+// QDir 扫描 + Utils::getThemeMapFromPath JSON 解析 → 全部 stub_ext 拦截为受控假数据
+// （Qt 内置类/项目静态函数均无虚接口可注入，按 test-types §7.5 选 stub_ext）。
+//
+// 分支清单 → 用例映射：
+// - ThemeListModel::ThemeListModel → 各用例 SetUp 构造（间接调 initThemes）
+// - initThemes: entryInfoList 空清单 → Constructor_EmptyThemeDir_YieldsZeroRows
+// - initThemes: 多主题 + 排序 lambda（≥2 主题触发比较） → Constructor_MultipleThemes_SortedByBgLightness
+// - setSelection: path 命中 → SetSelection_MatchingPath_EmitsRequestCurrentIndexOnce
+// - setSelection: path 未命中（循环走完不 break） → SetSelection_UnknownPath_EmitsNothing
+// - setFrameColor → SetFrameColor_TwoColors_StoredAndServedByData
+// - data: switch ThemeName/ThemePath/FrameNormalColor/FrameSelectedColor → Data_ParamRole_ReturnsExpectedValue(TEST_P)
+// - data: default 分支（未知角色返回无效 QVariant） → Data_ParamRole_ReturnsExpectedValue(TEST_P "unknown" 参数)
+// - rowCount → Constructor_EmptyThemeDir_YieldsZeroRows / Constructor_MultipleThemes_*（多处交叉断言）
+//
+// 最小清单完成情况：
+// | 1 | 每个公开方法 ≥1 用例 | 完成（ctor/dtor/setFrameColor/setSelection/rowCount/data；initThemes 经构造间接全覆盖） |
+// | 2 | 等价类划分（角色枚举/路径命中与否/目录空与非空） | 完成 |
+// | 3 | 边界值（空目录 0 行 / 首行 index(0,0)） | 完成 |
+// | 4 | TEST_P ≥3 组（data 角色 5 参数组） | 完成 |
+// | 5 | 分支清单映射 | 见上方 |
+// | 6 | if/switch/early-return 全分支 | 完成（sort 比较经多主题用例触发） |
+// | 7 | 异常路径 EXPECT_THROW | N/A（Qt 风格无 throw） |
+// | 8 | 负面场景（未知路径/未知角色/空目录） | 完成 |
+// | 9 | 强异常安全（未命中后模型行数不变） | 完成 |
+// | 10 | stub_ext（Qt 内置类 + 项目静态函数） | 完成 |
+//
+// 已知源码缺陷（只记录不改源码）：
+// - data() 未校验 index 行号边界：m_themes.at(r) 对越界 row（含默认 QModelIndex 的 -1）
+//   直接 QList::at 越界（UB/断言崩溃），违背 QAbstractItemModel 对无效索引返回
+//   QVariant() 的契约 → 见批次 session defects。
+
+#include <gtest/gtest.h>
+
+#include <QAbstractListModel>
+#include <QModelIndex>
+#include <QSignalSpy>
+#include <QStringList>
+#include <QVariant>
+
+#include "test_env.h"
+#include "themelistmodel.h"
+
+namespace {
+
+// 受控主题源：三个主题文件（entryInfoList 顺序：亮、暗、中），用于排序与命中测试
+FakeThemeSource makeThreeThemes()
+{
+    return {
+        { QStringLiteral("/ut-fake-themes/bright.theme"), makeThemeMap("Bright", "#FFFFFF") },
+        { QStringLiteral("/ut-fake-themes/dark.theme"), makeThemeMap("Dark", "#000000") },
+        { QStringLiteral("/ut-fake-themes/mid.theme"), makeThemeMap("Mid", "#808080") },
+    };
+}
+
+class ThemeListModelTest : public ::testing::Test {
+protected:
+    static void SetUpTestSuite() { thememoduleEnsureApp(); }
+
+    void SetUp() override
+    {
+        stub.clear();
+        source = makeThreeThemes();
+        installThemeSourceStubs(stub, source);
+        model = new ThemeListModel();
+    }
+
+    void TearDown() override
+    {
+        delete model;  // 覆盖 ~ThemeListModel
+        model = nullptr;
+        stub.clear();
+    }
+
+    stub_ext::StubExt stub;
+    FakeThemeSource source;
+    ThemeListModel *model = nullptr;
+};
+
+// ---- 构造 + initThemes + rowCount ----
+
+TEST_F(ThemeListModelTest, Constructor_EmptyThemeDir_YieldsZeroRows)
+{
+    // Arrange：重新用空目录构造（stub 换为空清单）
+    delete model;
+    installThemeSourceStubs(stub, FakeThemeSource());
+    model = new ThemeListModel();
+
+    // Act
+    const int rows = model->rowCount(QModelIndex());
+
+    // Assert：空清单 → 0 行（循环体不进入、空容器排序安全）
+    EXPECT_EQ(rows, 0);
+    EXPECT_EQ(model->rowCount(QModelIndex()), 0);  // 稳定性：重复调用结果一致
+}
+
+TEST_F(ThemeListModelTest, Constructor_MultipleThemes_SortedByBgLightness)
+{
+    // Arrange：entryInfoList 顺序为 亮(255)/暗(0)/中(128)
+
+    // Act：读取 ThemePath 角色按行取值
+    const int rows = model->rowCount(QModelIndex());
+    QStringList paths;
+    for (int row = 0; row < rows; ++row)
+        paths << model->data(model->index(row, 0), ThemeListModel::ThemePath).toString();
+
+    // Assert：3 行；按 background-color 亮度升序 → dark(0) < mid(128) < bright(255)
+    EXPECT_EQ(rows, 3);
+    EXPECT_EQ(paths, (QStringList() << "/ut-fake-themes/dark.theme"
+                                    << "/ut-fake-themes/mid.theme"
+                                    << "/ut-fake-themes/bright.theme"));
+}
+
+// ---- data()：角色等价类参数化（含 default 分支）----
+
+struct DataRoleCase {
+    int role;
+    QVariant expected;
+    QString caseName;
+};
+
+class ThemeListModelDataTest : public ThemeListModelTest,
+                               public ::testing::WithParamInterface<DataRoleCase> {
+};
+
+TEST_P(ThemeListModelDataTest, Data_ParamRole_ReturnsExpectedValue)
+{
+    // Arrange：首行主题经排序后为 dark 主题
+    const QModelIndex idx = model->index(0, 0);
+    ASSERT_EQ(model->data(idx, ThemeListModel::ThemePath).toString(),
+              QStringLiteral("/ut-fake-themes/dark.theme"));
+
+    // Act
+    const QVariant actual = model->data(idx, GetParam().role);
+
+    // Assert：每个角色返回精确期望值；未登记角色（default 分支）返回无效 QVariant
+    EXPECT_EQ(actual, GetParam().expected);
+    EXPECT_EQ(actual.isValid(), GetParam().expected.isValid());
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    RoleEquivalenceClasses, ThemeListModelDataTest,
+    ::testing::Values(
+        // ThemeName = Qt::DisplayRole，取 metadata.name
+        (DataRoleCase{ ThemeListModel::ThemeName, QVariant(QStringLiteral("Dark")), "name" }),
+        // ThemePath = Qt::UserRole，取排序后首行主题文件路径
+        (DataRoleCase{ ThemeListModel::ThemePath,
+                       QVariant(QStringLiteral("/ut-fake-themes/dark.theme")), "path" }),
+        // FrameNormalColor / FrameSelectedColor 未 setFrameColor 前为空串
+        (DataRoleCase{ ThemeListModel::FrameNormalColor, QVariant(QString("")), "normalColorDefault" }),
+        (DataRoleCase{ ThemeListModel::FrameSelectedColor, QVariant(QString("")), "selectedColorDefault" }),
+        // default 分支：未登记角色返回无效 QVariant
+        (DataRoleCase{ Qt::ToolTipRole, QVariant(), "unknownRoleInvalid" })),
+    [](const ::testing::TestParamInfo<DataRoleCase> &info) { return info.param.caseName.toStdString(); });
+
+// ---- setFrameColor ----
+
+TEST_F(ThemeListModelTest, SetFrameColor_TwoColors_StoredAndServedByData)
+{
+    // Arrange
+    const QModelIndex idx = model->index(1, 0);  // 排序后第 2 行（mid）
+
+    // Act
+    model->setFrameColor("#FF0000", "#00FF00");
+
+    // Assert：两种颜色经 data() 精确回读（状态变更断言）
+    EXPECT_EQ(model->data(idx, ThemeListModel::FrameSelectedColor).toString(),
+              QStringLiteral("#FF0000"));
+    EXPECT_EQ(model->data(idx, ThemeListModel::FrameNormalColor).toString(),
+              QStringLiteral("#00FF00"));
+    // 其它角色不受影响
+    EXPECT_EQ(model->data(idx, ThemeListModel::ThemeName).toString(),
+              QStringLiteral("Mid"));
+    EXPECT_EQ(model->rowCount(QModelIndex()), 3);
+}
+
+// ---- setSelection ----
+
+TEST_F(ThemeListModelTest, SetSelection_MatchingPath_EmitsRequestCurrentIndexOnce)
+{
+    // Arrange：监听信号
+    QSignalSpy spy(model, &ThemeListModel::requestCurrentIndex);
+    ASSERT_TRUE(spy.isValid());
+
+    // Act：命中排序后第 2 行（mid，行号 1）
+    model->setSelection(QStringLiteral("/ut-fake-themes/mid.theme"));
+
+    // Assert：恰好发射一次，携带行号 1 的索引（命中即 break）
+    EXPECT_EQ(spy.count(), 1);
+    EXPECT_EQ(spy.at(0).at(0).toModelIndex().row(), 1);
+    EXPECT_EQ(spy.at(0).at(0).toModelIndex().column(), 0);
+}
+
+TEST_F(ThemeListModelTest, SetSelection_UnknownPath_EmitsNothingAndKeepsRows)
+{
+    // Arrange
+    QSignalSpy spy(model, &ThemeListModel::requestCurrentIndex);
+    ASSERT_TRUE(spy.isValid());
+    const int rowsBefore = model->rowCount(QModelIndex());
+
+    // Act：未命中路径（循环完整走完，无 break）
+    model->setSelection(QStringLiteral("/ut-fake-themes/nonexistent.theme"));
+
+    // Assert：不发射信号；模型状态未损坏（强异常安全）
+    EXPECT_EQ(spy.count(), 0);
+    EXPECT_EQ(model->rowCount(QModelIndex()), rowsBefore);
+    EXPECT_EQ(model->rowCount(QModelIndex()), 3);
+}
+
+}  // namespace

--- a/tests/thememodule/test_themelistview.cpp
+++ b/tests/thememodule/test_themelistview.cpp
@@ -1,0 +1,245 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// ThemeListView（src/thememodule/themelistview.cpp）单元测试
+//
+// 类特征：QListView 子类（GUI 类），offscreen QApplication 无头构造；
+// 事件/滚动条/选择模型交互按 test-types §7.5 用 stub_ext 拦截 Qt 内置类。
+//
+// 分支清单 → 用例映射：
+// - ThemeListView::ThemeListView → 各用例 SetUp 构造（滚动模式/滚动条策略经构造后状态断言）
+// - adjustScrollbarMargins: !isVisible() 早退 → AdjustScrollbarMargins_HiddenView_SkipsLayoutRequest
+// - adjustScrollbarMargins: 可见 + 滚动条区域非空 → AdjustScrollbarMargins_VisibleView_SendsLayoutAndSetsMargins
+// - adjustScrollbarMargins: 可见 + 滚动条区域为空（else 分支，与 if 分支语句相同） → 同上用例覆盖（两分支 setViewportMargins 调用相同）
+// - eventFilter: FocusOut → focusOut 信号 → EventFilter_ParamEventType_FocusOutEmittedOrNot(TEST_P)
+// - eventFilter: 非 FocusOut → 不发射 → 同上 TEST_P "other" 参数
+// - selectionChanged: selectedIndexes 非空 → themeChanged → SelectionChanged_SingleSelection_EmitsThemePath
+// - selectionChanged: selectedIndexes 多项 → 每项发射 → SelectionChanged_MultiSelection_EmitsPerIndex
+// - selectionChanged: selectedIndexes 空 → 不发射 → SelectionChanged_EmptySelection_EmitsNothing
+//
+// 最小清单完成情况：
+// | 1 | 每个公开/保护方法 ≥1 用例 | 完成（ctor/dtor/adjustScrollbarMargins/eventFilter/selectionChanged） |
+// | 2 | 等价类划分（可见性/事件类型/选择形态） | 完成 |
+// | 3 | 边界值（空选择/多选/未知事件类型） | 完成 |
+// | 4 | TEST_P ≥3 组（eventFilter 3 事件类型参数） | 完成 |
+// | 5 | 分支清单映射 | 见上方 |
+// | 6 | if/early-return 全分支 | 完成 |
+// | 7 | 异常路径 EXPECT_THROW | N/A（Qt 风格无 throw） |
+// | 8 | 负面场景（空选择/非焦点事件） | 完成 |
+// | 9 | 强异常安全（空选择后状态不变） | 完成 |
+// | 10 | stub_ext（QApplication::sendEvent 计数） | 完成 |
+//
+// 已知源码缺陷（只记录不改源码）：
+// - adjustScrollbarMargins if/else 两分支 setViewportMargins(0,0,5,0) 完全相同，
+//   visibleRegion() 条件判断无实际效果（疑似复制粘贴残留）→ 见批次 session defects。
+
+#include <gtest/gtest.h>
+
+#include <QEvent>
+#include <QItemSelection>
+#include <QItemSelectionModel>
+#include <QMargins>
+#include <QModelIndex>
+#include <QSignalSpy>
+#include <QStringList>
+#include <QVariant>
+
+#include "test_env.h"
+#include "themelistmodel.h"
+#include "themelistview.h"
+
+namespace {
+
+// 暴露 protected override 以便直接调用（不修改源码）
+class TestableThemeListView : public ThemeListView {
+public:
+    using ThemeListView::ThemeListView;
+    using ThemeListView::eventFilter;          // protected → public
+    using ThemeListView::selectionChanged;     // protected → public
+};
+
+class ThemeListViewTest : public ::testing::Test {
+protected:
+    static void SetUpTestSuite() { thememoduleEnsureApp(); }
+
+    void SetUp() override
+    {
+        stub.clear();
+        installThemeSourceStubs(stub, {
+            { QStringLiteral("/ut-fake-themes/dark.theme"), makeThemeMap("Dark", "#000000") },
+            { QStringLiteral("/ut-fake-themes/bright.theme"), makeThemeMap("Bright", "#FFFFFF") },
+        });
+        model = new ThemeListModel();
+        view = new TestableThemeListView();
+        view->setModel(model);
+    }
+
+    void TearDown() override
+    {
+        // 先清 stub 再析构控件：避免 Qt 析构路径中的事件派发被计数 stub 吞掉
+        stub.clear();
+        delete view;  // 覆盖 ~ThemeListView
+        delete model;
+        view = nullptr;
+        model = nullptr;
+    }
+
+    // sendEvent 计数器（夹具成员，生命周期覆盖 stub 生效期——禁止栈局部引用捕获）
+    void installSendEventCounter()
+    {
+        totalSendEvent = 0;
+        layoutRequestToView = 0;
+        stub.set_lamda(&QCoreApplication::sendEvent,
+                       [this](QObject *receiver, QEvent *event) -> bool {
+                           ++totalSendEvent;
+                           if (event && event->type() == QEvent::LayoutRequest
+                               && receiver == view)
+                               ++layoutRequestToView;
+                           return true;
+                       });
+    }
+
+    stub_ext::StubExt stub;
+    int totalSendEvent = 0;
+    int layoutRequestToView = 0;
+    ThemeListModel *model = nullptr;
+    TestableThemeListView *view = nullptr;
+};
+
+// ---- 构造 ----
+
+TEST_F(ThemeListViewTest, Constructor_AppliesScrollPolicies)
+{
+    // Act：构造已完成（SetUp）
+    // Assert：逐像素滚动、垂直滚动条常显、水平滚动条常隐（构造函数行为断言）
+    EXPECT_EQ(view->verticalScrollMode(), QAbstractItemView::ScrollPerPixel);
+    EXPECT_EQ(view->verticalScrollBarPolicy(), Qt::ScrollBarAlwaysOn);
+    EXPECT_EQ(view->horizontalScrollBarPolicy(), Qt::ScrollBarAlwaysOff);
+}
+
+// ---- adjustScrollbarMargins ----
+
+TEST_F(ThemeListViewTest, AdjustScrollbarMargins_HiddenView_SkipsLayoutRequest)
+{
+    // Arrange：视图未 show()；拦截 QApplication::sendEvent 计数（不发真实事件）
+    installSendEventCounter();
+
+    // Act
+    view->adjustScrollbarMargins();
+
+    // Assert：不可见早退——不派发任何事件（含 LayoutRequest）、不改边距（初始边距全 0）
+    EXPECT_EQ(totalSendEvent, 0);
+    EXPECT_EQ(layoutRequestToView, 0);
+    const QMargins margins = view->viewportMargins();  // 经 -fno-access-control 访问 protected
+    EXPECT_EQ(margins.left(), 0);
+    EXPECT_EQ(margins.right(), 0);
+}
+
+TEST_F(ThemeListViewTest, AdjustScrollbarMargins_VisibleView_SendsLayoutAndSetsMargins)
+{
+    // Arrange：show 后可见；sendEvent 计数（Qt 内部其它事件派发允许存在）
+    view->resize(300, 400);
+    view->show();
+    ASSERT_TRUE(view->isVisible());
+    installSendEventCounter();
+
+    // Act
+    view->adjustScrollbarMargins();
+
+    // Assert：向本视图恰好派发 1 次 LayoutRequest；右边距被置 5
+    //（源码 if/else 两分支调用相同，无论 visibleRegion 哪边都落到同一断言）
+    EXPECT_EQ(layoutRequestToView, 1);
+    EXPECT_GE(totalSendEvent, 1);
+    const QMargins margins = view->viewportMargins();
+    EXPECT_EQ(margins.right(), 5);
+    EXPECT_EQ(margins.top(), 0);
+}
+
+// ---- eventFilter ----
+
+struct EventFilterCase {
+    QEvent::Type eventType;
+    int expectedSpyCount;
+    QString caseName;
+};
+
+class ThemeListViewEventFilterTest : public ThemeListViewTest,
+                                     public ::testing::WithParamInterface<EventFilterCase> {
+};
+
+TEST_P(ThemeListViewEventFilterTest, EventFilter_ParamEventType_FocusOutEmittedOrNot)
+{
+    // Arrange
+    QSignalSpy spy(view, &ThemeListView::focusOut);
+    ASSERT_TRUE(spy.isValid());
+    QEvent event(GetParam().eventType);
+
+    // Act
+    const bool filtered = view->eventFilter(view, &event);
+
+    // Assert：仅 FocusOut 发射一次信号；任何事件都不拦截（恒返回 false）
+    EXPECT_EQ(spy.count(), GetParam().expectedSpyCount);
+    EXPECT_FALSE(filtered);  // 期望不拦截：返回 false
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    EventEquivalenceClasses, ThemeListViewEventFilterTest,
+    ::testing::Values(
+        (EventFilterCase{ QEvent::FocusOut, 1, "focusOutEmits" }),
+        (EventFilterCase{ QEvent::Enter, 0, "enterIgnored" }),
+        (EventFilterCase{ QEvent::MouseButtonPress, 0, "mousePressIgnored" })),
+    [](const ::testing::TestParamInfo<EventFilterCase> &info) { return info.param.caseName.toStdString(); });
+
+// ---- selectionChanged ----
+
+TEST_F(ThemeListViewTest, SelectionChanged_SingleSelection_EmitsThemePath)
+{
+    // Arrange：模型 2 行（排序后 dark 行 0、bright 行 1）
+    QSignalSpy spy(view, &ThemeListView::themeChanged);
+    ASSERT_TRUE(spy.isValid());
+
+    // Act：经选择模型选中行 0（触发 selectionChanged 覆盖：先调基类再遍历选中项）
+    const QModelIndex idx = model->index(0, 0);
+    view->selectionModel()->select(QItemSelection(idx, idx),
+                                   QItemSelectionModel::ClearAndSelect);
+
+    // Assert：发射一次，携带行 0 的主题路径
+    EXPECT_EQ(spy.count(), 1);
+    EXPECT_EQ(spy.at(0).at(0).toString(), QStringLiteral("/ut-fake-themes/dark.theme"));
+}
+
+TEST_F(ThemeListViewTest, SelectionChanged_MultiSelection_EmitsPerIndex)
+{
+    // Arrange：同时选中两行
+    QSignalSpy spy(view, &ThemeListView::themeChanged);
+    ASSERT_TRUE(spy.isValid());
+    const QModelIndex first = model->index(0, 0);
+    const QModelIndex second = model->index(1, 0);
+    QItemSelection multi;
+    multi.append(QItemSelectionRange(first));
+    multi.append(QItemSelectionRange(second));
+
+    // Act
+    view->selectionModel()->select(multi, QItemSelectionModel::ClearAndSelect);
+
+    // Assert：每个选中索引各发射一次（循环遍历分支）
+    EXPECT_EQ(spy.count(), 2);
+    EXPECT_EQ(spy.at(0).at(0).toString(), QStringLiteral("/ut-fake-themes/dark.theme"));
+    EXPECT_EQ(spy.at(1).at(0).toString(), QStringLiteral("/ut-fake-themes/bright.theme"));
+}
+
+TEST_F(ThemeListViewTest, SelectionChanged_EmptySelection_EmitsNothing)
+{
+    // Arrange：空选择集
+    QSignalSpy spy(view, &ThemeListView::themeChanged);
+    ASSERT_TRUE(spy.isValid());
+
+    // Act：直接以空选择调用 protected 覆盖（selectedIndexes 为空 → 循环体不进入）
+    view->selectionChanged(QItemSelection(), QItemSelection());
+
+    // Assert：不发射；选择模型状态未受影响（强异常安全）
+    EXPECT_EQ(spy.count(), 0);
+    EXPECT_TRUE(view->selectionModel()->selectedIndexes().isEmpty());
+}
+
+}  // namespace

--- a/tests/thememodule/test_themepanel.cpp
+++ b/tests/thememodule/test_themepanel.cpp
@@ -1,0 +1,275 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// ThemePanel（src/thememodule/themepanel.cpp）单元测试
+//
+// 类特征：QWidget 子类（GUI 类），offscreen QApplication 无头构造。
+// Window 依赖处理：themepanel.cpp 以相对路径包含真实 ../widgets/window.h（无法用 -I 遮蔽），
+// 符号经 startmanager_ut_src 全量源码库提供；测试绝不真实实例化 Window——popup/hide
+// 仅经 m_window->geometry()（QWidget 单继承链上的非虚方法）读取父窗口几何，
+// 故父对象传普通 QWidget（DMainWindow→QWidget 单继承偏移 0，静态下转不改变地址）。
+//
+// 分支清单 → 用例映射：
+// - ThemePanel::ThemePanel → 各用例 SetUp 构造（含 connect 的 lambda 于 setSelectionTheme 用例覆盖）
+// - setBackground: lightness < 128（暗色 → 深色描边） / >= 128（亮色 → 浅色描边） → SetBackground_ParamLightness_SelectsFrameColor(TEST_P 3 组)
+// - popup → Popup_ShownView_AnimatesGeometryIntoView（含 valueChanged lambda 经动画真实触发）
+// - hide → Hide_AnimatesGeometryOutAndHidesPanel（finished → QWidget::hide 真实收尾）
+// - setFrameColor → SetFrameColor_ForwardsColorsToModel
+// - setSelectionTheme → SetSelectionTheme_KnownPath_UpdatesCurrentIndex（构造内 lambda 覆盖）
+// - paintEvent → PaintEvent_TwoFillPathCalls_BackgroundAndSeparator（fillPath 计数 + 颜色断言）
+//
+// 最小清单完成情况：
+// | 1 | 每个公开方法 ≥1 用例 | 完成（ctor/dtor/setBackground/popup/hide/setFrameColor/setSelectionTheme；paintEvent 为 protected 覆盖经直接调用） |
+// | 2 | 等价类划分（亮度两侧/路径已知未知） | 完成 |
+// | 3 | 边界值（lightness 恰为 128 走亮色分支） | 完成（TEST_P） |
+// | 4 | TEST_P ≥3 组（背景色 3 参数） | 完成 |
+// | 5 | 分支清单映射 | 见上方 |
+// | 6 | if/early-return 全分支 | 完成 |
+// | 7 | 异常路径 EXPECT_THROW | N/A（Qt 风格无 throw） |
+// | 8 | 负面场景（未知路径不崩溃且索引不变） | 完成 |
+// | 9 | 强异常安全（popup 后模型/行数不变） | 完成 |
+// | 10 | stub_ext（QPainter::fillPath 计数；主题数据源隔离） | 完成 |
+//
+// 动画策略：QPropertyAnimation 真实运行（offscreen 定时器驱动），QEventLoop+QTimer
+// 等待 250ms 动画完成，几何终值即断言依据；不 stub start。
+
+#include <gtest/gtest.h>
+
+#include <QColor>
+#include <QEventLoop>
+#include <QMargins>
+#include <QModelIndex>
+#include <QPainter>
+#include <QPainterPath>
+#include <QRect>
+#include <QSignalSpy>
+#include <QTimer>
+#include <QVariant>
+#include <QVBoxLayout>
+
+#include "test_env.h"
+#include "themelistmodel.h"
+#include "themelistview.h"
+#include "themepanel.h"
+
+namespace {
+
+// 等待动画（250ms）完成并处理收尾事件（finished → hide/deleteLater）
+inline void waitForAnimation(int msec = 420)
+{
+    QEventLoop loop;
+    QTimer::singleShot(msec, &loop, &QEventLoop::quit);
+    loop.exec();
+}
+
+class ThemePanelTest : public ::testing::Test {
+protected:
+    static void SetUpTestSuite() { thememoduleEnsureApp(); }
+
+    void SetUp() override
+    {
+        stub.clear();
+        installThemeSourceStubs(stub, {
+            { QStringLiteral("/ut-fake-themes/dark.theme"), makeThemeMap("Dark", "#000000") },
+            { QStringLiteral("/ut-fake-themes/bright.theme"), makeThemeMap("Bright", "#FFFFFF") },
+        });
+        // 父窗口：800x600，替代 Window（仅经 geometry() 被读取，不实例化真实主窗口）
+        parent = new QWidget();
+        parent->setGeometry(0, 0, 800, 600);
+        panel = new ThemePanel(parent);  // 内部构造 ThemeListView/ThemeListModel
+    }
+
+    void TearDown() override
+    {
+        // 确保动画对象随面板释放（finished 已 deleteLater 或作为子对象清理）
+        delete parent;  // 级联释放 panel → 覆盖 ~ThemePanel
+        parent = nullptr;
+        panel = nullptr;
+        stub.clear();
+    }
+
+    stub_ext::StubExt stub;
+    QWidget *parent = nullptr;
+    ThemePanel *panel = nullptr;
+};
+
+// ---- 构造 ----
+
+TEST_F(ThemePanelTest, Constructor_BuildsViewHierarchyAndStaysHidden)
+{
+    // Arrange/Act：构造已完成（SetUp）
+    const ThemeListView *view = panel->m_themeView;        // 经 -fno-access-control
+    const ThemeListModel *model = panel->m_themeModel;
+
+    // Assert：视图/模型就绪、模型已装载主题、面板初始隐藏、固定宽 250
+    ASSERT_NE(view, nullptr);
+    ASSERT_NE(model, nullptr);
+    EXPECT_EQ(view->accessibleName(), QStringLiteral("ThemeListView"));
+    EXPECT_EQ(view->objectName(), QStringLiteral("ThemeView"));
+    EXPECT_EQ(model->rowCount(QModelIndex()), 2);
+    EXPECT_EQ(view->model(), model);  // 视图已绑定模型
+    EXPECT_FALSE(panel->isVisible());  // 构造即隐藏
+    EXPECT_EQ(panel->minimumWidth(), 250);
+    EXPECT_EQ(panel->maximumWidth(), 250);  // setFixedWidth(250)
+
+    // 布局：内容边距与间距均为 0
+    const auto *layout = qobject_cast<const QVBoxLayout *>(panel->layout());
+    ASSERT_NE(layout, nullptr);    EXPECT_EQ(layout->contentsMargins(), QMargins(0, 0, 0, 0));
+    EXPECT_EQ(layout->spacing(), 0);
+}
+
+// ---- setBackground：亮度分支参数化 ----
+
+struct BackgroundCase {
+    QString backgroundHex;
+    QString expectedFrameName;
+    QString caseName;
+};
+
+class ThemePanelBackgroundTest : public ThemePanelTest,
+                                 public ::testing::WithParamInterface<BackgroundCase> {
+};
+
+TEST_P(ThemePanelBackgroundTest, SetBackground_ParamLightness_SelectsFrameColor)
+{
+    // Arrange
+    const QColor expectedFrame(GetParam().expectedFrameName);
+
+    // Act
+    panel->setBackground(GetParam().backgroundHex);
+
+    // Assert：背景色按入参落盘；描边色按亮度分支选取（暗色→#FFFFFF，亮色→#000000）
+    EXPECT_EQ(panel->m_backgroundColor.name(), QColor(GetParam().backgroundHex).name());
+    EXPECT_EQ(panel->m_frameColor.name(), expectedFrame.name());
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    LightnessEquivalenceClasses, ThemePanelBackgroundTest,
+    ::testing::Values(
+        // lightness=0 <128 → 暗色分支取 m_frameDarkColor(#FFFFFF)
+        (BackgroundCase{ QStringLiteral("#000000"), QStringLiteral("#FFFFFF"), "darkBackground" }),
+        // lightness=255 >=128 → 亮色分支取 m_frameLightColor(#000000)
+        (BackgroundCase{ QStringLiteral("#FFFFFF"), QStringLiteral("#000000"), "lightBackground" }),
+        // 边界：lightness=128（#808080）不小于 128 → 亮色分支
+        (BackgroundCase{ QStringLiteral("#808080"), QStringLiteral("#000000"), "boundaryLightness128" })),
+    [](const ::testing::TestParamInfo<BackgroundCase> &info) { return info.param.caseName.toStdString(); });
+
+// ---- popup ----
+
+TEST_F(ThemePanelTest, Popup_ShownView_AnimatesGeometryIntoView)
+{
+    // Arrange：父窗口与面板就位（面板初始几何 x=800 完全在窗口外）
+    parent->show();
+    panel->setGeometry(800, 30, 250, 100);
+    ASSERT_FALSE(panel->isVisible());
+
+    // Act：弹出入场（show/raise + 动画 x: 800 → 800-250）
+    panel->popup();
+    EXPECT_TRUE(panel->isVisible());  // popup 即显示（断言 1：副作用）
+
+    waitForAnimation();  // 等 250ms 动画跑完（期间 valueChanged lambda 被真实触发）
+
+    // Assert：动画终值 x=550、几何其余分量保持；模型行数不受影响（强异常安全）
+    EXPECT_EQ(panel->x(), 550);
+    EXPECT_EQ(panel->y(), 30);
+    EXPECT_EQ(panel->width(), 250);
+    EXPECT_EQ(panel->m_themeModel->rowCount(QModelIndex()), 2);
+}
+
+// ---- hide ----
+
+TEST_F(ThemePanelTest, Hide_AnimatesGeometryOutAndHidesPanel)
+{
+    // Arrange：先显示并置于收起前位置 x=550
+    parent->show();
+    panel->setGeometry(550, 30, 250, 100);
+    panel->show();
+    ASSERT_TRUE(panel->isVisible());
+
+    // Act：收起（动画 x: 800-250=550 → 800，完成后 QWidget::hide）
+    panel->hide();
+    waitForAnimation();
+
+    // Assert：动画终值 x=800；finished 链路真实执行到 QWidget::hide → 面板隐藏
+    EXPECT_EQ(panel->x(), 800);
+    EXPECT_EQ(panel->width(), 250);
+    EXPECT_FALSE(panel->isVisible());
+}
+
+// ---- setFrameColor ----
+
+TEST_F(ThemePanelTest, SetFrameColor_ForwardsColorsToModel)
+{
+    // Arrange
+    const QModelIndex idx = panel->m_themeModel->index(0, 0);
+
+    // Act
+    panel->setFrameColor("#123456", "#654321");
+
+    // Assert：转发到模型（经模型 data() 精确回读）
+    EXPECT_EQ(panel->m_themeModel->data(idx, ThemeListModel::FrameSelectedColor).toString(),
+              QStringLiteral("#123456"));
+    EXPECT_EQ(panel->m_themeModel->data(idx, ThemeListModel::FrameNormalColor).toString(),
+              QStringLiteral("#654321"));
+}
+
+// ---- setSelectionTheme ----
+
+TEST_F(ThemePanelTest, SetSelectionTheme_KnownPath_UpdatesCurrentIndex)
+{
+    // Arrange：监听模型的 requestCurrentIndex（构造内 connect 的 lambda 将其转到视图）
+    QSignalSpy spy(panel->m_themeModel, &ThemeListModel::requestCurrentIndex);
+    ASSERT_TRUE(spy.isValid());
+
+    // Act：选中已知主题路径（dark 排序后行 0）
+    panel->setSelectionTheme(QStringLiteral("/ut-fake-themes/dark.theme"));
+    QApplication::processEvents();  // 让 connect 的 lambda（同步直连也即时生效）执行
+
+    // Assert：模型发射定位索引；视图当前索引被 lambda 更新为行 0
+    EXPECT_EQ(spy.count(), 1);
+    EXPECT_EQ(panel->m_themeView->currentIndex().row(), 0);
+    EXPECT_EQ(panel->m_themeView->currentIndex().data(ThemeListModel::ThemePath).toString(),
+              QStringLiteral("/ut-fake-themes/dark.theme"));
+}
+
+TEST_F(ThemePanelTest, SetSelectionTheme_UnknownPath_KeepsCurrentIndex)
+{
+    // Arrange：预选行 1 作为基线
+    panel->m_themeView->setCurrentIndex(panel->m_themeModel->index(1, 0));
+    ASSERT_EQ(panel->m_themeView->currentIndex().row(), 1);
+
+    // Act：未知路径（模型循环不命中，无信号）
+    panel->setSelectionTheme(QStringLiteral("/ut-fake-themes/absent.theme"));
+    QApplication::processEvents();
+
+    // Assert：当前索引保持不变（负面场景 + 强异常安全）
+    EXPECT_EQ(panel->m_themeView->currentIndex().row(), 1);
+    EXPECT_EQ(panel->m_themeModel->rowCount(QModelIndex()), 2);
+}
+
+// ---- paintEvent ----
+
+TEST_F(ThemePanelTest, PaintEvent_TwoFillPathCalls_BackgroundAndSeparator)
+{
+    // Arrange：先定背景（背景 #123456 → 亮度 38 <128 → 描边取 #FFFFFF），
+    // 拦截 QPainter::fillPath 记录落笔颜色
+    panel->setBackground("#123456");
+    const QColor expectedBackground(QStringLiteral("#123456"));
+    const QColor expectedFrame(QStringLiteral("#FFFFFF"));
+    QStringList filledColors;
+    stub.set_lamda(&QPainter::fillPath,
+                   [&filledColors](QPainter *, const QPainterPath &, const QBrush &brush) {
+                       filledColors << brush.color().name();
+                   });
+    QPaintEvent event(QRect(0, 0, 250, 100));
+
+    // Act：直接调用 protected 覆盖（经 -fno-access-control）
+    panel->paintEvent(&event);
+
+    // Assert：恰好两次填充——先 0.9 透明度背景色，后 0.1 透明度描边色（分隔线）
+    ASSERT_EQ(filledColors.size(), 2);
+    EXPECT_EQ(filledColors.at(0), expectedBackground.name());
+    EXPECT_EQ(filledColors.at(1), expectedFrame.name());
+}
+
+}  // namespace


### PR DESCRIPTION
## 内容

新增 markdown 与主题模块的 GTest 单元测试：markdown 渲染/桥接/视图、滚动同步、主题序列化、视图模式状态机及主题面板组件，共 16 个文件。

## 说明

- 基于 master 独立拉出，可独立评审与合并
- 仅新增单元测试代码，不改动编辑器本体功能

## Summary by Sourcery

Expand automated unit-test coverage across the Markdown and theme modules without changing editor functionality.

Enhancements:
- Add comprehensive GoogleTest coverage for Markdown rendering, bridging, image handling, view state, scrolling, throttling, and theme serialization behavior.
- Add unit coverage for theme models, views, delegates, and panels, including theme loading, selection, rendering, and UI state transitions.

Build:
- Add CMake targets and test discovery configuration for Markdown and theme module test suites, including Qt Test and coverage dependencies.

Tests:
- Introduce isolated offscreen GTest executables covering 16 Markdown and theme module test files with controlled stubs and parameterized edge-case tests.