### PR TITLE
fix(editor): fix core defects found by unit test scan

### DIFF
--- a/src/editor/FlashTween.cpp
+++ b/src/editor/FlashTween.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2011-2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2011-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -109,7 +109,10 @@ void FlashTween::__runX()
     }
     else {
         qDebug() << "FlashTween X animation completed";
-        m_timerX->stop();
+        // 与 __runY 的防御风格保持一致
+        if (m_timerX != nullptr) {
+            m_timerX->stop();
+        }
     }
     qDebug() << "FlashTween X animation completed";
 }

--- a/src/editor/deletetextundocommand.cpp
+++ b/src/editor/deletetextundocommand.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2019 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2019 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -22,6 +22,9 @@ DeleteTextUndoCommand::DeleteTextUndoCommand(QTextCursor textcursor, TextEdit *e
         m_sInsertText = m_textCursor.selectedText();
     } else {
         qDebug() << "m_textCursor.hasSelection() is false";
+        // 无选区删除的是光标前一个字符，m_beginPos 记录被删字符位置（光标-1），
+        // 否则 undo 会把字符重插到原位置之后一位
+        m_beginPos = m_textCursor.position() - 1;
         int pos = m_textCursor.positionInBlock() - 1;
         if (pos >= 0) {
             qDebug() << "pos >= 0";
@@ -193,10 +196,12 @@ void DeleteTextUndoCommand2::undo()
     } else {
         qDebug() << "m_ColumnEditSelections.isEmpty() is false";
         int cnt = m_ColumnEditSelections.size();
-        for (int i = 0; i < cnt; i++) {
-            m_ColumnEditSelections[i].cursor.setPosition(m_beginPostion);
+        // 逆序恢复：redo 按序删除时记录的各选区位置在"全部删除后"的坐标系中有效，
+        // 逆序插入（先恢复靠后的选区）不会使靠前选区的记录位置发生偏移
+        for (int i = cnt - 1; i >= 0; i--) {
+            m_ColumnEditSelections[i].cursor.setPosition(m_selectBeginPosList.value(i));
             m_ColumnEditSelections[i].cursor.insertText(m_selectTextList[i]);
-            m_ColumnEditSelections[i].cursor.setPosition(m_beginPostion);
+            m_ColumnEditSelections[i].cursor.setPosition(m_selectBeginPosList.value(i));
             m_edit->setTextCursor(m_ColumnEditSelections[i].cursor);
         }
     }
@@ -243,8 +248,10 @@ void DeleteTextUndoCommand2::redo()
     } else {
         qDebug() << "m_ColumnEditSelections.isEmpty() is false";
         int cnt = m_ColumnEditSelections.size();
+        // 每个选区记录各自的起始位置，供 undo 恢复使用（ redo/undo 严格交替，先清空防御重复累积）
+        m_selectBeginPosList.clear();
         for (int i = 0; i < cnt; i++) {
-            m_beginPostion = m_ColumnEditSelections[i].cursor.selectionStart();
+            m_selectBeginPosList.append(m_ColumnEditSelections[i].cursor.selectionStart());
             m_ColumnEditSelections[i].cursor.deletePreviousChar();
             m_edit->setTextCursor(m_ColumnEditSelections[i].cursor);
         }

--- a/src/editor/deletetextundocommand.h
+++ b/src/editor/deletetextundocommand.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2019 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2019 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -45,6 +45,9 @@ private:
     QTextCursor m_textCursor;
     QString m_sInsertText;
     QList<QString> m_selectTextList;
+    // 列编辑时每个选区各自的起始位置（与 m_selectTextList 一一对应），
+    // 避免用单一成员值承载所有选区导致多选区 undo 恢复错位
+    QList<int> m_selectBeginPosList;
     QList<QTextEdit::ExtraSelection> m_ColumnEditSelections;
     QPlainTextEdit* m_edit;
     int m_beginPostion {0};

--- a/src/editor/dtextedit.cpp
+++ b/src/editor/dtextedit.cpp
@@ -2617,9 +2617,9 @@ bool TextEdit::updateKeywordSelectionsInView(QString keyword, QTextCharFormat ch
             }
             lastMatchPos = currentMatchPos;
 
-            // 调整为不区分大小写
+            // 匹配大小写不敏感（defaultCaseSensitive = Qt::CaseInsensitive），
+            // 查找小写 f 时大写 F 同样会入高亮列表
             Qt::CaseSensitivity option = defaultCaseSensitive;
-            /* 查找字符时，查找到完全相等的时候才高亮，如查找小写f时，大写的F不高亮 */
             if (!extra.cursor.selectedText().compare(keyword, option) || keyword.contains(endLine, option)) {
                 qDebug() << "Updating keyword selections in view with selected text";
                 listSelection->append(extra);
@@ -3092,55 +3092,6 @@ void TextEdit::setSyntaxDefinition(KSyntaxHighlighting::Definition def)
 {
     qDebug() << "Setting syntax definition";
     m_commentDefinition.setComments(def.singleLineCommentMarker(), def.multiLineCommentMarker().first,  def.multiLineCommentMarker().second);
-}
-
-bool TextEdit::setCursorKeywordSeletoin(int position, bool findNext)
-{
-    qDebug() << "Setting cursor keyword seletion";
-    int offsetLines = 3;
-
-    if (findNext) {
-        qDebug() << "Setting cursor keyword seletion with find next";
-        for (int i = 0; i < m_findMatchSelections.size(); i++) {
-            if (m_findMatchSelections[i].cursor.position() > position) {
-                qDebug() << "Setting cursor keyword seletion with find next and position greater than position";
-                m_findHighlightSelection.cursor = m_findMatchSelections[i].cursor;
-
-                jumpToLine(m_findMatchSelections[i].cursor.blockNumber() + offsetLines, false);
-
-                QTextCursor cursor = textCursor();
-                cursor.setPosition(m_findMatchSelections[i].cursor.position());
-
-                // Update cursor.
-                setTextCursor(cursor);
-
-                qDebug() << "Setting cursor keyword seletion return true";
-                return true;
-            }
-        }
-    } else {
-        qDebug() << "Setting cursor keyword seletion with find previous";
-        for (int i = m_findMatchSelections.size() - 1; i >= 0; i--) {
-            if (m_findMatchSelections[i].cursor.position() < position) {
-                qDebug() << "Setting cursor keyword seletion with find previous and position less than position";
-                m_findHighlightSelection.cursor = m_findMatchSelections[i].cursor;
-
-                jumpToLine(m_findMatchSelections[i].cursor.blockNumber() + offsetLines, false);
-
-                QTextCursor cursor = textCursor();
-                cursor.setPosition(m_findMatchSelections[i].cursor.position());
-
-                // Update cursor.
-                setTextCursor(cursor);
-
-                qDebug() << "Setting cursor keyword seletion return true";
-                return true;
-            }
-        }
-    }
-
-    qDebug() << "Setting cursor keyword seletion return false";
-    return false;
 }
 
 bool TextEdit::shouldDeferCursorHeavyUpdate(const QTextCursor &cursor, const QString &text) const
@@ -3687,6 +3638,8 @@ void TextEdit::slotNextBookMarkAction(bool checked)
     if (index == -1 && !m_listBookmark.isEmpty()) {
         qDebug() << "Slot next book mark action with index -1";
         jumpToLine(m_listBookmark.last(), false);
+        // 无书签命中时跳至末个书签后直接返回，避免落入下方 if/else 二次跳转
+        return;
     }
 
     if (index == m_listBookmark.count() - 1) {
@@ -3924,7 +3877,6 @@ QTextCursor TextEdit::findCursor(const QString &substr, const QString &text, int
         qDebug() << "Find failed - text not found";
         return QTextCursor();
     }
-    qDebug() << "Finding text completed";
 }
 
 /**
@@ -4792,8 +4744,10 @@ void TextEdit::slot_translate()
 QString TextEdit::getWordAtCursor()
 {
     qDebug() << "Get word at cursor";
-    if (!characterCount()) {
-        qDebug() << "Get word at cursor, characterCount() is 0";
+    // QTextDocument::characterCount() 恒 >= 1（含结尾分隔符），不能作为空文档判据；
+    // 空文档下 toPlainText().at(0) 会触发 QString 越界断言
+    if (document()->isEmpty()) {
+        qDebug() << "Get word at cursor, document is empty";
         return "";
     } else {
         qDebug() << "Get word at cursor, characterCount() is not 0";
@@ -5861,6 +5815,12 @@ QStringList TextEdit::readHistoryRecordofFilePath(QString key)
 void TextEdit::writeEncodeHistoryRecord()
 {
     qDebug() << "Write encode history record";
+    // EditWrapper 可能脱离 Window 独立构造（m_settings 未注入），
+    // 使用前判空，与 setTextFinished 的空判保护保持一致
+    if (!m_settings || !m_settings->settings) {
+        qWarning() << "Write encode history record, m_settings is null, skip";
+        return;
+    }
     QString history = m_settings->settings->option("advance.editor.browsing_encode_history")->value().toString();
 
     QStringList pathList = readHistoryRecordofFilePath("advance.editor.browsing_encode_history");
@@ -7179,6 +7139,8 @@ bool TextEdit::eventFilter(QObject *object, QEvent *event)
         if (object == m_pLeftAreaWidget->m_pBookMarkArea) {
             m_nBookMarkHoverLine = line;
             m_pLeftAreaWidget->m_pBookMarkArea->update();
+            // 与下方折叠区 HoverMove 分支的返回策略保持一致：事件已处理，不再透传基类
+            return true;
         } else if (object == m_pLeftAreaWidget->m_pFlodArea) {
             m_markFoldHighLightSelections.clear();
             renderAllSelections();
@@ -7386,336 +7348,6 @@ bool TextEdit::containsExtraSelection(QList<QTextEdit::ExtraSelection> listSelec
         }
     }
     return false;
-}
-
-void TextEdit::appendExtraSelection(QList<QTextEdit::ExtraSelection> wordMarkSelections
-                                    , QTextEdit::ExtraSelection selection, QString strColor
-                                    , QList<QTextEdit::ExtraSelection> *listSelections)
-{
-// 没有使用的方法，应该去除，降低维护成本
-// 由于需要处理对应的单元测试，暂时不完全移除此函数，后期将统一进行处理
-#if 1
-    // 去除参数未使用警告
-    Q_UNUSED(wordMarkSelections)
-    Q_UNUSED(selection)
-    Q_UNUSED(strColor)
-    Q_UNUSED(listSelections)
-#else
-    //如果文档中有标记
-    if (wordMarkSelections.count() > 0) {
-        bool bIsContains = false;///< 是否占用已有标记
-        int nWordMarkSelectionStart = 0,///< 已有标记起始位置
-            nSelectionStart = 0,///< 标记起始位置
-            nWordMarkSelectionEnd = 0,///< 已有标记结束位置
-            nSelectionEnd = 0;///< 标记结束位置
-
-        //按大小确定标记的起始和结束位置
-        if (selection.cursor.selectionStart() > selection.cursor.selectionEnd()) {
-            nSelectionStart = selection.cursor.selectionEnd();
-            nSelectionEnd = selection.cursor.selectionStart();
-        } else {
-            nSelectionStart = selection.cursor.selectionStart();
-            nSelectionEnd = selection.cursor.selectionEnd();
-        }
-
-        for (int i = 0; i < wordMarkSelections.count(); i++) {
-
-            //按大小确定已有标记的起始和结束位置
-            if (wordMarkSelections.value(i).cursor.selectionStart() > wordMarkSelections.value(i).cursor.selectionEnd()) {
-                nWordMarkSelectionStart = wordMarkSelections.value(i).cursor.selectionEnd();
-                nWordMarkSelectionEnd = wordMarkSelections.value(i).cursor.selectionStart();
-            } else {
-                nWordMarkSelectionStart = wordMarkSelections.value(i).cursor.selectionStart();
-                nWordMarkSelectionEnd = wordMarkSelections.value(i).cursor.selectionEnd();
-            }
-
-            //如果被已有标记包含
-            if ((nWordMarkSelectionStart <= nSelectionStart && nWordMarkSelectionEnd > nSelectionEnd)
-                    || (nWordMarkSelectionStart < nSelectionStart && nWordMarkSelectionEnd >= nSelectionEnd)) {
-
-                bIsContains = true;
-                selection.format.setBackground(QColor(strColor));
-
-                //如果标记格式不相同
-                if (wordMarkSelections.value(i).format != selection.format) {
-                    int nRemPos = 0;///< 标记插入位置
-
-                    //移除已有标记
-                    for (int j = 0; j < wordMarkSelections.count(); j++) {
-                        if (m_wordMarkSelections.value(j).cursor == wordMarkSelections.value(i).cursor
-                                && m_wordMarkSelections.value(j).format == wordMarkSelections.value(i).format) {
-
-                            m_wordMarkSelections.removeAt(j);
-                            nRemPos = j;
-                            break;
-                        }
-                    }
-
-                    //重新记录标记
-                    selection.cursor.setPosition(nWordMarkSelectionStart, QTextCursor::MoveAnchor);
-                    selection.cursor.setPosition(nSelectionStart, QTextCursor::KeepAnchor);
-                    selection.format.setBackground(wordMarkSelections.value(i).format.background());
-
-                    bool bIsInsert = false;///< 标记是否将原有标记分成两段
-
-                    //如果第一段存在
-                    if (selection.cursor.selectedText() != "") {
-                        bIsInsert = true;
-                        m_wordMarkSelections.insert(nRemPos, selection);
-                    }
-
-                    QTextEdit::ExtraSelection preSelection;
-                    preSelection.format = selection.format;
-                    preSelection.cursor = selection.cursor;
-
-                    selection.cursor.setPosition(nSelectionEnd, QTextCursor::MoveAnchor);
-                    selection.cursor.setPosition(nWordMarkSelectionEnd, QTextCursor::KeepAnchor);
-
-                    //如果第二段存在
-                    if (selection.cursor.selectedText() != "") {
-                        if (bIsInsert) {
-                            m_wordMarkSelections.insert(nRemPos + 1, selection);
-                        } else {
-                            m_wordMarkSelections.insert(nRemPos, selection);
-                        }
-                    }
-
-                    //从记录标记的表中替换原有标记（按标记动作记录）
-                    QList<QTextEdit::ExtraSelection> selecList;
-                    bool bIsFind = false;///< 是否有包含该标记的标记动作
-
-                    for (int j = 0; j < m_mapWordMarkSelections.count(); j++) {
-                        auto list = m_mapWordMarkSelections.value(j);
-
-                        for (int k = 0; k < list.count(); k++) {
-                            if (list.value(k).cursor == wordMarkSelections.value(i).cursor
-                                    && list.value(k).format == wordMarkSelections.value(i).format) {
-
-                                list.removeAt(k);
-                                selecList = list;
-                                bIsInsert = false;
-
-                                if (preSelection.cursor.selectedText() != "") {
-                                    bIsInsert = true;
-                                    selecList.insert(k, preSelection);
-                                }
-
-                                if (selection.cursor.selectedText() != "") {
-                                    if (bIsInsert) {
-                                        selecList.insert(k + 1, selection);
-                                    } else {
-                                        selecList.insert(k, selection);
-                                    }
-                                }
-
-                                bIsFind = true;
-                                break;
-                            }
-                        }
-
-                        if (bIsFind) {
-                            m_mapWordMarkSelections.remove(j);
-                            m_mapWordMarkSelections.insert(j, selecList);
-                            break;
-                        }
-                    }
-
-                    //记录新添加的标记
-                    selection.cursor.setPosition(nSelectionStart, QTextCursor::MoveAnchor);
-                    selection.cursor.setPosition(nSelectionEnd, QTextCursor::KeepAnchor);
-                    selection.format.setBackground(QColor(strColor));
-                    m_wordMarkSelections.append(selection);
-                    listSelections->append(selection);
-                }
-            } else if (nWordMarkSelectionStart >= nSelectionStart && nWordMarkSelectionEnd <= nSelectionEnd) { //如果标记包含已有标记
-                bIsContains = true;
-                selection.format.setBackground(QColor(strColor));
-
-                //移除已有标记
-                for (int j = 0; j < wordMarkSelections.count(); j++) {
-                    if (m_wordMarkSelections.value(j).cursor == wordMarkSelections.value(i).cursor
-                            && m_wordMarkSelections.value(j).format == wordMarkSelections.value(i).format) {
-                        m_wordMarkSelections.removeAt(j);
-                        break;
-                    }
-                }
-
-                //记录新添加的标记
-                m_wordMarkSelections.append(selection);
-
-                //如果标记格式不相同
-                if (wordMarkSelections.value(i).format != selection.format) {
-
-                    QList<QTextEdit::ExtraSelection> selecList;
-                    bool bIsFind = false;///< 是否有包含该标记的标记动作
-
-                    //从记录标记的表中替换原有标记（按标记动作记录）
-                    for (int j = 0; j < m_mapWordMarkSelections.count(); j++) {
-                        auto list = m_mapWordMarkSelections.value(j);
-                        for (int k = 0; k < list.count(); k++) {
-                            if (list.value(k).cursor == wordMarkSelections.value(i).cursor
-                                    && list.value(k).format == wordMarkSelections.value(i).format) {
-
-                                list.removeAt(k);
-                                selecList = list;
-                                bIsFind = true;
-                                break;
-                            }
-                        }
-
-                        if (bIsFind) {
-                            m_mapWordMarkSelections.remove(j);
-                            m_mapWordMarkSelections.insert(j, selecList);
-                            break;
-                        }
-                    }
-                }
-
-                listSelections->append(selection);
-            } else if (nWordMarkSelectionEnd < nSelectionEnd && nWordMarkSelectionStart < nSelectionStart
-                       && nWordMarkSelectionEnd > nSelectionStart) { //如果添加的标记占有原有标记的后段部分
-
-                selection.format.setBackground(QColor(strColor));
-                int nRemPos = 0;///< 标记插入位置
-
-                //移除已有标记
-                for (int j = 0; j < wordMarkSelections.count(); j++) {
-                    if (m_wordMarkSelections.value(j).cursor == wordMarkSelections.value(i).cursor
-                            && m_wordMarkSelections.value(j).format == wordMarkSelections.value(i).format) {
-                        m_wordMarkSelections.removeAt(j);
-                        nRemPos = j;
-                        break;
-                    }
-                }
-
-                //如果标记格式不相同
-                if (wordMarkSelections.value(i).format != selection.format) {
-
-                    //从记录标记的表中替换原有标记（分行记录）
-                    selection.cursor.setPosition(nWordMarkSelectionStart, QTextCursor::MoveAnchor);
-                    selection.cursor.setPosition(nSelectionStart, QTextCursor::KeepAnchor);
-                    selection.format.setBackground(wordMarkSelections.value(i).format.background());
-                    m_wordMarkSelections.insert(nRemPos, selection);
-
-                    QList<QTextEdit::ExtraSelection> selecList;
-                    bool bIsFind = false;///< 是否有包含该标记的标记动作
-
-                    //从记录标记的表中替换原有标记（按标记动作记录）
-                    for (int j = 0; j < m_mapWordMarkSelections.count(); j++) {
-                        auto list = m_mapWordMarkSelections.value(j);
-                        for (int k = 0; k < list.count(); k++) {
-                            if (list.value(k).cursor == wordMarkSelections.value(i).cursor
-                                    && list.value(k).format == wordMarkSelections.value(i).format) {
-                                list.removeAt(k);
-                                selecList = list;
-                                selecList.insert(k, selection);
-                                bIsFind = true;
-                                break;
-                            }
-                        }
-
-                        if (bIsFind) {
-                            m_mapWordMarkSelections.remove(j);
-                            m_mapWordMarkSelections.insert(j, selecList);
-                            break;
-                        }
-                    }
-
-                    //记录新添加的标记
-                    selection.cursor.setPosition(nSelectionStart, QTextCursor::MoveAnchor);
-                    selection.cursor.setPosition(nSelectionEnd, QTextCursor::KeepAnchor);
-                    selection.format.setBackground(QColor(strColor));
-                    m_wordMarkSelections.append(selection);
-                } else { //如果标记格式相同
-                    selection.cursor.setPosition(nWordMarkSelectionStart, QTextCursor::MoveAnchor);
-                    selection.cursor.setPosition(nSelectionEnd, QTextCursor::KeepAnchor);
-                    m_wordMarkSelections.insert(nRemPos, selection);
-                }
-
-                if (!bIsContains) {
-                    listSelections->append(selection);
-                }
-
-                bIsContains = true;
-            } else if (nWordMarkSelectionEnd > nSelectionEnd && nWordMarkSelectionStart > nSelectionStart
-                       && nWordMarkSelectionStart < nSelectionEnd) { //如果添加的标记占有原有标记的前段部分
-
-                selection.format.setBackground(QColor(strColor));
-                int nRemPos = 0;///< 标记插入位置
-
-                //移除已有标记
-                for (int j = 0; j < wordMarkSelections.count(); j++) {
-                    if (m_wordMarkSelections.value(j).cursor == wordMarkSelections.value(i).cursor
-                            && m_wordMarkSelections.value(j).format == wordMarkSelections.value(i).format) {
-                        m_wordMarkSelections.removeAt(j);
-                        nRemPos = j;
-                        break;
-                    }
-                }
-
-                //如果标记格式不相同
-                if (wordMarkSelections.value(i).format != selection.format) {
-
-                    //从记录标记的表中替换原有标记（分行记录）
-                    selection.cursor.setPosition(nSelectionEnd, QTextCursor::MoveAnchor);
-                    selection.cursor.setPosition(nWordMarkSelectionEnd, QTextCursor::KeepAnchor);
-                    selection.format.setBackground(wordMarkSelections.value(i).format.background());
-                    m_wordMarkSelections.insert(nRemPos, selection);
-
-                    QList<QTextEdit::ExtraSelection> selecList;
-                    bool bIsFind = false;
-
-                    //从记录标记的表中替换原有标记（按标记动作记录）
-                    for (int j = 0; j < m_mapWordMarkSelections.count(); j++) {
-                        auto list = m_mapWordMarkSelections.value(j);
-                        for (int k = 0; k < list.count(); k++) {
-                            if (list.value(k).cursor == wordMarkSelections.value(i).cursor
-                                    && list.value(k).format == wordMarkSelections.value(i).format) {
-                                list.removeAt(k);
-                                selecList = list;
-                                selecList.insert(k, selection);
-                                bIsFind = true;
-                                break;
-                            }
-                        }
-
-                        if (bIsFind) {
-                            m_mapWordMarkSelections.remove(j);
-                            m_mapWordMarkSelections.insert(j, selecList);
-                            break;
-                        }
-                    }
-
-                    //记录新添加的标记
-                    selection.cursor.setPosition(nSelectionStart, QTextCursor::MoveAnchor);
-                    selection.cursor.setPosition(nSelectionEnd, QTextCursor::KeepAnchor);
-                    selection.format.setBackground(QColor(strColor));
-                    m_wordMarkSelections.append(selection);
-                } else { //如果标记格式相同
-                    selection.cursor.setPosition(nSelectionStart, QTextCursor::MoveAnchor);
-                    selection.cursor.setPosition(nWordMarkSelectionEnd, QTextCursor::KeepAnchor);
-                    m_wordMarkSelections.insert(nRemPos, selection);
-                }
-
-                if (!bIsContains) {
-                    listSelections->append(selection);
-                }
-                bIsContains = true;
-            }
-        }
-
-        if (!bIsContains) {
-            selection.format.setBackground(QColor(strColor));
-            m_wordMarkSelections.append(selection);
-            listSelections->append(selection);
-        }
-
-    } else { //如果文档中没有标记
-        selection.format.setBackground(QColor(strColor));
-        m_wordMarkSelections.append(selection);
-        listSelections->append(selection);
-    }
-#endif
 }
 
 void TextEdit::onSelectionArea()
@@ -8316,7 +7948,7 @@ void TextEdit::keyPressEvent(QKeyEvent *e)
 //            setReadOnly(false);
             toggleReadOnlyMode();
             return;
-        } else if (key == "Shfit+J") {
+        } else if (key == "Shift+J") {
             scrollLineUp();
             return;
         } else if (key == "Shift+K") {
@@ -8683,6 +8315,7 @@ void TextEdit::keyPressEvent(QKeyEvent *e)
             return;
         } else if (key == Utils::getKeyshortcutFromKeymap(m_settings, "editor", "downcaseword")) {
             downcaseWord();
+            return;
         } else if (key == Utils::getKeyshortcutFromKeymap(m_settings, "editor", "capitalizeword")) {
             capitalizeWord();
             return;

--- a/src/editor/dtextedit.h
+++ b/src/editor/dtextedit.h
@@ -411,17 +411,6 @@ public:
      */
     bool containsExtraSelection(QList<QTextEdit::ExtraSelection> listSelections, QTextEdit::ExtraSelection selection);
 
-    /**
-     * @author liumaochuan ut000616
-     * @brief appendExtraSelection 在指定字符格式列表添加指定字符格式
-     * @param wordMarkSelections 指定字符格式列表
-     * @param selection 指定字符格式
-     * @param markColor 指定字符颜色格式
-     * @param listSelections 添加的指定字符格式列表
-     */
-    void appendExtraSelection(QList<QTextEdit::ExtraSelection> wordMarkSelections, QTextEdit::ExtraSelection selection
-                              , QString strColor, QList<QTextEdit::ExtraSelection> *listSelections);
-
     void setCursorStart(int pos);
     void writeEncodeHistoryRecord();
     QStringList readEncodeHistoryRecord();
@@ -603,7 +592,6 @@ private:
 
     //去除"*{*" "*}*" "*{*}*"跳过当做普通文本处理不折叠　梁卫东２０２０－０９－０１　１７：１６：４１
     bool blockContainStrBrackets(int line);
-    bool setCursorKeywordSeletoin(int position, bool findNext);
     void updateHighlightBrackets(const QChar &openChar, const QChar &closeChar);
 
     bool getNeedControlLine(int line, bool isVisable);

--- a/src/editor/editwrapper.cpp
+++ b/src/editor/editwrapper.cpp
@@ -1434,7 +1434,13 @@ QDateTime EditWrapper::getLastModifiedTime() const
 void EditWrapper::setLastModifiedTime(const QString &time)
 {
     qDebug() << "EditWrapper setLastModifiedTime, time:" << time;
-    m_tModifiedDateTime = QDateTime::fromString(time);
+    // 与写入侧 toString(Qt::ISODate) 对称的显式格式解析；
+    // 兼容历史记录中的默认 TextDate 格式，避免依赖 locale 相关默认重载
+    QDateTime dt = QDateTime::fromString(time, Qt::ISODate);
+    if (!dt.isValid()) {
+        dt = QDateTime::fromString(time);
+    }
+    m_tModifiedDateTime = dt;
 }
 void EditWrapper::updateModifyStatus(bool bModified)
 {

--- a/src/editor/editwrapper.h
+++ b/src/editor/editwrapper.h
@@ -45,8 +45,6 @@ public:
     EditWrapper(Window *window = nullptr, QWidget *parent = nullptr);
     ~EditWrapper();
 
-    //清除焦点　梁卫东　２０２０－０９－１４　１１：００：５０
-    void clearAllFocus();
     void setQuitFlag();
     bool isQuit();
     bool getFileLoading();
@@ -99,10 +97,7 @@ public:
 
     void hideWarningNotices();
     void checkForReload();
-    void initToastPosition();
     void showNotify(const QString &message, bool warning = false);
-    bool getTextChangeFlag();
-    void setTextChangeFlag(bool bFlag);
     void setLineNumberShow(bool bIsShow, bool bIsFirstShow = false);
     void setShowBlankCharacter(bool ok);
     void clearDoubleCharaterEncode();
@@ -163,8 +158,6 @@ protected:
 private:
     // 类似setPlainText(QString) 接口支持大文本加载 不卡顿 秒退出 梁卫东 2020年11月11日16:56:27
     void loadContent(const QByteArray &);
-    void handleHightlightChanged(const QString &name);
-    int GetCorrectUnicode1(const QByteArray &ba);
     // 文件加载时重新初始化部分设置
     void reinitOnFileLoad(const QByteArray &encode);
     // 懒创建 MarkdownView 渲染页（ReadView/LivePreview 且非纯文本只读模式时），已注入测试渲染器则跳过

--- a/src/editor/inserttextundocommand.cpp
+++ b/src/editor/inserttextundocommand.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2019 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2019 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -247,6 +247,9 @@ DragInsertTextUndoCommand::DragInsertTextUndoCommand(const QTextCursor &textcurs
 {
     qDebug() << "DragInsertTextUndoCommand created, text size:" << text.size()
                           << "cursor pos:" << textcursor.position() << "edit:" << edit;
+    // 与 InsertText/MidButton 命令保持一致：归一化 CRLF，
+    // 否则 undo 以含 \r 的长度计算删除区间会越界，导致恢复不完整
+    m_sInsertText.replace("\r\n", "\n");
     m_beginPostion = m_textCursor.selectionStart();
 }
 

--- a/src/editor/linenumberarea.cpp
+++ b/src/editor/linenumberarea.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017-2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2017-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -37,7 +37,7 @@ QSize LineNumberArea::sizeHint() const
 void LineNumberArea::mousePressEvent(QMouseEvent *e)
 {
     qDebug() << "LineNumberArea mousePressEvent at position:" << e->pos();
-//    m_pressPoint = e->pos();
+    m_pressPoint = e->pos();
 //    m_leftAreaWidget->update();
     m_leftAreaWidget->getEdit()->onPressedLineNumber(e->pos());
     QWidget::mousePressEvent(e);

--- a/src/widgets/window.cpp
+++ b/src/widgets/window.cpp
@@ -3064,7 +3064,7 @@ void Window::backupFile()
         } else {
             jsonObject.insert("modify", wrapper->isModified());
         }
-        jsonObject.insert("lastModifiedTime", wrapper->getLastModifiedTime().toString());
+        jsonObject.insert("lastModifiedTime", wrapper->getLastModifiedTime().toString(Qt::ISODate));
         QList<int> bookmarkList = wrapper->textEditor()->getBookmarkInfo();
         if (!bookmarkList.isEmpty()) {
             qInfo() << "bookmarkList is not empty";

--- a/tests/editor_core/test_dtextedit_edit.cpp
+++ b/tests/editor_core/test_dtextedit_edit.cpp
@@ -1127,9 +1127,16 @@ TEST_F(TextEditTest, GetWordAtCursor_MidWord_ReturnsPrefix)
     EXPECT_EQ(edit->toPlainText(), QString("typing"));
 }
 
-// 注：getWordAtCursor 空文档分支存在源码缺陷（characterCount() 恒 >= 1，
-// 守卫 !characterCount() 永不命中，空文档调用会在 toPlainText().at(0) 越界
-// 触发 Q_ASSERT），已记录 defects，不构造空文档用例。
+// getWordAtCursor 空文档分支已修复（守卫改用 document()->isEmpty()），补充空文档用例
+TEST_F(TextEditTest, GetWordAtCursor_EmptyDocument_ReturnsEmpty)
+{
+    // Arrange：空文档（原守卫 characterCount() 恒 >= 1 永不命中，会越界断言崩溃）
+    setDocText(QString(""));
+
+    // Act/Assert：空文档直接返回空串，不再崩溃
+    EXPECT_EQ(edit->getWordAtCursor(), QString(""));
+    EXPECT_EQ(edit->toPlainText(), QString(""));
+}
 
 // ---------------- 注释（封闭语法定义 *.utlang） ----------------
 

--- a/tests/editor_core/test_dtextedit_event.cpp
+++ b/tests/editor_core/test_dtextedit_event.cpp
@@ -1448,7 +1448,7 @@ TEST_F(TextEditTest, EventFilter_HoverMoveBookmark_SetsHoverLine)
     QHoverEvent ev(QEvent::HoverMove, QPointF(2, 20), QPointF(2, 18), Qt::NoModifier);
     edit->eventFilter(edit->getLeftAreaWidget()->m_pBookMarkArea, &ev);
 
-    // Assert：悬停行被记录（书签分支不拦截事件，透传基类返回 false）
+    // Assert：悬停行被记录（修复后书签分支与折叠区一致：拦截事件返回 true）
     EXPECT_EQ(edit->m_nBookMarkHoverLine, expectedLine);
     EXPECT_GT(expectedLine, 0); // 悬停行基于真实布局换算
 }

--- a/tests/editor_core/test_dtextedit_find.cpp
+++ b/tests/editor_core/test_dtextedit_find.cpp
@@ -154,25 +154,8 @@ TEST_F(TextEditTest, ReplaceAll_TwoMarksSorted_ComparatorAndOffsetsApplied)
     EXPECT_EQ(edit->toPlainText(), QString("mm X nn X"));
 }
 
-TEST_F(TextEditTest, SetCursorKeywordSeletoin_DirectDrive_MovesToMatch)
-{
-    // Arrange：建立查找选区（该方法为当前无调用方的私有遗留代码，白盒直测）
-    setDocText(QString("one two three"));
-    ASSERT_TRUE(edit->highlightKeyword(QString("two"), 0));
-    const int firstMatchPos = edit->m_findMatchSelections.first().cursor.position();
-
-    // Act：findNext=true 从 0 起 → 跳到首个匹配
-    const bool moved = edit->setCursorKeywordSeletoin(0, true);
-
-    // Assert
-    EXPECT_TRUE(moved);
-    EXPECT_EQ(edit->getPosition(), firstMatchPos);
-
-    // Act：findNext=false 从文档尾 → 回到最后一个匹配
-    const bool movedBack = edit->setCursorKeywordSeletoin(edit->toPlainText().size(), false);
-    // Assert
-    EXPECT_TRUE(movedBack);
-}
+// 注：原 SetCursorKeywordSeletoin_DirectDrive_MovesToMatch 直测的私有方法
+// 为无调用方死代码，已随缺陷修复删除（D-043）。
 
 TEST_F(TextEditTest, ReplaceAll_MarkCoveredByReplace_Removed)
 {

--- a/tests/editor_core/test_dtextedit_mark.cpp
+++ b/tests/editor_core/test_dtextedit_mark.cpp
@@ -709,20 +709,8 @@ TEST_F(TextEditTest, ContainsExtraSelection_MatchingCursorAndFormat_ReturnsTrue)
     EXPECT_FALSE(edit->containsExtraSelection(list, diff));
 }
 
-TEST_F(TextEditTest, AppendExtraSelection_NoOpImplementation_NoCrash)
-{
-    // Arrange：当前实现为 Q_UNUSED 空壳（保留待统一清理）
-    QList<QTextEdit::ExtraSelection> out;
-    QTextEdit::ExtraSelection sel;
-
-    // Act
-    edit->appendExtraSelection(QList<QTextEdit::ExtraSelection>(), sel,
-                               QString("#ff0000"), &out);
-
-    // Assert：空实现不产生输出
-    EXPECT_TRUE(out.isEmpty());
-    EXPECT_EQ(edit->m_wordMarkSelections.size(), 0); // 空实现不动内部状态
-}
+// 注：原 AppendExtraSelection_NoOpImplementation_NoCrash 直测的空壳方法
+// 已随缺陷修复删除（D-045，源码自述"没有使用的方法，应该去除"）。
 
 // ---------------- handleCursorMarkChanged / setHighLineCurrentLine（M17） ----------------
 

--- a/tests/editor_undo/test_deletetextundocommand.cpp
+++ b/tests/editor_undo/test_deletetextundocommand.cpp
@@ -75,8 +75,7 @@ TEST_F(DeleteTextUndoCommandTest, Redo_NoSelectionMidBlock_DeletesPreviousChar)
     // Assert：deletePreviousChar 删除 'b'
     EXPECT_EQ(docText(), QString("ac"));
     cmd.undo();
-    EXPECT_EQ(docText(), QString("acb"));                      // 非 "abc"：见 defect 注记
-    EXPECT_NE(docText(), QString("abc"));
+    EXPECT_EQ(docText(), QString("abc"));                       // 修复后恢复到原位置
 }
 
 // ---- CT1(块首)+R1/U1：块首删除的是上一行换行符（行合并）；undo 重插位置同 defect 注记 ----
@@ -94,8 +93,7 @@ TEST_F(DeleteTextUndoCommandTest, Redo_NoSelectionAtBlockStart_DeletesNewline)
     EXPECT_EQ(docText(), QString("abcd"));
     EXPECT_EQ(edit->document()->blockCount(), 1);
     cmd.undo();
-    EXPECT_EQ(docText(), QString("abc\nd"));                   // 非 "ab\ncd"：同 defect 注记
-    EXPECT_NE(docText(), QString("ab\ncd"));
+    EXPECT_EQ(docText(), QString("ab\ncd"));                   // 修复后恢复到原位置
 }
 
 // ---- CT2(真)+R2/U2：列编辑多选区 ----

--- a/tests/editor_undo/test_deletetextundocommand2.cpp
+++ b/tests/editor_undo/test_deletetextundocommand2.cpp
@@ -166,7 +166,7 @@ TEST_F(DeleteTextUndoCommand2Test, Redo_ColumnSingleSelection_ReversibleBothWays
 // 源码行为注记（defect 候选，见批次报告）：redo 列编辑循环里 m_beginPostion 被
 // 每个选区覆盖，undo 循环对所有选区统一使用最后写入值，导致多选区场景文本被
 // 恢复到最后一个选区起点而非各自起点；本用例按实际行为断言并保留可逆性失败的证据。
-TEST_F(DeleteTextUndoCommand2Test, Redo_ColumnMultiSelection_UndoUsesLastBeginPos)
+TEST_F(DeleteTextUndoCommand2Test, Redo_ColumnMultiSelection_UndoRestoresEachPosition)
 {
     // Arrange：两个列选区 [0,1) 与 [3,4)
     edit->setPlainText("aa\nbb");
@@ -181,10 +181,9 @@ TEST_F(DeleteTextUndoCommand2Test, Redo_ColumnMultiSelection_UndoUsesLastBeginPo
     // Assert：redo 删除两个选区内容
     EXPECT_EQ(docText(), QString("a\nb"));
 
-    // Act & Assert：undo 将两段文本都插到最后一个选区起点 position=3（实际行为）
+    // Act & Assert：修复后 undo 按各自选区起点恢复
     cmd.undo();
-    EXPECT_EQ(docText(), QString("a\nbab"));                   // 非 "aa\nbb"：见 defect 注记
-    EXPECT_NE(docText(), QString("aa\nbb"));
+    EXPECT_EQ(docText(), QString("aa\nbb"));
 }
 
 // ---- R2/U2 列编辑裸光标（块中/块首）：ctor2 捕获前字符与 "\n" 两分支 ----

--- a/tests/editor_undo/test_draginserttextundocommand.cpp
+++ b/tests/editor_undo/test_draginserttextundocommand.cpp
@@ -78,7 +78,7 @@ TEST_F(DragInsertTextUndoCommandTest, Redo_CursorAtDropTarget_SkipsRepositionBra
 // "\r\n" 计 2 个 QChar；QTextDocument 插入时把 "\r\n" 折叠为单个段落分隔符，
 // undo 计算 [begin, begin+4) 越界，setPosition 拒绝移动导致选区为空，deleteChar
 // 前向删除单字符 → 撤销结果错误（"line\nb" 而非 "line"）。按实际行为断言留证。
-TEST_F(DragInsertTextUndoCommandTest, Ctor_CrlfText_InsertFoldsButUndoOvershoots)
+TEST_F(DragInsertTextUndoCommandTest, Ctor_CrlfText_NormalizedAndUndoExact)
 {
     // Arrange
     edit->setPlainText("line");
@@ -88,13 +88,12 @@ TEST_F(DragInsertTextUndoCommandTest, Ctor_CrlfText_InsertFoldsButUndoOvershoots
     // Act
     cmd.redo();
 
-    // Assert：插入侧由 QTextDocument 折叠 "\r\n"，文档得到单个换行
+    // Assert：构造侧已归一化 "\r\n"，文档得到单个换行
     EXPECT_EQ(docText(), QString("linea\nb"));
 
-    // Act & Assert：undo 侧长度按 4 计算越界，仅前向删除一个字符（实际行为）
+    // Act & Assert：修复后 undo 长度按归一化文本计算，精确恢复
     cmd.undo();
-    EXPECT_EQ(docText(), QString("line\nb"));                  // 非 "line"：见 defect 注记
-    EXPECT_NE(docText(), QString("line"));
+    EXPECT_EQ(docText(), QString("line"));
 }
 
 // ---- CT/R1 输入等价类：ASCII / 中文 / emoji ----

--- a/tests/editor_wrapper/test_editwrapper.cpp
+++ b/tests/editor_wrapper/test_editwrapper.cpp
@@ -667,17 +667,22 @@ TEST_F(EditWrapperTest, UpdatePath_EmptyTruePath_FallsBackToFile)
 
 TEST_F(EditWrapperTest, LastModifiedTime_TextDateRoundTrip_PreservesTime)
 {
-    // Arrange: 生产契约（window.cpp）——传入 QDateTime::toString() 的 TextDate 文本。
-    // 注：源码 setLastModifiedTime 使用 fromString 默认格式重载（locale 相关），
-    // ISO 字符串（含 'T'）无法解析，疑似源码健壮性缺陷，已记 defects 不改源码。
+    // Arrange: 生产契约（window.cpp）——写入侧已改为 toString(Qt::ISODate)；
+    // 解析侧优先 ISODate、回退默认 TextDate（兼容历史记录）。
     const QDateTime stamp(QDate(2020, 5, 5), QTime(12, 30, 0));
 
-    // Act
-    m_wrapper->setLastModifiedTime(stamp.toString());
+    // Act: ISO 格式（新契约）
+    m_wrapper->setLastModifiedTime(stamp.toString(Qt::ISODate));
 
-    // Assert: 按 toString() 往返契约恢复同一时刻
+    // Assert: 精确恢复同一时刻
     EXPECT_EQ(m_wrapper->getLastModifiedTime(), stamp);
     EXPECT_FALSE(m_wrapper->getLastModifiedTime().isNull());
+
+    // Act: TextDate 格式（历史记录兼容回退）
+    m_wrapper->setLastModifiedTime(stamp.toString());
+
+    // Assert: 同样恢复同一时刻
+    EXPECT_EQ(m_wrapper->getLastModifiedTime(), stamp);
 }
 
 TEST_F(EditWrapperTest, DraftAndBackupFile_VariousPaths_DetectCorrectly)


### PR DESCRIPTION
## Summary
Fix 17 defects in editor core modules found by unit test scan (D-004/005/023/024/025/026/027/028/029/030/039/040/041/042/043/044/045):

- 空指针防护：writeEncodeHistoryRecord 判空 m_settings；getWordAtCursor 空文档守卫改用 document()->isEmpty()（characterCount 恒>=1，原守卫失效会越界断言崩溃）
- 撤销栈精确恢复：无选区删除记录被删字符位置（光标-1）；列编辑按选区独立记录位置并逆序恢复；Drag 插入构造归一化 CRLF
- 补齐缺失 return：downcaseword 分支、书签跳转 index==-1 分支、书签 HoverMove 与折叠区返回策略统一
- 修正 "Shfit+J" 拼写为 "Shift+J"，恢复只读模式滚行快捷键
- lastModifiedTime 解析改为显式 ISODate 并兼容历史 TextDate 记录（读写两侧对称）
- 删除死代码约 350 行：setCursorKeywordSeletoin、appendExtraSelection 空壳、不可达 qDebug、editwrapper.h 6 个无实现声明；恢复 m_pressPoint 赋值；修正高亮大小写注释

## Tests
- 同步更新按缺陷行为断言的用例并新增空文档回归用例
- editor_core ×4、editor_undo ×3、editor_wrapper ×1 全部通过

独立提交，不依赖其他分支。

## Summary by Sourcery

Harden editor core behavior and make undo, navigation, persistence, and interaction handling reliably reversible and crash-free.

Bug Fixes:
- Prevent crashes and incorrect behavior in editor core operations, including empty-document word lookup, missing settings, bookmark navigation, shortcut handling, event filtering, and timestamp parsing.
- Restore deleted text accurately for single-character, column-edit, and drag-insert undo operations.
- Fix missing control-flow returns and restore line-number interaction state handling.

Enhancements:
- Remove unused editor code and declarations, and clarify case-insensitive highlight behavior.

Tests:
- Update editor core, undo, and wrapper tests to verify corrected defect behavior and add empty-document and timestamp compatibility regression coverage.

Chores:
- Update copyright years in affected source files.