### PR TITLE
fix(peripheral): fix peripheral module defects from unit test scan

### DIFF
--- a/daemon/src/dbus.cpp
+++ b/daemon/src/dbus.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2017 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -41,7 +41,18 @@ bool DBus::saveFile(const QByteArray &path, const QByteArray &text, const QByteA
         QTextStream out(&file);
         out.setCodec(encoding);
         out << text;
+        // 检查写入与落盘状态，磁盘错误（ENOSPC、配额等）不得静默上报成功
+        out.flush();
+        if (out.status() != QTextStream::Ok) {
+            qWarning() << "Write stream failed:" << file.errorString();
+            file.close();
+            return false;
+        }
         file.close();
+        if (file.error() != QFile::NoError) {
+            qWarning() << "Flush to disk failed:" << file.errorString();
+            return false;
+        }
 
         return true;
     } else{

--- a/src/basepub/load_libs.c
+++ b/src/basepub/load_libs.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022-2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -40,8 +40,14 @@ static LoadLibs *newClass(void)
 
     pLibs->m_document_clip_copy = (uos_document_clip_copy)dlsym(handle, "document_clip_copy");
     PrintError();
+    if (pLibs->m_document_clip_copy == NULL) {
+        fprintf(stderr, "Error: dlsym resolve document_clip_copy failed\n");
+    }
     pLibs->m_document_close = (uos_document_close)dlsym(handle, "document_close");
     PrintError();
+    if (pLibs->m_document_close == NULL) {
+        fprintf(stderr, "Error: dlsym resolve document_close failed\n");
+    }
 
     assert(pLibs != NULL);
     return pLibs;
@@ -74,6 +80,10 @@ void setLibNames(LoadLibNames tmp)
     if(tmp.chZPDDLL == NULL) {
         g_ldnames.chZPDDLL = NULL;
     } else {
+        // 重复调用时先释放旧的分配，避免内存泄漏
+        if (g_ldnames.chZPDDLL != NULL) {
+            free(g_ldnames.chZPDDLL);
+        }
         g_ldnames.chZPDDLL = ( char*)malloc(strlen(tmp.chZPDDLL)+1);
         strcpy(g_ldnames.chZPDDLL,tmp.chZPDDLL);
     }

--- a/src/common/performancemonitor.cpp
+++ b/src/common/performancemonitor.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2019 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2019 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -33,7 +33,7 @@ void PerformanceMonitor::initializeAppStart()
     qDebug() << "Application start timestamp recorded:" << initializeAppStartMs;
 }
 
-void PerformanceMonitor::initializAppFinish()
+void PerformanceMonitor::initializeAppFinish()
 {
     QDateTime current = QDateTime::currentDateTime();
     qDebug() << qPrintable(LOG_FLAG)
@@ -52,7 +52,7 @@ void PerformanceMonitor::closeAppStart()
     qDebug() << "Application close process started, timestamp:" << closeAppStartMs;
 }
 
-void PerformanceMonitor::closeAPPFinish()
+void PerformanceMonitor::closeAppFinish()
 {
     QDateTime current = QDateTime::currentDateTime();
     qDebug() << qPrintable(LOG_FLAG)
@@ -83,5 +83,5 @@ void PerformanceMonitor::openFileFinish(const QString &strFileName, qint64 iFile
     openFileFinishMs = current.toMSecsSinceEpoch();
     qint64 time = openFileFinishMs - openFileStartMs;
     float fFilesize = iFileSize;
-    qInfo() << qPrintable(QString("%1 filename=%2 filezise=%3M opentime=%4ms #(Open file time)").arg(GRAB_POINT_OPEN_FILE_TIME).arg(strFileName).arg(QString::number(fFilesize/(1024*1024), 'f', 6)).arg(time));
+    qInfo() << qPrintable(QString("%1 filename=%2 filesize=%3M opentime=%4ms #(Open file time)").arg(GRAB_POINT_OPEN_FILE_TIME).arg(strFileName).arg(QString::number(fFilesize/(1024*1024), 'f', 6)).arg(time));
 }

--- a/src/common/performancemonitor.h
+++ b/src/common/performancemonitor.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2019 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2019 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -17,9 +17,9 @@ public:
     explicit PerformanceMonitor();
 
     static void initializeAppStart();
-    static void initializAppFinish();
+    static void initializeAppFinish();
     static void closeAppStart();
-    static void closeAPPFinish();
+    static void closeAppFinish();
     static void openFileStart();
     static void openFileFinish(const QString &strFileName, qint64 iFileSize);
 

--- a/src/dbus/com_deepin_dde_daemon_dock.h
+++ b/src/dbus/com_deepin_dde_daemon_dock.h
@@ -43,6 +43,10 @@ private:
 
 Q_DECLARE_METATYPE(DockRect)
 
+// 注册 DockRect 的 Qt/DBus 元类型（实现位于 com_deepin_dde_daemon_dock.cpp，
+// 与 types/windowinfomap.h 的 registerWindowInfoMapMetaType 声明风格保持一致）
+void registerDockRectMetaType();
+
 class ComDeepinDdeDaemonDockInterface: public QDBusAbstractInterface
 {
     Q_OBJECT

--- a/src/encodes/detectcode.cpp
+++ b/src/encodes/detectcode.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2019 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2019 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -1001,8 +1001,9 @@ bool DetectCode::convertEncodingTextCodec(QByteArray &inputStr,
         outStr = convertData.toUtf8();
     }
 
-    // 手动添加 UTF BOM 信息
-    outStr.append(gs_byteOrderMark.value(toCode));
+    // 手动添加 UTF BOM 信息：BOM 必须写在转换结果之前（BOM+data），
+    // 与上方 iconv 主路径的字节序保持一致，否则 UTF-16 目标产生 "data+BOM" 错误序列
+    outStr.prepend(gs_byteOrderMark.value(toCode));
     qDebug() << "Exit convertEncodingTextCodec, output size:" << outStr.size();
     return true;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -167,7 +167,7 @@ int main(int argc, char *argv[])
         dbus.registerObject("/com/deepin/Editor", startManager, QDBusConnection::ExportScriptableSlots);
         qDebug() << "DBus object registered at /com/deepin/Editor";
 
-        PerformanceMonitor::initializAppFinish();
+        PerformanceMonitor::initializeAppFinish();
         qDebug() << "Entering main event loop";
         return app.exec();
     }

--- a/src/startmanager.cpp
+++ b/src/startmanager.cpp
@@ -49,6 +49,11 @@ StartManager::~StartManager()
     if (m_instance == this) {
         m_instance = nullptr;
     }
+    // 释放登录管理 DBus 接口，避免泄漏
+    if (m_pLoginManager) {
+        delete m_pLoginManager;
+        m_pLoginManager = nullptr;
+    }
 }
 
 StartManager::StartManager(QObject *parent)
@@ -140,9 +145,9 @@ bool StartManager::isMultiWindow()
     return false;
 }
 
-bool StartManager::isTemFilesEmpty()
+bool StartManager::hasEmptyTemFile()
 {
-    qDebug() << "Enter isTemFilesEmpty";
+    qDebug() << "Enter hasEmptyTemFile";
     bool bIsEmpty = false;
 
     for (auto temFile : m_qlistTemFile) {
@@ -151,7 +156,7 @@ bool StartManager::isTemFilesEmpty()
         }
     }
 
-    qDebug() << "Exit isTemFilesEmpty, return" << bIsEmpty;
+    qDebug() << "Exit hasEmptyTemFile, return" << bIsEmpty;
     return bIsEmpty;
 }
 
@@ -567,7 +572,7 @@ void StartManager::openFilesInTab(QStringList files)
             Window *window = createWindow(true);
             window->showCenterWindow(true);
 
-            if (!isTemFilesEmpty()) {
+            if (!hasEmptyTemFile()) {
                 qDebug() << "Temporary files exist, attempting to recover";
                 int recoveredCount = recoverFile(window);
                 qDebug() << "Recovered" << recoveredCount << "files";
@@ -808,16 +813,16 @@ void StartManager::slotCloseWindow()
         QDir path = QDir::currentPath();
         if (!path.exists()) {
             return ;
-            qInfo() << "Window closed, remaining windows:" << m_windows.size();
-            qDebug() << "Exit slotCloseWindow";
         }
         path.setFilter(QDir::Files);
         QStringList nameList = path.entryList();
         foreach (auto name, nameList) {
             if (name.contains("tabPaths.txt")) {
                 qDebug() << "Delete tabPaths.txt";
-                QFile file(name);
-                file.remove();
+                // entryList 返回裸文件名，拼绝对路径后再删除，避免落点依赖进程工作目录
+                if (!QFile::remove(path.absoluteFilePath(name))) {
+                    qWarning() << "Failed to remove tabPaths.txt:" << path.absoluteFilePath(name);
+                }
             }
         }
 
@@ -831,7 +836,7 @@ void StartManager::slotCloseWindow()
             QApplication::quit();
         });
 
-        PerformanceMonitor::closeAPPFinish();
+        PerformanceMonitor::closeAppFinish();
     }
     qDebug() << "Exit slotCloseWindow";
 }

--- a/src/startmanager.h
+++ b/src/startmanager.h
@@ -42,10 +42,10 @@ public:
     bool isMultiWindow();
 
     /**
-     * @brief isTemFilesEmpty 是否需要备份
-     * @return　true or false
+     * @brief hasEmptyTemFile 历史临时文件记录列表中是否存在空串项
+     * @return　存在空串项返回 true；列表为空或全部有效返回 false
      */
-    bool isTemFilesEmpty();
+    bool hasEmptyTemFile();
 
     /**
      * @brief autoBackupFile 自动备份

--- a/src/thememodule/themelistmodel.cpp
+++ b/src/thememodule/themelistmodel.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2017 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -50,6 +50,11 @@ int ThemeListModel::rowCount(const QModelIndex &parent) const
 
 QVariant ThemeListModel::data(const QModelIndex &index, int role) const
 {
+    // 按 QAbstractItemModel 契约校验索引有效性，无效索引返回 QVariant()
+    if (!index.isValid() || index.row() < 0 || index.row() >= m_themes.size()) {
+        qWarning() << "Invalid index for row:" << index.row();
+        return QVariant();
+    }
     qDebug() << "Getting data for row:" << index.row() << "role:" << role;
     const int r = index.row();
 

--- a/src/thememodule/themelistview.cpp
+++ b/src/thememodule/themelistview.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2017 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -38,13 +38,9 @@ void ThemeListView::adjustScrollbarMargins()
     QEvent event(QEvent::LayoutRequest);
     QApplication::sendEvent(this, &event);
 
-    if (!verticalScrollBar()->visibleRegion().isEmpty()) {
-        qDebug() << "Setting viewport margins with scrollbar";
-        setViewportMargins(0, 0,5, 0);
-    } else {
-        qDebug() << "Setting viewport margins without scrollbar";
-        setViewportMargins(0, 0, 5, 0);
-    }
+    // 原先 if/else 两分支 margins 完全相同，条件判断无实际效果，已简化；
+    // 预留右侧 5px 给竖向滚动条
+    setViewportMargins(0, 0, 5, 0);
 }
 
 bool ThemeListView::eventFilter(QObject *, QEvent *event)

--- a/src/thememodule/themepanel.cpp
+++ b/src/thememodule/themepanel.cpp
@@ -85,6 +85,12 @@ void ThemePanel::setBackground(const QString &color)
 void ThemePanel::popup()
 {
     qDebug() << "Showing theme panel with animation";
+    // parent 非 Window（或为空）时 m_window 无效，直接早退避免空指针解引用
+    if (!m_window) {
+        qWarning() << "Theme panel has no host window, skip popup";
+        QWidget::show();
+        return;
+    }
     QWidget::show();
     QWidget::raise();
 
@@ -107,6 +113,12 @@ void ThemePanel::popup()
 void ThemePanel::hide()
 {
     qDebug() << "Hiding theme panel with animation";
+    // parent 非 Window（或为空）时 m_window 无效，直接早退避免空指针解引用
+    if (!m_window) {
+        qWarning() << "Theme panel has no host window, hide directly";
+        QWidget::hide();
+        return;
+    }
     QRect rect = geometry();
     QRect windowRect = m_window->geometry();
     QPropertyAnimation *animation = new QPropertyAnimation(this, "geometry");

--- a/tests/common2/test_detectcode.cpp
+++ b/tests/common2/test_detectcode.cpp
@@ -337,8 +337,8 @@ INSTANTIATE_TEST_SUITE_P(
         TextCodecCase{QByteArray::fromHex("D6D0CEC4"), QStringLiteral("GB18030"), QStringLiteral("UTF-8"), true, QStringLiteral("中文").toUtf8()},
         TextCodecCase{QByteArrayLiteral("abc"), QStringLiteral("UTF-8"), QStringLiteral("UT-NONE-T"), false, QByteArrayLiteral("")},
         TextCodecCase{QByteArray::fromHex("D6D0"), QStringLiteral("UT-NONE-F"), QStringLiteral("UTF-8"), false, QByteArrayLiteral("")},
-        // QTextCodec 路径 BOM 附加在转换数据之后（尾部）
-        TextCodecCase{QByteArrayLiteral("hi"), QStringLiteral("UTF-8"), QStringLiteral("UTF-16LE"), true, QByteArray::fromHex("68006900FFFE")}));
+        // QTextCodec 路径 BOM 前置（BOM+data，与 iconv 主路径字节序一致）
+        TextCodecCase{QByteArrayLiteral("hi"), QStringLiteral("UTF-8"), QStringLiteral("UTF-16LE"), true, QByteArray::fromHex("FFFE68006900")}));
 
 // ---------------- ChartDet_DetectingTextCoding（真实 chardet） ----------------
 

--- a/tests/common2/test_performancemonitor.cpp
+++ b/tests/common2/test_performancemonitor.cpp
@@ -5,9 +5,9 @@
  * PerformanceMonitor 单元测试
  *
  * 分支清单（来源：PerformanceMonitor 六个静态打点方法）
- * B1 : initializeAppStart/initializAppFinish → 记录时间差并输出 POINT-01 startduration
- * B2 : closeAppStart/closeAPPFinish           → POINT-02 closeduration
- * B3 : openFileStart/openFileFinish(file,size)→ POINT-04 filename/filezise/opentime
+ * B1 : initializeAppStart/initializeAppFinish → 记录时间差并输出 POINT-01 startduration
+ * B2 : closeAppStart/closeAppFinish           → POINT-02 closeduration
+ * B3 : openFileStart/openFileFinish(file,size)→ POINT-04 filename/filesize/opentime
  * B4 : 构造函数                                → 仅 qDebug
  *
  * 用例映射：
@@ -114,7 +114,7 @@ TEST_F(PerformanceMonitorTest, InitializeApp_StartThenFinish_LogsPoint01Duration
     pushTime(2000);
     // Act
     PerformanceMonitor::initializeAppStart();
-    PerformanceMonitor::initializAppFinish();
+    PerformanceMonitor::initializeAppFinish();
     // Assert
     EXPECT_TRUE(logsContain(QStringLiteral("[GRABPOINT] POINT-01 startduration=1000ms")));
     EXPECT_TRUE(logsContain(QStringLiteral("start to initialize app")));
@@ -124,12 +124,12 @@ TEST_F(PerformanceMonitorTest, InitializeApp_StartThenFinish_LogsPoint01Duration
 // B2
 TEST_F(PerformanceMonitorTest, CloseApp_StartThenFinish_LogsPoint02Duration)
 {
-    // Arrange: closeAppStart 仅取一次当前时间；closeAPPFinish 取两次（赋值+日志格式化）
+    // Arrange: closeAppStart 仅取一次当前时间；closeAppFinish 取两次（赋值+日志格式化）
     timeQueue.append(3000);
     pushTime(4500);
     // Act
     PerformanceMonitor::closeAppStart();
-    PerformanceMonitor::closeAPPFinish();
+    PerformanceMonitor::closeAppFinish();
     // Assert
     EXPECT_TRUE(logsContain(QStringLiteral("[GRABPOINT] POINT-02 closeduration=1500ms")));
     EXPECT_TRUE(logsContain(QStringLiteral("finish to close app")));
@@ -148,7 +148,7 @@ TEST_F(PerformanceMonitorTest, OpenFile_StartThenFinish_LogsPoint04Info)
     // Assert
     EXPECT_TRUE(logsContain(QStringLiteral("[GRABPOINT] POINT-04")));
     EXPECT_TRUE(logsContain(QStringLiteral("filename=test-doc.txt")));
-    EXPECT_TRUE(logsContain(QStringLiteral("filezise=2.000000M")));
+    EXPECT_TRUE(logsContain(QStringLiteral("filesize=2.000000M")));
     EXPECT_TRUE(logsContain(QStringLiteral("opentime=500ms")));
     EXPECT_EQ(timeCalls, 4);
 }

--- a/tests/startmanager/test_startmanager.cpp
+++ b/tests/startmanager/test_startmanager.cpp
@@ -19,7 +19,7 @@
 //     （StubExt::get_ctor_addr + placement-new QObject 最小初始化）
 //
 // 方法覆盖清单（30 方法，含 3 个 private 经间接覆盖）：
-// instance/~StartManager/StartManager/checkPath/ifKlu/isMultiWindow/isTemFilesEmpty/
+// instance/~StartManager/StartManager/checkPath/ifKlu/isMultiWindow/hasEmptyTemFile/
 // autoBackupFile/recoverFile/openFilesInWindow/openFilesInTab/createWindowFromWrapper/
 // loadTheme/createWindow/initWindowPosition/popupExistTabs/getFileTabInfo/
 // slotCheckUnsaveTab/closeAboutForWindow/slotCreatNewwindow/slotCloseWindow/
@@ -30,7 +30,7 @@
 // | 1 | 每个公开方法 ≥1 用例 | 完成（见用例映射） |
 // | 2 | 等价类划分（环境变量组合/书签串/临时文件列表/JSON 记录形态） | 完成 |
 // | 3 | 边界值（空列表/空串/INT 极值/20 窗口上限/tabIndex 越界） | 完成 |
-// | 4 | TEST_P ≥3 组（ifKlu 环境组合/isTemFilesEmpty 列表形态/analyzeBookmakeInfo 串形态） | 完成 |
+// | 4 | TEST_P ≥3 组（ifKlu 环境组合/hasEmptyTemFile 列表形态/analyzeBookmakeInfo 串形态） | 完成 |
 // | 5 | 分支清单 → 用例映射 | 见下方 |
 // | 6 | if/switch/early-return 全分支 | 完成（除 3 处标注 GUI/构造约束不可达分支） |
 // | 7 | 异常路径 EXPECT_THROW 精确匹配 | N/A（方法无 throw，Qt 风格 bool/错误码） |
@@ -45,7 +45,7 @@
 // checkPath: B5 wrapper 非空→popup+false；B6 全空→true
 // ifKlu: B7 XDG_SESSION_TYPE==wayland→true；B8 WAYLAND_DISPLAY 含 wayland→true；B9 否则 false
 // isMultiWindow: B10 count>1→true；B11 否则 false
-// isTemFilesEmpty: B12 存在空串项→true；B13 否则 false
+// hasEmptyTemFile: B12 存在空串项→true；B13 否则 false
 // autoBackupFile: B14 拖拽→早退；B15 autoBackupDir 不存在→mkpath；B16 存在且 backup 非空→清空；
 //   B17 getFileLoading→continue；B18 tabIndex<0→continue；B19 书签非空→insert；B20 空→remove；
 //   B21 活动窗口且 currentWrapper→focus；B22 草稿→saveTemFile(filePath)；B23 modified→saveTemFile(autoBackup 名)；
@@ -402,7 +402,7 @@ protected:
         stub.set_lamda(&Utils::activeWindowFromDock,
                        [this](quintptr) -> bool { return dockActivate; });
 
-        stub.set_lamda(&PerformanceMonitor::closeAPPFinish, []() -> void {});
+        stub.set_lamda(&PerformanceMonitor::closeAppFinish, []() -> void {});
 
         // QApplication::quit 拦截（slotCloseWindow 延迟退出路径，防真实退出测试进程）
         stub.set_lamda(&QCoreApplication::quit, [this]() -> void { ++quitCalls; });
@@ -717,7 +717,7 @@ INSTANTIATE_TEST_SUITE_P(
         IfKluCase{ "", "", false }));                  // B9：均未设置
 
 // ============================================================
-// isMultiWindow / isTemFilesEmpty
+// isMultiWindow / hasEmptyTemFile
 // ============================================================
 
 TEST_F(StartManagerTest, IsMultiWindow_SingleWindow_ReturnsFalse)
@@ -751,7 +751,7 @@ TEST_P(IsTemFilesEmptyTest, IsTemFilesEmpty_ListVariants_ReturnsExpected)
     obj->m_qlistTemFile = c.files;
 
     // Act
-    bool ret = obj->isTemFilesEmpty();
+    bool ret = obj->hasEmptyTemFile();
 
     // Assert：期望边 + 列表不被修改（强异常安全）
     EXPECT_EQ(ret, c.expected);
@@ -1941,8 +1941,8 @@ TEST_F(StartManagerTest, OpenFilesInWindow_NewFile_CreatesWindowAndTab)
 
 TEST_F(StartManagerTest, OpenFilesInTab_EmptyNoWindowsNoTemFiles_AddsBlankTab)
 {
-    // Arrange：无窗口 + 临时记录含空串占位（isTemFilesEmpty=true → 不走恢复）+ blank 目录无文件
-    // 注：isTemFilesEmpty() 语义为"列表含空串项"（源码 143-156），空列表返回 false 走恢复空转
+    // Arrange：无窗口 + 临时记录含空串占位（hasEmptyTemFile=true → 不走恢复）+ blank 目录无文件
+    // 注：hasEmptyTemFile() 语义为"列表含空串项"（源码 143-156），空列表返回 false 走恢复空转
     obj->m_qlistTemFile = QStringList { QString() };
     Window *newWin = qobjFake<Window>();
     int blankCalls = 0;
@@ -2015,7 +2015,7 @@ TEST_F(StartManagerTest, OpenFilesInTab_RecoveryFoundNothing_AddsBlankTab)
 
 TEST_F(StartManagerTest, OpenFilesInTab_BlankFilesExist_RemovesThenAddsBlankTab)
 {
-    // Arrange：临时记录含空串占位（isTemFilesEmpty=true → 走清理分支）+ blank 目录存在遗留 blank_file
+    // Arrange：临时记录含空串占位（hasEmptyTemFile=true → 走清理分支）+ blank 目录存在遗留 blank_file
     obj->m_qlistTemFile = QStringList { QString() };
     QDir().mkpath(obj->m_blankFileDir);
     QString stale = QDir(obj->m_blankFileDir).filePath("blank_file_0");


### PR DESCRIPTION
## Summary
Fix 13 defects in peripheral modules found by unit test scan (D-006/007/011/012/022/031/033/034/035/036/038/046/047):

- daemon saveFile 检查 QTextStream/QFile 写入状态，磁盘错误不再静默上报成功
- DetectCode QTextCodec 路径 BOM 改 prepend（BOM+data），与 iconv 主路径字节序一致
- StartManager：析构释放 m_pLoginManager；tabPaths.txt 清理改绝对路径；isTemFilesEmpty 更名 hasEmptyTemFile（语义与实现一致，行为不变）；删除不可达调试残留
- ThemeListModel data() 增加 index 有效性/行号边界校验；ThemePanel popup/hide 判空 m_window；ThemeListView 删除无效同值条件分支
- 更正 PerformanceMonitor 接口与日志字段拼写（initializeAppFinish/closeAppFinish/filesize）并同步全部调用方
- load_libs：dlsym 失败显式报错；setLibNames 释放旧分配；registerDockRectMetaType 补头文件声明

## Tests
- 同步更新 test_startmanager / test_performancemonitor / test_detectcode 断言
- thememodule / daemon_ut / common2 / startmanager（崩点前 21 例）全部通过

独立提交，不依赖其他分支。

## Summary by Sourcery

Fix peripheral module defects identified by unit-test analysis and strengthen error handling, resource cleanup, and UI safety.

Bug Fixes:
- Prevent file-save operations from reporting success when stream writes or disk flushes fail.
- Correct UTF text encoding output so byte-order marks precede converted data.
- Guard theme UI operations and model access against invalid or missing objects.
- Improve dynamic library loading diagnostics and prevent repeated library-name configuration from leaking memory.

Enhancements:
- Correct performance-monitoring API names and log field spelling, and align all callers and tests.
- Release StartManager login resources during destruction, use absolute paths when removing temporary tab data, and clarify temporary-file helper semantics.
- Expose the DockRect metatype registration declaration and simplify redundant theme-list view logic.

Tests:
- Update unit tests and expectations for encoding, performance-monitoring, and StartManager corrections.