### PR TITLE
chore: update version to 6.6.1

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-deepin-editor (6.5.59) unstable; urgency=medium
+deepin-editor (6.6.1) unstable; urgency=medium
 
   * fix(ut): fix null pointer crash and static variable bug in source
   * test(editor): extend TextEdit and Window tests, fix crashes

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.editor
   name: "deepin-editor"
-  version: 6.5.59.1
+  version: 6.6.1.1
   kind: app
   description: |
     editor for deepin os.


### PR DESCRIPTION
as title

Log: update version

## Summary by Sourcery

Chores:
- Update the package version metadata to 6.6.1.1 and refresh the Debian changelog.