### PR TITLE
fix(build): disable unit tests in linglong package build

### DIFF
--- a/linglong.yaml
+++ b/linglong.yaml
@@ -32,6 +32,7 @@ build: |
         -DCMAKE_SAFETYTEST_ARG="CMAKE_SAFETYTEST_ARG_OFF" \
         -DCMAKE_BUILD_TYPE=Release \
         -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
+        -DBUILD_TESTS=OFF \
         -DVERSION=${VERSION}
   cmake --build build -j`nproc`
   cmake --build build --target install > install.log 2>&1


### PR DESCRIPTION
## Summary
- `BUILD_TESTS` 选项默认为 ON（CMakeLists.txt: `option(BUILD_TESTS "Build unit tests" ON)`），玲珑打包构建未显式关闭，导致容器内编译整个 tests/ 树
- tests/daemon_ut 的 polkit 垫片头（shim 转发 `#include <polkitqt1-authority.h>`）依赖宿主机 polkit-qt dev 包，构建容器中不存在该头，触发 `fatal error: polkitqt1-authority.h: No such file or directory` → `stage build error`（本地与 uos-eagle 流水线 b17d23bd 均复现）
- 修复：linglong.yaml 的 cmake 命令增加 `-DBUILD_TESTS=OFF`，单元测试仍由宿主机/CI 的 `tests/test-prj-running.sh` 流程承载

## Tests
- 本地 ll-builder 验证：清理宿主 `build/` 后配置通过；单测流程不受影响（BUILD_TESTS 仅影响打包构建默认值）