### PR TITLE
fix(tests): make ApplyQss assertion tolerant to SPDX header

### DIFF
--- a/tests/common/test_utils.cpp
+++ b/tests/common/test_utils.cpp
@@ -225,7 +225,10 @@ TEST_F(UtilsTest, ApplyQss_RegisteredQss_AppliesFileContent)
     Utils::applyQss(&w, QString::fromLatin1("test.qss"));
 
     // Assert
-    EXPECT_EQ(w.styleSheet(), QString::fromLatin1("QWidget { color: red; background-color: blue; }\n"));
+    // test.qss 为满足 REUSE 规范带有 SPDX 版权注释头，applyQss 会原样读入整个文件，
+    // 且 Qt6 QWidget::styleSheet() 返回规范化内容（无尾部换行）——
+    // 严格相等断言对文件头与格式归一化敏感，改为断言规则内容存在
+    EXPECT_TRUE(w.styleSheet().contains(QString::fromLatin1("QWidget { color: red; background-color: blue; }")));
     EXPECT_TRUE(w.styleSheet().contains(QString::fromLatin1("color: red")));
 }
 


### PR DESCRIPTION
## Summary
- UT 全量 1980 例中唯一的存量失败：`UtilsTest.ApplyQss_RegisteredQss_AppliesFileContent`
- 根因：test.qss 为满足 REUSE 规范带上了 `/* SPDX-FileCopyrightText ... */` 注释头，`Utils::applyQss` 原样读入整个文件，而用例以**不含 SPDX 头且带尾部 \n** 的字面量做严格相等断言；Qt6 `styleSheet()` 返回规范化内容，二者必然不等
- 修复：严格相等改为 `contains("QWidget { color: red; background-color: blue; }")`，对文件头与格式归一化免疫（下一行原有 `contains("color: red")` 保留）

## Tests
- 本机 test_utils 全量 123/123 通过（原失败用例转绿）
- 仅调整测试断言，不改任何产品代码

## Summary by Sourcery

Relax the ApplyQss stylesheet test to accept valid file headers and normalized stylesheet output.

Bug Fixes:
- Make the ApplyQss test assertion tolerant of SPDX headers and Qt6 stylesheet formatting normalization.

Tests:
- Update the ApplyQss unit test to validate the expected stylesheet rule without relying on exact full-file equality.