### PR TITLE
chore: update version to 6.6.2

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,16 @@
+deepin-editor (6.6.2) unstable; urgency=medium
+
+  * fix(tests): make ApplyQss assertion tolerant to SPDX header
+  * fix(build): disable unit tests in linglong package build
+  * chore: update version to 6.6.1
+  * chore: update version to 6.5.59
+  * fix(peripheral): fix peripheral module defects from unit test scan
+  * fix(common): fix common/controls/widgets defects from unit test scan
+  * fix(editor): fix core defects found by unit test scan
+
+ -- xiepengfei <xiepengfei@uniontech.com>  Mon, 07 Sep 2026 16:25:59 +0800
+
+
 deepin-editor (6.6.1) unstable; urgency=medium
 
   * fix(ut): fix null pointer crash and static variable bug in source

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.editor
   name: "deepin-editor"
-  version: 6.6.1.1
+  version: 6.6.2.1
   kind: app
   description: |
     editor for deepin os.


### PR DESCRIPTION
## Summary
- 版本升级 6.6.1 → 6.6.2，linglong.yaml 同步 6.6.1.1 → 6.6.2.1

## Changelog
- fix(editor): fix core defects found by unit test scan（17 项 UT 扫描缺陷）
- fix(common): fix common/controls/widgets defects from unit test scan（15 项）
- fix(peripheral): fix peripheral module defects from unit test scan（13 项）
- fix(build): disable unit tests in linglong package build（修复玲珑流水线）
- fix(tests): make ApplyQss assertion tolerant to SPDX header（消除存量误报）

## Summary by Sourcery

Bump the project release to version 6.6.2.

Chores:
- Update the project and Linglong package versions to 6.6.2 and 6.6.2.1, respectively.
- Refresh the Debian changelog for the 6.6.2 release.