### PR TITLE
[AT] deepin-editor 编辑模式用例

### DIFF
--- a/tests/at/yaml/edit_mode/edit_mode.suite.yaml
+++ b/tests/at/yaml/edit_mode/edit_mode.suite.yaml
@@ -1,0 +1,53 @@
+name: edit_mode_suite
+app: deepin-editor
+description: ''
+module: edit_mode
+tags: []
+fast_fail: false
+env_check: []
+setup:
+- action: session_start
+  command: deepin-editor
+  wait: 3.0
+suites:
+- id: readonly_mode_s1
+  name: 只读模式
+  description: 验证切换到查看视图后输入被阻止，再通过右键菜单切回编辑模式后可正常输入
+  tags: []
+  steps:
+  - action: keyboard_hot_key
+    key: ctrl+t
+  - action: element_action
+    selector:
+      name: ViewModeMenu
+      role: combo box
+    do: click
+  - action: keyboard_press
+    key: down
+  - action: keyboard_press
+    key: enter
+  - wait: 1.0
+  - action: keyboard_type
+    text: read only
+  - action: element_action
+    selector:
+      name: TextEditor
+      role: text
+    do: right_click
+  - wait: 0.5
+  - action: keyboard_press
+    key: right
+  - action: keyboard_press
+    key: enter
+  - wait: 1.0
+  - action: keyboard_type
+    text: edit
+  assert_steps:
+  - action: assert_element
+    selector:
+      name: TextEditor
+      role: text
+  - action: assert_ocr_exists
+    text: edit
+teardown:
+- action: session_stop

--- a/tests/at/yaml/edit_mode/elements.yaml
+++ b/tests/at/yaml/edit_mode/elements.yaml
@@ -1,0 +1,16 @@
+elements:
+  MainWindow:
+    name: MainWindow
+    role: frame
+  TextEditor:
+    name: TextEditor
+    role: text
+  ViewModeMenu:
+    name: ViewModeMenu
+    role: combo box
+  EditorBottomBar:
+    name: EditorBottomBar
+    role: panel
+  Tabbar:
+    name: Tabbar
+    role: page tab list


### PR DESCRIPTION
## AT-SPI 测试套件：编辑模式

### 测试场景
验证 deepin-editor 的编辑模式与只读模式切换功能：

1. 启动 deepin-editor
2. 快捷键 Ctrl+T 新开标签页
3. 点击底部栏「编辑模式」下拉菜单 → 选择「查看视图」（只读模式）
4. 键盘输入 "read only"（期望：输入被阻止）
5. 编辑区右键菜单 → 视图模式 → 编辑模式（切回编辑模式）
6. 键盘输入 "edit"
7. 期望：能够输入 "edit"

### 新增文件
- `tests/at/yaml/edit_mode/elements.yaml` — 元素清单（5 个元素）
- `tests/at/yaml/edit_mode/edit_mode.suite.yaml` — 测试套件（1 个 case）

### 元素来源（setAccessibleName）
| 元素名 | 源码位置 |
|--------|----------|
| MainWindow | src/widgets/window.cpp |
| TextEditor | src/editor/editwrapper.cpp |
| ViewModeMenu | src/widgets/bottombar.cpp |
| EditorBottomBar | src/editor/editwrapper.cpp |
| Tabbar | src/widgets/window.cpp |

### 说明
- 未修改项目源代码
- 仅新增 AT 测试用例

## Summary by Sourcery

Tests:
- Add an AT-SPI test covering switching between read-only and edit modes and verifying input behavior in each mode.