### PR TITLE
fix(window): guard find bar close without current wrapper

### DIFF
--- a/src/widgets/window.cpp
+++ b/src/widgets/window.cpp
@@ -2336,15 +2336,27 @@ void Window::rehighlightPrintDoc(QTextDocument *doc, CSyntaxHighlighter *highlig
 void Window::updateSizeMode()
 {
     qDebug() << "Update size mode";
+    EditWrapper *wrapper = currentWrapper();
+    if (!wrapper) {
+        qWarning() << "No current wrapper, skip size mode update";
+        return;
+    }
+
+    BottomBar *bottomBar = wrapper->bottomBar();
+    if (!bottomBar) {
+        qWarning() << "No bottom bar, skip size mode update";
+        return;
+    }
+
     if (m_findBar && m_findBar->isVisible()) {
         qDebug() << "Find bar is visible, updating its position";
-        currentWrapper()->bottomBar()->updateSize(m_findBar->height() + 8, true);
+        bottomBar->updateSize(m_findBar->height() + 8, true);
         m_findBar->move(QPoint(4, height() - m_findBar->height() - 4));
     }
 
     if (m_replaceBar && m_replaceBar->isVisible()) {
         qDebug() << "Replace bar is visible, updating its position";
-        currentWrapper()->bottomBar()->updateSize(m_replaceBar->height() + 8, true);
+        bottomBar->updateSize(m_replaceBar->height() + 8, true);
         m_replaceBar->move(QPoint(4, height() - m_replaceBar->height() - 4));
     }
 
@@ -3666,15 +3678,29 @@ void Window::slotFindbarClose()
 {
     qDebug() << "slotFindbarClose";
     EditWrapper *wrapper = currentWrapper();
-
-    if (wrapper->bottomBar()->isHidden()) {
-        qDebug() << "bottom bar is hidden, show it";
-        wrapper->bottomBar()->show();
+    if (!wrapper) {
+        qWarning() << "No current wrapper, ignore find bar close";
+        return;
     }
 
-    wrapper->bottomBar()->updateSize(BottomBar::defaultHeight(), false);
-    currentWrapper()->textEditor()->setFocus();
-    currentWrapper()->textEditor()->tellFindBarClose();
+    BottomBar *bottomBar = wrapper->bottomBar();
+    if (!bottomBar) {
+        qWarning() << "No bottom bar, ignore find bar close";
+        return;
+    }
+
+    if (bottomBar->isHidden()) {
+        qDebug() << "bottom bar is hidden, show it";
+        bottomBar->show();
+    }
+
+    bottomBar->updateSize(BottomBar::defaultHeight(), false);
+    if (auto *textEditor = wrapper->textEditor()) {
+        textEditor->setFocus();
+        textEditor->tellFindBarClose();
+    } else {
+        qWarning() << "No text editor, ignore find bar close focus update";
+    }
     qDebug() << "slotFindbarClose end";
 }
 
@@ -3682,15 +3708,29 @@ void Window::slotReplacebarClose()
 {
     qDebug() << "slotReplacebarClose";
     EditWrapper *wrapper = currentWrapper();
-
-    if (wrapper->bottomBar()->isHidden()) {
-        qDebug() << "bottom bar is hidden, show it";
-        wrapper->bottomBar()->show();
+    if (!wrapper) {
+        qWarning() << "No current wrapper, ignore replace bar close";
+        return;
     }
 
-    wrapper->bottomBar()->updateSize(BottomBar::defaultHeight(), false);
-    currentWrapper()->textEditor()->setFocus();
-    currentWrapper()->textEditor()->tellFindBarClose();
+    BottomBar *bottomBar = wrapper->bottomBar();
+    if (!bottomBar) {
+        qWarning() << "No bottom bar, ignore replace bar close";
+        return;
+    }
+
+    if (bottomBar->isHidden()) {
+        qDebug() << "bottom bar is hidden, show it";
+        bottomBar->show();
+    }
+
+    bottomBar->updateSize(BottomBar::defaultHeight(), false);
+    if (auto *textEditor = wrapper->textEditor()) {
+        textEditor->setFocus();
+        textEditor->tellFindBarClose();
+    } else {
+        qWarning() << "No text editor, ignore replace bar close focus update";
+    }
     qDebug() << "slotReplacebarClose end";
 }
 

--- a/tests/widgets_ut/test_window.cpp
+++ b/tests/widgets_ut/test_window.cpp
@@ -1774,6 +1774,33 @@ TEST_F(WindowTest, SlotReplacebarClose_ShowsBottomBar)
     EXPECT_NE(m_win->currentWrapper(), nullptr);
 }
 
+TEST_F(WindowTest, SlotFindbarClose_NoWrapper_NoCrash)
+{
+    // Act: 异步关闭查找栏时当前 wrapper 可能已被切换/销毁，应安全早退
+    m_win->slotFindbarClose();
+
+    // Assert
+    EXPECT_EQ(m_win->currentWrapper(), nullptr);
+}
+
+TEST_F(WindowTest, SlotReplacebarClose_NoWrapper_NoCrash)
+{
+    // Act: 异步关闭替换栏时当前 wrapper 可能已被切换/销毁，应安全早退
+    m_win->slotReplacebarClose();
+
+    // Assert
+    EXPECT_EQ(m_win->currentWrapper(), nullptr);
+}
+
+TEST_F(WindowTest, UpdateSizeMode_NoWrapper_NoCrash)
+{
+    // Act: 窗口尺寸变化回调可能早于编辑区创建，应安全早退
+    m_win->updateSizeMode();
+
+    // Assert
+    EXPECT_EQ(m_win->currentWrapper(), nullptr);
+}
+
 TEST_F(WindowTest, SlotSwitchToReplaceBar_FromVisibleFindBar_CarriesText)
 {
     // Arrange: 查找栏可见并输入关键词


### PR DESCRIPTION
Avoid null dereference when find/replace bar close callbacks run after the current edit wrapper is unavailable.

修复查找/替换栏异步关闭时 currentWrapper 为空导致崩溃的问题。

Log: 修复查找栏关闭空指针崩溃

Influence: 避免文本编辑器在 AT 场景或异步切换窗口时崩溃。

## Summary by Sourcery

Guard asynchronous find/replace bar and size updates against unavailable editor state to prevent crashes during window transitions.

Bug Fixes:
- Prevent find/replace bar callbacks and window size updates from crashing when the current editor wrapper, bottom bar, or text editor is unavailable.

Enhancements:
- Add diagnostic warnings and safely skip UI updates when required editor components are missing.

Tests:
- Add coverage confirming find-bar close, replace-bar close, and size-mode updates safely handle a missing current wrapper.