### PR TITLE
fix: clear custom path input on restore default

### DIFF
--- a/translations/deepin-editor_zh_CN.ts
+++ b/translations/deepin-editor_zh_CN.ts
@@ -1029,7 +1029,7 @@
         <location filename="../src/editor/dtextedit.cpp" line="2868"/>
         <location filename="../src/editor/dtextedit.cpp" line="2870"/>
         <source>Please install UOS AI from the app store first.</source>
-        <translation>请前往应用商店安装“UOS AI”后再使用</translation>
+        <translation>请前往应用商店安装“小U同学”后再使用</translation>
     </message>
     <message>
         <location filename="../src/editor/dtextedit.cpp" line="292"/>


### PR DESCRIPTION
## Summary by Sourcery

Update the Chinese translation to use the current UOS AI product name.