### PR TITLE
fix: clear custom path input on restore default

### DIFF
--- a/src/common/settings.cpp
+++ b/src/common/settings.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2011-2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2011-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -271,8 +271,8 @@ QWidget* Settings::createSavingPathWgt(QObject* obj)
     });
 
     auto custompath = s_pSetting->settings->option("advance.open_save_setting.open_save_custom_path");
-    connect(custompath, &Dtk::Core::DSettingsOption::valueChanged, [=](QVariant var){
-        //pathwgt->setEditText(var.toString());
+    connect(custompath, &Dtk::Core::DSettingsOption::valueChanged, pathwgt, [=](QVariant var){
+        pathwgt->setEditText(var.toString());
     });
 
     return optionWidget.second;

--- a/src/resources/settings.json
+++ b/src/resources/settings.json
@@ -2155,7 +2155,8 @@
                         },
                         {
                             "key": "open_save_custom_path",
-                            "hide": true
+                            "hide": true,
+                            "default": ""
                         }
                     ]
 


### PR DESCRIPTION
## Root Cause Analysis

When the user clicks "Restore Default" in the text editor settings dialog, DTK's `DSettings::reset()` resets `open_save_custom_path` to its default value (empty). However, the `valueChanged` callback in `settings.cpp:275` has the `setEditText(var.toString())` call commented out, so the UI input field does not sync with the config value change and keeps showing the old custom path.

The `onSaveIdChanged()` method in `pathsettintwgt.cpp` is **not** the right place to fix this — it is called on every mode switch (clicking radio buttons), so adding `setEditText("")` there would clear the path even when the user just switches modes without restoring defaults, which is incorrect behavior.

Key evidence:
- `settings.cpp:275` — `pathwgt->setEditText(var.toString())` is commented out
- `settings.json:2157` — `open_save_custom_path` missing `"default"` field
- `pathsettintwgt.cpp:36-44` — `onSaveIdChanged` is called on mode switches, not just restore default

## Fix

1. **`src/common/settings.cpp:275`** — Uncommented `pathwgt->setEditText(var.toString())` in `createSavingPathWgt()`. This callback only fires when `open_save_custom_path` config value actually changes (restore default resets to empty, or user selects a new path), **not** on mode switches.
2. **`src/resources/settings.json`** — Added `"default": ""` to `open_save_custom_path` option, ensuring DTK reset behavior is deterministic.

`pathsettintwgt.cpp` is **not modified** — `onSaveIdChanged()` handles mode switching (checkbox/button state), and should not clear the input field on every switch.

## Change Safety Assessment

### Code Safety

- **Risk Level**: Low
- The `setEditText(var.toString())` line was commented out since its initial introduction in commit `fa243034` (version 6.0.6 upgrade) — uncommenting it is the first time it's enabled, does not revert any historical fix
- `createSavingPathWgt` is called by DTK's `DSettingsWidgetFactory` for creating the settings UI widget — no signature change, no thread safety concerns

### Business Impact Scope

Only affects the "Open/Save Location" settings UI. When config value changes (restore default → empty, or new path selection), the input field now syncs. Mode switches are unaffected — `open_save_custom_path` does not change on mode switch, so the callback is not triggered.

### Verification Suggestion

1. Set a custom path in settings, then click "Restore Default" — verify the custom path input is cleared
2. Switch between all three save path modes — verify the input field is NOT cleared (only restore default or new path selection changes it)

---

## 根因分析

当用户在文本编辑器设置对话框中点击"恢复默认"时，DTK 的 `DSettings::reset()` 将 `open_save_custom_path` 重置为默认值（空）。但 `settings.cpp:275` 的 `valueChanged` 回调中 `setEditText(var.toString())` 被注释掉，UI 输入框未同步配置值变化，仍显示旧的自定义路径。

`pathsettintwgt.cpp` 的 `onSaveIdChanged()` **不是**正确的修复位置——该方法在每次模式切换（点击单选按钮）时都会被调用，在此处清空输入框会导致用户仅切换模式时路径被错误隐藏，属于错误行为。

关键证据：
- `settings.cpp:275` — `pathwgt->setEditText(var.toString())` 被注释掉
- `settings.json:2157` — `open_save_custom_path` 缺少 `default` 字段
- `pathsettintwgt.cpp:36-44` — `onSaveIdChanged` 在模式切换时被调用，非仅在恢复默认时

## 修复方案

1. **`src/common/settings.cpp:275`** — 取消注释 `pathwgt->setEditText(var.toString())`。该回调仅在 `open_save_custom_path` 配置值实际变化时触发（恢复默认重置为空、或用户选择新路径），**不影响普通模式切换**。
2. **`src/resources/settings.json`** — 为 `open_save_custom_path` 添加 `"default": ""`，确保 DTK reset 行为确定。

**不修改 `pathsettintwgt.cpp`**——`onSaveIdChanged()` 处理模式切换（复选框/按钮状态），不应在每次切换时清空输入框。

## 改动安全评估

### 代码安全评估

- **风险等级**: 低风险
- `setEditText(var.toString())` 从 commit `fa243034`（版本 6.0.6 升级）引入时即被注释——本次取消注释是首次启用，不撤销任何历史修复
- `createSavingPathWgt` 被 DTK 的 `DSettingsWidgetFactory` 调用——无签名变更，无线程安全问题

### 业务影响范围

仅影响"打开/保存位置"设置 UI。配置值变化时（恢复默认→空、或选择新路径）输入框同步更新。模式切换不受影响——`open_save_custom_path` 在模式切换时不变化，回调不会被触发。

### 验证建议

1. 在设置中设置自定义路径，然后点击"恢复默认"——验证自定义路径输入框被清空
2. 在三种保存路径模式间切换——验证输入框不被清空（仅恢复默认或选择新路径时变化）

PMS: BUG-375947

## Summary by Sourcery

Ensure the custom path field reflects restored default settings without being cleared during ordinary path-mode switches.

Bug Fixes:
- Synchronize the custom open/save path input with configuration changes so restoring defaults clears stale path text.

Chores:
- Define an explicit empty default for the custom open/save path setting.
- Update the copyright year in the settings implementation.