### PR TITLE
[AT] deepin-editor AT-SPI 测试套件（element-map 双字段管线）

### DIFF
--- a/tests/at/cases_mapped.yaml
+++ b/tests/at/cases_mapped.yaml
@@ -1,0 +1,41 @@
+version: '1.0'
+cases:
+- id: suite_编辑模式_001_s1
+  name: 只读模式_切换视图后输入
+  module: 编辑模式
+  steps:
+  - step_type: action
+    action: keyboard_hot_key
+    key: ctrl+t
+  - step_type: action
+    action: dtk_dropdown_menu
+    selector:
+      name: ViewModeMenu
+    items:
+    - 查看视图
+  - step_type: action
+    action: keyboard_type
+    text: read only
+  - step_type: action
+    action: dtk_context_menu
+    selector:
+      context_trigger:
+        name: EditorStack
+      name: EditorStack
+    items:
+    - 视图模式
+    - 编辑模式
+  - step_type: action
+    action: keyboard_type
+    text: edit
+  - step_type: assert
+    action: assert_element
+    selector:
+      name: EditorStack
+  - step_type: assert
+    action: assert_element
+    selector:
+      accessible_id: Tabbar
+  - step_type: assert
+    action: assert_ocr_exists
+    text: edit

--- a/tests/at/coverage-report.yaml
+++ b/tests/at/coverage-report.yaml
@@ -1,0 +1,13 @@
+scan_total: 2
+transient_items:
+- name: ViewModeMenu
+  role: menu
+  ui_name: 编辑模式菜单
+  locator: name
+unreachable: 0
+denominator: 2
+covered: 2
+uncovered: 0
+coverage: 100.0
+passed: true
+uncovered_elements: []

--- a/tests/at/element-coverage-manifest.yaml
+++ b/tests/at/element-coverage-manifest.yaml
@@ -1,0 +1,20 @@
+version: '1.0'
+source: at-case-authoring:element-map.yaml
+scan_total: 2
+elements:
+  Tabbar:
+    role: page tab
+    ui_name: 标签页
+    desc: 标签页栏，用于多标签页切换
+    locator: accessible_id
+  EditorStack:
+    role: layered pane
+    ui_name: 编辑区
+    desc: 文本编辑区域，显示和输入文本内容
+    locator: name
+transient_items:
+- name: ViewModeMenu
+  role: menu
+  ui_name: 编辑模式菜单
+  desc: 底部视图模式下拉菜单(DDropdownMenu)，切换编辑/只读/实时预览
+unresolved: []

--- a/tests/at/yaml/elements.yaml
+++ b/tests/at/yaml/elements.yaml
@@ -1,0 +1,7 @@
+elements:
+  ViewModeMenu:
+    name: ViewModeMenu
+  EditorStack:
+    name: EditorStack
+  Tabbar:
+    accessible_id: Tabbar

--- a/tests/at/yaml/编辑模式/编辑模式.suite.yaml
+++ b/tests/at/yaml/编辑模式/编辑模式.suite.yaml
@@ -1,0 +1,50 @@
+name: 编辑模式_suite
+app: deepin-editor
+module: 编辑模式
+setup:
+- action: session_start
+  command: deepin-editor
+  wait: 3.0
+suites:
+- id: suite_编辑模式_001_s1
+  name: 只读模式_切换视图后输入
+  description: ''
+  steps:
+  - step_type: action
+    action: keyboard_hot_key
+    key: ctrl+t
+  - step_type: action
+    action: dtk_dropdown_menu
+    selector:
+      name: ViewModeMenu
+    items:
+    - 查看视图
+  - step_type: action
+    action: keyboard_type
+    text: read only
+  - step_type: action
+    action: dtk_context_menu
+    selector:
+      context_trigger:
+        name: EditorStack
+      name: EditorStack
+    items:
+    - 视图模式
+    - 编辑模式
+  - step_type: action
+    action: keyboard_type
+    text: edit
+  assert_steps:
+  - step_type: assert
+    action: assert_element
+    selector:
+      name: EditorStack
+  - step_type: assert
+    action: assert_element
+    selector:
+      accessible_id: Tabbar
+  - step_type: assert
+    action: assert_ocr_exists
+    text: edit
+teardown:
+- action: session_stop


### PR DESCRIPTION
## 概述

为 deepin-editor（文本编辑器）新增「编辑模式-只读模式」AT-SPI 测试套件。

## 测试场景

- suite: 编辑模式
- case: 只读模式
- 步骤: 启动应用 → Ctrl+T 新开标签页 → 底部编辑模式菜单选择「查看视图」→ 键盘输入「read only」→ 编辑区右键菜单切换「编辑模式」→ 键盘输入「edit」→ 断言输入成功

## 交付物

- tests/at/yaml/elements.yaml
- tests/at/yaml/编辑模式/编辑模式.suite.yaml
- tests/at/element-coverage-manifest.yaml
- tests/at/coverage-report.yaml
- tests/at/cases_mapped.yaml

## 验证结果

- 覆盖率门禁: 100% (2/2)
- Gate 5 (语义安全): PASS
- Gate 4 (生成): PASS
- 运行时 smoke: 需在有桌面环境后执行验收

## element-map 双字段

| ui_name | id_name | object_name | role |
|---------|---------|-------------|------|
| 标签页 | Tabbar | Tabbar | page tab |
| 编辑模式菜单 | ViewModeMenu | (空) | menu (瞬态) |
| 编辑区 | EditorStack | (空) | layered pane |

> 不修改项目源代码，仅新增 tests/at/ 下测试套件。

## Summary by Sourcery

Add AT-SPI coverage for switching deepin-editor between view and edit modes.

New Features:
- Add an AT-SPI test case covering switching between read-only and edit modes and verifying text input.

Enhancements:
- Define element mappings and coverage metadata for the editor tab bar, editing area, and transient view-mode menu.

Tests:
- Add generated case mappings, an editor-mode suite definition, and coverage reports with 100% mapped-element coverage.