### PR TITLE
test: add V6.6 AT-SPI test suites for find count display and markdown…

### DIFF
--- a/src/controls/linebar.cpp
+++ b/src/controls/linebar.cpp
@@ -33,6 +33,7 @@ LineBar::LineBar(DLineEdit *parent)
 
     // label 和清除按钮直接 parent 到内嵌 lineEdit，覆盖在输入框内部
     m_matchCountLabel = new QLabel(lineEdit());
+    m_matchCountLabel->setAccessibleName("MatchCountLabel");
     int fontsize = DFontSizeManager::instance()->fontPixelSize(DFontSizeManager::T9);
     QFont labelFont = m_matchCountLabel->font();
     labelFont.setPixelSize(fontsize);

--- a/src/editor/dtextedit.cpp
+++ b/src/editor/dtextedit.cpp
@@ -541,6 +541,7 @@ void TextEdit::initRightClickedMenu()
 
     // Init view mode sub menu（§8.1：三子项互斥可选；默认「编辑模式」选中、「实时预览」置灰）
     m_viewModeMenu = new DMenu(tr("View Mode"), this);
+    m_viewModeMenu->setAccessibleName("ViewModeContextMenu");
     QActionGroup *pViewModeGroup = new QActionGroup(this);
     m_actEditView->setCheckable(true);
     m_actReadView->setCheckable(true);

--- a/src/editor/markdown/markdownview.cpp
+++ b/src/editor/markdown/markdownview.cpp
@@ -81,6 +81,7 @@ MarkdownView::MarkdownView(QWidget *parent)
     : QWebEngineView(parent)
     , m_bridge(new MarkdownBridge(this))
 {
+    setAccessibleName("MarkdownView");
     connect(m_bridge, &MarkdownBridge::ready, this, &MarkdownView::onBridgeReady);
     connect(m_bridge, &MarkdownBridge::contentChanged, this, &MarkdownView::contentChanged);
     connect(m_bridge, &MarkdownBridge::scrollRatioChanged, this, &MarkdownView::scrollRatioChanged);

--- a/src/widgets/bottombar.cpp
+++ b/src/widgets/bottombar.cpp
@@ -65,6 +65,8 @@ BottomBar::BottomBar(QWidget *parent)
 
     initFormatMenu();
 
+    m_pHighlightMenu->setAccessibleName("HighlightMenu");
+
     // —— Markdown 视图模式 combobox（§8.2，与编码格式菜单同型）——
     m_pViewModeMenu = new DDropdownMenu();
     m_pViewModeMenu->setAccessibleName("ViewModeMenu");


### PR DESCRIPTION
… rendering

Add 32 test cases (22 active, 10 unsupported) covering two V6.6 features:
- Find result index/total display (7 active suites, all PASS)
- Markdown document rendering (15 active suites, all PASS)

Also add missing accessible names for AT-SPI element discovery:
- MatchCountLabel in linebar.cpp
- MarkdownView in markdownview.cpp
- ViewModeContextMenu in dtextedit.cpp
- HighlightMenu in bottombar.cpp

Update expected_names.yaml with 7 new element entries.

Flaky cases (md-009/md-010 consecutive right-click timing) removed from suite and marked manual with reason in standard/mapped yaml.

Verification: youqu at run 22/22 specs PASS (find-count 7/7, markdown-render 15/15)

## Summary by Sourcery

Expand V6.6 accessibility test coverage for find results and Markdown rendering while improving UI element discoverability.

Enhancements:
- Add accessible names to find-count, Markdown, view-mode, and highlight-menu UI elements to support AT-SPI discovery.

Tests:
- Add AT-SPI coverage for V6.6 find-result count displays and Markdown rendering, with passing active suites and documented unsupported or flaky cases.

Chores:
- Update AT-SPI expected element names and mark timing-sensitive cases for manual verification.