### PR TITLE
[AT] deepin-editor AT-SPI 测试套件（element-map 双字段管线）

### DIFF
--- a/tests/at/cases_mapped.yaml
+++ b/tests/at/cases_mapped.yaml
@@ -1,0 +1,50 @@
+version: '1.0'
+cases:
+- id: case_encoding_switch_s1
+  name: 编码切换
+  module: edit_mode
+  steps:
+  - step_type: action
+    action: keyboard_hot_key
+    key: ctrl+t
+  - step_type: action
+    action: mouse_click
+    selector:
+      name: DropdownToolButton
+      role: push button
+  - step_type: action
+    action: dtk_context_menu
+    selector:
+      name: DropdownToolButton
+      role: push button
+    items:
+    - 简体中文
+    - GB18030
+  - step_type: action
+    action: keyboard_type
+    text: UOS给世界更好的选择
+  - step_type: action
+    action: mouse_click
+    selector:
+      name: DropdownToolButton
+      role: push button
+  - step_type: action
+    action: dtk_context_menu
+    selector:
+      name: DropdownToolButton
+      role: push button
+    items:
+    - Unicode
+    - UTF-8
+  - step_type: action
+    action: keyboard_press
+    key: enter
+  - step_type: action
+    action: keyboard_hot_key
+    key: ctrl+s
+  - step_type: action
+    action: file_dialog_select
+    path: /tmp/test_encoding_switch.txt
+  - step_type: assert
+    action: assert_file_exists
+    path: /tmp/test_encoding_switch.txt

--- a/tests/at/coverage-report.yaml
+++ b/tests/at/coverage-report.yaml
@@ -1,0 +1,11 @@
+scan_total: 1
+unreachable: 0
+denominator: 1
+covered: 1
+uncovered: 0
+coverage: 100.0
+passed: true
+accessible_named: 1
+accessible_covered: 1
+accessible_coverage: 100.0
+uncovered_elements: []

--- a/tests/at/element-coverage-manifest.yaml
+++ b/tests/at/element-coverage-manifest.yaml
@@ -1,0 +1,8 @@
+scan_total: 1
+total: 1
+elements:
+  DropdownToolButton:
+    role: push button
+    source: src/widgets/ddropdownmenu.cpp
+    type: DDropdownMenu
+    name_source: accessible

--- a/tests/at/yaml/edit_mode/edit_mode.suite.yaml
+++ b/tests/at/yaml/edit_mode/edit_mode.suite.yaml
@@ -1,0 +1,59 @@
+name: edit_mode_suite
+app: deepin-editor
+module: edit_mode
+setup:
+- action: session_start
+  command: deepin-editor
+  wait: 3.0
+suites:
+- id: case_encoding_switch_s1
+  name: 编码切换
+  description: ''
+  steps:
+  - step_type: action
+    action: keyboard_hot_key
+    key: ctrl+t
+  - step_type: action
+    action: mouse_click
+    selector:
+      name: DropdownToolButton
+      role: push button
+  - step_type: action
+    action: dtk_context_menu
+    selector:
+      name: DropdownToolButton
+      role: push button
+    items:
+    - 简体中文
+    - GB18030
+  - step_type: action
+    action: keyboard_type
+    text: UOS给世界更好的选择
+  - step_type: action
+    action: mouse_click
+    selector:
+      name: DropdownToolButton
+      role: push button
+  - step_type: action
+    action: dtk_context_menu
+    selector:
+      name: DropdownToolButton
+      role: push button
+    items:
+    - Unicode
+    - UTF-8
+  - step_type: action
+    action: keyboard_press
+    key: enter
+  - step_type: action
+    action: keyboard_hot_key
+    key: ctrl+s
+  - step_type: action
+    action: file_dialog_select
+    path: /tmp/test_encoding_switch.txt
+  assert_steps:
+  - step_type: assert
+    action: assert_file_exists
+    path: /tmp/test_encoding_switch.txt
+teardown:
+- action: session_stop

--- a/tests/at/yaml/elements.yaml
+++ b/tests/at/yaml/elements.yaml
@@ -1,0 +1,4 @@
+elements:
+  DropdownToolButton:
+    name: DropdownToolButton
+    role: push button


### PR DESCRIPTION
## AT-SPI 测试套件：编码切换

### 新增模块
- **edit_mode** — 编辑模式

### 新增用例
| 用例ID | 用例名称 | 步骤数 |
|--------|----------|--------|
| case_encoding_switch_s1 | 编码切换 | 10 |

### 用例步骤概要
1. 启动 deepin-editor
2. Ctrl+T 新开标签页
3. 点击底部编码下拉菜单，选择 简体中文→GB18030
4. 键盘输入 "UOS给世界更好的选择"
5. 点击底部编码下拉菜单，选择 Unicode→UTF-8
6. 按回车键
7. Ctrl+S 保存文件
8. 断言文件存在

### 元素覆盖率
- 扫描元素: 1
- 覆盖元素: 1
- 覆盖率: 100%
- DropdownToolButton (accessible_name, source: src/widgets/ddropdownmenu.cpp)

### 验证结果
- Gate 5 (Semantic Safety): PASS
- Gate 4 (Generation): PASS
- 覆盖门禁: 100% PASS

## Summary by Sourcery

Add an AT-SPI encoding-switch test suite for deepin-editor with mapped element coverage.

New Features:
- Add an AT-SPI edit-mode test covering encoding conversion, text entry, and saving a file.

Enhancements:
- Define the mapped DropdownToolButton element and its accessibility metadata for the test pipeline.

Tests:
- Add element coverage manifests and reports confirming 100% coverage for the mapped control.