### PR TITLE
[AT] deepin-editor 编码切换 测试套件（element-map 双字段管线）

### DIFF
--- a/tests/at/cases_mapped.yaml
+++ b/tests/at/cases_mapped.yaml
@@ -1,0 +1,35 @@
+version: '1.0'
+cases:
+- id: suite_编辑模式_001_s1
+  name: 编码切换
+  module: 编辑模式
+  steps:
+  - step_type: action
+    action: keyboard_hot_key
+    key: ctrl+t
+  - step_type: action
+    action: dtk_dropdown_menu
+    selector:
+      accessible_id: PToolButton
+    items:
+    - 简体中文
+    - GB18030
+  - step_type: action
+    action: keyboard_type
+    text: UOS给世界更好的选择
+  - step_type: action
+    action: dtk_dropdown_menu
+    selector:
+      accessible_id: PToolButton
+    items:
+    - PActUtf8
+  - step_type: action
+    action: keyboard_press
+    key: enter
+  - step_type: action
+    action: file_dialog_select
+    path: /tmp/test_encoding_switch.txt
+    wait: 3.0
+  - step_type: assert
+    action: assert_file_exists
+    path: /tmp/test_encoding_switch.txt

--- a/tests/at/coverage-report.yaml
+++ b/tests/at/coverage-report.yaml
@@ -1,0 +1,9 @@
+scan_total: 2
+transient_items: []
+unreachable: 0
+denominator: 2
+covered: 2
+uncovered: 0
+coverage: 100.0
+passed: true
+uncovered_elements: []

--- a/tests/at/element-coverage-manifest.yaml
+++ b/tests/at/element-coverage-manifest.yaml
@@ -1,0 +1,16 @@
+version: '1.0'
+source: at-case-authoring:element-map.yaml
+scan_total: 2
+elements:
+  PToolButton:
+    role: push button
+    ui_name: 编码菜单按钮
+    desc: 底部编码切换下拉菜单触发按钮(DDropdownMenu共享PToolButton)，来自定向需求
+    locator: accessible_id
+  PActUtf8:
+    role: menu item
+    ui_name: UTF-8编码选项
+    desc: 编码菜单中UTF-8选项QAction(setObjectName=PActUtf8)，来自定向需求
+    locator: accessible_id
+transient_items: []
+unresolved: []

--- a/tests/at/yaml/elements.yaml
+++ b/tests/at/yaml/elements.yaml
@@ -1,0 +1,7 @@
+elements:
+  PToolButton:
+    accessible_id: PToolButton
+  PActUtf8:
+    name: PActUtf8
+    role: menu item
+    accessible_id: PActUtf8

--- a/tests/at/yaml/编辑模式/编辑模式.suite.yaml
+++ b/tests/at/yaml/编辑模式/编辑模式.suite.yaml
@@ -1,0 +1,44 @@
+name: 编辑模式_suite
+app: deepin-editor
+module: 编辑模式
+setup:
+- action: session_start
+  command: deepin-editor
+  wait: 3.0
+suites:
+- id: suite_编辑模式_001_s1
+  name: 编码切换
+  description: ''
+  steps:
+  - step_type: action
+    action: keyboard_hot_key
+    key: ctrl+t
+  - step_type: action
+    action: dtk_dropdown_menu
+    selector:
+      accessible_id: PToolButton
+    items:
+    - 简体中文
+    - GB18030
+  - step_type: action
+    action: keyboard_type
+    text: UOS给世界更好的选择
+  - step_type: action
+    action: dtk_dropdown_menu
+    selector:
+      accessible_id: PToolButton
+    items:
+    - PActUtf8
+  - step_type: action
+    action: keyboard_press
+    key: enter
+  - step_type: action
+    action: file_dialog_select
+    path: /tmp/test_encoding_switch.txt
+    wait: 3.0
+  assert_steps:
+  - step_type: assert
+    action: assert_file_exists
+    path: /tmp/test_encoding_switch.txt
+teardown:
+- action: session_stop


### PR DESCRIPTION
## 概述

为 deepin-editor「编码切换」功能生成 AT-SPI 测试套件（场景四 形态A 定向生成）。

## 测试套件内容

- **模块**: 编辑模式
- **用例数**: 1
- **元素覆盖率**: 100%（2/2 持久元素）
- **Gate 4/5**: PASS
- **Smoke 测试**: PASS

## 交付物

- `tests/at/yaml/elements.yaml`
- `tests/at/yaml/编辑模式/编辑模式.suite.yaml`
- `tests/at/element-coverage-manifest.yaml`
- `tests/at/coverage-report.yaml`
- `tests/at/cases_mapped.yaml`

## Summary by Sourcery

为 deepin-editor 添加编辑模式编码切换的 AT-SPI 自动化测试套件。

New Features:
- 新增 deepin-editor 编辑模式编码切换的自动化验收测试用例。

Enhancements:
- 建立编码切换测试所需的元素映射与元素覆盖清单。

Tests:
- 新增测试用例映射、套件配置及覆盖率报告，验证编码切换、文本输入和文件保存流程，并实现 100% 持久元素覆盖。